### PR TITLE
Reorganize data-managing widgets to accommodate global data

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'compose_box.dart';
 import 'message_list.dart';
-import '../model/store.dart';
+import 'store.dart';
 
 class ZulipApp extends StatelessWidget {
   const ZulipApp({super.key});
@@ -28,80 +28,11 @@ class ZulipApp extends StatelessWidget {
   }
 }
 
-class PerAccountRoot extends StatefulWidget {
-  const PerAccountRoot({super.key, required this.child});
-
-  final Widget child;
-
-  @override
-  State<PerAccountRoot> createState() => _PerAccountRootState();
-}
-
-class _PerAccountRootState extends State<PerAccountRoot> {
-  PerAccountStore? store;
-
-  @override
-  void initState() {
-    super.initState();
-    (() async {
-      final store = await PerAccountStore.load();
-      setState(() {
-        this.store = store;
-      });
-    })();
-  }
-
-  @override
-  void reassemble() {
-    // The [reassemble] method runs upon hot reload, in development.
-    // Here, we rerun parsing the messages.  This gives us the same
-    // highly productive workflow of Flutter hot reload when developing
-    // changes there as we have on changes to widgets.
-    store?.reassemble();
-    super.reassemble();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // TODO: factor out the use of LoadingPage to be configured by the widget, like [widget.child] is
-    if (store == null) return const LoadingPage();
-    return PerAccountStoreWidget(store: store!, child: widget.child);
-  }
-}
-
 /// The Zulip "brand color", a purplish blue.
 ///
 /// This is chosen as the sRGB midpoint of the Zulip logo's gradient.
 // As computed by Anders: https://github.com/zulip/zulip-mobile/pull/4467
 const kZulipBrandColor = Color.fromRGBO(0x64, 0x92, 0xfe, 1);
-
-class LoadingPage extends StatelessWidget {
-  const LoadingPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: CircularProgressIndicator());
-  }
-}
-
-class PerAccountStoreWidget extends InheritedNotifier<PerAccountStore> {
-  const PerAccountStoreWidget(
-      {super.key, required PerAccountStore store, required super.child})
-      : super(notifier: store);
-
-  PerAccountStore get store => notifier!;
-
-  static PerAccountStore of(BuildContext context) {
-    final widget =
-        context.dependOnInheritedWidgetOfExactType<PerAccountStoreWidget>();
-    assert(widget != null, 'No PerAccountStoreWidget ancestor');
-    return widget!.store;
-  }
-
-  @override
-  bool updateShouldNotify(covariant PerAccountStoreWidget oldWidget) =>
-      store != oldWidget.store;
-}
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../model/store.dart';
 import 'compose_box.dart';
 import 'message_list.dart';
 import 'store.dart';
@@ -19,12 +20,14 @@ class ZulipApp extends StatelessWidget {
         // Or try this tool to see the whole palette:
         //   https://m3.material.io/theme-builder#/custom
         colorScheme: ColorScheme.fromSeed(seedColor: kZulipBrandColor));
-    // Just one account for now.
-    return PerAccountRoot(
-      child: MaterialApp(
-        title: 'Zulip',
-        theme: theme,
-        home: const HomePage()));
+    return DataRoot(
+      child: PerAccountRoot(
+        // Just one account for now.
+        accountId: GlobalStore.fixtureAccountId,
+        child: MaterialApp(
+          title: 'Zulip',
+          theme: theme,
+          home: const HomePage())));
   }
 }
 

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -9,13 +9,29 @@ class ZulipApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = ThemeData(
+        // This applies Material 3's color system to produce a palette of
+        // appropriately matching and contrasting colors for use in a UI.
+        // The Zulip brand color is a starting point, but doesn't end up as
+        // one that's directly used.  (After all, we didn't design it for that
+        // purpose; we designed a logo.)  See docs:
+        //   https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html
+        // Or try this tool to see the whole palette:
+        //   https://m3.material.io/theme-builder#/custom
+        colorScheme: ColorScheme.fromSeed(seedColor: kZulipBrandColor));
     // Just one account for now.
