### PR TITLE
api: Centralize interpreting HTTP response in one place

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -34,13 +34,43 @@ abstract class ApiConnection {
   //   that ensures nothing assumes base class has a real API key
   final Auth auth;
 
+  Future<http.Response> send(http.BaseRequest request);
+
   void close();
 
-  Future<String> get(String route, Map<String, dynamic>? params);
+  Future<String> get(String route, Map<String, dynamic>? params) async {
+    final url = auth.realmUrl.replace(
+        path: "/api/v1/$route", queryParameters: encodeParameters(params));
+    assert(debugLog("GET $url"));
+    final request = http.Request('GET', url);
+    final response = await send(request);
+    return _decodeResponse(response);
+  }
 
-  Future<String> post(String route, Map<String, dynamic>? params);
+  Future<String> post(String route, Map<String, dynamic>? params) async {
+    final url = auth.realmUrl.replace(path: "/api/v1/$route");
+    final request = http.Request('POST', url);
+    if (params != null) {
+      request.bodyFields = encodeParameters(params)!;
+    }
+    final response = await send(request);
+    return _decodeResponse(response);
+  }
 
-  Future<String> postFileFromStream(String route, Stream<List<int>> content, int length, { String? filename });
+  Future<String> postFileFromStream(String route, Stream<List<int>> content, int length, { String? filename }) async {
+    http.MultipartRequest request = http.MultipartRequest('POST', Uri.parse("${auth.realmUrl}/api/v1/$route"))
+      ..files.add(http.MultipartFile('file', content, length, filename: filename));
+    final response = await send(request);
+    return _decodeResponse(response);
+  }
+
+  static String _decodeResponse(http.Response response) {
+    if (response.statusCode != 200) {
+      final request = response.request!;
+      throw Exception("error on ${request.method} ${request.url.path}: status ${response.statusCode}");
+    }
+    return utf8.decode(response.bodyBytes);
+  }
 }
 
 // TODO memoize auth header on LiveApiConnection and PerAccountStore
@@ -71,45 +101,10 @@ class LiveApiConnection extends ApiConnection {
   }
 
   @override
