### PR TITLE
msglist: Use HTTP header instead of URL query param to auth image requests

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -37,17 +37,19 @@ abstract class ApiConnection {
   Future<String> post(String route, Map<String, dynamic>? params);
 }
 
+// TODO memoize
+Map<String, String> authHeader(Auth auth) {
+  final authBytes = utf8.encode("${auth.email}:${auth.apiKey}");
+  return {
+    'Authorization': 'Basic ${base64.encode(authBytes)}',
+  };
+}
+
 /// An [ApiConnection] that makes real network requests to a real server.
 class LiveApiConnection extends ApiConnection {
   LiveApiConnection({required super.auth});
 
-  Map<String, String> _headers() {
-    // TODO memoize
-    final authBytes = utf8.encode("${auth.email}:${auth.apiKey}");
-    return {
-      'Authorization': 'Basic ${base64.encode(authBytes)}',
-    };
-  }
+  Map<String, String> _headers() => authHeader(auth);
 
   @override
   Future<String> get(String route, Map<String, dynamic>? params) async {

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -457,7 +457,7 @@ class MessageImageEmoji extends StatelessWidget {
               // too low.
               top: -1.5,
               child: RealmContentNetworkImage(
-                resolvedSrc.toString(),
+                resolvedSrc,
                 filterQuality: FilterQuality.medium,
                 width: size,
                 height: size,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -469,6 +469,15 @@ class MessageImageEmoji extends StatelessWidget {
 // Small helpers.
 //
 
+/// Resolve `src` to `account`'s realm, if relative
+// This may dissolve when we start passing around URLs as `Uri` objects instead
+// of strings.
+String resolveUrl(String url, Account account) {
+  final realmUrl = Uri.parse(account.realmUrl); // TODO clean this up
+  final resolved = realmUrl.resolve(url); // TODO handle if fails to parse
+  return resolved.toString();
+}
+
 /// Resolve URL if relative; add the user's API key if appropriate.
 ///
 /// The API key is added if the URL is on the realm, and is an endpoint

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -478,7 +478,7 @@ String rewriteImageUrl(String src, Account account) {
   final resolved = realmUrl.resolve(src); // TODO handle if fails to parse
 
   Uri adjustedSrc = resolved;
-  if (_sameOrigin(resolved, realmUrl)) {
+  if (resolved.origin == realmUrl.origin) {
     if (_kInlineApiRoutes.any((regexp) => regexp.hasMatch(resolved.path))) {
       final delimiter = resolved.query.isNotEmpty ? '&' : '';
       adjustedSrc = resolved
@@ -495,8 +495,6 @@ final List<RegExp> _kInlineApiRoutes = [
   RegExp(r'^/thumbnail$'),
   RegExp(r'^/avatar/')
 ];
-
-bool _sameOrigin(Uri x, Uri y) => x.origin == y.origin;
 
 InlineSpan _errorUnimplemented(UnimplementedNode node) {
   // For now this shows error-styled HTML code even in release mode,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -496,9 +496,8 @@ final List<RegExp> _kInlineApiRoutes = [
   RegExp(r'^/avatar/')
 ];
 
-bool _sameOrigin(Uri x, Uri y) => // TODO factor better; fact-check
+bool _sameOrigin(Uri x, Uri y) => // TODO factor better
     x.scheme == y.scheme &&
-    x.userInfo == y.userInfo &&
     x.host == y.host &&
     x.port == y.port;
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -496,10 +496,7 @@ final List<RegExp> _kInlineApiRoutes = [
   RegExp(r'^/avatar/')
 ];
 
-bool _sameOrigin(Uri x, Uri y) => // TODO factor better
-    x.scheme == y.scheme &&
-    x.host == y.host &&
-    x.port == y.port;
+bool _sameOrigin(Uri x, Uri y) => x.origin == y.origin;
 
 InlineSpan _errorUnimplemented(UnimplementedNode node) {
   // For now this shows error-styled HTML code even in release mode,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -290,10 +290,10 @@ class MessageWithSender extends StatelessWidget {
 
     final avatarUrl = message.avatar_url == null // TODO get from user data
         ? null // TODO handle computing gravatars
-        : rewriteImageUrl(message.avatar_url!, store.account);
+        : resolveUrl(message.avatar_url!, store.account);
     final avatar = (avatarUrl == null)
         ? const SizedBox.shrink()
-        : Image.network(
+        : RealmContentNetworkImage(
             avatarUrl,
             filterQuality: FilterQuality.medium,
           );

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/widgets/content.dart';
+
+void main() {
+  testWidgets('Throws if no `PerAccountStoreWidget` ancestor', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const RealmContentNetworkImage('https://zulip.invalid/path/to/image.png', filterQuality: FilterQuality.medium));
+    expect(tester.takeException(), isAssertionError);
+  });
+
+  // TODO(#30): Simulate a `PerAccountStoreWidget` ancestor, to use in more tests:
+  // TODO: 'Includes auth header if `src` is on-realm'
+  // TODO: 'Excludes auth header if `src` is off-realm'
+}


### PR DESCRIPTION
Keeping the user's API key out of these URLs makes it easier to
avoid leaking the API key, e.g. to the clipboard with a future "copy
image link" feature.