### PR TITLE
Make API logic testable, and start testing some

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -127,6 +127,7 @@ abstract class Message {
   final String subject; // TODO call it "topic" internally; also similar others
   // final List<string> submessages; // TODO handle
   final int timestamp;
+  String get type;
 
   // final List<TopicLink> topic_links; // TODO handle
   // final string type; // handled by runtime type of object
@@ -166,6 +167,10 @@ abstract class Message {
 
 @JsonSerializable()
 class StreamMessage extends Message {
+  @override
+  @JsonKey(includeToJson: true)
+  String get type => 'stream';
+
   final String display_recipient;
   final int stream_id;
 
@@ -217,6 +222,10 @@ class PmRecipient {
 
 @JsonSerializable()
 class PmMessage extends Message {
+  @override
+  @JsonKey(includeToJson: true)
+  String get type => 'private';
+
   final List<PmRecipient> display_recipient;
 
   PmMessage({

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -124,6 +124,7 @@ Map<String, dynamic> _$StreamMessageToJson(StreamMessage instance) =>
       'flags': instance.flags,
       'match_content': instance.match_content,
       'match_subject': instance.match_subject,
+      'type': instance.type,
       'display_recipient': instance.display_recipient,
       'stream_id': instance.stream_id,
     };
@@ -182,5 +183,6 @@ Map<String, dynamic> _$PmMessageToJson(PmMessage instance) => <String, dynamic>{
       'flags': instance.flags,
       'match_content': instance.match_content,
       'match_subject': instance.match_subject,
+      'type': instance.type,
       'display_recipient': instance.display_recipient,
     };

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -71,7 +71,7 @@ class PerAccountStore extends ChangeNotifier {
   ///
   /// In the future this might load an old snapshot from local storage first.
   static Future<PerAccountStore> load(Account account) async {
-    final connection = ApiConnection(auth: account);
+    final connection = LiveApiConnection(auth: account);
 
     final stopwatch = Stopwatch()..start();
     final initialSnapshot = await registerQueue(connection); // TODO retry

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -1,0 +1,35 @@
+import 'package:zulip/api/core.dart';
+import 'package:zulip/model/store.dart';
+
+/// An [ApiConnection] that accepts and replays canned responses, for testing.
+class FakeApiConnection extends ApiConnection {
+  FakeApiConnection({required String realmUrl, required String email})
+      : super(auth: Account(
+                realmUrl: realmUrl, email: email, apiKey: _fakeApiKey));
+
+  String? _nextResponse;
+
+  // TODO: This mocking API will need to get richer to support all the tests we need.
+
+  void prepare(String response) {
+    assert(_nextResponse == null,
+        'FakeApiConnection.prepare was called while already expecting a request');
+    _nextResponse = response;
+  }
+
+  @override
+  Future<String> get(String route, Map<String, dynamic>? params) async {
+    final response = _nextResponse;
+    _nextResponse = null;
+    return response!;
+  }
+
+  @override
+  Future<String> post(String route, Map<String, dynamic>? params) async {
+    final response = _nextResponse;
+    _nextResponse = null;
+    return response!;
+  }
+}
+
+const String _fakeApiKey = 'fake-api-key';

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:checks/checks.dart';
+import 'package:zulip/api/model/events.dart';
+import 'package:zulip/api/model/model.dart';
+
+extension EventChecks on Subject<Event> {
+  Subject<int> get id => has((e) => e.id, 'id');
+  Subject<String> get type => has((e) => e.type, 'type');
+}
+
+extension UnexpectedEventChecks on Subject<UnexpectedEvent> {
+  Subject<Map<String, dynamic>> get json => has((e) => e.json, 'json');
+}
+
+extension AlertWordsEventChecks on Subject<AlertWordsEvent> {
+  Subject<List<String>> get alert_words => has((e) => e.alert_words, 'alert_words');
+}
+
+extension MessageEventChecks on Subject<MessageEvent> {
+  Subject<Message> get message => has((e) => e.message, 'message');
+}
+
+extension HeartbeatEventChecks on Subject<HeartbeatEvent> {
+  // No properties not covered by Event.
+}
+
+// Add more extensions here for more event types as needed.
+// Keep them in the same order as the event types' own definitions.

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -1,0 +1,22 @@
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/events.dart';
+
+import '../../example_data.dart' as eg;
+import 'events_checks.dart';
+import 'model_checks.dart';
+
+void main() {
+  test('message: move flags into message object', () {
+    final message = eg.streamMessage();
+    MessageEvent mkEvent(List<String> flags) => Event.fromJson({
+        'type': 'message',
+        'id': 1,
+        'message': message.toJson()..remove('flags'),
+        'flags': flags,
+      }) as MessageEvent;
+    check(mkEvent(message.flags)).message.jsonEquals(message);
+    check(mkEvent([])).message.flags.deepEquals([]);
+    check(mkEvent(['read'])).message.flags.deepEquals(['read']);
+  });
+}

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -1,0 +1,16 @@
+import 'package:checks/checks.dart';
+import 'package:zulip/api/model/model.dart';
+
+extension MessageChecks on Subject<Message> {
+  Subject<Map<String, dynamic>> get toJson => has((e) => e.toJson(), 'toJson');
+
+  void jsonEquals(Message expected) {
+    toJson.deepEquals(expected.toJson());
+  }
+
+  Subject<List<String>> get flags => has((e) => e.flags, 'flags');
+
+  // TODO accessors for other fields
+}
+
+// TODO similar extensions for other types in model

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/api/route/messages.dart';
+
+import '../fake_api.dart';
+import 'route_checks.dart';
+
+void main() {
+  test('sendMessage accepts fixture realm', () async {
+    final connection = FakeApiConnection(
+        realmUrl: 'https://chat.zulip.org/', email: 'self@mail.example');
+    connection.prepare(jsonEncode(SendMessageResult(id: 42).toJson()));
+    check(sendMessage(connection, content: 'hello', topic: 'world'))
+        .completes(it()..id.equals(42));
+  });
+
+  test('sendMessage rejects unexpected realm', () async {
+    final connection = FakeApiConnection(
+        realmUrl: 'https://chat.example/', email: 'self@mail.example');
+    connection.prepare(jsonEncode(SendMessageResult(id: 42).toJson()));
+    check(sendMessage(connection, content: 'hello', topic: 'world'))
+        .throws();
+  });
+}

--- a/test/api/route/route_checks.dart
+++ b/test/api/route/route_checks.dart
@@ -1,0 +1,11 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:checks/checks.dart';
+import 'package:zulip/api/route/messages.dart';
+
+extension SendMessageResultChecks on Subject<SendMessageResult> {
+  Subject<int> get id => has((e) => e.id, 'id');
+  Subject<String?> get deliver_at => has((e) => e.deliver_at, 'deliver_at');
+}
+
+// TODO add similar extensions for other classes in api/route/*.dart

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1,0 +1,45 @@
+import 'package:zulip/api/model/model.dart';
+
+final _messagePropertiesBase = {
+  'is_me_message': false,
+  'last_edit_timestamp': null,
+  'recipient_id': 32, // obsolescent in API, and ignored
+};
+
+// When we have a User object, this can take that as an argument.
+Map<String, dynamic> _messagePropertiesFromSender() {
+  return {
+    'client': 'ExampleClient',
+    'sender_email': 'a-person@example',
+    'sender_full_name': 'A Person',
+    'sender_id': 12345, // TODO generate example IDs
+    'sender_realm_str': 'zulip',
+  };
+}
+
+// When we have a Stream object, this can take that as an argument.
+// Also it can default explicitly to an example stream.
+StreamMessage streamMessage(
+    {String? streamName, int? streamId}) {
+  // The use of JSON here is convenient in order to delegate parts of the data
+  // to helper functions.  The main downside is that it loses static typing
+  // of the properties as we're constructing the data.  That's probably OK
+  // because (a) this is only for tests; (b) the types do get checked
+  // dynamically in the constructor, so any ill-typing won't propagate further.
+  return StreamMessage.fromJson({
+    ..._messagePropertiesBase,
+    ..._messagePropertiesFromSender(),
+    'display_recipient': streamName ?? 'a stream',
+    'stream_id': streamId ?? 123, // TODO generate example IDs
+
+    'content': '<p>This is an example stream message.</p>',
+    'content_type': 'text/html',
+    'flags': [],
+    'id': 1234567, // TODO generate example IDs
+    'subject': 'example topic',
+    'timestamp': 1678139636,
+    'type': 'stream',
+  });
+}
+
+// TODO example data for many more types


### PR DESCRIPTION
This is motivated just now by #21 by way of a couple of steps of yak-shaving (while #21 is itself yak-shaving for #13 which is for #11.) But it's also something we'll clearly want in any case.

For #21, we'll want some logic where the `GlobalStore` keeps around a collection of `PerAccountStore`s, and when asked can pull out an existing one or load up a new one as needed. Because the loading is async (it involves talking to the server to fetch initial data; in the future it might start by reading a local snapshot from a database, but that'll also be async), the logic to prevent two concurrent calls from redundantly both doing the work is a bit more than trivial. I wrote up that logic and then figured it should have a test.

But the test shouldn't go try to talk to an actual Zulip server. So we'll need a way to swap in a fake implementation of talking to the server, for tests. This gets us part of the way there, far enough to write a few tests to validate that it works.
