### PR TITLE
api: Write tests for ApiConnection.get, post, postFileFromStream

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -85,7 +85,8 @@ class ApiConnection {
   }
 
   Future<Map<String, dynamic>> postFileFromStream(String route, Stream<List<int>> content, int length, { String? filename }) async {
-    http.MultipartRequest request = http.MultipartRequest('POST', Uri.parse("$realmUrl/api/v1/$route"))
+    final url = realmUrl.replace(path: "/api/v1/$route");
+    final request = http.MultipartRequest('POST', url)
       ..files.add(http.MultipartFile('file', content, length, filename: filename));
     return send(request);
   }

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -9,9 +9,14 @@ import '../example_data.dart' as eg;
 /// An [http.Client] that accepts and replays canned responses, for testing.
 class FakeHttpClient extends http.BaseClient {
 
+  http.BaseRequest? lastRequest;
+
   List<int>? _nextResponseBytes;
 
-  // TODO: This mocking API will need to get richer to support all the tests we need.
+  // Please add more features to this mocking API as needed.  For example:
+  //  * preparing an HTTP status other than 200
+  //  * preparing an exception instead of an [http.StreamedResponse]
+  //  * preparing more than one request, and logging more than one request
 
   void prepare({String? body}) {
     assert(_nextResponseBytes == null,
@@ -23,6 +28,7 @@ class FakeHttpClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) {
     final responseBytes = _nextResponseBytes!;
     _nextResponseBytes = null;
+    lastRequest = request;
     final byteStream = http.ByteStream.fromBytes(responseBytes);
     return Future.value(http.StreamedResponse(byteStream, 200, request: request));
   }
@@ -40,6 +46,8 @@ class FakeApiConnection extends ApiConnection {
     : super(client: client);
 
   final FakeHttpClient client;
+
+  http.BaseRequest? get lastRequest => client.lastRequest;
 
   void prepare({String? body}) {
     client.prepare(body: body);

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -55,6 +55,24 @@ class FakeApiConnection extends ApiConnection {
 
   final FakeHttpClient client;
 
+  /// Run the given callback on a fresh [FakeApiConnection], then close it,
+  /// using try/finally.
+  static Future<T> with_<T>(
+    Future<T> Function(FakeApiConnection connection) fn, {
+    Uri? realmUrl,
+    Account? account,
+  }) async {
+    assert((account == null) || (realmUrl == null));
+    final connection = (account != null)
+      ? FakeApiConnection.fromAccount(account)
+      : FakeApiConnection(realmUrl: realmUrl);
+    try {
+      return fn(connection);
+    } finally {
+      connection.close();
+    }
+  }
+
   http.BaseRequest? get lastRequest => client.lastRequest;
 
   void prepare({String? body}) {

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -40,10 +40,18 @@ class FakeApiConnection extends ApiConnection {
     : this._(realmUrl: realmUrl ?? eg.realmUrl, client: FakeHttpClient());
 
   FakeApiConnection.fromAccount(Account account)
-    : this(realmUrl: account.realmUrl);
+    : this._(
+        realmUrl: account.realmUrl,
+        email: account.email,
+        apiKey: account.apiKey,
+        client: FakeHttpClient());
 
-  FakeApiConnection._({required super.realmUrl, required this.client})
-    : super(client: client);
+  FakeApiConnection._({
+    required super.realmUrl,
+    super.email,
+    super.apiKey,
+    required this.client,
+  }) : super(client: client);
 
   final FakeHttpClient client;
 

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -13,10 +13,10 @@ class FakeHttpClient extends http.BaseClient {
 
   // TODO: This mocking API will need to get richer to support all the tests we need.
 
-  void prepare(String response) {
+  void prepare({String? body}) {
     assert(_nextResponseBytes == null,
-        'FakeApiConnection.prepare was called while already expecting a request');
-    _nextResponseBytes = utf8.encode(response);
+      'FakeApiConnection.prepare was called while already expecting a request');
+    _nextResponseBytes = utf8.encode(body ?? '');
   }
 
   @override
@@ -41,7 +41,7 @@ class FakeApiConnection extends ApiConnection {
 
   final FakeHttpClient client;
 
-  void prepare(String response) {
-    client.prepare(response);
+  void prepare({String? body}) {
+    client.prepare(body: body);
   }
 }

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -4,6 +4,8 @@ import 'package:http/http.dart' as http;
 import 'package:zulip/api/core.dart';
 import 'package:zulip/model/store.dart';
 
+import '../example_data.dart' as eg;
+
 /// An [http.Client] that accepts and replays canned responses, for testing.
 class FakeHttpClient extends http.BaseClient {
 
@@ -28,14 +30,14 @@ class FakeHttpClient extends http.BaseClient {
 
 /// An [ApiConnection] that accepts and replays canned responses, for testing.
 class FakeApiConnection extends ApiConnection {
-  FakeApiConnection({required Uri realmUrl})
-    : this._(realmUrl: realmUrl, client: FakeHttpClient());
+  FakeApiConnection({Uri? realmUrl})
+    : this._(realmUrl: realmUrl ?? eg.realmUrl, client: FakeHttpClient());
 
   FakeApiConnection.fromAccount(Account account)
     : this(realmUrl: account.realmUrl);
 
-  FakeApiConnection._({required Uri realmUrl, required this.client})
-    : super(client: client, realmUrl: realmUrl);
+  FakeApiConnection._({required super.realmUrl, required this.client})
+    : super(client: client);
 
   final FakeHttpClient client;
 

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -11,7 +11,7 @@ void main() {
   test('sendMessage accepts fixture realm', () async {
     final connection = FakeApiConnection(
         realmUrl: Uri.parse('https://chat.zulip.org/'));
-    connection.prepare(jsonEncode(SendMessageResult(id: 42).toJson()));
+    connection.prepare(body: jsonEncode(SendMessageResult(id: 42).toJson()));
     check(sendMessage(connection, content: 'hello', topic: 'world'))
         .completes(it()..id.equals(42));
   });
@@ -19,7 +19,7 @@ void main() {
   test('sendMessage rejects unexpected realm', () async {
     final connection = FakeApiConnection(
         realmUrl: Uri.parse('https://chat.example/'));
-    connection.prepare(jsonEncode(SendMessageResult(id: 42).toJson()));
+    connection.prepare(body: jsonEncode(SendMessageResult(id: 42).toJson()));
     check(sendMessage(connection, content: 'hello', topic: 'world'))
         .throws();
   });

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -1,0 +1,26 @@
+/// `package:checks`-related extensions for the Dart standard library.
+///
+/// Use this file for types in the Dart SDK, as well as in other
+/// packages published by the Dart team that function as
+/// part of the Dart standard library.
+
+import 'package:checks/checks.dart';
+
+extension UriChecks on Subject<Uri> {
+  Subject<String> get asString => has((u) => u.toString(), 'toString'); // TODO(checks): what's a good convention for this?
+
+  Subject<String> get scheme => has((u) => u.scheme, 'scheme');
+  Subject<String> get authority => has((u) => u.authority, 'authority');
+  Subject<String> get userInfo => has((u) => u.userInfo, 'userInfo');
+  Subject<String> get host => has((u) => u.host, 'host');
+  Subject<int> get port => has((u) => u.port, 'port');
+  Subject<String> get path => has((u) => u.path, 'path');
+  Subject<String> get query => has((u) => u.query, 'query');
+  Subject<String> get fragment => has((u) => u.fragment, 'fragment');
+  Subject<List<String>> get pathSegments => has((u) => u.pathSegments, 'pathSegments');
+  Subject<Map<String, String>> get queryParameters => has((u) => u.queryParameters, 'queryParameters');
+  Subject<Map<String, List<String>>> get queryParametersAll => has((u) => u.queryParametersAll, 'queryParametersAll');
+  Subject<bool> get isAbsolute => has((u) => u.isAbsolute, 'isAbsolute');
+  Subject<String> get origin => has((u) => u.origin, 'origin');
+  // TODO hasScheme, other has*, data
+}

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -43,3 +43,17 @@ extension HttpRequestChecks on Subject<http.Request> {
   Subject<String> get body => has((r) => r.body, 'body');
   Subject<Map<String, String>> get bodyFields => has((r) => r.bodyFields, 'bodyFields');
 }
+
+extension HttpMultipartRequestChecks on Subject<http.MultipartRequest> {
+  Subject<Map<String, String>> get fields => has((r) => r.fields, 'fields');
+  Subject<List<http.MultipartFile>> get files => has((r) => r.files, 'files');
+  Subject<int> get contentLength => has((r) => r.contentLength, 'contentLength');
+}
+
+extension HttpMultipartFileChecks on Subject<http.MultipartFile> {
+  Subject<String> get field => has((f) => f.field, 'field');
+  Subject<int> get length => has((f) => f.length, 'length');
+  Subject<String?> get filename => has((f) => f.filename, 'filename');
+  // TODO Subject<MediaType> get contentType => has((f) => f.contentType, 'contentType');
+  Subject<bool> get isFinalized => has((f) => f.isFinalized, 'isFinalized');
+}

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -4,7 +4,10 @@
 /// packages published by the Dart team that function as
 /// part of the Dart standard library.
 
+import 'dart:convert';
+
 import 'package:checks/checks.dart';
+import 'package:http/http.dart' as http;
 
 extension UriChecks on Subject<Uri> {
   Subject<String> get asString => has((u) => u.toString(), 'toString'); // TODO(checks): what's a good convention for this?
@@ -23,4 +26,20 @@ extension UriChecks on Subject<Uri> {
   Subject<bool> get isAbsolute => has((u) => u.isAbsolute, 'isAbsolute');
   Subject<String> get origin => has((u) => u.origin, 'origin');
   // TODO hasScheme, other has*, data
+}
+
+extension HttpBaseRequestChecks on Subject<http.BaseRequest> {
+  Subject<String> get method => has((r) => r.method, 'method');
+  Subject<Uri> get url => has((r) => r.url, 'url');
+  Subject<int?> get contentLength => has((r) => r.contentLength, 'contentLength');
+  Subject<Map<String, String>> get headers => has((r) => r.headers, 'headers');
+  // TODO persistentConnection, followRedirects, maxRedirects, finalized
+}
+
+extension HttpRequestChecks on Subject<http.Request> {
+  Subject<int> get contentLength => has((r) => r.contentLength, 'contentLength');
+  Subject<Encoding> get encoding => has((r) => r.encoding, 'encoding');
+  Subject<List<int>> get bodyBytes => has((r) => r.bodyBytes, 'bodyBytes'); // TODO or Uint8List?
+  Subject<String> get body => has((r) => r.body, 'body');
+  Subject<Map<String, String>> get bodyFields => has((r) => r.bodyFields, 'bodyFields');
 }

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -2,6 +2,8 @@ import 'package:checks/checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/login.dart';
 
+import '../stdlib_checks.dart';
+
 void main() {
   group('ServerUrlTextEditingController.tryParse', () {
     final controller = ServerUrlTextEditingController();
@@ -11,9 +13,7 @@ void main() {
         controller.text = text;
         final result = controller.tryParse();
         check(result.error).isNull();
-        check(result.url)
-          .isNotNull() // catch `null` here instead of by its .toString()
-          .has((url) => url.toString(), 'toString()').equals(expectedUrl);
+        check(result.url).isNotNull().asString.equals(expectedUrl);
       });
     }
 


### PR DESCRIPTION
The main ingredient here is that we have FakeHttpClient log the last `http.Request` object it was passed, and we add some `package:checks` extensions so that tests can conveniently inspect that request.

We also fix a small bug in `ApiConnection.postFileFromStream`, which writing these tests uncovered: it was doubling the slash at the start of the URL path.

This makes another step toward #37.