### PR TITLE
api: Add getMessageCompat helper, for servers with and without FL 120

### DIFF
--- a/lib/api/model/narrow.dart
+++ b/lib/api/model/narrow.dart
@@ -97,3 +97,20 @@ class ApiNarrowPmWith extends ApiNarrowDm {
 
   ApiNarrowPmWith._(super.operand, {super.negated});
 }
+
+class ApiNarrowMessageId extends ApiNarrowElement {
+  @override String get operator => 'id';
+
+  // The API requires a string, even though message IDs are ints:
+  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60id.3A123.60.20narrow.20in.20.60GET.20.2Fmessages.60/near/1591465
+  // TODO(server-future) Send ints to future servers that support them. For how
+  //   to handle the migration, see [ApiNarrowDm.resolve].
+  @override final String operand;
+
+  ApiNarrowMessageId(int operand, {super.negated}) : operand = operand.toString();
+
+  factory ApiNarrowMessageId.fromJson(Map<String, dynamic> json) => ApiNarrowMessageId(
+    int.parse(json['operand'] as String),
+    negated: json['negated'] as bool? ?? false,
+  );
+}

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -1,10 +1,54 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
+import '../exception.dart';
 import '../model/model.dart';
 import '../model/narrow.dart';
 
 part 'messages.g.dart';
+
+/// Convenience function to get a single message from any server.
+///
+/// This encapsulates a server-feature check.
+///
+/// Gives null if the server reports that the message doesn't exist.
+// TODO(server-5) Simplify this away; just use getMessage.
+Future<Message?> getMessageCompat(ApiConnection connection, {
+  required int messageId,
+  bool? applyMarkdown,
+}) async {
+  final useLegacyApi = connection.zulipFeatureLevel! < 120;
+  if (useLegacyApi) {
+    final response = await getMessages(connection,
+      narrow: [ApiNarrowMessageId(messageId)],
+      anchor: NumericAnchor(messageId),
+      numBefore: 0,
+      numAfter: 0,
+      applyMarkdown: applyMarkdown,
+
+      // Hard-code this param to `true`, as the new single-message API
+      // effectively does:
+      //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60client_gravatar.60.20in.20.60messages.2F.7Bmessage_id.7D.60/near/1418337
+      clientGravatar: true,
+    );
+    return response.messages.firstOrNull;
+  } else {
+    try {
+      final response = await getMessage(connection,
+        messageId: messageId,
+        applyMarkdown: applyMarkdown,
+      );
+      return response.message;
+    } on ZulipApiException catch (e) {
+      if (e.code == 'BAD_REQUEST') {
+        // Servers use this code when the message doesn't exist, according to
+        // the example in the doc.
+        return null;
+      }
+      rethrow;
+    }
+  }
+}
 
 /// https://zulip.com/api/get-message
 ///

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -6,6 +6,35 @@ import '../model/narrow.dart';
 
 part 'messages.g.dart';
 
+/// https://zulip.com/api/get-message
+///
+/// This binding only supports feature levels 120+.
+// TODO(server-5) remove FL 120+ mention in doc, and the related `assert`
+Future<GetMessageResult> getMessage(ApiConnection connection, {
+  required int messageId,
+  bool? applyMarkdown,
+}) {
+  assert(connection.zulipFeatureLevel! >= 120);
+  return connection.get('getMessage', GetMessageResult.fromJson, 'messages/$messageId', {
+    if (applyMarkdown != null) 'apply_markdown': applyMarkdown,
+  });
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class GetMessageResult {
+  // final String rawContent; // deprecated; ignore
+  final Message message;
+
+  GetMessageResult({
+    required this.message,
+  });
+
+  factory GetMessageResult.fromJson(Map<String, dynamic> json) =>
+    _$GetMessageResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$GetMessageResultToJson(this);
+}
+
 /// https://zulip.com/api/get-messages
 Future<GetMessagesResult> getMessages(ApiConnection connection, {
   required ApiNarrow narrow,

--- a/lib/api/route/messages.g.dart
+++ b/lib/api/route/messages.g.dart
@@ -8,6 +8,16 @@ part of 'messages.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+GetMessageResult _$GetMessageResultFromJson(Map<String, dynamic> json) =>
+    GetMessageResult(
+      message: Message.fromJson(json['message'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$GetMessageResultToJson(GetMessageResult instance) =>
+    <String, dynamic>{
+      'message': instance.message,
+    };
+
 GetMessagesResult _$GetMessagesResultFromJson(Map<String, dynamic> json) =>
     GetMessagesResult(
       anchor: json['anchor'] as int,


### PR DESCRIPTION
We can use this to get raw Markdown content for quote-and-reply
(#116) and for the "Share" option on a message. For those, we only
care about the raw Markdown content and so could just as well have
used the `raw_content` field on the get-single-message response, for
servers pre-120. But...

We can also use this for #73, "Handle Zulip-internal links by
navigation", to follow /near/<id> links through topic/stream moves
(see implementation in zulip-mobile). For that, we'll need more than
just the message's raw Markdown.

Fixes: #140