### PR TITLE
Add DataBinding; start testing code that uses PerAccountStoreWidget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'licenses.dart';
 import 'log.dart';
+import 'model/binding.dart';
 import 'widgets/app.dart';
 
 void main() {
@@ -11,5 +12,6 @@ void main() {
     return true;
   }());
   LicenseRegistry.addLicense(additionalLicenses);
+  LiveDataBinding.ensureInitialized();
   runApp(const ZulipApp());
 }

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/foundation.dart';
+
+import '../widgets/store.dart';
+import 'store.dart';
+
+/// A singleton service providing the app's data.
+///
+/// Only one instance will be constructed in the lifetime of the app,
+/// by calling the `ensureInitialized` static method on a subclass.
+/// This instance can be accessed as [instance].
+///
+/// Most code should not interact with the bindings directly.
+/// Instead, use the corresponding higher-level APIs that expose the bindings'
+/// functionality in a widget-oriented way.
+///
+/// This piece of architecture is modelled on the "binding" classes in Flutter
+/// itself.  For discussion, see [BindingBase], [WidgetsFlutterBinding], and
+/// [TestWidgetsFlutterBinding].
+/// This version is simplified because we don't (yet?) have enough complexity
+/// to put into these bindings to need to use mixins to split them up.
+abstract class DataBinding {
+  DataBinding() {
+    assert(_instance == null);
+    initInstance();
+  }
+
+  /// The single instance of [DataBinding].
+  static DataBinding get instance => checkInstance(_instance);
+  static DataBinding? _instance;
+
+  static T checkInstance<T extends DataBinding>(T? instance) {
+    assert(() {
+      if (instance == null) {
+        throw FlutterError.fromParts([
+          ErrorSummary('Zulip binding has not yet been initialized.'),
+          ErrorHint(
+            'In the app, this is done by the `LiveDataBinding.ensureInitialized()` call '
+            'in the `void main()` method.',
+          ),
+        ]);
+      }
+      return true;
+    }());
+    return instance!;
+  }
+
+  @protected
+  @mustCallSuper
+  void initInstance() {
+    _instance = this;
+  }
+
+  /// Prepare the app's [GlobalStore], loading the necessary data.
+  ///
+  /// Generally the app should call this function only once.
+  ///
+  /// This is part of the implementation of [GlobalStoreWidget].
+  /// In application code, use [GlobalStoreWidget.of] to get access
+  /// to a [GlobalStore].
+  Future<GlobalStore> loadGlobalStore();
+}
+
+/// A concrete binding for use in the live application.
+///
+/// The global store returned by [loadGlobalStore], and consequently by
+/// [GlobalStoreWidget.of] in application code, will be a [LiveGlobalStore].
+/// It therefore uses a live server and live, persistent local database.
+class LiveDataBinding extends DataBinding {
+  /// Initialize the binding if necessary, and ensure it is a [LiveDataBinding].
+  static LiveDataBinding ensureInitialized() {
+    if (DataBinding._instance == null) {
+      LiveDataBinding();
+    }
+    return DataBinding.instance as LiveDataBinding;
+  }
+
+  @override
+  Future<GlobalStore> loadGlobalStore() {
+    return LiveGlobalStore.load();
+  }
+}

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -37,6 +37,10 @@ abstract class DataBinding {
             'In the app, this is done by the `LiveDataBinding.ensureInitialized()` call '
             'in the `void main()` method.',
           ),
