### PR TITLE
deps: Switch to getting Flutter from the main channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,15 @@ samples, guidance on mobile development, and a full API reference.
 
 ### Dependencies
 
-While in the prototype phase, we use the latest beta version of Flutter.
-Use `flutter channel beta` and `flutter upgrade` to get the right version.
+While in the prototype phase, we use the latest Flutter from Flutter's
+main branch.  Use `flutter channel main` and `flutter upgrade`.
+
+We don't pin a specific version, because Flutter itself doesn't offer
+a way to do so.  So far that hasn't been a problem.  When it becomes one,
+we'll figure it out; there are several tools for this in the Flutter
+community.  See [issue #15][].
+
+[issue #15]: https://github.com/zulip/zulip-flutter/issues/15
 
 
 ### Server credentials
@@ -76,7 +83,15 @@ $ flutter pub run build_runner watch --delete-conflicting-outputs
 
 ### Upgrading Flutter
 
-When there's a new Flutter beta, we'll take the upgrade promptly:
+We regularly increment our lower bounds on Flutter and Dart versions,
+to make sure there's not too much divergence in the versions people
+are using.
+
+When there's a new beta (which happens a couple of times per month),
+that's a good prompt to do this.  We also do this when there's a
+new PR merged that we particularly want to take.
+
+To update the version bounds:
 * Use `flutter upgrade` to upgrade your local Flutter and Dart.
 * Update the lower bounds at `environment` in `pubspec.yaml`
   to the new versions, as seen in `flutter --version`.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -553,5 +553,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.0.0-218.1.beta <4.0.0"
-  flutter: ">=3.8.0-10.1.pre"
+  dart: ">=3.0.0-277.0.dev <4.0.0"
+  flutter: ">=3.8.0-17.0.pre.49"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,12 +19,13 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1+1
 
 environment:
-  # We use a beta version of Flutter while developing a prototype,
-  # and the corresponding beta version of the Dart SDK.  The hope is
+  # We use a development version of Flutter while developing a prototype,
+  # and the corresponding dev version of the Dart SDK.  The hope is
   # that by the time we want to release, these will have become stable.
-  # TODO: Switch to stable Flutter and Dart versions before general release.
-  sdk: '>=3.0.0-218.1.beta <4.0.0'
-  flutter: '>=3.8.0-10.1.pre <4.0.0'
+  # TODO: Before general release, switch to stable Flutter and Dart versions,
+  #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
+  sdk: '>=3.0.0-277.0.dev <4.0.0'
+  flutter: '>=3.8.0-17.0.pre.49'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
In particular this gets us the new scroll curve for Android that fixes several issues with scrolling:
  https://github.com/flutter/flutter/pull/120420

Also drop the upper bound on Flutter versions from the pubspec.yaml, as it turns out it's ignored.
See #15.