### PR TITLE
api: Carry zulipFeatureLevel on ApiConnection, and use it for sending "direct" and "dm"

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -24,6 +24,7 @@ class ApiConnection {
   /// For talking to a live server, use [ApiConnection.live].
   ApiConnection({
     required this.realmUrl,
+    required this.zulipFeatureLevel, // required even though nullable; see field doc
     String? email,
     String? apiKey,
     required http.Client client,
@@ -34,10 +35,30 @@ class ApiConnection {
        _client = client;
 
   /// Construct an API connection that talks to a live Zulip server over the real network.
-  ApiConnection.live({required Uri realmUrl, String? email, String? apiKey})
-    : this(realmUrl: realmUrl, email: email, apiKey: apiKey, client: http.Client());
+  ApiConnection.live({
+    required Uri realmUrl,
+    required int? zulipFeatureLevel, // required even though nullable; see field doc
+    String? email,
+    String? apiKey,
+  }) : this(client: http.Client(),
+            realmUrl: realmUrl, zulipFeatureLevel: zulipFeatureLevel,
+            email: email, apiKey: apiKey);
 
   final Uri realmUrl;
+
+  /// The server's last known Zulip feature level, if any.
+  ///
+  /// Individual route/endpoint bindings may use this to adapt
+  /// for compatibility with older servers.
+  ///
+  /// If this is null, this [ApiConnection] may be used only for the
+  /// [getServerSettings] route.  Calls to other routes may throw an exception.
+  /// Constructors therefore require this as a parameter, so that a null value
+  /// must be passed explicitly.
+  ///
+  /// See:
+  ///  * API docs at <https://zulip.com/api/changelog>.
+  int? zulipFeatureLevel;
 
   final String? _authValue;
 

--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -7,11 +7,12 @@ part 'account.g.dart';
 /// https://zulip.com/api/fetch-api-key
 Future<FetchApiKeyResult> fetchApiKey({
   required Uri realmUrl,
+  required int? zulipFeatureLevel,
   required String username,
   required String password,
 }) async {
   // TODO make this function testable by taking ApiConnection from caller
-  final connection = ApiConnection.live(realmUrl: realmUrl);
+  final connection = ApiConnection.live(realmUrl: realmUrl, zulipFeatureLevel: zulipFeatureLevel);
   try {
     return await connection.post('fetchApiKey', FetchApiKeyResult.fromJson, 'fetch_api_key', {
       'username': RawParameter(username),

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -99,13 +99,14 @@ Future<SendMessageResult> sendMessage(
   String? queueId,
   String? localId,
 }) {
+  final supportsTypeDirect = connection.zulipFeatureLevel! >= 174; // TODO(server-7)
   return connection.post('sendMessage', SendMessageResult.fromJson, 'messages', {
     if (destination is StreamDestination) ...{
       'type': RawParameter('stream'),
       'to': destination.streamId,
       'topic': RawParameter(destination.topic),
     } else if (destination is DmDestination) ...{
-      'type': RawParameter('private'), // TODO(#146): use 'direct' where possible
+      'type': supportsTypeDirect ? RawParameter('direct') : RawParameter('private'),
       'to': destination.userIds,
     } else ...(
       throw Exception('impossible destination') // TODO(dart-3) show this statically

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -17,6 +17,13 @@ Future<GetMessagesResult> getMessages(ApiConnection connection, {
   bool? applyMarkdown,
   // bool? useFirstUnreadAnchor // omitted because deprecated
 }) {
+  if (narrow.any((element) => element is ApiNarrowDm)) {
+    final supportsOperatorDm = connection.zulipFeatureLevel! >= 177; // TODO(server-7)
+    narrow = narrow.map((element) => switch (element) {
+      ApiNarrowDm() => element.resolve(legacy: !supportsOperatorDm),
+      _             => element,
+    }).toList();
+  }
   return connection.get('getMessages', GetMessagesResult.fromJson, 'messages', {
     'narrow': narrow,
     'anchor': switch (anchor) {

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -17,9 +17,10 @@ part 'realm.g.dart';
 //     https://github.com/zulip/zulip-flutter/pull/55#discussion_r1160267577
 Future<GetServerSettingsResult> getServerSettings({
   required Uri realmUrl,
+  required int? zulipFeatureLevel,
 }) async {
   // TODO make this function testable by taking ApiConnection from caller
-  final connection = ApiConnection.live(realmUrl: realmUrl);
+  final connection = ApiConnection.live(realmUrl: realmUrl, zulipFeatureLevel: zulipFeatureLevel);
   try {
     return await connection.get('getServerSettings', GetServerSettingsResult.fromJson, 'server_settings', null);
   } finally {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -164,7 +164,7 @@ class PerAccountStore extends ChangeNotifier {
   final ApiConnection connection;
 
   // TODO(#135): Keep all this data updated by handling Zulip events from the server.
-  final String zulipVersion;
+  final String zulipVersion; // TODO get from account; update there on initial snapshot
   final Map<int, User> users;
   final Map<int, ZulipStream> streams;
   final Map<int, Subscription> subscriptions;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -161,7 +161,7 @@ class PerAccountStore extends ChangeNotifier {
        maxFileUploadSizeMib = initialSnapshot.maxFileUploadSizeMib;
 
   final Account account;
-  final ApiConnection connection;
+  final ApiConnection connection; // TODO(#135): update zulipFeatureLevel with events
 
   // TODO(#135): Keep all this data updated by handling Zulip events from the server.
   final String zulipVersion; // TODO get from account; update there on initial snapshot
@@ -344,7 +344,8 @@ class LivePerAccountStore extends PerAccountStore {
   /// In the future this might load an old snapshot from local storage first.
   static Future<PerAccountStore> load(Account account) async {
     final connection = ApiConnection.live(
-      realmUrl: account.realmUrl, email: account.email, apiKey: account.apiKey);
+      realmUrl: account.realmUrl, zulipFeatureLevel: account.zulipFeatureLevel,
+      email: account.email, apiKey: account.apiKey);
 
     final stopwatch = Stopwatch()..start();
     final initialSnapshot = await registerQueue(connection); // TODO retry

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -150,7 +150,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
     try {
       final GetServerSettingsResult serverSettings;
       try {
-        serverSettings = await getServerSettings(realmUrl: url!);
+        serverSettings = await getServerSettings(realmUrl: url!, zulipFeatureLevel: null);
       } catch (e) {
         if (!context.mounted) {
           return;
@@ -255,7 +255,9 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
   Future<int> _getUserId(FetchApiKeyResult fetchApiKeyResult) async {
     final FetchApiKeyResult(:email, :apiKey) = fetchApiKeyResult;
     final connection = ApiConnection.live( // TODO make this widget testable
-      realmUrl: widget.serverSettings.realmUri, email: email, apiKey: apiKey);
+      realmUrl: widget.serverSettings.realmUri,
+      zulipFeatureLevel: widget.serverSettings.zulipFeatureLevel,
+      email: email, apiKey: apiKey);
     return (await getOwnUser(connection)).userId;
   }
 
@@ -279,7 +281,9 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
       final FetchApiKeyResult result;
       try {
         result = await fetchApiKey(
-          realmUrl: realmUrl, username: username, password: password);
+          realmUrl: realmUrl,
+          zulipFeatureLevel: widget.serverSettings.zulipFeatureLevel,
+          username: username, password: password);
       } on ApiRequestException catch (e) {
         if (!context.mounted) return;
         // TODO(#105) give more helpful feedback. The RN app is

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -115,7 +115,7 @@ class FakeApiConnection extends ApiConnection {
       ? FakeApiConnection.fromAccount(account)
       : FakeApiConnection(realmUrl: realmUrl);
     try {
-      return fn(connection);
+      return await fn(connection);
     } finally {
       connection.close();
     }

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -150,6 +150,18 @@ void main() {
         await checkSendMessage(connection,
           destination: DmDestination(userIds: userIds), content: content,
           expectedBodyFields: {
+            'type': 'direct',
+            'to': jsonEncode(userIds),
+            'content': content,
+          });
+      });
+    });
+
+    test('to DM conversation, with legacy type "private"', () {
+      return FakeApiConnection.with_(zulipFeatureLevel: 173, (connection) async {
+        await checkSendMessage(connection,
+          destination: DmDestination(userIds: userIds), content: content,
+          expectedBodyFields: {
             'type': 'private',
             'to': jsonEncode(userIds),
             'content': content,

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -7,6 +7,7 @@ import 'package:zulip/api/model/narrow.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/narrow.dart';
 
+import '../../example_data.dart' as eg;
 import '../../stdlib_checks.dart';
 import '../fake_api.dart';
 import 'route_checks.dart';
@@ -80,8 +81,13 @@ void main() {
         ]));
 
         await checkNarrow([ApiNarrowDm([123, 234])], jsonEncode([
+          {'operator': 'dm', 'operand': [123, 234]},
+        ]));
+        connection.zulipFeatureLevel = 176;
+        await checkNarrow([ApiNarrowDm([123, 234])], jsonEncode([
           {'operator': 'pm-with', 'operand': [123, 234]},
         ]));
+        connection.zulipFeatureLevel = eg.futureZulipFeatureLevel;
       });
     });
 

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -3,50 +3,60 @@ import 'dart:convert';
 import 'package:checks/checks.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/narrow.dart';
 import 'package:zulip/api/route/messages.dart';
+import 'package:zulip/model/narrow.dart';
 
 import '../../stdlib_checks.dart';
 import '../fake_api.dart';
 import 'route_checks.dart';
 
 void main() {
-  test('sendMessage to stream', () {
-    return FakeApiConnection.with_((connection) async {
-      const streamId = 123;
-      const topic = 'world';
-      const content = 'hello';
-      connection.prepare(json: SendMessageResult(id: 42).toJson());
-      final result = await sendMessage(connection,
-        destination: StreamDestination(streamId, topic), content: content);
-      check(result).id.equals(42);
-      check(connection.lastRequest).isNotNull().isA<http.Request>()
-        ..method.equals('POST')
-        ..url.path.equals('/api/v1/messages')
-        ..bodyFields.deepEquals({
-          'type': 'stream',
-          'to': streamId.toString(),
-          'topic': topic,
-          'content': content,
-        });
-    });
-  });
+  group('sendMessage', () {
+    const streamId = 123;
+    const content = 'hello';
+    const topic = 'world';
+    const userIds = [23, 34];
 
-  test('sendMessage to DM conversation', () {
-    return FakeApiConnection.with_((connection) async {
-      const userIds = [23, 34];
-      const content = 'hi there';
+    Future<void> checkSendMessage(
+      FakeApiConnection connection, {
+      required MessageDestination destination,
+      required String content,
+      required Map<String, String> expectedBodyFields,
+    }) async {
       connection.prepare(json: SendMessageResult(id: 42).toJson());
       final result = await sendMessage(connection,
-        destination: DmDestination(userIds: userIds), content: content);
+        destination: destination, content: content);
       check(result).id.equals(42);
       check(connection.lastRequest).isNotNull().isA<http.Request>()
         ..method.equals('POST')
         ..url.path.equals('/api/v1/messages')
-        ..bodyFields.deepEquals({
-          'type': 'private',
-          'to': jsonEncode(userIds),
-          'content': content,
-        });
+        ..bodyFields.deepEquals(expectedBodyFields);
+    }
+
+    test('to stream', () {
+      return FakeApiConnection.with_((connection) async {
+        await checkSendMessage(connection,
+          destination: StreamDestination(streamId, topic), content: content,
+          expectedBodyFields: {
+            'type': 'stream',
+            'to': streamId.toString(),
+            'topic': topic,
+            'content': content,
+          });
+      });
+    });
+
+    test('to DM conversation', () {
+      return FakeApiConnection.with_((connection) async {
+        await checkSendMessage(connection,
+          destination: DmDestination(userIds: userIds), content: content,
+          expectedBodyFields: {
+            'type': 'private',
+            'to': jsonEncode(userIds),
+            'content': content,
+          });
+      });
     });
   });
 }

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -8,6 +8,7 @@ final Uri realmUrl = Uri.parse('https://chat.example/');
 
 const String recentZulipVersion = '6.1';
 const int recentZulipFeatureLevel = 164;
+const int futureZulipFeatureLevel = 9999;
 
 User user({int? userId, String? email, String? fullName}) {
   return User(


### PR DESCRIPTION
Fixes: #146 

---

In #146 I listed these two spots where we'd want to use this capability once we added it, and mentioned that there might be others. On scanning through a grep for `TODO.server`, though, these are the only such places that I find.