-  Future<String> get(String route, Map<String, dynamic>? params) async {
+  Future<http.Response> send(http.BaseRequest request) async {
     assert(_isOpen);
-    final url = auth.realmUrl.replace(
-        path: "/api/v1/$route", queryParameters: encodeParameters(params));
-    assert(debugLog("GET $url"));
-    final request = http.Request('GET', url)..headers.addAll(_headers());
-    final response = await http.Response.fromStream(await _client.send(request));
-    if (response.statusCode != 200) {
-      throw Exception("error on GET $route: status ${response.statusCode}");
-    }
-    return utf8.decode(response.bodyBytes);
-  }
-
-  @override
-  Future<String> post(String route, Map<String, dynamic>? params) async {
-    assert(_isOpen);
-    final url = auth.realmUrl.replace(path: "/api/v1/$route");
-    final request = http.Request('POST', url)..headers.addAll(_headers());
-    if (params != null) {
-      request.bodyFields = encodeParameters(params)!;
-    }
-    final response = await http.Response.fromStream(await _client.send(request));
-    if (response.statusCode != 200) {
-      throw Exception("error on POST $route: status ${response.statusCode}");
-    }
-    return utf8.decode(response.bodyBytes);
-  }
-
-  @override
-  Future<String> postFileFromStream(String route, Stream<List<int>> content, int length, { String? filename }) async {
-    assert(_isOpen);
-    http.MultipartRequest request = http.MultipartRequest('POST', Uri.parse("${auth.realmUrl}/api/v1/$route"))
-      ..files.add(http.MultipartFile('file', content, length, filename: filename))
-      ..headers.addAll(_headers());
-    final response = await http.Response.fromStream(await _client.send(request));
-    if (response.statusCode != 200) {
-      throw Exception("error on file-upload POST $route: status ${response.statusCode}");
-    }
-    return utf8.decode(response.bodyBytes);
+    request.headers.addAll(_headers());
+    return http.Response.fromStream(await _client.send(request));
   }
 }
 

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -53,7 +53,10 @@ class ApiConnection {
     assert(_isOpen);
     addAuth(request);
     final response = await http.Response.fromStream(await _client.send(request));
-    return _decodeResponse(response);
+    if (response.statusCode != 200) {
+      throw Exception("error on ${request.method} ${request.url.path}: status ${response.statusCode}");
+    }
+    return utf8.decode(response.bodyBytes);
   }
 
   void close() {
@@ -83,14 +86,6 @@ class ApiConnection {
     http.MultipartRequest request = http.MultipartRequest('POST', Uri.parse("$realmUrl/api/v1/$route"))
       ..files.add(http.MultipartFile('file', content, length, filename: filename));
     return send(request);
-  }
-
-  static String _decodeResponse(http.Response response) {
-    if (response.statusCode != 200) {
-      final request = response.request!;
-      throw Exception("error on ${request.method} ${request.url.path}: status ${response.statusCode}");
-    }
-    return utf8.decode(response.bodyBytes);
   }
 }
 

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -52,11 +52,11 @@ class ApiConnection {
   Future<String> send(http.BaseRequest request) async {
     assert(_isOpen);
     addAuth(request);
-    final response = await http.Response.fromStream(await _client.send(request));
+    final response = await _client.send(request);
     if (response.statusCode != 200) {
       throw Exception("error on ${request.method} ${request.url.path}: status ${response.statusCode}");
     }
-    return utf8.decode(response.bodyBytes);
+    return utf8.decode((await http.Response.fromStream(response)).bodyBytes);
   }
 
   void close() {

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -92,7 +92,9 @@ Map<String, String> authHeader({required String email, required String apiKey}) 
 
 /// An [ApiConnection] that makes real network requests to a real server.
 class LiveApiConnection extends ApiConnection {
-  LiveApiConnection({required super.auth});
+  LiveApiConnection({
+    required super.auth,
+  }) : _authValue = _authHeaderValue(email: auth.email, apiKey: auth.apiKey);
 
   final http.Client _client = http.Client();
 
@@ -105,10 +107,11 @@ class LiveApiConnection extends ApiConnection {
     _isOpen = false;
   }
 
+  final String _authValue;
+
   @override
   void addAuth(http.BaseRequest request) {
-    // TODO memoize auth header value on LiveApiConnection
-    request.headers['Authorization'] = _authHeaderValue(email: auth.email, apiKey: auth.apiKey);
+    request.headers['Authorization'] = _authValue;
   }
 
   @override

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -19,11 +19,26 @@ class RawParameter {
 ///  * `FakeApiConnection` in the test suite, which implements this
 ///    for use in tests.
 abstract class ApiConnection {
-  ApiConnection({required http.Client client, required this.realmUrl}) : _client = client;
+  ApiConnection({
+    required this.realmUrl,
+    String? email,
+    String? apiKey,
+    required http.Client client,
+  }) : assert((email != null) == (apiKey != null)),
+       _authValue = (email != null && apiKey != null)
+         ? _authHeaderValue(email: email, apiKey: apiKey)
+         : null,
+       _client = client;
 
   final Uri realmUrl;
 
-  void addAuth(http.BaseRequest request);
+  final String? _authValue;
+
+  void addAuth(http.BaseRequest request) {
+    if (_authValue != null) {
+      request.headers['Authorization'] = _authValue!;
+    }
+  }
 
   final http.Client _client;
 
@@ -96,15 +111,7 @@ class LiveApiConnection extends ApiConnection {
     required super.realmUrl,
     required String email,
     required String apiKey,
-  }) : _authValue = _authHeaderValue(email: email, apiKey: apiKey),
-       super(client: http.Client());
-
-  final String _authValue;
-
-  @override
-  void addAuth(http.BaseRequest request) {
-    request.headers['Authorization'] = _authValue;
-  }
+  }) : super(email: email, apiKey: apiKey, client: http.Client());
 }
 
 Map<String, String>? encodeParameters(Map<String, dynamic>? params) {

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -56,7 +56,7 @@ class ApiConnection {
     if (response.statusCode != 200) {
       throw Exception("error on ${request.method} ${request.url.path}: status ${response.statusCode}");
     }
-    return utf8.decode((await http.Response.fromStream(response)).bodyBytes);
+    return utf8.decode(await response.stream.toBytes());
   }
 
   void close() {

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -14,11 +14,12 @@ class RawParameter {
 /// All the information to talk to a Zulip server, real or fake.
 ///
 /// See also:
-///  * [LiveApiConnection], which implements this for talking to a
-///    real Zulip server.
 ///  * `FakeApiConnection` in the test suite, which implements this
 ///    for use in tests.
-abstract class ApiConnection {
+class ApiConnection {
+  /// Construct an API connection with an arbitrary [http.Client], real or fake.
+  ///
+  /// For talking to a live server, use [ApiConnection.live].
   ApiConnection({
     required this.realmUrl,
     String? email,
@@ -29,6 +30,10 @@ abstract class ApiConnection {
          ? _authHeaderValue(email: email, apiKey: apiKey)
          : null,
        _client = client;
+
+  /// Construct an API connection that talks to a live Zulip server over the real network.
+  ApiConnection.live({required Uri realmUrl, String? email, String? apiKey})
+    : this(realmUrl: realmUrl, email: email, apiKey: apiKey, client: http.Client());
 
   final Uri realmUrl;
 
@@ -103,15 +108,6 @@ Map<String, String> authHeader({required String email, required String apiKey}) 
   return {
     'Authorization': _authHeaderValue(email: email, apiKey: apiKey),
   };
-}
-
-/// An [ApiConnection] that makes real network requests to a real server.
-class LiveApiConnection extends ApiConnection {
-  LiveApiConnection({
-    required super.realmUrl,
-    required String email,
-    required String apiKey,
-  }) : super(email: email, apiKey: apiKey, client: http.Client());
 }
 
 Map<String, String>? encodeParameters(Map<String, dynamic>? params) {

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -13,13 +13,20 @@ Future<FetchApiKeyResult> fetchApiKey({
   required String username,
   required String password,
 }) async {
-  // TODO dedupe this part with LiveApiConnection; make this function testable
-  final response = await http.post(
-    realmUrl.replace(path: "/api/v1/fetch_api_key"),
-    body: encodeParameters({
-      'username': RawParameter(username),
-      'password': RawParameter(password),
-    }));
+  // TODO dedupe with LiveApiConnection; make this function testable
+  final client = http.Client();
+  final http.Response response;
+  try {
+    response = await client.post(
+      realmUrl.replace(path: "/api/v1/fetch_api_key"),
+      body: encodeParameters({
+        'username': RawParameter(username),
+        'password': RawParameter(password),
+      }));
+  } finally {
+    client.close();
+  }
+
   if (response.statusCode != 200) {
     throw Exception('error on POST fetch_api_key: status ${response.statusCode}');
   }

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
@@ -12,7 +10,7 @@ Future<FetchApiKeyResult> fetchApiKey({
   required String username,
   required String password,
 }) async {
-  final String data;
+  final Map<String, dynamic> data;
   // TODO make this function testable by taking ApiConnection from caller
   final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
@@ -24,8 +22,7 @@ Future<FetchApiKeyResult> fetchApiKey({
     connection.close();
   }
 
-  final json = jsonDecode(data);
-  return FetchApiKeyResult.fromJson(json);
+  return FetchApiKeyResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -13,16 +13,17 @@ Future<FetchApiKeyResult> fetchApiKey({
   required String username,
   required String password,
 }) async {
+  final request = http.Request('POST', realmUrl.replace(path: "/api/v1/fetch_api_key"))
+    ..bodyFields = encodeParameters({
+      'username': RawParameter(username),
+      'password': RawParameter(password),
+    })!;
+
   // TODO dedupe with LiveApiConnection; make this function testable
   final client = http.Client();
   final http.Response response;
   try {
-    response = await client.post(
-      realmUrl.replace(path: "/api/v1/fetch_api_key"),
-      body: encodeParameters({
-        'username': RawParameter(username),
-        'password': RawParameter(password),
-      }));
+    response = await http.Response.fromStream(await client.send(request));
   } finally {
     client.close();
   }

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -19,7 +19,7 @@ Future<FetchApiKeyResult> fetchApiKey({
       'password': RawParameter(password),
     })!;
 
-  // TODO dedupe with LiveApiConnection; make this function testable
+  // TODO dedupe with ApiConnection; make this function testable
   final client = http.Client();
   final http.Response response;
   try {

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
@@ -21,8 +19,7 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection) async {
       'user_settings_object': true,
     },
   });
-  final json = jsonDecode(data);
-  return InitialSnapshot.fromJson(json);
+  return InitialSnapshot.fromJson(data);
 }
 
 /// https://zulip.com/api/get-events
@@ -34,7 +31,7 @@ Future<GetEventsResult> getEvents(ApiConnection connection, {
     if (lastEventId != null) 'last_event_id': lastEventId,
     if (dontBlock != null) 'dont_block': dontBlock,
   });
-  return GetEventsResult.fromJson(jsonDecode(data));
+  return GetEventsResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
@@ -18,7 +16,7 @@ Future<GetMessagesResult> getMessages(ApiConnection connection, {
     'num_before': numBefore,
     'num_after': numAfter,
   });
-  return GetMessagesResult.fromJson(jsonDecode(data));
+  return GetMessagesResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -79,7 +77,7 @@ Future<SendMessageResult> sendMessage(
     'topic': RawParameter(topic),
     'content': RawParameter(content),
   });
-  return SendMessageResult.fromJson(jsonDecode(data));
+  return SendMessageResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -106,7 +104,7 @@ Future<UploadFileResult> uploadFile(
   required String filename,
 }) async {
   final data = await connection.postFileFromStream('user_uploads', content, length, filename: filename);
-  return UploadFileResult.fromJson(jsonDecode(data));
+  return UploadFileResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -69,7 +69,7 @@ Future<SendMessageResult> sendMessage(
 }) async {
   // assert() is less verbose but would have no effect in production, I think:
   //   https://dart.dev/guides/language/language-tour#assert
-  if (connection.auth.realmUrl.origin != 'https://chat.zulip.org') {
+  if (connection.realmUrl.origin != 'https://chat.zulip.org') {
     throw Exception('This binding can currently only be used on https://chat.zulip.org.');
   }
 

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
+
+import '../core.dart';
 
 part 'realm.g.dart';
 
@@ -19,21 +20,14 @@ part 'realm.g.dart';
 Future<GetServerSettingsResult> getServerSettings({
   required Uri realmUrl,
 }) async {
-  final request = http.Request('GET', realmUrl.replace(path: "/api/v1/server_settings"));
-
-  // TODO dedupe with ApiConnection; make this function testable
-  final client = http.Client();
-  final http.Response response;
+  final String data;
+  // TODO make this function testable by taking ApiConnection from caller
+  final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
-    response = await http.Response.fromStream(await client.send(request));
+    data = await connection.get('server_settings', null);
   } finally {
-    client.close();
+    connection.close();
   }
-
-  if (response.statusCode != 200) {
-    throw Exception('error on GET server_settings: status ${response.statusCode}');
-  }
-  final data = utf8.decode(response.bodyBytes);
 
   final json = jsonDecode(data);
   return GetServerSettingsResult.fromJson(json);

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -19,12 +19,13 @@ part 'realm.g.dart';
 Future<GetServerSettingsResult> getServerSettings({
   required Uri realmUrl,
 }) async {
+  final request = http.Request('GET', realmUrl.replace(path: "/api/v1/server_settings"));
+
   // TODO dedupe with LiveApiConnection; make this function testable
   final client = http.Client();
   final http.Response response;
   try {
-    response = await client.get(
-      realmUrl.replace(path: "/api/v1/server_settings"));
+    response = await http.Response.fromStream(await client.send(request));
   } finally {
     client.close();
   }

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -19,9 +19,16 @@ part 'realm.g.dart';
 Future<GetServerSettingsResult> getServerSettings({
   required Uri realmUrl,
 }) async {
-  // TODO dedupe this part with LiveApiConnection; make this function testable
-  final response = await http.get(
-    realmUrl.replace(path: "/api/v1/server_settings"));
+  // TODO dedupe with LiveApiConnection; make this function testable
+  final client = http.Client();
+  final http.Response response;
+  try {
+    response = await client.get(
+      realmUrl.replace(path: "/api/v1/server_settings"));
+  } finally {
+    client.close();
+  }
+
   if (response.statusCode != 200) {
     throw Exception('error on GET server_settings: status ${response.statusCode}');
   }

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -21,7 +21,7 @@ Future<GetServerSettingsResult> getServerSettings({
 }) async {
   final request = http.Request('GET', realmUrl.replace(path: "/api/v1/server_settings"));
 
-  // TODO dedupe with LiveApiConnection; make this function testable
+  // TODO dedupe with ApiConnection; make this function testable
   final client = http.Client();
   final http.Response response;
   try {

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
@@ -20,7 +18,7 @@ part 'realm.g.dart';
 Future<GetServerSettingsResult> getServerSettings({
   required Uri realmUrl,
 }) async {
-  final String data;
+  final Map<String, dynamic> data;
   // TODO make this function testable by taking ApiConnection from caller
   final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
@@ -29,8 +27,7 @@ Future<GetServerSettingsResult> getServerSettings({
     connection.close();
   }
 
-  final json = jsonDecode(data);
-  return GetServerSettingsResult.fromJson(json);
+  return GetServerSettingsResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/users.dart
+++ b/lib/api/route/users.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
@@ -12,7 +10,7 @@ part 'users.g.dart';
 /// as a workaround on old servers.
 Future<GetOwnUserResult> getOwnUser(ApiConnection connection) async {
   final data = await connection.get('users/me', {});
-  return GetOwnUserResult.fromJson(jsonDecode(data));
+  return GetOwnUserResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -329,7 +329,7 @@ class LivePerAccountStore extends PerAccountStore {
   /// In the future this might load an old snapshot from local storage first.
   static Future<PerAccountStore> load(Account account) async {
     final connection = LiveApiConnection(
-      auth: Auth(realmUrl: account.realmUrl, email: account.email, apiKey: account.apiKey));
+      realmUrl: account.realmUrl, email: account.email, apiKey: account.apiKey);
 
     final stopwatch = Stopwatch()..start();
     final initialSnapshot = await registerQueue(connection); // TODO retry

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -252,7 +252,7 @@ class PerAccountStore extends ChangeNotifier {
 /// database file in the app's persistent storage on the device.
 ///
 /// The per-account stores will be instances of [LivePerAccountStore],
-/// with data loaded through [LiveApiConnection].
+/// with data loaded through a live [ApiConnection].
 class LiveGlobalStore extends GlobalStore {
   LiveGlobalStore._({
     required AppDatabase db,
@@ -328,7 +328,7 @@ class LivePerAccountStore extends PerAccountStore {
   ///
   /// In the future this might load an old snapshot from local storage first.
   static Future<PerAccountStore> load(Account account) async {
-    final connection = LiveApiConnection(
+    final connection = ApiConnection.live(
       realmUrl: account.realmUrl, email: account.email, apiKey: account.apiKey);
 
     final stopwatch = Stopwatch()..start();
@@ -354,7 +354,7 @@ class LivePerAccountStore extends PerAccountStore {
       final result = await getEvents(connection,
           queueId: queueId, lastEventId: lastEventId);
       // TODO handle errors on get-events; retry with backoff
-      // TODO abort long-poll and close LiveApiConnection on [dispose]
+      // TODO abort long-poll and close ApiConnection on [dispose]
       final events = result.events;
       for (final event in events) {
         handleEvent(event);

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -252,7 +252,7 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
 
   Future<int> _getUserId(FetchApiKeyResult fetchApiKeyResult) async {
     final FetchApiKeyResult(:email, :apiKey) = fetchApiKeyResult;
-    final connection = LiveApiConnection( // TODO make this widget testable
+    final connection = ApiConnection.live( // TODO make this widget testable
       realmUrl: widget.serverSettings.realmUri, email: email, apiKey: apiKey);
     return (await getOwnUser(connection)).userId;
   }

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -252,9 +252,8 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
 
   Future<int> _getUserId(FetchApiKeyResult fetchApiKeyResult) async {
     final FetchApiKeyResult(:email, :apiKey) = fetchApiKeyResult;
-    final auth = Auth(
+    final connection = LiveApiConnection( // TODO make this widget testable
       realmUrl: widget.serverSettings.realmUri, email: email, apiKey: apiKey);
-    final connection = LiveApiConnection(auth: auth); // TODO make this widget testable
     return (await getOwnUser(connection)).userId;
   }
 

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
 import 'package:zulip/api/core.dart';
 import 'package:zulip/model/store.dart';
 
@@ -10,14 +13,14 @@ class FakeApiConnection extends ApiConnection {
   FakeApiConnection.fromAccount(Account account)
       : this(realmUrl: account.realmUrl, email: account.email);
 
-  String? _nextResponse;
+  List<int>? _nextResponseBytes;
 
   // TODO: This mocking API will need to get richer to support all the tests we need.
 
   void prepare(String response) {
-    assert(_nextResponse == null,
+    assert(_nextResponseBytes == null,
         'FakeApiConnection.prepare was called while already expecting a request');
-    _nextResponse = response;
+    _nextResponseBytes = utf8.encode(response);
   }
 
   @override
@@ -26,24 +29,10 @@ class FakeApiConnection extends ApiConnection {
   }
 
   @override
-  Future<String> get(String route, Map<String, dynamic>? params) async {
-    final response = _nextResponse;
-    _nextResponse = null;
-    return response!;
-  }
-
-  @override
-  Future<String> post(String route, Map<String, dynamic>? params) async {
-    final response = _nextResponse;
-    _nextResponse = null;
-    return response!;
-  }
-
-  @override
-  Future<String> postFileFromStream(String route, Stream<List<int>> content, int length, { String? filename }) async {
-    final response = _nextResponse;
-    _nextResponse = null;
-    return response!;
+  Future<http.Response> send(http.BaseRequest request) async {
+    final responseBytes = _nextResponseBytes!;
+    _nextResponseBytes = null;
+    return http.Response.bytes(responseBytes, 200, request: request);
   }
 }
 

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -28,15 +28,14 @@ class FakeHttpClient extends http.BaseClient {
 
 /// An [ApiConnection] that accepts and replays canned responses, for testing.
 class FakeApiConnection extends ApiConnection {
-  FakeApiConnection({required Uri realmUrl, required String email})
-    : this._(realmUrl: realmUrl, email: email, client: FakeHttpClient());
+  FakeApiConnection({required Uri realmUrl})
+    : this._(realmUrl: realmUrl, client: FakeHttpClient());
 
   FakeApiConnection.fromAccount(Account account)
-    : this(realmUrl: account.realmUrl, email: account.email);
+    : this(realmUrl: account.realmUrl);
 
-  FakeApiConnection._({required Uri realmUrl, required String email, required this.client})
-    : super(client: client, auth: Auth(
-        realmUrl: realmUrl, email: email, apiKey: _fakeApiKey));
+  FakeApiConnection._({required Uri realmUrl, required this.client})
+    : super(client: client, realmUrl: realmUrl);
 
   final FakeHttpClient client;
 
@@ -49,5 +48,3 @@ class FakeApiConnection extends ApiConnection {
     // do nothing
   }
 }
-
-const String _fakeApiKey = 'fake-api-key';

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -4,14 +4,8 @@ import 'package:http/http.dart' as http;
 import 'package:zulip/api/core.dart';
 import 'package:zulip/model/store.dart';
 
-/// An [ApiConnection] that accepts and replays canned responses, for testing.
-class FakeApiConnection extends ApiConnection {
-  FakeApiConnection({required Uri realmUrl, required String email})
-      : super(auth: Auth(
-                realmUrl: realmUrl, email: email, apiKey: _fakeApiKey));
-
-  FakeApiConnection.fromAccount(Account account)
-      : this(realmUrl: account.realmUrl, email: account.email);
+/// An [http.Client] that accepts and replays canned responses, for testing.
+class FakeHttpClient extends http.BaseClient {
 
   List<int>? _nextResponseBytes;
 
@@ -24,20 +18,35 @@ class FakeApiConnection extends ApiConnection {
   }
 
   @override
-  void close() {
-    // TODO: record connection closed; assert open in methods
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    final responseBytes = _nextResponseBytes!;
+    _nextResponseBytes = null;
+    final byteStream = http.ByteStream.fromBytes(responseBytes);
+    return Future.value(http.StreamedResponse(byteStream, 200, request: request));
+  }
+}
+
+/// An [ApiConnection] that accepts and replays canned responses, for testing.
+class FakeApiConnection extends ApiConnection {
+  FakeApiConnection({required Uri realmUrl, required String email})
+    : this._(realmUrl: realmUrl, email: email, client: FakeHttpClient());
+
+  FakeApiConnection.fromAccount(Account account)
+    : this(realmUrl: account.realmUrl, email: account.email);
+
+  FakeApiConnection._({required Uri realmUrl, required String email, required this.client})
+    : super(client: client, auth: Auth(
+        realmUrl: realmUrl, email: email, apiKey: _fakeApiKey));
+
+  final FakeHttpClient client;
+
+  void prepare(String response) {
+    client.prepare(response);
   }
 
   @override
   void addAuth(http.BaseRequest request) {
     // do nothing
-  }
-
-  @override
-  Future<http.Response> send(http.BaseRequest request) async {
-    final responseBytes = _nextResponseBytes!;
-    _nextResponseBytes = null;
-    return http.Response.bytes(responseBytes, 200, request: request);
   }
 }
 

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -42,9 +42,4 @@ class FakeApiConnection extends ApiConnection {
   void prepare(String response) {
     client.prepare(response);
   }
-
-  @override
-  void addAuth(http.BaseRequest request) {
-    // do nothing
-  }
 }

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -29,6 +29,11 @@ class FakeApiConnection extends ApiConnection {
   }
 
   @override
+  void addAuth(http.BaseRequest request) {
+    // do nothing
+  }
+
+  @override
   Future<http.Response> send(http.BaseRequest request) async {
     final responseBytes = _nextResponseBytes!;
     _nextResponseBytes = null;

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -10,7 +10,7 @@ import 'route_checks.dart';
 void main() {
   test('sendMessage accepts fixture realm', () async {
     final connection = FakeApiConnection(
-        realmUrl: Uri.parse('https://chat.zulip.org/'), email: 'self@mail.example');
+        realmUrl: Uri.parse('https://chat.zulip.org/'));
     connection.prepare(jsonEncode(SendMessageResult(id: 42).toJson()));
     check(sendMessage(connection, content: 'hello', topic: 'world'))
         .completes(it()..id.equals(42));
@@ -18,7 +18,7 @@ void main() {
 
   test('sendMessage rejects unexpected realm', () async {
     final connection = FakeApiConnection(
-        realmUrl: Uri.parse('https://chat.example/'), email: 'self@mail.example');
+        realmUrl: Uri.parse('https://chat.example/'));
     connection.prepare(jsonEncode(SendMessageResult(id: 42).toJson()));
     check(sendMessage(connection, content: 'hello', topic: 'world'))
         .throws();


### PR DESCRIPTION
(Stacked atop #93.)

This helps set us up for #37: we're going to add significant new logic for interpreting the HTTP response from an API call, in order to throw appropriate exceptions, and in order to do that we'll want just one place for that logic to have to go.

As a bonus, this also simplifies the code, with a net negative diffstat, and makes the core API layer more testable.
