### PR TITLE
store: Have GlobalStore manage one PerAccountStore per account

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -37,6 +37,10 @@ class GlobalStore extends ChangeNotifier {
   // TODO settings (those that are per-device rather than per-account)
   // TODO push token, and other data corresponding to GlobalSessionState
 
+  Future<PerAccountStore> loadPerAccount(Account account) {
+    return PerAccountStore.load(account);
+  }
+
   // Just an Iterable, not the actual Map, to avoid clients mutating the map.
   // Mutations should go through the setters/mutators below.
   Iterable<Account> get accounts => _accounts.values;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -34,6 +34,8 @@ abstract class GlobalStore extends ChangeNotifier {
   final Map<int, PerAccountStore> _perAccountStores = {};
   final Map<int, Future<PerAccountStore>> _perAccountStoresLoading = {};
 
+  PerAccountStore? perAccountSync(int accountId) => _perAccountStores[accountId];
+
   Future<PerAccountStore> perAccount(int accountId) async {
     // First, see if we have the store already.
     PerAccountStore? store = _perAccountStores[accountId];

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -23,7 +23,7 @@ class ZulipApp extends StatelessWidget {
     return GlobalStoreWidget(
       child: PerAccountStoreWidget(
         // Just one account for now.
-        accountId: GlobalStore.fixtureAccountId,
+        accountId: LiveGlobalStore.fixtureAccountId,
         child: MaterialApp(
           title: 'Zulip',
           theme: theme,

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -153,14 +153,25 @@ class _PerAccountStoreWidgetState extends State<PerAccountStoreWidget> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final globalStore = GlobalStoreWidget.of(context);
-    (() async {
-      final store = await globalStore.perAccount(widget.accountId);
-      if (store != this.store) {
-        setState(() {
-          this.store = store;
-        });
-      }
-    })();
+    // If we already have data, get it immediately. This avoids showing one
+    // frame of loading indicator each time we have a new PerAccountStoreWidget.
+    final store = globalStore.perAccountSync(widget.accountId);
+    if (store != null) {
+      _setStore(store);
+    } else {
+      // If we don't already have data, wait for it.
+      (() async {
+        _setStore(await globalStore.perAccount(widget.accountId));
+      })();
+    }
+  }
+
+  void _setStore(PerAccountStore store) {
+    if (store != this.store) {
+      setState(() {
+        this.store = store;
+      });
+    }
   }
 
   @override

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -153,22 +153,13 @@ class _PerAccountStoreWidgetState extends State<PerAccountStoreWidget> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final globalStore = GlobalStoreWidget.of(context);
-    final account = globalStore.getAccount(widget.accountId);
-    assert(account != null, 'Account not found on global store');
-    if (store != null) {
-      // The data we use to auth to the server should be unchanged;
-      // changing those should mean a new account ID in our database.
-      assert(account!.realmUrl == store!.account.realmUrl);
-      assert(account!.email == store!.account.email);
-      assert(account!.apiKey == store!.account.apiKey);
-      // TODO if Account has anything else change, update the PerAccountStore for that
-      return;
-    }
     (() async {
-      final store = await globalStore.loadPerAccount(account!);
-      setState(() {
-        this.store = store;
-      });
+      final store = await globalStore.perAccount(widget.accountId);
+      if (store != this.store) {
+        setState(() {
+          this.store = store;
+        });
+      }
     })();
   }
 

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -55,7 +55,7 @@ class _GlobalStoreWidgetState extends State<GlobalStoreWidget> {
   void initState() {
     super.initState();
     (() async {
-      final store = await GlobalStore.load();
+      final store = await LiveGlobalStore.load();
       setState(() {
         this.store = store;
       });

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -165,7 +165,7 @@ class _PerAccountStoreWidgetState extends State<PerAccountStoreWidget> {
       return;
     }
     (() async {
-      final store = await PerAccountStore.load(account!);
+      final store = await globalStore.loadPerAccount(account!);
       setState(() {
         this.store = store;
       });

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -7,6 +7,9 @@ class FakeApiConnection extends ApiConnection {
       : super(auth: Account(
                 realmUrl: realmUrl, email: email, apiKey: _fakeApiKey));
 
+  FakeApiConnection.fromAccount(Account account)
+      : this(realmUrl: account.realmUrl, email: account.email);
+
   String? _nextResponse;
 
   // TODO: This mocking API will need to get richer to support all the tests we need.

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1,4 +1,16 @@
+import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
+import 'package:zulip/model/store.dart';
+
+const String realmUrl = 'https://chat.example/';
+
+const String recentZulipVersion = '6.1';
+const int recentZulipFeatureLevel = 164;
+
+const Account selfAccount =
+    Account(realmUrl: realmUrl, email: 'self@example', apiKey: 'asdfqwer');
+const Account otherAccount =
+    Account(realmUrl: realmUrl, email: 'other@example', apiKey: 'sdfgwert');
 
 final _messagePropertiesBase = {
   'is_me_message': false,
@@ -43,3 +55,14 @@ StreamMessage streamMessage(
 }
 
 // TODO example data for many more types
+
+final InitialSnapshot initialSnapshot = InitialSnapshot(
+  queue_id: '1:2345',
+  last_event_id: 1,
+  zulip_feature_level: recentZulipFeatureLevel,
+  zulip_version: recentZulipVersion,
+  zulip_merge_base: recentZulipVersion,
+  alert_words: ['klaxon'],
+  custom_profile_fields: [],
+  subscriptions: [], // TODO add subscriptions to example initial snapshot
+);

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/model/store.dart';
+
+import '../api/fake_api.dart';
+import '../example_data.dart' as eg;
+
+void main() {
+  test('GlobalStore.perAccount sequential case', () async {
+    final accounts = {1: eg.selfAccount, 2: eg.otherAccount};
+    final globalStore = TestGlobalStore(accounts: accounts);
+    List<Completer<PerAccountStore>> completers(int accountId) =>
+        globalStore.completers[accounts[accountId]]!;
+
+    final future1 = globalStore.perAccount(1);
+    final store1 = PerAccountStore.fromInitialSnapshot(
+      account: eg.selfAccount,
+      connection: FakeApiConnection.fromAccount(eg.selfAccount),
+      initialSnapshot: eg.initialSnapshot,
+    );
+    completers(1).single.complete(store1);
+    check(await future1).identicalTo(store1);
+    check(await globalStore.perAccount(1)).identicalTo(store1);
+    check(completers(1)).length.equals(1);
+
+    final future2 = globalStore.perAccount(2);
+    final store2 = PerAccountStore.fromInitialSnapshot(
+        account: eg.otherAccount,
+        connection: FakeApiConnection.fromAccount(eg.otherAccount),
+        initialSnapshot: eg.initialSnapshot,
+    );
+    completers(2).single.complete(store2);
+    check(await future2).identicalTo(store2);
+    check(await globalStore.perAccount(2)).identicalTo(store2);
+    check(await globalStore.perAccount(1)).identicalTo(store1);
+
+    // Only one loadPerAccount call was made per account.
+    check(completers(1)).length.equals(1);
+    check(completers(2)).length.equals(1);
+  });
+
+  test('GlobalStore.perAccount concurrent case', () async {
+    final accounts = {1: eg.selfAccount, 2: eg.otherAccount};
+    final globalStore = TestGlobalStore(accounts: accounts);
+    List<Completer<PerAccountStore>> completers(int accountId) =>
+        globalStore.completers[accounts[accountId]]!;
+
+    final future1a = globalStore.perAccount(1);
+    final future1b = globalStore.perAccount(1);
+    // These should produce just one loadPerAccount call.
+    check(completers(1)).length.equals(1);
+
+    final future2 = globalStore.perAccount(2);
+    final store1 = PerAccountStore.fromInitialSnapshot(
+      account: eg.selfAccount,
+      connection: FakeApiConnection.fromAccount(eg.selfAccount),
+      initialSnapshot: eg.initialSnapshot,
+    );
+    final store2 = PerAccountStore.fromInitialSnapshot(
+      account: eg.otherAccount,
+      connection: FakeApiConnection.fromAccount(eg.otherAccount),
+      initialSnapshot: eg.initialSnapshot,
+    );
+    completers(1).single.complete(store1);
+    completers(2).single.complete(store2);
+    check(await future1a).identicalTo(store1);
+    check(await future1b).identicalTo(store1);
+    check(await future2).identicalTo(store2);
+    check(await globalStore.perAccount(1)).identicalTo(store1);
+    check(await globalStore.perAccount(2)).identicalTo(store2);
+    check(completers(1)).length.equals(1);
+    check(completers(2)).length.equals(1);
+  });
+}
+
+class TestGlobalStore extends GlobalStore {
+  TestGlobalStore({required super.accounts});
+
+  Map<Account, List<Completer<PerAccountStore>>> completers = {};
+
+  @override
+  Future<PerAccountStore> loadPerAccount(Account account) {
+    final completer = Completer<PerAccountStore>();
+    (completers[account] ??= []).add(completer);
+    return completer.future;
+  }
+}


### PR DESCRIPTION
This is stacked atop #26.

As part of #21, we'll want to be able to freely instantiate a `PerAccountStoreWidget` whenever we want to mark some subtree as being for a particular account, and have that cheaply just refer to the already-loaded data for that account. This PR does that by having a `GlobalStore` maintain a `PerAccountStore` for each account, which `PerAccountStoreWidget` asks it for when it's first mounted in the element tree.

Because the logic in `GlobalStore` to maintain that, and in particular to avoid redundant requests if several `PerAccountStoreWidget`s ask about the same account at the beginning, is a bit complex, we want tests for it. To make those possible, we split both `GlobalStore` and `PerAccountStore` into a base class (which keeps the name) and a subclass that adds the using-real-data part which a unit test will want to leave out.

We also make sure to accommodate this fun trick (in `_PerAccountStoreWidgetState`):
```dart
    // If we already have data, get it immediately. This avoids showing one
    // frame of loading indicator each time we have a new PerAccountStoreWidget.
    final store = globalStore.ofAccountSync(widget.accountId);
    if (store != null) {
      _setStore(store);
    } else {
      // If we don't already have data, wait for it.
      (() async {
        _setStore(await globalStore.ofAccount(widget.accountId));
      })();
    }
```
Fortunately the nature of that trick means that other code generally won't have to think about it; just use `PerAccountWidget`.

(We might eventually want to play the same kind of trick in a small number of other places, where we depend on data that's loaded outside of the initial fetch (and so isn't guaranteed by simply having a `PerAccountState`) but that we'll sometimes have already loaded. The message list is the main example that comes to mind.)
