### PR TITLE
store: Add PerAccountStore.users data structure, as Map<int, User>

### DIFF
--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -23,6 +23,86 @@ Map<String, dynamic> _$AlertWordsEventToJson(AlertWordsEvent instance) =>
       'alert_words': instance.alertWords,
     };
 
+RealmUserAddEvent _$RealmUserAddEventFromJson(Map<String, dynamic> json) =>
+    RealmUserAddEvent(
+      id: json['id'] as int,
+      person: User.fromJson(json['person'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$RealmUserAddEventToJson(RealmUserAddEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'person': instance.person,
+    };
+
+RealmUserUpdateCustomProfileField _$RealmUserUpdateCustomProfileFieldFromJson(
+        Map<String, dynamic> json) =>
+    RealmUserUpdateCustomProfileField(
+      id: json['id'] as int,
+      value: json['value'] as String?,
+      renderedValue: json['rendered_value'] as String?,
+    );
+
+Map<String, dynamic> _$RealmUserUpdateCustomProfileFieldToJson(
+        RealmUserUpdateCustomProfileField instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'value': instance.value,
+      'rendered_value': instance.renderedValue,
+    };
+
+RealmUserUpdateEvent _$RealmUserUpdateEventFromJson(
+        Map<String, dynamic> json) =>
+    RealmUserUpdateEvent(
+      id: json['id'] as int,
+      userId: RealmUserUpdateEvent._readFromPerson(json, 'user_id') as int,
+      fullName:
+          RealmUserUpdateEvent._readFromPerson(json, 'full_name') as String?,
+      avatarUrl:
+          RealmUserUpdateEvent._readFromPerson(json, 'avatar_url') as String?,
+      avatarVersion:
+          RealmUserUpdateEvent._readFromPerson(json, 'avatar_version') as int?,
+      timezone:
+          RealmUserUpdateEvent._readFromPerson(json, 'timezone') as String?,
+      botOwnerId:
+          RealmUserUpdateEvent._readFromPerson(json, 'bot_owner_id') as int?,
+      role: RealmUserUpdateEvent._readFromPerson(json, 'role') as int?,
+      isBillingAdmin:
+          RealmUserUpdateEvent._readFromPerson(json, 'is_billing_admin')
+              as bool?,
+      deliveryEmail:
+          RealmUserUpdateEvent._readFromPerson(json, 'delivery_email')
+              as String?,
+      customProfileField: RealmUserUpdateEvent._readFromPerson(
+                  json, 'custom_profile_field') ==
+              null
+          ? null
+          : RealmUserUpdateCustomProfileField.fromJson(
+              RealmUserUpdateEvent._readFromPerson(json, 'custom_profile_field')
+                  as Map<String, dynamic>),
+      newEmail:
+          RealmUserUpdateEvent._readFromPerson(json, 'new_email') as String?,
+    );
+
+Map<String, dynamic> _$RealmUserUpdateEventToJson(
+        RealmUserUpdateEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'user_id': instance.userId,
+      'full_name': instance.fullName,
+      'avatar_url': instance.avatarUrl,
+      'avatar_version': instance.avatarVersion,
+      'timezone': instance.timezone,
+      'bot_owner_id': instance.botOwnerId,
+      'role': instance.role,
+      'is_billing_admin': instance.isBillingAdmin,
+      'delivery_email': instance.deliveryEmail,
+      'custom_profile_field': instance.customProfileField,
+      'new_email': instance.newEmail,
+    };
+
 HeartbeatEvent _$HeartbeatEventFromJson(Map<String, dynamic> json) =>
     HeartbeatEvent(
       id: json['id'] as int,

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -23,7 +23,32 @@ class InitialSnapshot {
 
   final int maxFileUploadSizeMib;
 
+  @JsonKey(readValue: _readUsersIsActiveFallbackTrue)
+  final List<User> realmUsers;
+  @JsonKey(readValue: _readUsersIsActiveFallbackFalse)
+  final List<User> realmNonActiveUsers;
+  @JsonKey(readValue: _readUsersIsActiveFallbackTrue)
+  final List<User> crossRealmBots;
+
   // TODO etc., etc.
+
+  // `is_active` is sometimes absent:
+  //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371603
+  // But for our model it's convenient to always have it; so, fill it in.
+  static Object? _readUsersIsActiveFallbackTrue(Map json, String key) {
+    final list = (json[key] as List<dynamic>);
+    for (final Map<String, dynamic> user in list) {
+      user.putIfAbsent('is_active', () => true);
+    }
+    return list;
+  }
+  static Object? _readUsersIsActiveFallbackFalse(Map json, String key) {
+    final list = (json[key] as List<dynamic>);
+    for (final Map<String, dynamic> user in list) {
+      user.putIfAbsent('is_active', () => false);
+    }
+    return list;
+  }
 
   InitialSnapshot({
     this.queueId,
@@ -35,6 +60,9 @@ class InitialSnapshot {
     required this.customProfileFields,
     required this.subscriptions,
     required this.maxFileUploadSizeMib,
+    required this.realmUsers,
+    required this.realmNonActiveUsers,
+    required this.crossRealmBots,
   });
 
   factory InitialSnapshot.fromJson(Map<String, dynamic> json) =>

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -25,6 +25,19 @@ InitialSnapshot _$InitialSnapshotFromJson(Map<String, dynamic> json) =>
           .map((e) => Subscription.fromJson(e as Map<String, dynamic>))
           .toList(),
       maxFileUploadSizeMib: json['max_file_upload_size_mib'] as int,
+      realmUsers:
+          (InitialSnapshot._readUsersIsActiveFallbackTrue(json, 'realm_users')
+                  as List<dynamic>)
+              .map((e) => User.fromJson(e as Map<String, dynamic>))
+              .toList(),
+      realmNonActiveUsers: (InitialSnapshot._readUsersIsActiveFallbackFalse(
+              json, 'realm_non_active_users') as List<dynamic>)
+          .map((e) => User.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      crossRealmBots: (InitialSnapshot._readUsersIsActiveFallbackTrue(
+              json, 'cross_realm_bots') as List<dynamic>)
+          .map((e) => User.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
@@ -38,4 +51,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
       'custom_profile_fields': instance.customProfileFields,
       'subscriptions': instance.subscriptions,
       'max_file_upload_size_mib': instance.maxFileUploadSizeMib,
+      'realm_users': instance.realmUsers,
+      'realm_non_active_users': instance.realmNonActiveUsers,
+      'cross_realm_bots': instance.crossRealmBots,
     };

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -30,6 +30,70 @@ Map<String, dynamic> _$CustomProfileFieldToJson(CustomProfileField instance) =>
       'display_in_profile_summary': instance.displayInProfileSummary,
     };
 
+ProfileFieldUserData _$ProfileFieldUserDataFromJson(
+        Map<String, dynamic> json) =>
+    ProfileFieldUserData(
+      value: json['value'] as String,
+      renderedValue: json['rendered_value'] as String?,
+    );
+
+Map<String, dynamic> _$ProfileFieldUserDataToJson(
+        ProfileFieldUserData instance) =>
+    <String, dynamic>{
+      'value': instance.value,
+      'rendered_value': instance.renderedValue,
+    };
+
+User _$UserFromJson(Map<String, dynamic> json) => User(
+      userId: json['user_id'] as int,
+      deliveryEmailStaleDoNotUse: json['delivery_email'] as String?,
+      email: json['email'] as String,
+      fullName: json['full_name'] as String,
+      dateJoined: json['date_joined'] as String,
+      isActive: json['is_active'] as bool,
+      isOwner: json['is_owner'] as bool,
+      isAdmin: json['is_admin'] as bool,
+      isGuest: json['is_guest'] as bool,
+      isBillingAdmin: json['is_billing_admin'] as bool?,
+      isBot: json['is_bot'] as bool,
+      botType: json['bot_type'] as int?,
+      botOwnerId: json['bot_owner_id'] as int?,
+      role: json['role'] as int,
+      timezone: json['timezone'] as String,
+      avatarUrl: json['avatar_url'] as String?,
+      avatarVersion: json['avatar_version'] as int,
+      profileData:
+          (User._readProfileData(json, 'profile_data') as Map<String, dynamic>?)
+              ?.map(
+        (k, e) => MapEntry(int.parse(k),
+            ProfileFieldUserData.fromJson(e as Map<String, dynamic>)),
+      ),
+      isSystemBot: User._readIsSystemBot(json, 'is_system_bot') as bool?,
+    );
+
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'user_id': instance.userId,
+      'delivery_email': instance.deliveryEmailStaleDoNotUse,
+      'email': instance.email,
+      'full_name': instance.fullName,
+      'date_joined': instance.dateJoined,
+      'is_active': instance.isActive,
+      'is_owner': instance.isOwner,
+      'is_admin': instance.isAdmin,
+      'is_guest': instance.isGuest,
+      'is_billing_admin': instance.isBillingAdmin,
+      'is_bot': instance.isBot,
+      'bot_type': instance.botType,
+      'bot_owner_id': instance.botOwnerId,
+      'role': instance.role,
+      'timezone': instance.timezone,
+      'avatar_url': instance.avatarUrl,
+      'avatar_version': instance.avatarVersion,
+      'profile_data':
+          instance.profileData?.map((k, e) => MapEntry(k.toString(), e)),
+      'is_system_bot': instance.isSystemBot,
+    };
+
 Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       streamId: json['stream_id'] as int,
       name: json['name'] as String,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -147,6 +147,10 @@ class PerAccountStore extends ChangeNotifier {
     required this.connection,
     required InitialSnapshot initialSnapshot,
   })  : zulipVersion = initialSnapshot.zulipVersion,
+        users = Map.fromEntries(initialSnapshot.realmUsers
+          .followedBy(initialSnapshot.realmNonActiveUsers)
+          .followedBy(initialSnapshot.crossRealmBots)
+          .map((user) => MapEntry(user.userId, user))),
         subscriptions = Map.fromEntries(initialSnapshot.subscriptions.map(
                 (subscription) => MapEntry(subscription.streamId, subscription))),
         maxFileUploadSizeMib = initialSnapshot.maxFileUploadSizeMib;
@@ -155,6 +159,7 @@ class PerAccountStore extends ChangeNotifier {
   final ApiConnection connection;
 
   final String zulipVersion;
+  final Map<int, User> users;
   final Map<int, Subscription> subscriptions;
   final int maxFileUploadSizeMib; // No event for this.
 
@@ -188,6 +193,39 @@ class PerAccountStore extends ChangeNotifier {
     } else if (event is AlertWordsEvent) {
       debugPrint("server event: alert_words");
       // We don't yet store this data, so there's nothing to update.
+    } else if (event is RealmUserAddEvent) {
+      debugPrint("server event: realm_user/add");
+      users[event.person.userId] = event.person;
+      notifyListeners();
+    } else if (event is RealmUserRemoveEvent) {
+      debugPrint("server event: realm_user/remove");
+      users.remove(event.userId);
+      notifyListeners();
+    } else if (event is RealmUserUpdateEvent) {
+      debugPrint("server event: realm_user/update");
+      final user = users[event.userId];
+      if (user == null) {
+        return; // TODO log
+      }
+      if (event.fullName != null)       user.fullName                   = event.fullName!;
+      if (event.avatarUrl != null)      user.avatarUrl                  = event.avatarUrl!;
+      if (event.avatarVersion != null)  user.avatarVersion              = event.avatarVersion!;
+      if (event.timezone != null)       user.timezone                   = event.timezone!;
+      if (event.botOwnerId != null)     user.botOwnerId                 = event.botOwnerId!;
+      if (event.role != null)           user.role                       = event.role!;
+      if (event.isBillingAdmin != null) user.isBillingAdmin             = event.isBillingAdmin!;
+      if (event.deliveryEmail != null)  user.deliveryEmailStaleDoNotUse = event.deliveryEmail!;
+      if (event.newEmail != null)       user.email                      = event.newEmail!;
+      if (event.customProfileField != null) {
+        final profileData = (user.profileData ??= {});
+        final update = event.customProfileField!;
+        if (update.value != null) {
+          profileData[update.id] = ProfileFieldUserData(value: update.value!, renderedValue: update.renderedValue);
+        } else {
+          profileData.remove(update.id);
+        }
+      }
+      notifyListeners();
     } else if (event is MessageEvent) {
       debugPrint("server event: message ${jsonEncode(event.message.toJson())}");
       for (final view in _messageListViews) {

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -1,0 +1,47 @@
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/model.dart';
+
+void main() {
+  group('User', () {
+    final Map<String, dynamic> baseJson = Map.unmodifiable({
+      'user_id': 123,
+      'delivery_email': 'name@example.com',
+      'email': 'name@example.com',
+      'full_name': 'A User',
+      'date_joined': '2023-04-28',
+      'is_active': true,
+      'is_owner': false,
+      'is_admin': false,
+      'is_guest': false,
+      'is_billing_admin': false,
+      'is_bot': false,
+      'role': 400,
+      'timezone': 'UTC',
+      'avatar_version': 0,
+      'profile_data': <String, dynamic>{},
+    });
+
+    User mkUser (Map<String, dynamic> specialJson) {
+      return User.fromJson({ ...baseJson, ...specialJson });
+    }
+
+    test('delivery_email', () {
+      check(mkUser({'delivery_email': 'name@email.com'}).deliveryEmailStaleDoNotUse)
+        .equals('name@email.com');
+    });
+
+    test('profile_data', () {
+      check(mkUser({'profile_data': <String, dynamic>{}}).profileData).isNull();
+      check(mkUser({'profile_data': null}).profileData).isNull();
+      check(mkUser({'profile_data': {'1': {'value': 'foo'}}}).profileData)
+        .isNotNull().deepEquals({1: it()});
+    });
+
+    test('is_system_bot', () {
+      check(mkUser({}).isSystemBot).isNull();
+      check(mkUser({'is_cross_realm_bot': true}).isSystemBot).equals(true);
+      check(mkUser({'is_system_bot': true}).isSystemBot).equals(true);
+    });
+  });
+}

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -83,4 +83,7 @@ final InitialSnapshot initialSnapshot = InitialSnapshot(
   customProfileFields: [],
   subscriptions: [], // TODO add subscriptions to example initial snapshot
   maxFileUploadSizeMib: 25,
+  realmUsers: [],
+  realmNonActiveUsers: [],
+  crossRealmBots: [],
 );


### PR DESCRIPTION
Seeing the convenient line `flutter: initial fetch time: …` in the logs, I decided to do some trials before and after these commits. 🙂 First after, then I went back and did before (i.e. `main` 915216760c78f6624f9cd46568dad525fc9664ab).

```
After:

3790ms
2842ms
2774ms
2781ms
2735ms
2851ms
2954ms
2926ms
2888ms
2998ms

Before:

2798ms
2551ms
2916ms
3017ms
2832ms
3032ms
2281ms
3400ms
2868ms
2387ms
```