### PR TITLE
deps: Run `pod update sqlite3` to resolve `pod install` error

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -50,18 +50,18 @@ PODS:
   - SDWebImage/Core (5.15.5)
   - share_plus (0.0.1):
     - Flutter
-  - sqlite3 (3.41.0):
-    - sqlite3/common (= 3.41.0)
-  - sqlite3/common (3.41.0)
-  - sqlite3/fts5 (3.41.0):
+  - sqlite3 (3.41.2):
+    - sqlite3/common (= 3.41.2)
+  - sqlite3/common (3.41.2)
+  - sqlite3/fts5 (3.41.2):
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.41.0):
+  - sqlite3/perf-threadsafe (3.41.2):
     - sqlite3/common
-  - sqlite3/rtree (3.41.0):
+  - sqlite3/rtree (3.41.2):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
-    - sqlite3 (~> 3.41.0)
+    - sqlite3 (~> 3.41.2)
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
@@ -118,8 +118,8 @@ SPEC CHECKSUMS:
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
-  sqlite3: d31b2b69d59bd1b4ab30e5c92eb18fd8e82fa392
-  sqlite3_flutter_libs: 78f93cb854d4680595bc2c63c57209a104b2efb1
+  sqlite3: fd89671d969f3e73efe503ce203e28b016b58f68
+  sqlite3_flutter_libs: 04ba0d14a04335a2fbf9a331e8664f401fbccdd5
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
 
 PODFILE CHECKSUM: 985e5b058f26709dc81f9ae74ea2b2775bdbcefe


### PR DESCRIPTION
In f28dd0bfcb, we upgraded the Dart package sqlite3_flutter_libs past simolus3/sqlite3.dart@c16721003, which bumped the version of the `sqlite3` pod published on CocoaPods (not to be confused with the Dart package with that same name on pub.dev).

So in `flutter run` targeting an iOS device, the `pod install` step would fail with output including the following:

```
    [!] CocoaPods could not find compatible versions for pod "sqlite3":
      In snapshot (Podfile.lock):
        sqlite3 (= 3.41.0, ~> 3.41.0)

      In Podfile:
        sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`) was resolved to 0.0.1, which depends on
          sqlite3 (~> 3.41.2)

    You have either:
     * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
     * changed the constraints of dependency `sqlite3` inside your development pod `sqlite3_flutter_libs`.
       You should run `pod update sqlite3` to apply changes you've made.
```

Flutter then gave its own output, along the lines of just that first bullet point:

```
Error: CocoaPods's specs repository is too out-of-date to satisfy dependencies.
To update the CocoaPods specs, run:
  pod repo update

Exception: Error running pod install
```

But actually, after studying both bullet points and trying their suggested fixes, it turns out the second one is right. So, follow it here by running `pod update sqlite3`.