+          ErrorHint(
+            'In a test, one can call `TestDataBinding.ensureInitialized()` as the '
+            'first line in the test\'s `main()` method to initialize the binding.',
+          ),
         ]);
       }
       return true;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -37,8 +37,8 @@ export 'database.dart' show Account, AccountsCompanion;
 ///  * [LiveGlobalStore], the implementation of this class that
 ///    we use outside of tests.
 abstract class GlobalStore extends ChangeNotifier {
-  GlobalStore({required Map<int, Account> accounts})
-    : _accounts = accounts;
+  GlobalStore({required Iterable<Account> accounts})
+    : _accounts = Map.fromEntries(accounts.map((a) => MapEntry(a.id, a)));
 
   /// A cache of the [Accounts] table in the underlying data store.
   final Map<int, Account> _accounts;
@@ -279,10 +279,7 @@ class LiveGlobalStore extends GlobalStore {
   static Future<GlobalStore> load() async {
     final db = AppDatabase(NativeDatabase.createInBackground(await _dbFile()));
     final accounts = await db.select(db.accounts).get();
-    return LiveGlobalStore._(
-      db: db,
-      accounts: Map.fromEntries(accounts.map((a) => MapEntry(a.id, a))),
-    );
+    return LiveGlobalStore._(db: db, accounts: accounts);
   }
 
   /// The file path to use for the app database.

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../model/binding.dart';
 import '../model/store.dart';
 
 /// Provides access to the app's data.
@@ -54,7 +55,7 @@ class _GlobalStoreWidgetState extends State<GlobalStoreWidget> {
   void initState() {
     super.initState();
     (() async {
-      final store = await LiveGlobalStore.load();
+      final store = await DataBinding.instance.loadGlobalStore();
       setState(() {
         this.store = store;
       });

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+import 'package:zulip/model/binding.dart';
+import 'package:zulip/model/store.dart';
+
+import 'test_store.dart';
+
+/// A concrete binding for use in the `flutter test` environment.
+///
+/// Tests that will mount a [GlobalStoreWidget] should initialize this binding
+/// by calling [ensureInitialized] at the start of the `main` method.
+///
+/// Individual test functions that mount a [GlobalStoreWidget] may then use
+/// [globalStore] to access the global store provided to the [GlobalStoreWidget],
+/// and [TestGlobalStore.add] to set up test data there.  Such test functions
+/// must also call [reset] to clean up the global store.
+///
+/// The global store returned by [loadGlobalStore], and consequently by
+/// [GlobalStoreWidget.of] in application code, will be a [TestGlobalStore].
+class TestDataBinding extends DataBinding {
+  /// Initialize the binding if necessary, and ensure it is a [TestDataBinding].
+  ///
+  /// This method is idempotent; calling it repeatedly simply returns the
+  /// existing binding.
+  ///
+  /// If there is an existing binding but it is not a [TestDataBinding],
+  /// this method throws an error.
+  static TestDataBinding ensureInitialized() {
+    if (_instance == null) {
+      TestDataBinding();
+    }
+    return instance;
+  }
+
+  /// The single instance of the binding.
+  static TestDataBinding get instance => DataBinding.checkInstance(_instance);
+  static TestDataBinding? _instance;
+
+  @override
+  void initInstance() {
+    super.initInstance();
+    _instance = this;
+  }
+
+  /// The current global store offered to a [GlobalStoreWidget].
+  ///
+  /// The store is created lazily when accessing this getter, or when mounting
+  /// a [GlobalStoreWidget].  The same store will continue to be provided until
+  /// a call to [reset].
+  ///
+  /// Tests that access this getter, or that mount a [GlobalStoreWidget],
+  /// should clean up by calling [reset].
+  TestGlobalStore get globalStore => _globalStore ??= TestGlobalStore(accounts: []);
+  TestGlobalStore? _globalStore;
+
+  bool _debugAlreadyLoaded = false;
+
+  /// Reset all test data to a clean state.
+  ///
+  /// Tests that mount a [GlobalStoreWidget], or that access [globalStore],
+  /// should clean up by calling this method.  Typically this is done using
+  /// [addTearDown], like `addTearDown(TestDataBinding.instance.reset);`.
+  void reset() {
+    _globalStore?.dispose();
+    _globalStore = null;
+    assert(() {
+      _debugAlreadyLoaded = false;
+      return true;
+    }());
+  }
+
+  @override
+  Future<GlobalStore> loadGlobalStore() {
+    assert(() {
+      if (_debugAlreadyLoaded) {
+        throw FlutterError.fromParts([
+          ErrorSummary('The same test global store was loaded twice.'),
+          ErrorDescription(
+            'The global store is loaded when a [GlobalStoreWidget] is mounted.  '
+            'In the app, only one [GlobalStoreWidget] element is ever mounted, '
+            'and the global store is loaded only once.  In tests, after mounting '
+            'a [GlobalStoreWidget] and before doing so again, the method '
+            '[TestGlobalStore.reset] must be called in order to provide a fresh store.',
+          ),
+          ErrorHint(
+            'Typically this is accomplished using [addTearDown], like '
+            '`addTearDown(TestDataBinding.instance.reset);`.',
+          ),
+        ]);
+      }
+      _debugAlreadyLoaded = true;
+      return true;
+    }());
+    return Future.value(globalStore);
+  }
+}

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -1,0 +1,9 @@
+import 'package:checks/checks.dart';
+import 'package:zulip/model/store.dart';
+
+extension GlobalStoreChecks on Subject<GlobalStore> {
+  Subject<Iterable<Account>> get accounts => has((x) => x.accounts, 'accounts');
+  Subject<Iterable<int>> get accountIds => has((x) => x.accountIds, 'accountIds');
+  Subject<Iterable<({ int accountId, Account account })>> get accountEntries => has((x) => x.accountEntries, 'accountEntries');
+  Subject<Account?> getAccount(int id) => has((x) => x.getAccount(id), 'getAccount($id)');
+}

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -6,6 +6,7 @@ import 'package:zulip/model/store.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
+import 'test_store.dart';
 
 void main() {
   final account1 = eg.selfAccount.copyWith(id: 1);
@@ -13,7 +14,7 @@ void main() {
 
   test('GlobalStore.perAccount sequential case', () async {
     final accounts = [account1, account2];
-    final globalStore = TestGlobalStore(accounts: accounts);
+    final globalStore = LoadingTestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
       globalStore.completers[accounts[accountId - 1]]!;
 
@@ -46,7 +47,7 @@ void main() {
 
   test('GlobalStore.perAccount concurrent case', () async {
     final accounts = [account1, account2];
-    final globalStore = TestGlobalStore(accounts: accounts);
+    final globalStore = LoadingTestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
       globalStore.completers[accounts[accountId - 1]]!;
 
@@ -79,7 +80,7 @@ void main() {
 
   test('GlobalStore.perAccountSync', () async {
     final accounts = [account1, account2];
-    final globalStore = TestGlobalStore(accounts: accounts);
+    final globalStore = LoadingTestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
       globalStore.completers[accounts[accountId - 1]]!;
 
@@ -101,8 +102,8 @@ void main() {
   });
 }
 
-class TestGlobalStore extends GlobalStore {
-  TestGlobalStore({required super.accounts});
+class LoadingTestGlobalStore extends TestGlobalStore {
+  LoadingTestGlobalStore({required super.accounts});
 
   Map<Account, List<Completer<PerAccountStore>>> completers = {};
 
@@ -111,23 +112,5 @@ class TestGlobalStore extends GlobalStore {
     final completer = Completer<PerAccountStore>();
     (completers[account] ??= []).add(completer);
     return completer.future;
-  }
-
-  int _nextAccountId = 1;
-
-  @override
-  Future<Account> doInsertAccount(AccountsCompanion data) async {
-    final accountId = _nextAccountId;
-    _nextAccountId++;
-    return Account(
-      id: accountId,
-      realmUrl: data.realmUrl.value,
-      userId: data.userId.value,
-      email: data.email.value,
-      apiKey: data.apiKey.value,
-      zulipFeatureLevel: data.zulipFeatureLevel.value,
-      zulipVersion: data.zulipVersion.value,
-      zulipMergeBase: data.zulipMergeBase.value,
-    );
   }
 }

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -12,10 +12,10 @@ void main() {
   final account2 = eg.otherAccount.copyWith(id: 2);
 
   test('GlobalStore.perAccount sequential case', () async {
-    final accounts = {1: account1, 2: account2};
+    final accounts = [account1, account2];
     final globalStore = TestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
-      globalStore.completers[accounts[accountId]]!;
+      globalStore.completers[accounts[accountId - 1]]!;
 
     final future1 = globalStore.perAccount(1);
     final store1 = PerAccountStore.fromInitialSnapshot(
@@ -45,10 +45,10 @@ void main() {
   });
 
   test('GlobalStore.perAccount concurrent case', () async {
-    final accounts = {1: account1, 2: account2};
+    final accounts = [account1, account2];
     final globalStore = TestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
-      globalStore.completers[accounts[accountId]]!;
+      globalStore.completers[accounts[accountId - 1]]!;
 
     final future1a = globalStore.perAccount(1);
     final future1b = globalStore.perAccount(1);
@@ -78,10 +78,10 @@ void main() {
   });
 
   test('GlobalStore.perAccountSync', () async {
-    final accounts = {1: account1, 2: account2};
+    final accounts = [account1, account2];
     final globalStore = TestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
-      globalStore.completers[accounts[accountId]]!;
+      globalStore.completers[accounts[accountId - 1]]!;
 
     check(globalStore.perAccountSync(1)).isNull();
     final future1 = globalStore.perAccount(1);

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -8,16 +8,19 @@ import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 
 void main() {
+  final account1 = eg.selfAccount.copyWith(id: 1);
+  final account2 = eg.otherAccount.copyWith(id: 2);
+
   test('GlobalStore.perAccount sequential case', () async {
-    final accounts = {1: eg.selfAccount, 2: eg.otherAccount};
+    final accounts = {1: account1, 2: account2};
     final globalStore = TestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
       globalStore.completers[accounts[accountId]]!;
 
     final future1 = globalStore.perAccount(1);
     final store1 = PerAccountStore.fromInitialSnapshot(
-      account: eg.selfAccount,
-      connection: FakeApiConnection.fromAccount(eg.selfAccount),
+      account: account1,
+      connection: FakeApiConnection.fromAccount(account1),
       initialSnapshot: eg.initialSnapshot,
     );
     completers(1).single.complete(store1);
@@ -27,8 +30,8 @@ void main() {
 
     final future2 = globalStore.perAccount(2);
     final store2 = PerAccountStore.fromInitialSnapshot(
-      account: eg.otherAccount,
-      connection: FakeApiConnection.fromAccount(eg.otherAccount),
+      account: account2,
+      connection: FakeApiConnection.fromAccount(account2),
       initialSnapshot: eg.initialSnapshot,
     );
     completers(2).single.complete(store2);
@@ -42,7 +45,7 @@ void main() {
   });
 
   test('GlobalStore.perAccount concurrent case', () async {
-    final accounts = {1: eg.selfAccount, 2: eg.otherAccount};
+    final accounts = {1: account1, 2: account2};
     final globalStore = TestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
       globalStore.completers[accounts[accountId]]!;
@@ -54,13 +57,13 @@ void main() {
 
     final future2 = globalStore.perAccount(2);
     final store1 = PerAccountStore.fromInitialSnapshot(
-      account: eg.selfAccount,
-      connection: FakeApiConnection.fromAccount(eg.selfAccount),
+      account: account1,
+      connection: FakeApiConnection.fromAccount(account1),
       initialSnapshot: eg.initialSnapshot,
     );
     final store2 = PerAccountStore.fromInitialSnapshot(
-      account: eg.otherAccount,
-      connection: FakeApiConnection.fromAccount(eg.otherAccount),
+      account: account2,
+      connection: FakeApiConnection.fromAccount(account2),
       initialSnapshot: eg.initialSnapshot,
     );
     completers(1).single.complete(store1);
@@ -75,7 +78,7 @@ void main() {
   });
 
   test('GlobalStore.perAccountSync', () async {
-    final accounts = {1: eg.selfAccount, 2: eg.otherAccount};
+    final accounts = {1: account1, 2: account2};
     final globalStore = TestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
       globalStore.completers[accounts[accountId]]!;
@@ -84,8 +87,8 @@ void main() {
     final future1 = globalStore.perAccount(1);
     check(globalStore.perAccountSync(1)).isNull();
     final store1 = PerAccountStore.fromInitialSnapshot(
-      account: eg.selfAccount,
-      connection: FakeApiConnection.fromAccount(eg.selfAccount),
+      account: account1,
+      connection: FakeApiConnection.fromAccount(account1),
       initialSnapshot: eg.initialSnapshot,
     );
     completers(1).single.complete(store1);

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -1,6 +1,62 @@
 import 'package:zulip/api/model/events.dart';
+import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/store.dart';
+import 'package:zulip/widgets/store.dart';
+
+import '../api/fake_api.dart';
+
+/// A [GlobalStore] containing data provided by callers,
+/// and that causes no database queries or network requests.
+///
+/// Tests can provide data to the store by calling [add].
+///
+/// The per-account stores will use [FakeApiConnection].
+///
+/// See also [TestDataBinding.globalStore], which provides one of these.
+class TestGlobalStore extends GlobalStore {
+  TestGlobalStore({required super.accounts});
+
+  final Map<int, InitialSnapshot> _initialSnapshots = {};
+
+  /// Add an account and corresponding server data to the test data.
+  ///
+  /// The given account will be added to the store.
+  /// The given initial snapshot will be used to initialize a corresponding
+  /// [PerAccountStore] when [perAccount] is subsequently called for this
+  /// account, in particular when a [PerAccountStoreWidget] is mounted.
+  Future<void> add(Account account, InitialSnapshot initialSnapshot) async {
+    await insertAccount(account.toCompanion(false));
+    assert(!_initialSnapshots.containsKey(account.id));
+    _initialSnapshots[account.id] = initialSnapshot;
+  }
+
+  int _nextAccountId = 1;
+
+  @override
+  Future<Account> doInsertAccount(AccountsCompanion data) async {
+    final accountId = data.id.present ? data.id.value : _nextAccountId++;
+    return Account(
+      id: accountId,
+      realmUrl: data.realmUrl.value,
+      userId: data.userId.value,
+      email: data.email.value,
+      apiKey: data.apiKey.value,
+      zulipFeatureLevel: data.zulipFeatureLevel.value,
+      zulipVersion: data.zulipVersion.value,
+      zulipMergeBase: data.zulipMergeBase.value,
+    );
+  }
+
+  @override
+  Future<PerAccountStore> loadPerAccount(Account account) {
+    return Future.value(PerAccountStore.fromInitialSnapshot(
+      account: account,
+      connection: FakeApiConnection.fromAccount(account),
+      initialSnapshot: _initialSnapshots[account.id]!,
+    ));
+  }
+}
 
 extension PerAccountStoreTestExtension on PerAccountStore {
   void addUser(User user) {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/content.dart';
@@ -6,7 +7,7 @@ void main() {
   testWidgets('Throws if no `PerAccountStoreWidget` ancestor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const RealmContentNetworkImage('https://zulip.invalid/path/to/image.png', filterQuality: FilterQuality.medium));
-    expect(tester.takeException(), isAssertionError);
+    check(tester.takeException()).isA<AssertionError>();
   });
 
   // TODO(#30): Simulate a `PerAccountStoreWidget` ancestor, to use in more tests:

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1,16 +1,124 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/core.dart';
 import 'package:zulip/widgets/content.dart';
+import 'package:zulip/widgets/store.dart';
+
+import '../example_data.dart' as eg;
+import '../model/binding.dart';
 
 void main() {
-  testWidgets('Throws if no `PerAccountStoreWidget` ancestor', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const RealmContentNetworkImage('https://zulip.invalid/path/to/image.png', filterQuality: FilterQuality.medium));
-    check(tester.takeException()).isA<AssertionError>();
-  });
+  TestDataBinding.ensureInitialized();
 
-  // TODO(#30): Simulate a `PerAccountStoreWidget` ancestor, to use in more tests:
-  // TODO: 'Includes auth header if `src` is on-realm'
-  // TODO: 'Excludes auth header if `src` is off-realm'
+  group('RealmContentNetworkImage', () {
+    final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);
+
+    Future<String?> actualAuthHeader(WidgetTester tester, String src) async {
+      final globalStore = TestDataBinding.instance.globalStore;
+      addTearDown(TestDataBinding.instance.reset);
+      await globalStore.add(eg.selfAccount, eg.initialSnapshot);
+
+      final httpClient = _FakeHttpClient();
+      debugNetworkImageHttpClientProvider = () => httpClient;
+      httpClient.request.response
+        ..statusCode = HttpStatus.ok
+        ..content = kSolidBlueAvatar;
+
+      await tester.pumpWidget(GlobalStoreWidget(
+        child: PerAccountStoreWidget(accountId: eg.selfAccount.id,
+          child: RealmContentNetworkImage(src))));
+      await tester.pump();
+      await tester.pump();
+
+      final headers = httpClient.request.headers.values;
+      check(authHeaders.keys).deepEquals(['Authorization']);
+      return headers['Authorization']?.single;
+    }
+
+    testWidgets('includes auth header if `src` on-realm', (tester) async {
+      check(await actualAuthHeader(tester, 'https://chat.example/image.png'))
+        .isNotNull().equals(authHeaders['Authorization']!);
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('excludes auth header if `src` off-realm', (tester) async {
+      check(await actualAuthHeader(tester, 'https://other.example/image.png'))
+        .isNull();
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('throws if no `PerAccountStoreWidget` ancestor', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const RealmContentNetworkImage('https://zulip.invalid/path/to/image.png', filterQuality: FilterQuality.medium));
+      check(tester.takeException()).isA<AssertionError>();
+    });
+  });
 }
+
+class _FakeHttpClient extends Fake implements HttpClient {
+  final _FakeHttpClientRequest request = _FakeHttpClientRequest();
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async => request;
+}
+
+class _FakeHttpClientRequest extends Fake implements HttpClientRequest {
+  final _FakeHttpClientResponse response = _FakeHttpClientResponse();
+
+  @override
+  final _FakeHttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async => response;
+}
+
+class _FakeHttpHeaders extends Fake implements HttpHeaders {
+  final Map<String, List<String>> values = {};
+
+  @override
+  void add(String name, Object value, {bool preserveHeaderCase = false}) {
+    (values[name] ??= []).add(value.toString());
+  }
+}
+
+class _FakeHttpClientResponse extends Fake implements HttpClientResponse {
+  @override
+  int statusCode = HttpStatus.ok;
+
+  late List<int> content;
+
+  @override
+  int get contentLength => content.length;
+
+  @override
+  HttpClientResponseCompressionState get compressionState => HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  StreamSubscription<List<int>> listen(void Function(List<int> event)? onData, {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    return Stream.value(content).listen(
+      onData, onDone: onDone, onError: onError, cancelOnError: cancelOnError);
+  }
+}
+
+/// A 100x100 PNG image of solid Zulip blue, [kZulipBrandColor].
+// Made from the following SVG:
+//   <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1">
+//     <rect style="fill:#6492fe;fill-opacity:1" width="1" height="1" x="0" y="0" />
+//   </svg>
+// with `inkscape tmp.svg -w 100 --export-png=tmp1.png`,
+// `zopflipng tmp1.png tmp.png`,
+// and `xxd -i tmp.png`.
+const List<int> kSolidBlueAvatar = [
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x64,
+  0x01, 0x03, 0x00, 0x00, 0x00, 0x4a, 0x2c, 0x07, 0x17, 0x00, 0x00, 0x00,
+  0x03, 0x50, 0x4c, 0x54, 0x45, 0x64, 0x92, 0xfe, 0xf1, 0xd6, 0x69, 0xa5,
+  0x00, 0x00, 0x00, 0x13, 0x49, 0x44, 0x41, 0x54, 0x78, 0x01, 0x63, 0xa0,
+  0x2b, 0x18, 0x05, 0xa3, 0x60, 0x14, 0x8c, 0x82, 0x51, 0x00, 0x00, 0x05,
+  0x78, 0x00, 0x01, 0x1e, 0xcd, 0x28, 0xcd, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+];

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -1,0 +1,39 @@
+import 'package:checks/checks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/model/store.dart';
+import 'package:zulip/widgets/store.dart';
+
+import '../model/binding.dart';
+import '../example_data.dart' as eg;
+import '../model/store_checks.dart';
+
+void main() {
+  TestDataBinding.ensureInitialized();
+
+  testWidgets('GlobalStoreWidget', (WidgetTester tester) async {
+    addTearDown(TestDataBinding.instance.reset);
+
+    GlobalStore? globalStore;
+    await tester.pumpWidget(
+      GlobalStoreWidget(
+        child: Builder(
+          builder: (context) {
+            globalStore = GlobalStoreWidget.of(context);
+            return const SizedBox.shrink();
+          })));
+    // First, shows a loading page instead of child.
+    check(tester.any(find.byType(CircularProgressIndicator))).isTrue();
+    check(globalStore).isNull();
+
+    await tester.pump();
+    // Then after loading, mounts child instead, with provided store.
+    check(tester.any(find.byType(CircularProgressIndicator))).isFalse();
+    check(globalStore).identicalTo(TestDataBinding.instance.globalStore);
+
+    await TestDataBinding.instance.globalStore.add(eg.selfAccount, eg.initialSnapshot);
+    check(globalStore).isNotNull()
+      .accountEntries.single
+      .equals((accountId: eg.selfAccount.id, account: eg.selfAccount));
+  });
+}

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -36,4 +36,26 @@ void main() {
       .accountEntries.single
       .equals((accountId: eg.selfAccount.id, account: eg.selfAccount));
   });
+
+  testWidgets('PerAccountStoreWidget', (tester) async {
+    final globalStore = TestDataBinding.instance.globalStore;
+    addTearDown(TestDataBinding.instance.reset);
+    await globalStore.add(eg.selfAccount, eg.initialSnapshot);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GlobalStoreWidget(
+          child: PerAccountStoreWidget(
+            accountId: eg.selfAccount.id,
+            child: Builder(
+              builder: (context) {
+                final store = PerAccountStoreWidget.of(context);
+                return Text('found store, account: ${store.account.id}');
+              })))));
+    await tester.pump();
+    await tester.pump();
+
+    tester.widget(find.text('found store, account: ${eg.selfAccount.id}'));
+  });
 }


### PR DESCRIPTION
This implements #30 with an architecture modeled on Flutter's own "binding" concept, along the lines anticipated in the issue's description.

Along the way we add tests for GlobalStoreWidget and PerAccountStoreWidget, including a test for the slightly tricky — and important for a smooth UX — "zero-frame loading" optimization that PerAccountStoreWidget has. Then we add the tests we've wanted for RealmContentNetworkImage, a widget that consumes data from PerAccountStoreWidget, demonstrating that such code is now testable and completing #30.

The setup code required in individual tests still feels a bit unwieldy, and I think it's likely we'll either tweak it in the future or add convenience abstractions on top of it. But the time for that is after we have a few more examples — at this point we really just have the one example (testing RealmContentNetworkImage), because I think the tests for GlobalStoreWidget and PerAccountStoreWidget will probably not fit the same abstractions that would be most convenient for typical application code that consumes a PerAccountStoreWidget.

Fixes: #30 
