### PR TITLE
deps: Sync ios/Podfile.lock with recent dependency upgrades

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -103,15 +103,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_settings: d103828c9f5d515c4df9ee754dabd443f7cedcf3
-  device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
+  device_info_plus: 7545d84d8d1b896cb16a4ff98c19f07ec4b298ea
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
   file_picker: ce3938a0df3cc1ef404671531facef740d03f920
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
-  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
-  share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
+  share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
   sqlite3: d31b2b69d59bd1b4ab30e5c92eb18fd8e82fa392
   sqlite3_flutter_libs: 78f93cb854d4680595bc2c63c57209a104b2efb1
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f


### PR DESCRIPTION
These changes get made automatically for me when I build/run the iOS app, which I believe is when `pod install` gets run.

It looks like a symptom of `pod install` not being done in 861a92911 (in the case of `path_provider_foundation`) and in 99dd6a7e4 (in the cases of `device_info_plus` and `share_plus`).