### PR TITLE
compose: Add `tooltip` to send button

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -547,6 +547,8 @@ class _StreamSendButtonState extends State<_StreamSendButton> {
         color: backgroundColor,
       ),
       child: IconButton(
+        tooltip: 'Send',
+
         // Match the height of the content input. Zeroing the padding lets the
         // constraints take over.
         constraints: const BoxConstraints(minWidth: _sendButtonSize, minHeight: _sendButtonSize),


### PR DESCRIPTION
Looks like I forgot to get this one in #98, oops.