### PR TITLE
login: Be a bit more helpful in realm-url-input UI

### DIFF
--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// A space to use for [InputDecoration.helperText] so the layout doesn't jump.
+///
+/// In particular, U+200B ZERO WIDTH SPACE.
+///
+/// See [FormField.validator] :
+/// >  Alternating between error and normal state can cause the height of the
+/// >  [TextFormField] to change if no other subtext decoration is set on the
+/// >  field. To create a field whose height is fixed regardless of whether or
+/// >  not an error is displayed, either wrap the  [TextFormField] in a fixed
+/// >  height parent like [SizedBox], or set the [InputDecoration.helperText]
+/// >  parameter to a space.
+const String kLayoutPinningHelperText = '\u200b';

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -279,7 +279,7 @@ class _EmailPasswordLoginPageState extends State<EmailPasswordLoginPage> {
         return;
       }
 
-      await Navigator.of(context).pushAndRemoveUntil(
+      Navigator.of(context).pushAndRemoveUntil(
         HomePage.buildRoute(accountId: accountId),
         (route) => (route is! _LoginSequenceRoute),
       );

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -202,6 +202,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
                 onSubmitted: (value) => _onSubmitted(context),
                 keyboardType: TextInputType.url,
                 autocorrect: false,
+                textInputAction: TextInputAction.go,
                 decoration: InputDecoration(
                   labelText: 'Your Zulip server URL',
                   errorText: errorText,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -72,15 +72,17 @@ class _AddAccountPageState extends State<AddAccountPage> {
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400),
-            child: TextField(
-              controller: _controller,
-              onSubmitted: (value) => _onSubmitted(context, value),
-              keyboardType: TextInputType.url,
-              decoration: InputDecoration(
-                labelText: 'Your Zulip server URL',
-                suffixIcon: InkWell(
-                  onTap: () => _onSubmitted(context, _controller.text),
-                  child: const Icon(Icons.arrow_forward))))))));
+            child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              TextField(
+                controller: _controller,
+                onSubmitted: (value) => _onSubmitted(context, value),
+                keyboardType: TextInputType.url,
+                decoration: const InputDecoration(labelText: 'Your Zulip server URL')),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () => _onSubmitted(context, _controller.text),
+                child: const Text('Continue')),
+            ])))));
   }
 }
 

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -7,6 +7,7 @@ import '../api/route/users.dart';
 import '../model/store.dart';
 import 'app.dart';
 import 'dialog.dart';
