### PR TITLE
api: Throw a structured exception when a request fails

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -51,6 +51,7 @@ class ApiConnection {
 
   Future<Map<String, dynamic>> send(http.BaseRequest request) async {
     assert(_isOpen);
+    assert(debugLog("${request.method} ${request.url}"));
     addAuth(request);
     final response = await _client.send(request);
     if (response.statusCode != 200) {
@@ -70,7 +71,6 @@ class ApiConnection {
   Future<Map<String, dynamic>> get(String route, Map<String, dynamic>? params) async {
     final url = realmUrl.replace(
         path: "/api/v1/$route", queryParameters: encodeParameters(params));
-    assert(debugLog("GET $url"));
     final request = http.Request('GET', url);
     return send(request);
   }

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -146,13 +146,11 @@ ApiRequestException _makeApiException(String routeName, int httpStatus, Map<Stri
       );
     }
   } else if (500 <= httpStatus && httpStatus <= 599) {
-    return Server5xxException(routeName: routeName, httpStatus: httpStatus);
+    return Server5xxException(
+      routeName: routeName, httpStatus: httpStatus, data: json);
   }
   return MalformedServerResponseException( // TODO(log): systematically log these
-    routeName: routeName,
-    httpStatus: httpStatus,
-    data: json,
-  );
+    routeName: routeName, httpStatus: httpStatus, data: json);
 }
 
 String _authHeaderValue({required String email, required String apiKey}) {

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -49,7 +49,7 @@ class ApiConnection {
 
   bool _isOpen = true;
 
-  Future<Map<String, dynamic>> send(http.BaseRequest request) async {
+  Future<Map<String, dynamic>> send(String routeName, http.BaseRequest request) async {
     assert(_isOpen);
     assert(debugLog("${request.method} ${request.url}"));
     addAuth(request);
@@ -68,27 +68,27 @@ class ApiConnection {
     _isOpen = false;
   }
 
-  Future<Map<String, dynamic>> get(String route, Map<String, dynamic>? params) async {
+  Future<Map<String, dynamic>> get(String routeName, String path, Map<String, dynamic>? params) async {
     final url = realmUrl.replace(
-        path: "/api/v1/$route", queryParameters: encodeParameters(params));
+        path: "/api/v1/$path", queryParameters: encodeParameters(params));
     final request = http.Request('GET', url);
-    return send(request);
+    return send(routeName, request);
   }
 
-  Future<Map<String, dynamic>> post(String route, Map<String, dynamic>? params) async {
-    final url = realmUrl.replace(path: "/api/v1/$route");
+  Future<Map<String, dynamic>> post(String routeName, String path, Map<String, dynamic>? params) async {
+    final url = realmUrl.replace(path: "/api/v1/$path");
     final request = http.Request('POST', url);
     if (params != null) {
       request.bodyFields = encodeParameters(params)!;
     }
-    return send(request);
+    return send(routeName, request);
   }
 
-  Future<Map<String, dynamic>> postFileFromStream(String route, Stream<List<int>> content, int length, { String? filename }) async {
-    final url = realmUrl.replace(path: "/api/v1/$route");
+  Future<Map<String, dynamic>> postFileFromStream(String routeName, String path, Stream<List<int>> content, int length, { String? filename }) async {
+    final url = realmUrl.replace(path: "/api/v1/$path");
     final request = http.MultipartRequest('POST', url)
       ..files.add(http.MultipartFile('file', content, length, filename: filename));
-    return send(request);
+    return send(routeName, request);
   }
 }
 

--- a/lib/api/exception.dart
+++ b/lib/api/exception.dart
@@ -69,7 +69,17 @@ class NetworkException extends ApiRequestException {
 abstract class ServerException extends ApiRequestException {
   final int httpStatus;
 
-  ServerException({required super.routeName, required this.httpStatus, required super.message});
+  /// The response body, decoded as a JSON object.
+  ///
+  /// This is null if the body could not be read, or was not a valid JSON object.
+  final Map<String, dynamic>? data;
+
+  ServerException({
+    required super.routeName,
+    required this.httpStatus,
+    required this.data,
+    required super.message,
+  });
 }
 
 /// A server error, acknowledged by the server via a 5xx HTTP status code.
@@ -77,6 +87,7 @@ class Server5xxException extends ServerException {
   Server5xxException({
     required super.routeName,
     required super.httpStatus,
+    required super.data,
   }) : assert(500 <= httpStatus && httpStatus <= 599),
        super(message: 'Network request failed: HTTP status $httpStatus'); // TODO(i18n)
 }
@@ -95,14 +106,9 @@ class Server5xxException extends ServerException {
 ///
 /// See docs: https://zulip.com/api/rest-error-handling
 class MalformedServerResponseException extends ServerException {
-  /// The response body, decoded as a JSON object.
-  ///
-  /// This is null if the body could not be read, or was not a valid JSON object.
-  final Map<String, dynamic>? data;
-
   MalformedServerResponseException({
     required super.routeName,
     required super.httpStatus,
-    required this.data,
+    required super.data,
   }) : super(message: 'Server gave malformed response; HTTP status $httpStatus'); // TODO(i18n)
 }

--- a/lib/api/exception.dart
+++ b/lib/api/exception.dart
@@ -1,0 +1,108 @@
+
+/// Some kind of error from a Zulip API network request.
+sealed class ApiRequestException implements Exception {
+  /// The name of the Zulip API route for the request.
+  ///
+  /// Generally this is the OpenAPI operation ID for the endpoint
+  /// (as seen in the URL of the endpoint's API documentation),
+  /// converted to camel case.
+  /// For example, the endpoint documented at <https://zulip.com/api/get-messages>
+  /// is the one with OpenAPI operation ID "get-messages",
+  /// and its route name would be "getMessages".
+  final String routeName;
+
+  /// A user-facing description of the error.
+  ///
+  /// For [ZulipApiException] this is supplied by the server as the `message`
+  /// property in the JSON response, and is translated into the user's language.
+  final String message;
+
+  ApiRequestException({required this.routeName, required this.message});
+}
+
+/// An error returned through the Zulip server API.
+///
+/// See API docs: https://zulip.com/api/rest-error-handling
+class ZulipApiException extends ApiRequestException {
+
+  /// The Zulip API error code returned by the server.
+  final String code;
+
+  /// The HTTP status code returned by the server.
+  ///
+  /// This is always in the range 400..499.
+  final int httpStatus;
+
+  /// The error's JSON data, if any, beyond the properties common to all errors.
+  ///
+  /// This consists of the properties other than `result`, `code`, and `msg`.
+  ///
+  /// For most types of errors, this will be empty.
+  final Map<String, dynamic> data;
+
+  ZulipApiException({
+    required super.routeName,
+    required this.code,
+    required this.httpStatus,
+    required this.data,
+    required super.message,
+  }) : assert(400 <= httpStatus && httpStatus <= 499);
+}
+
+/// A network-level error that prevented even getting an HTTP response.
+class NetworkException extends ApiRequestException {
+  /// The exception describing the underlying error.
+  ///
+  /// This can be any exception value that [http.Client.send] throws.
+  /// Ideally that would always be an [http.ClientException],
+  /// but empirically it can be [TlsException] and possibly others.
+  final Object cause;
+
+  NetworkException({required super.routeName, required super.message, required this.cause});
+}
+
+/// Some kind of server-side error in handling the request.
+///
+/// This should always represent either some kind of operational issue
+/// on the server, or a bug in the server where its responses don't
+/// agree with the documented API.
+abstract class ServerException extends ApiRequestException {
+  final int httpStatus;
+
+  ServerException({required super.routeName, required this.httpStatus, required super.message});
+}
+
+/// A server error, acknowledged by the server via a 5xx HTTP status code.
+class Server5xxException extends ServerException {
+  Server5xxException({
+    required super.routeName,
+    required super.httpStatus,
+  }) : assert(500 <= httpStatus && httpStatus <= 599),
+       super(message: 'Network request failed: HTTP status $httpStatus'); // TODO(i18n)
+}
+
+/// An error where the server's response doesn't match the Zulip API.
+///
+/// This means either the server's HTTP status wasn't one that the docs say the
+/// server may give, or the body didn't contain appropriately-shaped JSON
+/// for the HTTP status.
+///
+/// When the HTTP status is 200 (success), this means the body didn't match
+/// the specific JSON schema expected for the particular route.
+///
+/// When the HTTP status is 4xx (client error), this means the body didn't match
+/// the JSON schema expected for error results in the Zulip API in general.
+///
+/// See docs: https://zulip.com/api/rest-error-handling
+class MalformedServerResponseException extends ServerException {
+  /// The response body, decoded as a JSON object.
+  ///
+  /// This is null if the body could not be read, or was not a valid JSON object.
+  final Map<String, dynamic>? data;
+
+  MalformedServerResponseException({
+    required super.routeName,
+    required super.httpStatus,
+    required this.data,
+  }) : super(message: 'Server gave malformed response; HTTP status $httpStatus'); // TODO(i18n)
+}

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -10,19 +10,16 @@ Future<FetchApiKeyResult> fetchApiKey({
   required String username,
   required String password,
 }) async {
-  final Map<String, dynamic> data;
   // TODO make this function testable by taking ApiConnection from caller
   final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
-    data = await connection.post('fetchApiKey', 'fetch_api_key', {
+    return await connection.post('fetchApiKey', FetchApiKeyResult.fromJson, 'fetch_api_key', {
       'username': RawParameter(username),
       'password': RawParameter(password),
     });
   } finally {
     connection.close();
   }
-
-  return FetchApiKeyResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -14,7 +14,7 @@ Future<FetchApiKeyResult> fetchApiKey({
   // TODO make this function testable by taking ApiConnection from caller
   final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
-    data = await connection.post('fetch_api_key', {
+    data = await connection.post('fetchApiKey', 'fetch_api_key', {
       'username': RawParameter(username),
       'password': RawParameter(password),
     });

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -7,8 +7,8 @@ import '../model/initial_snapshot.dart';
 part 'events.g.dart';
 
 /// https://zulip.com/api/register-queue
-Future<InitialSnapshot> registerQueue(ApiConnection connection) async {
-  final data = await connection.post('registerQueue', 'register', {
+Future<InitialSnapshot> registerQueue(ApiConnection connection) {
+  return connection.post('registerQueue', InitialSnapshot.fromJson, 'register', {
     'apply_markdown': true,
     'slim_presence': true,
     'client_capabilities': {
@@ -19,19 +19,17 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection) async {
       'user_settings_object': true,
     },
   });
-  return InitialSnapshot.fromJson(data);
 }
 
 /// https://zulip.com/api/get-events
 Future<GetEventsResult> getEvents(ApiConnection connection, {
   required String queueId, int? lastEventId, bool? dontBlock,
-}) async {
-  final data = await connection.get('getEvents', 'events', {
+}) {
+  return connection.get('getEvents', GetEventsResult.fromJson, 'events', {
     'queue_id': RawParameter(queueId),
     if (lastEventId != null) 'last_event_id': lastEventId,
     if (dontBlock != null) 'dont_block': dontBlock,
   });
-  return GetEventsResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -8,7 +8,7 @@ part 'events.g.dart';
 
 /// https://zulip.com/api/register-queue
 Future<InitialSnapshot> registerQueue(ApiConnection connection) async {
-  final data = await connection.post('register', {
+  final data = await connection.post('registerQueue', 'register', {
     'apply_markdown': true,
     'slim_presence': true,
     'client_capabilities': {
@@ -26,7 +26,7 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection) async {
 Future<GetEventsResult> getEvents(ApiConnection connection, {
   required String queueId, int? lastEventId, bool? dontBlock,
 }) async {
-  final data = await connection.get('events', {
+  final data = await connection.get('getEvents', 'events', {
     'queue_id': RawParameter(queueId),
     if (lastEventId != null) 'last_event_id': lastEventId,
     if (dontBlock != null) 'dont_block': dontBlock,

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -9,14 +9,13 @@ part 'messages.g.dart';
 Future<GetMessagesResult> getMessages(ApiConnection connection, {
   required int numBefore,
   required int numAfter,
-}) async {
-  final data = await connection.get('getMessages', 'messages', {
+}) {
+  return connection.get('getMessages', GetMessagesResult.fromJson, 'messages', {
     // 'narrow': [], // TODO parametrize
     'anchor': 999999999, // TODO parametrize; use RawParameter for strings
     'num_before': numBefore,
     'num_after': numAfter,
   });
-  return GetMessagesResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -64,20 +63,19 @@ Future<SendMessageResult> sendMessage(
   ApiConnection connection, {
   required String content,
   required String topic,
-}) async {
+}) {
   // assert() is less verbose but would have no effect in production, I think:
   //   https://dart.dev/guides/language/language-tour#assert
   if (connection.realmUrl.origin != 'https://chat.zulip.org') {
     throw Exception('This binding can currently only be used on https://chat.zulip.org.');
   }
 
-  final data = await connection.post('sendMessage', 'messages', {
+  return connection.post('sendMessage', SendMessageResult.fromJson, 'messages', {
     'type': RawParameter('stream'), // TODO parametrize
     'to': 7, // TODO parametrize; this is `#test here`
     'topic': RawParameter(topic),
     'content': RawParameter(content),
   });
-  return SendMessageResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -102,10 +100,9 @@ Future<UploadFileResult> uploadFile(
   required Stream<List<int>> content,
   required int length,
   required String filename,
-}) async {
-  final data = await connection.postFileFromStream('uploadFile', 'user_uploads',
+}) {
+  return connection.postFileFromStream('uploadFile', UploadFileResult.fromJson, 'user_uploads',
     content, length, filename: filename);
-  return UploadFileResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -10,7 +10,7 @@ Future<GetMessagesResult> getMessages(ApiConnection connection, {
   required int numBefore,
   required int numAfter,
 }) async {
-  final data = await connection.get('messages', {
+  final data = await connection.get('getMessages', 'messages', {
     // 'narrow': [], // TODO parametrize
     'anchor': 999999999, // TODO parametrize; use RawParameter for strings
     'num_before': numBefore,
@@ -71,7 +71,7 @@ Future<SendMessageResult> sendMessage(
     throw Exception('This binding can currently only be used on https://chat.zulip.org.');
   }
 
-  final data = await connection.post('messages', {
+  final data = await connection.post('sendMessage', 'messages', {
     'type': RawParameter('stream'), // TODO parametrize
     'to': 7, // TODO parametrize; this is `#test here`
     'topic': RawParameter(topic),
@@ -103,7 +103,8 @@ Future<UploadFileResult> uploadFile(
   required int length,
   required String filename,
 }) async {
-  final data = await connection.postFileFromStream('user_uploads', content, length, filename: filename);
+  final data = await connection.postFileFromStream('uploadFile', 'user_uploads',
+    content, length, filename: filename);
   return UploadFileResult.fromJson(data);
 }
 

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -22,7 +22,7 @@ Future<GetServerSettingsResult> getServerSettings({
   // TODO make this function testable by taking ApiConnection from caller
   final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
-    data = await connection.get('server_settings', null);
+    data = await connection.get('getServerSettings', 'server_settings', null);
   } finally {
     connection.close();
   }

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -18,16 +18,13 @@ part 'realm.g.dart';
 Future<GetServerSettingsResult> getServerSettings({
   required Uri realmUrl,
 }) async {
-  final Map<String, dynamic> data;
   // TODO make this function testable by taking ApiConnection from caller
   final connection = ApiConnection.live(realmUrl: realmUrl);
   try {
-    data = await connection.get('getServerSettings', 'server_settings', null);
+    return await connection.get('getServerSettings', GetServerSettingsResult.fromJson, 'server_settings', null);
   } finally {
     connection.close();
   }
-
-  return GetServerSettingsResult.fromJson(data);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/users.dart
+++ b/lib/api/route/users.dart
@@ -9,7 +9,7 @@ part 'users.g.dart';
 /// This route's return type is simplified because we use it only
 /// as a workaround on old servers.
 Future<GetOwnUserResult> getOwnUser(ApiConnection connection) async {
-  final data = await connection.get('users/me', {});
+  final data = await connection.get('getOwnUser', 'users/me', {});
   return GetOwnUserResult.fromJson(data);
 }
 

--- a/lib/api/route/users.dart
+++ b/lib/api/route/users.dart
@@ -8,9 +8,8 @@ part 'users.g.dart';
 ///
 /// This route's return type is simplified because we use it only
 /// as a workaround on old servers.
-Future<GetOwnUserResult> getOwnUser(ApiConnection connection) async {
-  final data = await connection.get('getOwnUser', 'users/me', {});
-  return GetOwnUserResult.fromJson(data);
+Future<GetOwnUserResult> getOwnUser(ApiConnection connection) {
+  return connection.get('getOwnUser', GetOwnUserResult.fromJson, 'users/me', {});
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../api/core.dart';
+import '../api/exception.dart';
 import '../api/route/account.dart';
 import '../api/route/realm.dart';
 import '../api/route/users.dart';
@@ -155,7 +156,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
           return;
         }
         // TODO(#105) give more helpful feedback; see `fetchServerSettings`
-        //   in zulip-mobile's src/message/fetchActions.js. Needs #37.
+        //   in zulip-mobile's src/message/fetchActions.js.
         showErrorDialog(context: context,
           title: 'Could not connect', message: 'Failed to connect to server:\n$url');
         return;
@@ -279,12 +280,15 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
       try {
         result = await fetchApiKey(
           realmUrl: realmUrl, username: username, password: password);
-      } on Exception { // TODO(#37): distinguish API exceptions
+      } on ApiRequestException catch (e) {
         if (!context.mounted) return;
-        // TODO(#105) give more helpful feedback. Needs #37. The RN app is
+        // TODO(#105) give more helpful feedback. The RN app is
         //   unhelpful here; we should at least recognize invalid auth errors, and
         //   errors for deactivated user or realm (see zulip-mobile#4571).
-        showErrorDialog(context: context, title: 'Login failed');
+        final message = (e is ZulipApiException)
+          ? 'The server said:\n\n${e.message}'
+          : e.message;
+        showErrorDialog(context: context, title: 'Login failed', message: message);
         return;
       }
 

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:checks/checks.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/scaffolding.dart';
@@ -13,7 +11,7 @@ void main() {
   test('ApiConnection.get', () async {
     Future<void> checkRequest(Map<String, dynamic>? params, String expectedRelativeUrl) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
-        connection.prepare(body: jsonEncode({}));
+        connection.prepare(json: {});
         await connection.get(kExampleRouteName, (json) => json, 'example/route', params);
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('GET')
@@ -41,7 +39,7 @@ void main() {
   test('ApiConnection.post', () async {
     Future<void> checkRequest(Map<String, dynamic>? params, String expectedBody, {bool expectContentType = true}) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
-        connection.prepare(body: jsonEncode({}));
+        connection.prepare(json: {});
         await connection.post(kExampleRouteName, (json) => json, 'example/route', params);
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('POST')
@@ -71,7 +69,7 @@ void main() {
   test('ApiConnection.postFileFromStream', () async {
     Future<void> checkRequest(List<List<int>> content, int length, String? filename) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
-        connection.prepare(body: jsonEncode({}));
+        connection.prepare(json: {});
         await connection.postFileFromStream(
           kExampleRouteName, (json) => json, 'example/route',
           Stream.fromIterable(content), length, filename: filename);
@@ -102,7 +100,7 @@ void main() {
 
   test('API success result', () async {
     await FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
-      connection.prepare(body: jsonEncode({'result': 'success', 'x': 3}));
+      connection.prepare(json: {'result': 'success', 'x': 3});
       final result = await connection.get(
         kExampleRouteName, (json) => json['x'], 'example/route', {'y': 'z'});
       check(result).equals(3);

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -14,7 +14,7 @@ void main() {
     Future<void> checkRequest(Map<String, dynamic>? params, String expectedRelativeUrl) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(body: jsonEncode({}));
-        await connection.get(kExampleRouteName, 'example/route', params);
+        await connection.get(kExampleRouteName, (json) => json, 'example/route', params);
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('GET')
           ..url.asString.equals('${eg.realmUrl.origin}$expectedRelativeUrl')
@@ -42,7 +42,7 @@ void main() {
     Future<void> checkRequest(Map<String, dynamic>? params, String expectedBody, {bool expectContentType = true}) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(body: jsonEncode({}));
-        await connection.post(kExampleRouteName, 'example/route', params);
+        await connection.post(kExampleRouteName, (json) => json, 'example/route', params);
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('POST')
           ..url.asString.equals('${eg.realmUrl.origin}/api/v1/example/route')
@@ -73,7 +73,7 @@ void main() {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(body: jsonEncode({}));
         await connection.postFileFromStream(
-          kExampleRouteName, 'example/route',
+          kExampleRouteName, (json) => json, 'example/route',
           Stream.fromIterable(content), length, filename: filename);
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -104,8 +104,8 @@ void main() {
     await FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
       connection.prepare(body: jsonEncode({'result': 'success', 'x': 3}));
       final result = await connection.get(
-        kExampleRouteName, 'example/route', {'y': 'z'});
-      check(result).deepEquals({'result': 'success', 'x': 3});
+        kExampleRouteName, (json) => json['x'], 'example/route', {'y': 'z'});
+      check(result).equals(3);
     });
   });
 }

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -14,7 +14,7 @@ void main() {
     Future<void> checkRequest(Map<String, dynamic>? params, String expectedRelativeUrl) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(body: jsonEncode({}));
-        await connection.get('example/route', params);
+        await connection.get(kExampleRouteName, 'example/route', params);
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('GET')
           ..url.asString.equals('${eg.realmUrl.origin}$expectedRelativeUrl')
@@ -42,7 +42,7 @@ void main() {
     Future<void> checkRequest(Map<String, dynamic>? params, String expectedBody, {bool expectContentType = true}) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(body: jsonEncode({}));
-        await connection.post('example/route', params);
+        await connection.post(kExampleRouteName, 'example/route', params);
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('POST')
           ..url.asString.equals('${eg.realmUrl.origin}/api/v1/example/route')
@@ -73,7 +73,7 @@ void main() {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(body: jsonEncode({}));
         await connection.postFileFromStream(
-          'example/route',
+          kExampleRouteName, 'example/route',
           Stream.fromIterable(content), length, filename: filename);
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -104,8 +104,10 @@ void main() {
     await FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
       connection.prepare(body: jsonEncode({'result': 'success', 'x': 3}));
       final result = await connection.get(
-        'example/route', {'y': 'z'});
+        kExampleRouteName, 'example/route', {'y': 'z'});
       check(result).deepEquals({'result': 'success', 'x': 3});
     });
   });
 }
+
+const kExampleRouteName = 'exampleRoute';

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -193,11 +193,14 @@ void main() {
       return check(tryRequest(httpStatus: httpStatus, json: json, body: body))
         .throws<Server5xxException>(it()
           ..routeName.equals(kExampleRouteName)
-          ..httpStatus.equals(httpStatus));
+          ..httpStatus.equals(httpStatus)
+          ..data.deepEquals(json));
     }
 
     await check5xx(httpStatus: 500, json: {'result': 'error'});
     await check5xx(httpStatus: 503, body: '');
+    await check5xx(httpStatus: 503,
+      json: {'result': 'error', 'code': 'EXTERNAL_SERVICE_UNAVAILABLE', 'msg': 'Dang'});
     await check5xx(httpStatus: 599, body: '');
   });
 

--- a/test/api/exception_checks.dart
+++ b/test/api/exception_checks.dart
@@ -18,6 +18,7 @@ extension NetworkExceptionChecks on Subject<NetworkException> {
 
 extension ServerExceptionChecks on Subject<ServerException> {
   Subject<int> get httpStatus => has((e) => e.httpStatus, 'httpStatus');
+  Subject<Map<String, dynamic>?> get data => has((e) => e.data, 'data');
 }
 
 extension Server5xxExceptionChecks on Subject<Server5xxException> {
@@ -25,5 +26,5 @@ extension Server5xxExceptionChecks on Subject<Server5xxException> {
 }
 
 extension MalformedServerResponseExceptionChecks on Subject<MalformedServerResponseException> {
-  Subject<Map<String, dynamic>?> get data => has((e) => e.data, 'data');
+  // no properties not on ServerException
 }

--- a/test/api/exception_checks.dart
+++ b/test/api/exception_checks.dart
@@ -1,0 +1,29 @@
+import 'package:checks/checks.dart';
+import 'package:zulip/api/exception.dart';
+
+extension ApiRequestExceptionChecks on Subject<ApiRequestException> {
+  Subject<String> get routeName => has((e) => e.routeName, 'routeName');
+  Subject<String> get message => has((e) => e.message, 'message');
+}
+
+extension ZulipApiExceptionChecks on Subject<ZulipApiException> {
+  Subject<String> get code => has((e) => e.code, 'code');
+  Subject<int> get httpStatus => has((e) => e.httpStatus, 'httpStatus');
+  Subject<Map<String, dynamic>> get data => has((e) => e.data, 'data');
+}
+
+extension NetworkExceptionChecks on Subject<NetworkException> {
+  Subject<Object> get cause => has((e) => e.cause, 'cause');
+}
+
+extension ServerExceptionChecks on Subject<ServerException> {
+  Subject<int> get httpStatus => has((e) => e.httpStatus, 'httpStatus');
+}
+
+extension Server5xxExceptionChecks on Subject<Server5xxException> {
+  // no properties not on ServerException
+}
+
+extension MalformedServerResponseExceptionChecks on Subject<MalformedServerResponseException> {
+  Subject<Map<String, dynamic>?> get data => has((e) => e.data, 'data');
+}

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:checks/checks.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/route/messages.dart';
@@ -11,7 +9,7 @@ void main() {
   test('sendMessage accepts fixture realm', () async {
     final connection = FakeApiConnection(
         realmUrl: Uri.parse('https://chat.zulip.org/'));
-    connection.prepare(body: jsonEncode(SendMessageResult(id: 42).toJson()));
+    connection.prepare(json: SendMessageResult(id: 42).toJson());
     check(sendMessage(connection, content: 'hello', topic: 'world'))
         .completes(it()..id.equals(42));
   });
@@ -19,7 +17,7 @@ void main() {
   test('sendMessage rejects unexpected realm', () async {
     final connection = FakeApiConnection(
         realmUrl: Uri.parse('https://chat.example/'));
-    connection.prepare(body: jsonEncode(SendMessageResult(id: 42).toJson()));
+    connection.prepare(json: SendMessageResult(id: 42).toJson());
     check(() => sendMessage(connection, content: 'hello', topic: 'world'))
         .throws();
   });

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -20,7 +20,7 @@ void main() {
     final connection = FakeApiConnection(
         realmUrl: Uri.parse('https://chat.example/'));
     connection.prepare(body: jsonEncode(SendMessageResult(id: 42).toJson()));
-    check(sendMessage(connection, content: 'hello', topic: 'world'))
+    check(() => sendMessage(connection, content: 'hello', topic: 'world'))
         .throws();
   });
 }

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -9,6 +9,16 @@ import 'dart:convert';
 import 'package:checks/checks.dart';
 import 'package:http/http.dart' as http;
 
+extension NullableMapChecks<K, V> on Subject<Map<K, V>?> {
+  void deepEquals(Map<Object?, Object?>? expected) {
+    if (expected == null) {
+      return isNull();
+    } else {
+      return isNotNull().deepEquals(expected);
+    }
+  }
+}
+
 extension UriChecks on Subject<Uri> {
   Subject<String> get asString => has((u) => u.toString(), 'toString'); // TODO(checks): what's a good convention for this?
 


### PR DESCRIPTION
This follows up on the test infrastructure in #112 and the refactorings in #96.

These exceptions are quite a lot like the ones we have in zulip-mobile, defined in `src/api/apiErrors.js` there.  The main differences are:

 * Each exception has a `routeName` property, to identify what route was involved.  This is information that can be quite helpful in debugging; and while it should typically be possible to work it out from looking at the stack, it's nicer to be explicit.

 * The exception types are named like FooException, whereas they're FooError in zulip-mobile.  This is just to conform to Dart convention, where there's an Exception type and an Error type, and these are definitely Exception and not Error because they don't necessarily represent any bug in the program.

 * We include JSON data on 5xx errors, just like on client errors and on malformed responses from the server. This has valid use cases:
     https://chat.zulip.org/#narrow/stream/378-api-design/topic/Previewable.20URL.20Api/near/1568331
   so we might as well write this system this way in the first place.

Also begin to use the new structured exceptions, by carrying out part of #105. In particular, we'll now show messages from the server like "Your username or password is incorrect" or "Enter a valid email address."

Fixes: #37
Fixes-partly: #105
