### PR TITLE
store: Update `streams` and `subscriptions` on stream-create/delete events

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -25,6 +25,14 @@ abstract class Event {
           case 'update': return RealmUserUpdateEvent.fromJson(json);
           default: return UnexpectedEvent.fromJson(json);
         }
+      case 'stream':
+        final op = json['op'] as String;
+        switch (op) {
+          case 'create': return StreamCreateEvent.fromJson(json);
+          case 'delete': return StreamDeleteEvent.fromJson(json);
+          // TODO(#182): case 'update': …
+          default: return UnexpectedEvent.fromJson(json);
+        }
       case 'message': return MessageEvent.fromJson(json);
       case 'heartbeat': return HeartbeatEvent.fromJson(json);
       // TODO add many more event types
@@ -178,6 +186,54 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   @override
   Map<String, dynamic> toJson() => _$RealmUserUpdateEventToJson(this);
 }
+
+/// A Zulip event of type `stream`.
+abstract class StreamEvent extends Event {
+  @override
+  @JsonKey(includeToJson: true)
+  String get type => 'stream';
+
+  String get op;
+
+  StreamEvent({required super.id});
+}
+
+/// A [StreamEvent] with op `create`: https://zulip.com/api/get-events#stream-create
+@JsonSerializable(fieldRename: FieldRename.snake)
+class StreamCreateEvent extends StreamEvent {
+  @override
+  String get op => 'create';
+
+  final List<ZulipStream> streams;
+
+  StreamCreateEvent({required super.id, required this.streams});
+
+  factory StreamCreateEvent.fromJson(Map<String, dynamic> json) =>
+    _$StreamCreateEventFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$StreamCreateEventToJson(this);
+}
+
+/// A [StreamEvent] with op `delete`: https://zulip.com/api/get-events#stream-delete
+@JsonSerializable(fieldRename: FieldRename.snake)
+class StreamDeleteEvent extends StreamEvent {
+  @override
+  String get op => 'delete';
+
+  final List<ZulipStream> streams;
+
+  StreamDeleteEvent({required super.id, required this.streams});
+
+  factory StreamDeleteEvent.fromJson(Map<String, dynamic> json) =>
+    _$StreamDeleteEventFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$StreamDeleteEventToJson(this);
+}
+
+// TODO(#182) StreamUpdateEvent, for a [StreamEvent] with op `update`:
+//   https://zulip.com/api/get-events#stream-update
 
 /// A Zulip event of type `message`.
 // TODO use [JsonSerializable] here too, using its customization features,

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -103,6 +103,36 @@ Map<String, dynamic> _$RealmUserUpdateEventToJson(
       'new_email': instance.newEmail,
     };
 
+StreamCreateEvent _$StreamCreateEventFromJson(Map<String, dynamic> json) =>
+    StreamCreateEvent(
+      id: json['id'] as int,
+      streams: (json['streams'] as List<dynamic>)
+          .map((e) => ZulipStream.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$StreamCreateEventToJson(StreamCreateEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'streams': instance.streams,
+    };
+
+StreamDeleteEvent _$StreamDeleteEventFromJson(Map<String, dynamic> json) =>
+    StreamDeleteEvent(
+      id: json['id'] as int,
+      streams: (json['streams'] as List<dynamic>)
+          .map((e) => ZulipStream.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$StreamDeleteEventToJson(StreamDeleteEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'streams': instance.streams,
+    };
+
 HeartbeatEvent _$HeartbeatEventFromJson(Map<String, dynamic> json) =>
     HeartbeatEvent(
       id: json['id'] as int,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -239,6 +239,19 @@ class PerAccountStore extends ChangeNotifier {
       }
       autocompleteViewManager.handleRealmUserUpdateEvent(event);
       notifyListeners();
+    } else if (event is StreamCreateEvent) {
+      assert(debugLog("server event: stream/create"));
+      streams.addEntries(event.streams.map((stream) => MapEntry(stream.streamId, stream)));
+      // (Don't touch `subscriptions`. If the user is subscribed to the stream,
+      // details will come in a later `subscription` event.)
+      notifyListeners();
+    } else if (event is StreamDeleteEvent) {
+      assert(debugLog("server event: stream/delete"));
+      for (final stream in event.streams) {
+        streams.remove(stream.streamId);
+        subscriptions.remove(stream.streamId);
+      }
+      notifyListeners();
     } else if (event is MessageEvent) {
       assert(debugLog("server event: message ${jsonEncode(event.message.toJson())}"));
       for (final view in _messageListViews) {

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -68,4 +68,12 @@ extension PerAccountStoreTestExtension on PerAccountStore {
       addUser(user);
     }
   }
+
+  void addStream(ZulipStream stream) {
+    addStreams([stream]);
+  }
+
+  void addStreams(List<ZulipStream> streams) {
+    handleEvent(StreamCreateEvent(id: 1, streams: streams));
+  }
 }


### PR DESCRIPTION
Also, add `addStream` / `addStreams` helpers to `PerAccountStoreTestExtension`. We'll use those soon, to write tests for message-link creation for quote-and-reply.

Fixes: #181
Related: #182