### PR TITLE
sticky_header [nfc]: Use new SlottedMultiChildRenderObjectWidget base class

### DIFF
--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -210,9 +210,8 @@ class RenderSliverStickyHeaderList extends RenderSliverList {
 
 enum StickyHeaderSlot { header, content }
 
-class StickyHeader extends RenderObjectWidget
-    with SlottedMultiChildRenderObjectWidgetMixin<StickyHeaderSlot, RenderBox> {
-  StickyHeader(
+class StickyHeader extends SlottedMultiChildRenderObjectWidget<StickyHeaderSlot, RenderBox> {
+  const StickyHeader(
       {super.key,
       this.direction = AxisDirection.down,
       this.header,


### PR DESCRIPTION
This was introduced recently upstream, deprecating the old mixin SlottedMultiChildRenderObjectWidgetMixin.

This change follows up on 2f0f4692f (from #103), which handled the mandatory part of the same upstream API change.