### PR TITLE
Say "DM"/"direct message" instead of "PM"/"private message", in UI and code

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -298,7 +298,7 @@ abstract class Message {
   factory Message.fromJson(Map<String, dynamic> json) {
     final type = json['type'] as String;
     if (type == 'stream') return StreamMessage.fromJson(json);
-    if (type == 'private') return PmMessage.fromJson(json);
+    if (type == 'private') return DmMessage.fromJson(json);
     throw Exception("Message.fromJson: unexpected message type $type");
   }
 
@@ -344,7 +344,7 @@ class StreamMessage extends Message {
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
-class PmRecipient {
+class DmRecipient {
   final int id;
   final String email;
   final String fullName;
@@ -352,23 +352,23 @@ class PmRecipient {
   // final String? shortName; // obsolete, ignore
   // final bool? isMirrorDummy; // obsolete, ignore
 
-  PmRecipient({required this.id, required this.email, required this.fullName});
+  DmRecipient({required this.id, required this.email, required this.fullName});
 
-  factory PmRecipient.fromJson(Map<String, dynamic> json) =>
-    _$PmRecipientFromJson(json);
+  factory DmRecipient.fromJson(Map<String, dynamic> json) =>
+    _$DmRecipientFromJson(json);
 
-  Map<String, dynamic> toJson() => _$PmRecipientToJson(this);
+  Map<String, dynamic> toJson() => _$DmRecipientToJson(this);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
-class PmMessage extends Message {
+class DmMessage extends Message {
   @override
   @JsonKey(includeToJson: true)
   String get type => 'private';
 
-  final List<PmRecipient> displayRecipient;
+  final List<DmRecipient> displayRecipient;
 
-  PmMessage({
+  DmMessage({
     super.avatarUrl,
     required super.client,
     required super.content,
@@ -389,9 +389,9 @@ class PmMessage extends Message {
     required this.displayRecipient,
   });
 
-  factory PmMessage.fromJson(Map<String, dynamic> json) =>
-    _$PmMessageFromJson(json);
+  factory DmMessage.fromJson(Map<String, dynamic> json) =>
+    _$DmMessageFromJson(json);
 
   @override
-  Map<String, dynamic> toJson() => _$PmMessageToJson(this);
+  Map<String, dynamic> toJson() => _$DmMessageToJson(this);
 }

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -225,20 +225,20 @@ Map<String, dynamic> _$StreamMessageToJson(StreamMessage instance) =>
       'stream_id': instance.streamId,
     };
 
-PmRecipient _$PmRecipientFromJson(Map<String, dynamic> json) => PmRecipient(
+DmRecipient _$DmRecipientFromJson(Map<String, dynamic> json) => DmRecipient(
       id: json['id'] as int,
       email: json['email'] as String,
       fullName: json['full_name'] as String,
     );
 
-Map<String, dynamic> _$PmRecipientToJson(PmRecipient instance) =>
+Map<String, dynamic> _$DmRecipientToJson(DmRecipient instance) =>
     <String, dynamic>{
       'id': instance.id,
       'email': instance.email,
       'full_name': instance.fullName,
     };
 
-PmMessage _$PmMessageFromJson(Map<String, dynamic> json) => PmMessage(
+DmMessage _$DmMessageFromJson(Map<String, dynamic> json) => DmMessage(
       avatarUrl: json['avatar_url'] as String?,
       client: json['client'] as String,
       content: json['content'] as String,
@@ -257,11 +257,11 @@ PmMessage _$PmMessageFromJson(Map<String, dynamic> json) => PmMessage(
       matchContent: json['match_content'] as String?,
       matchSubject: json['match_subject'] as String?,
       displayRecipient: (json['display_recipient'] as List<dynamic>)
-          .map((e) => PmRecipient.fromJson(e as Map<String, dynamic>))
+          .map((e) => DmRecipient.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$PmMessageToJson(PmMessage instance) => <String, dynamic>{
+Map<String, dynamic> _$DmMessageToJson(DmMessage instance) => <String, dynamic>{
       'avatar_url': instance.avatarUrl,
       'client': instance.client,
       'content': instance.content,

--- a/lib/api/model/narrow.dart
+++ b/lib/api/model/narrow.dart
@@ -46,14 +46,15 @@ class ApiNarrowTopic extends ApiNarrowElement {
   );
 }
 
-class ApiNarrowPmWith extends ApiNarrowElement {
-  @override String get operator => 'pm-with'; // TODO(server-7): use 'dm' where possible
+/// An [ApiNarrowElement] with the 'dm', or legacy 'pm-with', operator.
+class ApiNarrowDm extends ApiNarrowElement {
+  @override String get operator => 'pm-with'; // TODO(#146): use 'dm' where possible
 
   @override final List<int> operand;
 
-  ApiNarrowPmWith(this.operand, {super.negated});
+  ApiNarrowDm(this.operand, {super.negated});
 
-  factory ApiNarrowPmWith.fromJson(Map<String, dynamic> json) => ApiNarrowPmWith(
+  factory ApiNarrowDm.fromJson(Map<String, dynamic> json) => ApiNarrowDm(
     (json['operand'] as List<dynamic>).map((e) => e as int).toList(),
     negated: json['negated'] as bool? ?? false,
   );

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -104,8 +104,8 @@ Future<SendMessageResult> sendMessage(
       'type': RawParameter('stream'),
       'to': destination.streamId,
       'topic': RawParameter(destination.topic),
-    } else if (destination is PmDestination) ...{
-      'type': RawParameter('private'), // TODO(server-7)
+    } else if (destination is DmDestination) ...{
+      'type': RawParameter('private'), // TODO(#146): use 'direct' where possible
       'to': destination.userIds,
     } else ...(
       throw Exception('impossible destination') // TODO(dart-3) show this statically
@@ -118,7 +118,7 @@ Future<SendMessageResult> sendMessage(
 
 /// Which conversation to send a message to, in [sendMessage].
 ///
-/// This is either a [StreamDestination] or a [PmDestination].
+/// This is either a [StreamDestination] or a [DmDestination].
 sealed class MessageDestination {}
 
 /// A conversation in a stream, for specifying to [sendMessage].
@@ -132,12 +132,12 @@ class StreamDestination extends MessageDestination {
   final String topic;
 }
 
-/// A PM conversation, for specifying to [sendMessage].
+/// A DM conversation, for specifying to [sendMessage].
 ///
 /// The server accepts a list of Zulip API emails as an alternative to
 /// a list of user IDs, but this binding currently doesn't.
-class PmDestination extends MessageDestination {
-  PmDestination({required this.userIds});
+class DmDestination extends MessageDestination {
+  DmDestination({required this.userIds});
 
   final List<int> userIds;
 }

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -90,4 +90,4 @@ class TopicNarrow extends Narrow {
   int get hashCode => Object.hash('TopicNarrow', streamId, topic);
 }
 
-// TODO other narrow types: PMs/DMs; starred, mentioned; searches; arbitrary
+// TODO other narrow types: DMs; starred, mentioned; searches; arbitrary

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -196,11 +196,11 @@ class MessageItem extends StatelessWidget {
       restBorderColor = _kStreamMessageBorderColor;
       recipientHeader = StreamTopicRecipientHeader(
         message: msg, streamColor: highlightBorderColor);
-    } else if (message is PmMessage) {
-      final msg = (message as PmMessage);
-      highlightBorderColor = _kPmRecipientHeaderColor;
-      restBorderColor = _kPmRecipientHeaderColor;
-      recipientHeader = PmRecipientHeader(message: msg);
+    } else if (message is DmMessage) {
+      final msg = (message as DmMessage);
+      highlightBorderColor = _kDmRecipientHeaderColor;
+      restBorderColor = _kDmRecipientHeaderColor;
+      recipientHeader = DmRecipientHeader(message: msg);
     } else {
       throw Exception("impossible message type: ${message.runtimeType}");
     }
@@ -299,23 +299,23 @@ class StreamTopicRecipientHeader extends StatelessWidget {
 
 final _kStreamMessageBorderColor = const HSLColor.fromAHSL(1, 0, 0, 0.88).toColor();
 
-class PmRecipientHeader extends StatelessWidget {
-  const PmRecipientHeader({super.key, required this.message});
+class DmRecipientHeader extends StatelessWidget {
+  const DmRecipientHeader({super.key, required this.message});
 
-  final PmMessage message;
+  final DmMessage message;
 
   @override
   Widget build(BuildContext context) {
     return Align(
       alignment: Alignment.centerLeft,
       child: RecipientHeaderChevronContainer(
-        color: _kPmRecipientHeaderColor,
-        child: const Text("Private message", // TODO PM recipient headers
+        color: _kDmRecipientHeaderColor,
+        child: const Text("Direct message", // TODO DM recipient headers
           style: TextStyle(color: Colors.white))));
   }
 }
 
-final _kPmRecipientHeaderColor =
+final _kDmRecipientHeaderColor =
     const HSLColor.fromAHSL(1, 0, 0, 0.27).toColor();
 
 /// A widget with the distinctive chevron-tailed shape in Zulip recipient headers.

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -31,13 +31,13 @@ void main() {
     });
   });
 
-  test('sendMessage to PM conversation', () {
+  test('sendMessage to DM conversation', () {
     return FakeApiConnection.with_((connection) async {
       const userIds = [23, 34];
       const content = 'hi there';
       connection.prepare(json: SendMessageResult(id: 42).toJson());
       final result = await sendMessage(connection,
-        destination: PmDestination(userIds: userIds), content: content);
+        destination: DmDestination(userIds: userIds), content: content);
       check(result).id.equals(42);
       check(connection.lastRequest).isNotNull().isA<http.Request>()
         ..method.equals('POST')


### PR DESCRIPTION
There was only one occurrence in the UI, in [DmRecipientHeader].

The remaining few places we refer to the old names are in the context of the server API.  We have issue #146 open to start using the new names there where possible.

Fixes: #145