### PR TITLE
content [nfc]: Store `message` on MessageContent widget

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:html/dom.dart' as dom;
 
+import '../api/model/model.dart';
 import '../model/content.dart';
 import '../model/store.dart';
 import 'app.dart';
@@ -13,8 +14,9 @@ const double kBaseFontSize = 14;
 /// This does not include metadata like the sender's name and avatar, the time,
 /// or the message's status as starred or edited.
 class MessageContent extends StatelessWidget {
-  const MessageContent({super.key, required this.content});
+  const MessageContent({super.key, required this.message, required this.content});
 
+  final Message message;
   final ZulipContent content;
 
   @override

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -321,7 +321,7 @@ class MessageWithSender extends StatelessWidget {
                 Text(message.sender_full_name, // TODO get from user data
                     style: const TextStyle(fontWeight: FontWeight.bold)),
                 const SizedBox(height: 4),
-                MessageContent(content: content),
+                MessageContent(message: message, content: content),
               ])),
           Container(
               width: 80,


### PR DESCRIPTION
As discussed on CZO:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20lightbox/near/1512718