-    return const PerAccountRoot();
+    return PerAccountRoot(
+      child: MaterialApp(
+        title: 'Zulip',
+        theme: theme,
+        home: const HomePage()));
   }
 }
 
 class PerAccountRoot extends StatefulWidget {
-  const PerAccountRoot({super.key});
+  const PerAccountRoot({super.key, required this.child});
+
+  final Widget child;
 
   @override
   State<PerAccountRoot> createState() => _PerAccountRootState();
@@ -47,23 +63,9 @@ class _PerAccountRootState extends State<PerAccountRoot> {
 
   @override
   Widget build(BuildContext context) {
+    // TODO: factor out the use of LoadingPage to be configured by the widget, like [widget.child] is
     if (store == null) return const LoadingPage();
-    return PerAccountStoreWidget(
-        store: store!,
-        child: MaterialApp(
-          title: 'Zulip',
-          theme: ThemeData(
-              // This applies Material 3's color system to produce a palette of
-              // appropriately matching and contrasting colors for use in a UI.
-              // The Zulip brand color is a starting point, but doesn't end up as
-              // one that's directly used.  (After all, we didn't design it for that
-              // purpose; we designed a logo.)  See docs:
-              //   https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html
-              // Or try this tool to see the whole palette:
-              //   https://m3.material.io/theme-builder#/custom
-              colorScheme: ColorScheme.fromSeed(seedColor: kZulipBrandColor)),
-          home: const HomePage(),
-        ));
+    return PerAccountStoreWidget(store: store!, child: widget.child);
   }
 }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'dialog.dart';
 
-import 'app.dart';
 import '../api/route/messages.dart';
+import 'store.dart';
 
 const double _inputVerticalPadding = 8;
 const double _sendButtonSize = 36;

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -4,7 +4,7 @@ import 'package:html/dom.dart' as dom;
 import '../api/model/model.dart';
 import '../model/content.dart';
 import '../model/store.dart';
-import 'app.dart';
+import 'store.dart';
 
 /// The font size for message content in a plain unstyled paragraph.
 const double kBaseFontSize = 14;

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -7,9 +7,9 @@ import '../model/content.dart';
 import '../model/message_list.dart';
 import '../model/narrow.dart';
 import '../model/store.dart';
-import 'app.dart';
 import 'content.dart';
 import 'sticky_header.dart';
+import 'store.dart';
 
 class MessageList extends StatefulWidget {
   const MessageList({Key? key}) : super(key: key);

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../model/store.dart';
+
+class PerAccountRoot extends StatefulWidget {
+  const PerAccountRoot({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<PerAccountRoot> createState() => _PerAccountRootState();
+}
+
+class _PerAccountRootState extends State<PerAccountRoot> {
+  PerAccountStore? store;
+
+  @override
+  void initState() {
+    super.initState();
+    (() async {
+      final store = await PerAccountStore.load();
+      setState(() {
+        this.store = store;
+      });
+    })();
+  }
+
+  @override
+  void reassemble() {
+    // The [reassemble] method runs upon hot reload, in development.
+    // Here, we rerun parsing the messages.  This gives us the same
+    // highly productive workflow of Flutter hot reload when developing
+    // changes there as we have on changes to widgets.
+    store?.reassemble();
+    super.reassemble();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: factor out the use of LoadingPage to be configured by the widget, like [widget.child] is
+    if (store == null) return const LoadingPage();
+    return PerAccountStoreWidget(store: store!, child: widget.child);
+  }
+}
+
+class PerAccountStoreWidget extends InheritedNotifier<PerAccountStore> {
+  const PerAccountStoreWidget(
+      {super.key, required PerAccountStore store, required super.child})
+      : super(notifier: store);
+
+  PerAccountStore get store => notifier!;
+
+  static PerAccountStore of(BuildContext context) {
+    final widget =
+    context.dependOnInheritedWidgetOfExactType<PerAccountStoreWidget>();
+    assert(widget != null, 'No PerAccountStoreWidget ancestor');
+    return widget!.store;
+  }
+
+  @override
+  bool updateShouldNotify(covariant PerAccountStoreWidget oldWidget) =>
+      store != oldWidget.store;
+}
+
+class LoadingPage extends StatelessWidget {
+  const LoadingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -2,9 +2,62 @@ import 'package:flutter/material.dart';
 
 import '../model/store.dart';
 
-class PerAccountRoot extends StatefulWidget {
-  const PerAccountRoot({super.key, required this.child});
+class DataRoot extends StatefulWidget {
+  const DataRoot({super.key, required this.child});
 
+  final Widget child;
+
+  @override
+  State<DataRoot> createState() => _DataRootState();
+}
+
+class _DataRootState extends State<DataRoot> {
+  GlobalStore? store;
+
+  @override
+  void initState() {
+    super.initState();
+    (() async {
+      final store = await GlobalStore.load();
+      setState(() {
+        this.store = store;
+      });
+    })();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final store = this.store;
+    // TODO: factor out the use of LoadingPage to be configured by the widget, like [widget.child] is
+    if (store == null) return const LoadingPage();
+    return GlobalStoreWidget(store: store, child: widget.child);
+  }
+}
+
+class GlobalStoreWidget extends InheritedNotifier<GlobalStore> {
+  const GlobalStoreWidget(
+      {super.key, required GlobalStore store, required super.child})
+      : super(notifier: store);
+
+  GlobalStore get store => notifier!;
+
+  static GlobalStore of(BuildContext context) {
+    final widget =
+        context.dependOnInheritedWidgetOfExactType<GlobalStoreWidget>();
+    assert(widget != null, 'No GlobalStoreWidget ancestor');
+    return widget!.store;
+  }
+
+  @override
+  bool updateShouldNotify(covariant GlobalStoreWidget oldWidget) =>
+      store != oldWidget.store;
+}
+
+class PerAccountRoot extends StatefulWidget {
+  const PerAccountRoot(
+      {super.key, required this.accountId, required this.child});
+
+  final int accountId;
   final Widget child;
 
   @override
@@ -15,10 +68,22 @@ class _PerAccountRootState extends State<PerAccountRoot> {
   PerAccountStore? store;
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final globalStore = GlobalStoreWidget.of(context);
+    final account = globalStore.getAccount(widget.accountId);
+    assert(account != null, 'Account not found on global store');
+    if (store != null) {
+      // The data we use to auth to the server should be unchanged;
+      // changing those should mean a new account ID in our database.
+      assert(account!.realmUrl == store!.account.realmUrl);
+      assert(account!.email == store!.account.email);
+      assert(account!.apiKey == store!.account.apiKey);
+      // TODO if Account has anything else change, update the PerAccountStore for that
+      return;
+    }
     (() async {
-      final store = await PerAccountStore.load();
+      final store = await PerAccountStore.load(account!);
       setState(() {
         this.store = store;
       });


### PR DESCRIPTION
Another step toward #13 . This sets up an appropriate home (the `GlobalStore`) for data like the list of accounts, and which one is the active account (the one we should immediately show on launching the app), to live.