+import 'input.dart';
 import 'store.dart';
 
 class _LoginSequenceRoute extends MaterialPageRoute<void> {
@@ -203,7 +204,10 @@ class _EmailPasswordLoginPageState extends State<EmailPasswordLoginPage> {
         return null;
       },
       textInputAction: TextInputAction.next,
-      decoration: const InputDecoration(labelText: 'Email address'));
+      decoration: const InputDecoration(
+        labelText: 'Email address',
+        helperText: kLayoutPinningHelperText,
+      ));
 
     final passwordField = TextFormField(
       key: _passwordKey,
@@ -221,6 +225,7 @@ class _EmailPasswordLoginPageState extends State<EmailPasswordLoginPage> {
       onFieldSubmitted: (value) => _submit(),
       decoration: InputDecoration(
         labelText: 'Password',
+        helperText: kLayoutPinningHelperText,
         suffixIcon: Semantics(label: 'Hide password', toggled: _obscurePassword,
           child: IconButton(
             onPressed: _handlePasswordVisibilityPress,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -203,6 +203,11 @@ class _AddAccountPageState extends State<AddAccountPage> {
                 keyboardType: TextInputType.url,
                 autocorrect: false,
                 textInputAction: TextInputAction.go,
+                onEditingComplete: () {
+                  // Repeat default implementation by clearing IME compose session…
+                  _controller.clearComposing();
+                  // …but leave out unfocusing the input in case more editing is needed.
+                },
                 decoration: InputDecoration(
                   labelText: 'Your Zulip server URL',
                   errorText: errorText,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -201,6 +201,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
                 controller: _controller,
                 onSubmitted: (value) => _onSubmitted(context),
                 keyboardType: TextInputType.url,
+                autocorrect: false,
                 decoration: InputDecoration(
                   labelText: 'Your Zulip server URL',
                   errorText: errorText,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -147,7 +147,19 @@ class _AddAccountPageState extends State<AddAccountPage> {
       _inProgress = true;
     });
     try {
-      final serverSettings = await getServerSettings(realmUrl: url!);
+      final GetServerSettingsResult serverSettings;
+      try {
+        serverSettings = await getServerSettings(realmUrl: url!);
+      } catch (e) {
+        if (!context.mounted) {
+          return;
+        }
+        // TODO(#35) give more helpful feedback; see `fetchServerSettings`
+        //   in zulip-mobile's src/message/fetchActions.js. Needs #37.
+        showErrorDialog(context: context,
+          title: 'Could not connect', message: 'Failed to connect to server:\n$url');
+        return;
+      }
       // https://github.com/dart-lang/linter/issues/4007
       // ignore: use_build_context_synchronously
       if (!context.mounted) {

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -204,7 +204,8 @@ class _AddAccountPageState extends State<AddAccountPage> {
                 decoration: InputDecoration(
                   labelText: 'Your Zulip server URL',
                   errorText: errorText,
-                  helperText: kLayoutPinningHelperText)),
+                  helperText: kLayoutPinningHelperText,
+                  hintText: 'your-org.zulipchat.com')),
               const SizedBox(height: 8),
               ElevatedButton(
                 onPressed: !_inProgress && errorText == null

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -1,0 +1,44 @@
+import 'package:checks/checks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/widgets/login.dart';
+
+void main() {
+  group('ServerUrlTextEditingController.tryParse', () {
+    final controller = ServerUrlTextEditingController();
+
+    expectUrlFromText(String text, String expectedUrl) {
+      test('text "$text" gives URL "$expectedUrl"', () {
+        controller.text = text;
+        final result = controller.tryParse();
+        check(result.error).isNull();
+        check(result.url)
+          .isNotNull() // catch `null` here instead of by its .toString()
+          .has((url) => url.toString(), 'toString()').equals(expectedUrl);
+      });
+    }
+
+    expectErrorFromText(String text, ServerUrlValidationError expectedError) {
+      test('text "$text" gives error "$expectedError"', () {
+        controller.text = text;
+        final result = controller.tryParse();
+        check(result.url).isNull();
+        check(result.error).equals(expectedError);
+      });
+    }
+
+    expectUrlFromText('https://chat.zulip.org',   'https://chat.zulip.org');
+    expectUrlFromText('https://chat.zulip.org/',  'https://chat.zulip.org/');
+    expectUrlFromText(' https://chat.zulip.org ', 'https://chat.zulip.org');
+    expectUrlFromText('http://chat.zulip.org',    'http://chat.zulip.org');
+    expectUrlFromText('chat.zulip.org',           'https://chat.zulip.org');
+    expectUrlFromText('192.168.1.21:9991',        'https://192.168.1.21:9991');
+    expectUrlFromText('http://192.168.1.21:9991', 'http://192.168.1.21:9991');
+
+    expectErrorFromText('',                  ServerUrlValidationError.empty);
+    expectErrorFromText(' ',                 ServerUrlValidationError.empty);
+    expectErrorFromText('zulip://foo',       ServerUrlValidationError.unsupportedSchemeZulip);
+    expectErrorFromText('ftp://foo',         ServerUrlValidationError.unsupportedSchemeOther);
+    expectErrorFromText('!@#*asd;l4fkj',     ServerUrlValidationError.invalidUrl);
+    expectErrorFromText('email@example.com', ServerUrlValidationError.noUseEmail);
+  });
+}


### PR DESCRIPTION
This leaves plenty more to do for #35, but this should be pretty helpful for people filling out the realm-URL input.

This PR align this UI with zulip-mobile in several ways toward #35:
- We give feedback when the input doesn't look right:
  - when it's empty
  - when URL parsing fails
  - when a scheme is given other than `http` or `https`
  - when the text looks like an email address
- We accept a URL with the leading `https://` left implicit
- We show a progress spinner for the server-settings request
- We show an error dialog when the server-settings request fails
- We use "your-org.zulipchat.com" as hint text in the input component, like in zulip-mobile

It also aligns with zulip-mobile in a few smaller ways that are nice, but maybe don't fall under #35 
- The software keyboard says "go" instead of "done"
- Autocorrect is turned off (it was getting annoying for me)
- We don't remove focus from the input on submitting through the software keyboard

Fixes-partly: #35