### PR TITLE
Touchable links in messages

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -66,6 +66,8 @@ PODS:
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
   - SwiftyGif (5.4.4)
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - app_settings (from `.symlinks/plugins/app_settings/ios`)
@@ -77,6 +79,7 @@ DEPENDENCIES:
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -105,6 +108,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   sqlite3_flutter_libs:
     :path: ".symlinks/plugins/sqlite3_flutter_libs/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   app_settings: d103828c9f5d515c4df9ee754dabd443f7cedcf3
@@ -121,6 +126,7 @@ SPEC CHECKSUMS:
   sqlite3: fd89671d969f3e73efe503ce203e28b016b58f68
   sqlite3_flutter_libs: 04ba0d14a04335a2fbf9a331e8664f401fbccdd5
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: 985e5b058f26709dc81f9ae74ea2b2775bdbcefe
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,6 @@ void main() {
     return true;
   }());
   LicenseRegistry.addLicense(additionalLicenses);
-  LiveDataBinding.ensureInitialized();
+  LiveZulipBinding.ensureInitialized();
   runApp(const ZulipApp());
 }

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
+export 'package:url_launcher/url_launcher.dart' show LaunchMode;
 
 import '../widgets/store.dart';
 import 'store.dart';
 
-/// A singleton service providing the app's data.
+/// A singleton service providing the app's data and use of Flutter plugins.
 ///
 /// Only one instance will be constructed in the lifetime of the app,
 /// by calling the `ensureInitialized` static method on a subclass.
@@ -62,6 +64,14 @@ abstract class ZulipBinding {
   /// In application code, use [GlobalStoreWidget.of] to get access
   /// to a [GlobalStore].
   Future<GlobalStore> loadGlobalStore();
+
+  /// Pass [url] to the underlying platform, via package:url_launcher.
+  ///
+  /// This wraps [url_launcher.launchUrl].
+  Future<bool> launchUrl(
+    Uri url, {
+    url_launcher.LaunchMode mode = url_launcher.LaunchMode.platformDefault,
+  });
 }
 
 /// A concrete binding for use in the live application.
@@ -69,6 +79,9 @@ abstract class ZulipBinding {
 /// The global store returned by [loadGlobalStore], and consequently by
 /// [GlobalStoreWidget.of] in application code, will be a [LiveGlobalStore].
 /// It therefore uses a live server and live, persistent local database.
+///
+/// Methods wrapping a plugin, like [launchUrl], invoke the actual
+/// underlying plugin method.
 class LiveZulipBinding extends ZulipBinding {
   /// Initialize the binding if necessary, and ensure it is a [LiveZulipBinding].
   static LiveZulipBinding ensureInitialized() {
@@ -81,5 +94,13 @@ class LiveZulipBinding extends ZulipBinding {
   @override
   Future<GlobalStore> loadGlobalStore() {
     return LiveGlobalStore.load();
+  }
+
+  @override
+  Future<bool> launchUrl(
+    Uri url, {
+    url_launcher.LaunchMode mode = url_launcher.LaunchMode.platformDefault,
+  }) {
+    return url_launcher.launchUrl(url, mode: mode);
   }
 }

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -18,27 +18,27 @@ import 'store.dart';
 /// [TestWidgetsFlutterBinding].
 /// This version is simplified because we don't (yet?) have enough complexity
 /// to put into these bindings to need to use mixins to split them up.
-abstract class DataBinding {
-  DataBinding() {
+abstract class ZulipBinding {
+  ZulipBinding() {
     assert(_instance == null);
     initInstance();
   }
 
-  /// The single instance of [DataBinding].
-  static DataBinding get instance => checkInstance(_instance);
-  static DataBinding? _instance;
+  /// The single instance of [ZulipBinding].
+  static ZulipBinding get instance => checkInstance(_instance);
+  static ZulipBinding? _instance;
 
-  static T checkInstance<T extends DataBinding>(T? instance) {
+  static T checkInstance<T extends ZulipBinding>(T? instance) {
     assert(() {
       if (instance == null) {
         throw FlutterError.fromParts([
           ErrorSummary('Zulip binding has not yet been initialized.'),
           ErrorHint(
-            'In the app, this is done by the `LiveDataBinding.ensureInitialized()` call '
+            'In the app, this is done by the `LiveZulipBinding.ensureInitialized()` call '
             'in the `void main()` method.',
           ),
           ErrorHint(
-            'In a test, one can call `TestDataBinding.ensureInitialized()` as the '
+            'In a test, one can call `TestZulipBinding.ensureInitialized()` as the '
             'first line in the test\'s `main()` method to initialize the binding.',
           ),
         ]);
@@ -69,13 +69,13 @@ abstract class DataBinding {
 /// The global store returned by [loadGlobalStore], and consequently by
 /// [GlobalStoreWidget.of] in application code, will be a [LiveGlobalStore].
 /// It therefore uses a live server and live, persistent local database.
-class LiveDataBinding extends DataBinding {
-  /// Initialize the binding if necessary, and ensure it is a [LiveDataBinding].
-  static LiveDataBinding ensureInitialized() {
-    if (DataBinding._instance == null) {
-      LiveDataBinding();
+class LiveZulipBinding extends ZulipBinding {
+  /// Initialize the binding if necessary, and ensure it is a [LiveZulipBinding].
+  static LiveZulipBinding ensureInitialized() {
+    if (ZulipBinding._instance == null) {
+      LiveZulipBinding();
     }
-    return DataBinding.instance as LiveDataBinding;
+    return ZulipBinding.instance as LiveZulipBinding;
   }
 
   @override

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -399,7 +399,6 @@ class InlineCodeNode extends InlineContainerNode {
 class LinkNode extends InlineContainerNode {
   const LinkNode({super.debugHtmlNode, required super.nodes, required this.url});
 
-  // TODO(#71): Use [LinkNode.url] to open links
   final String url; // Left as a string, to defer parsing until link actually followed.
 
   // Unlike other [ContentNode]s, the identity is useful to show in debugging
@@ -559,6 +558,9 @@ class _ZulipContentParser {
             || classes.contains('user-group-mention'))
         && (classes.length == 1
             || (classes.length == 2 && classes.contains('silent')))) {
+      // TODO assert UserMentionNode can't contain LinkNode;
+      //   either a debug-mode check, or perhaps we can make expectations much
+      //   tighter on a UserMentionNode's contents overall.
       return UserMentionNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
     }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -673,13 +673,32 @@ void _launchUrl(BuildContext context, String urlString) async {
     url = store.account.realmUrl.resolve(urlString);
   } on FormatException { // TODO(log)
     await showError(context, null);
+    if (!context.mounted) return; // TODO(dart): redundant for sake of lint
     return;
   }
 
   bool launched = false;
   String? errorMessage;
   try {
-    launched = await ZulipBinding.instance.launchUrl(url);
+    launched = await ZulipBinding.instance.launchUrl(url,
+      mode: switch (Theme.of(context).platform) {
+        // TODO(upstream) The url_launcher default on Android is a weird UX:
+        //   opens a webview in-app, but on a blank black background.
+        //   The status bar is hidden:
+        //     https://github.com/flutter/flutter/issues/120883
+        //   but also there's no app bar, no location bar, no share button;
+        //   no browser chrome at all.
+        //   Probably what we really want is a "Chrome custom tab":
+        //     https://github.com/flutter/flutter/issues/18589
+        // TODO(upstream) With url_launcher's LaunchMode.externalApplication
+        //   on Android, we still don't get the normal Android UX for
+        //   opening a URL in a browser, where the system gives the user
+        //   a bit of UI to choose which browser to use:
+        //     https://github.com/zulip/zulip-flutter/issues/74#issuecomment-1514040730
+        TargetPlatform.android => LaunchMode.externalApplication,
+        _ => LaunchMode.platformDefault,
+      },
+    );
   } on PlatformException catch (e) {
     errorMessage = e.message;
   }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -97,7 +97,7 @@ class Paragraph extends StatelessWidget {
     // The paragraph has vertical CSS margins, but those have no effect.
     if (node.nodes.isEmpty) return const SizedBox();
 
-    final text = InlineContent(nodes: node.nodes, style: null);
+    final text = _buildBlockInlineContainer(node: node, style: null);
 
     // If the paragraph didn't actually have a `p` element in the HTML,
     // then apply no margins.  (For example, these are seen in list items.)
@@ -122,9 +122,9 @@ class Heading extends StatelessWidget {
     assert(node.level == HeadingLevel.h6);
     return Padding(
       padding: const EdgeInsets.only(top: 15, bottom: 5),
-      child: InlineContent(
+      child: _buildBlockInlineContainer(
         style: const TextStyle(fontWeight: FontWeight.w600, height: 1.4),
-        nodes: node.nodes));
+        node: node));
   }
 }
 
@@ -296,6 +296,36 @@ class _SingleChildScrollViewWithScrollbarState
 //
 // Inline layout.
 //
+
+Widget _buildBlockInlineContainer({
+  required TextStyle? style,
+  required BlockInlineContainerNode node,
+}) {
+  if (node.links == null) {
+    return InlineContent(style: style, nodes: node.nodes);
+  }
+  return _BlockInlineContainer(
+    links: node.links!, style: style, nodes: node.nodes);
+}
+
+class _BlockInlineContainer extends StatefulWidget {
+  const _BlockInlineContainer(
+    {required this.links, required this.style, required this.nodes});
+
+  final List<LinkNode> links;
+  final TextStyle? style;
+  final List<InlineContentNode> nodes;
+
+  @override
+  State<_BlockInlineContainer> createState() => _BlockInlineContainerState();
+}
+
+class _BlockInlineContainerState extends State<_BlockInlineContainer> {
+  @override
+  Widget build(BuildContext context) {
+    return InlineContent(style: widget.style, nodes: widget.nodes);
+  }
+}
 
 class InlineContent extends StatelessWidget {
   InlineContent({

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -333,9 +333,6 @@ class _InlineContentBuilder {
   }
 
   InlineSpan _buildNode(InlineContentNode node) {
-    InlineSpan styled(List<InlineContentNode> nodes, TextStyle style) =>
-      _buildNodes(nodes, style: style);
-
     if (node is TextNode) {
       return TextSpan(text: node.text);
     } else if (node is LineBreakInlineNode) {
@@ -343,15 +340,13 @@ class _InlineContentBuilder {
       // and our parser doesn't.  So don't do anything here.
       return const TextSpan(text: "");
     } else if (node is StrongNode) {
-      return styled(node.nodes, const TextStyle(fontWeight: FontWeight.w600));
+      return _buildStrong(node);
     } else if (node is EmphasisNode) {
-      return styled(node.nodes, const TextStyle(fontStyle: FontStyle.italic));
+      return _buildEmphasis(node);
+    } else if (node is LinkNode) {
+      return _buildLink(node);
     } else if (node is InlineCodeNode) {
       return _buildInlineCode(node);
-    } else if (node is LinkNode) {
-      // TODO make link touchable
-      return styled(node.nodes,
-        TextStyle(color: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor()));
     } else if (node is UserMentionNode) {
       return WidgetSpan(alignment: PlaceholderAlignment.middle,
         child: UserMention(node: node));
@@ -367,6 +362,18 @@ class _InlineContentBuilder {
       // TODO(dart-3): Use a sealed class / pattern matching to eliminate this case.
       throw Exception("impossible InlineContentNode: ${node.debugHtmlText}");
     }
+  }
+
+  InlineSpan _buildStrong(StrongNode node) => _buildNodes(node.nodes,
+    style: const TextStyle(fontWeight: FontWeight.w600));
+
+  InlineSpan _buildEmphasis(EmphasisNode node) => _buildNodes(node.nodes,
+    style: const TextStyle(fontStyle: FontStyle.italic));
+
+  InlineSpan _buildLink(LinkNode node) {
+    // TODO make link touchable
+    return _buildNodes(node.nodes,
+      style: TextStyle(color: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor()));
   }
 
   InlineSpan _buildInlineCode(InlineCodeNode node) {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1,4 +1,3 @@
-import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -172,12 +171,13 @@ class _MessageListState extends State<MessageList> {
       // TODO: Offer `ScrollViewKeyboardDismissBehavior.interactive` (or
       //   similar) if that is ever offered:
       //     https://github.com/flutter/flutter/issues/57609#issuecomment-1355340849
-      keyboardDismissBehavior: Platform.isIOS
+      keyboardDismissBehavior: switch (Theme.of(context).platform) {
         // This seems to offer the only built-in way to close the keyboard
         // on iOS. It's not ideal; see TODO above.
-        ? ScrollViewKeyboardDismissBehavior.onDrag
+        TargetPlatform.iOS => ScrollViewKeyboardDismissBehavior.onDrag,
         // The Android keyboard seems to have a built-in close button.
-        : ScrollViewKeyboardDismissBehavior.manual,
+        _ => ScrollViewKeyboardDismissBehavior.manual,
+      },
 
       itemCount: length,
       // Setting reverse: true means the scroll starts at the bottom.

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -55,7 +55,7 @@ class _GlobalStoreWidgetState extends State<GlobalStoreWidget> {
   void initState() {
     super.initState();
     (() async {
-      final store = await DataBinding.instance.loadGlobalStore();
+      final store = await ZulipBinding.instance.loadGlobalStore();
       setState(() {
         this.store = store;
       });

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -19,6 +19,7 @@ final TextStyle kMonospaceTextStyle = TextStyle(
 
   // Oddly, iOS doesn't handle 'monospace':
   //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20monospace.20font.20fallback/near/1570622
+  // TODO use Theme.of, not Platform, so that this is testable (needs a BuildContext)
   fontFamilyFallback: Platform.isIOS ? ['Menlo', 'Courier'] : ['monospace'],
 
   inherit: true,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import package_info_plus
 import path_provider_foundation
 import share_plus
 import sqlite3_flutter_libs
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
@@ -19,4 +20,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -26,6 +26,8 @@ PODS:
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
@@ -35,6 +37,7 @@ DEPENDENCIES:
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -55,6 +58,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   sqlite3_flutter_libs:
     :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
@@ -65,6 +70,7 @@ SPEC CHECKSUMS:
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   sqlite3: fd89671d969f3e73efe503ce203e28b016b58f68
   sqlite3_flutter_libs: 00a50503d69f7ab0fe85a5ff25b33082f4df4ce9
+  url_launcher_macos: 5335912b679c073563f29d89d33d10d459f95451
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -925,11 +925,43 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: eb1e00ab44303d50dd487aab67ebc575456c146c6af44422f9c13889984c00f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.11"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: eed4e6a1164aa9794409325c3b707ff424d4d1c2a785e7db67f8bbda00e36e51
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.35"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "9af7ea73259886b92199f9e42c116072f05ff9bea2dcb339ab935dfc957392c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       sha256: "207f4ddda99b95b4d4868320a352d374b0b7e05eefad95a4a26f57da413443f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "91ee3e75ea9dadf38036200c5d3743518f4a5eb77a8d13fda1ee5764373f185e"
       url: "https://pub.dev"
     source: hosted
     version: "3.0.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   image_picker: ^0.8.7+3
   package_info_plus: ^4.0.1
   collection: ^1.17.2
+  url_launcher: ^6.1.11
 
 dev_dependencies:
   flutter_test:

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -16,24 +16,24 @@ import 'test_store.dart';
 ///
 /// The global store returned by [loadGlobalStore], and consequently by
 /// [GlobalStoreWidget.of] in application code, will be a [TestGlobalStore].
-class TestDataBinding extends DataBinding {
-  /// Initialize the binding if necessary, and ensure it is a [TestDataBinding].
+class TestZulipBinding extends ZulipBinding {
+  /// Initialize the binding if necessary, and ensure it is a [TestZulipBinding].
   ///
   /// This method is idempotent; calling it repeatedly simply returns the
   /// existing binding.
   ///
-  /// If there is an existing binding but it is not a [TestDataBinding],
+  /// If there is an existing binding but it is not a [TestZulipBinding],
   /// this method throws an error.
-  static TestDataBinding ensureInitialized() {
+  static TestZulipBinding ensureInitialized() {
     if (_instance == null) {
-      TestDataBinding();
+      TestZulipBinding();
     }
     return instance;
   }
 
   /// The single instance of the binding.
-  static TestDataBinding get instance => DataBinding.checkInstance(_instance);
-  static TestDataBinding? _instance;
+  static TestZulipBinding get instance => ZulipBinding.checkInstance(_instance);
+  static TestZulipBinding? _instance;
 
   @override
   void initInstance() {
@@ -58,7 +58,7 @@ class TestDataBinding extends DataBinding {
   ///
   /// Tests that mount a [GlobalStoreWidget], or that access [globalStore],
   /// should clean up by calling this method.  Typically this is done using
-  /// [addTearDown], like `addTearDown(TestDataBinding.instance.reset);`.
+  /// [addTearDown], like `addTearDown(TestZulipBinding.instance.reset);`.
   void reset() {
     _globalStore?.dispose();
     _globalStore = null;
@@ -83,7 +83,7 @@ class TestDataBinding extends DataBinding {
           ),
           ErrorHint(
             'Typically this is accomplished using [addTearDown], like '
-            '`addTearDown(TestDataBinding.instance.reset);`.',
+            '`addTearDown(TestZulipBinding.instance.reset);`.',
           ),
         ]);
       }

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -13,7 +13,7 @@ import '../api/fake_api.dart';
 ///
 /// The per-account stores will use [FakeApiConnection].
 ///
-/// See also [TestDataBinding.globalStore], which provides one of these.
+/// See also [TestZulipBinding.globalStore], which provides one of these.
 class TestGlobalStore extends GlobalStore {
   TestGlobalStore({required super.accounts});
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -24,10 +24,10 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   required Message message,
   required Narrow narrow,
 }) async {
-  addTearDown(TestDataBinding.instance.reset);
+  addTearDown(TestZulipBinding.instance.reset);
 
-  await TestDataBinding.instance.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-  final store = await TestDataBinding.instance.globalStore.perAccount(eg.selfAccount.id);
+  await TestZulipBinding.instance.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+  final store = await TestZulipBinding.instance.globalStore.perAccount(eg.selfAccount.id);
   store.addUser(eg.user(userId: message.senderId));
   if (message is StreamMessage) {
     store.addStream(eg.stream(streamId: message.streamId));
@@ -61,7 +61,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
 }
 
 void main() {
-  TestDataBinding.ensureInitialized();
+  TestZulipBinding.ensureInitialized();
 
   group('QuoteAndReplyButton', () {
     ComposeBoxController? findComposeBoxController(WidgetTester tester) {
@@ -133,7 +133,7 @@ void main() {
     testWidgets('in stream narrow', (WidgetTester tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: StreamNarrow(message.streamId));
-      final store = await TestDataBinding.instance.globalStore.perAccount(eg.selfAccount.id);
+      final store = await TestZulipBinding.instance.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -151,7 +151,7 @@ void main() {
     testWidgets('in topic narrow', (WidgetTester tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await TestDataBinding.instance.globalStore.perAccount(eg.selfAccount.id);
+      final store = await TestZulipBinding.instance.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -170,7 +170,7 @@ void main() {
       final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
       await setupToMessageActionSheet(tester,
         message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
-      final store = await TestDataBinding.instance.globalStore.perAccount(eg.selfAccount.id);
+      final store = await TestZulipBinding.instance.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -188,7 +188,7 @@ void main() {
     testWidgets('request has an error', (WidgetTester tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await TestDataBinding.instance.globalStore.perAccount(eg.selfAccount.id);
+      final store = await TestZulipBinding.instance.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -19,7 +19,7 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   group('LinkNode interactions', () {
-    const expectedModeAndroid = LaunchMode.platformDefault;
+    const expectedModeAndroid = LaunchMode.externalApplication;
 
     // The Flutter test font uses square glyphs, so width equals height:
     //   https://github.com/flutter/flutter/wiki/Flutter-Test-Fonts
@@ -43,7 +43,8 @@ void main() {
         '<p><a href="https://example/">hello</a></p>');
 
       await tester.tap(find.text('hello'));
-      const expectedMode = LaunchMode.platformDefault;
+      final expectedMode = defaultTargetPlatform == TargetPlatform.android ?
+        LaunchMode.externalApplication : LaunchMode.platformDefault;
       check(TestZulipBinding.instance.takeLaunchUrlCalls())
         .single.equals((url: Uri.parse('https://example/'), mode: expectedMode));
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -2,17 +2,120 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:checks/checks.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:zulip/api/core.dart';
+import 'package:zulip/model/content.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/store.dart';
 
 import '../example_data.dart' as eg;
 import '../model/binding.dart';
+import 'dialog_checks.dart';
 
 void main() {
   TestZulipBinding.ensureInitialized();
+
+  group('LinkNode interactions', () {
+    const expectedModeAndroid = LaunchMode.platformDefault;
+
+    // The Flutter test font uses square glyphs, so width equals height:
+    //   https://github.com/flutter/flutter/wiki/Flutter-Test-Fonts
+    const fontSize = 48.0;
+
+    Future<void> prepareContent(WidgetTester tester, String html) async {
+      final globalStore = TestZulipBinding.instance.globalStore;
+      addTearDown(TestZulipBinding.instance.reset);
+      await globalStore.add(eg.selfAccount, eg.initialSnapshot());
+
+      await tester.pumpWidget(GlobalStoreWidget(child: MaterialApp(
+        home: PerAccountStoreWidget(accountId: eg.selfAccount.id,
+          child: BlockContentList(
+            nodes: parseContent(html).nodes)))));
+      await tester.pump();
+      await tester.pump();
+    }
+
+    testWidgets('can tap a link to open URL', (tester) async {
+      await prepareContent(tester,
+        '<p><a href="https://example/">hello</a></p>');
+
+      await tester.tap(find.text('hello'));
+      const expectedMode = LaunchMode.platformDefault;
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://example/'), mode: expectedMode));
+    }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
+
+    testWidgets('multiple links in paragraph', (tester) async {
+      await prepareContent(tester,
+        '<p><a href="https://a/">foo</a> bar <a href="https://b/">baz</a></p>');
+      final base = tester.getTopLeft(find.text('foo bar baz'))
+        .translate(fontSize/2, fontSize/2); // middle of first letter
+
+      await tester.tapAt(base.translate(5*fontSize, 0)); // "foo bXr baz"
+      check(TestZulipBinding.instance.takeLaunchUrlCalls()).isEmpty();
+
+      await tester.tapAt(base.translate(1*fontSize, 0)); // "fXo bar baz"
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://a/'), mode: expectedModeAndroid));
+
+      await tester.tapAt(base.translate(9*fontSize, 0)); // "foo bar bXz"
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://b/'), mode: expectedModeAndroid));
+    });
+
+    testWidgets('link nested in other spans', (tester) async {
+      await prepareContent(tester,
+        '<p><strong><em><a href="https://a/">word</a></em></strong></p>');
+      await tester.tap(find.text('word'));
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://a/'), mode: expectedModeAndroid));
+    });
+
+    testWidgets('link containing other spans', (tester) async {
+      await prepareContent(tester,
+        '<p><a href="https://a/">two <strong><em><code>words</code></em></strong></a></p>');
+      final base = tester.getTopLeft(find.text('two words'))
+        .translate(fontSize/2, fontSize/2); // middle of first letter
+
+      await tester.tapAt(base.translate(1*fontSize, 0)); // "tXo words"
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://a/'), mode: expectedModeAndroid));
+
+      await tester.tapAt(base.translate(6*fontSize, 0)); // "two woXds"
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://a/'), mode: expectedModeAndroid));
+    });
+
+    testWidgets('relative links are resolved', (tester) async {
+      await prepareContent(tester,
+        '<p><a href="/a/b?c#d">word</a></p>');
+      await tester.tap(find.text('word'));
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('${eg.realmUrl}a/b?c#d'), mode: expectedModeAndroid));
+    });
+
+    testWidgets('link inside HeadingNode', (tester) async {
+      await prepareContent(tester,
+        '<h6><a href="https://a/">word</a></h6>');
+      await tester.tap(find.text('word'));
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('https://a/'), mode: expectedModeAndroid));
+    });
+
+    testWidgets('error dialog if invalid link', (tester) async {
+      await prepareContent(tester,
+        '<p><a href="file:///etc/bad">word</a></p>');
+      TestZulipBinding.instance.launchUrlResult = false;
+      await tester.tap(find.text('word'));
+      await tester.pump();
+      check(TestZulipBinding.instance.takeLaunchUrlCalls())
+        .single.equals((url: Uri.parse('file:///etc/bad'), mode: expectedModeAndroid));
+      checkErrorDialog(tester, expectedTitle: 'Unable to open link');
+    });
+  });
 
   group('RealmContentNetworkImage', () {
     final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -12,14 +12,14 @@ import '../example_data.dart' as eg;
 import '../model/binding.dart';
 
 void main() {
-  TestDataBinding.ensureInitialized();
+  TestZulipBinding.ensureInitialized();
 
   group('RealmContentNetworkImage', () {
     final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);
 
     Future<String?> actualAuthHeader(WidgetTester tester, String src) async {
-      final globalStore = TestDataBinding.instance.globalStore;
-      addTearDown(TestDataBinding.instance.reset);
+      final globalStore = TestZulipBinding.instance.globalStore;
+      addTearDown(TestZulipBinding.instance.reset);
       await globalStore.add(eg.selfAccount, eg.initialSnapshot());
 
       final httpClient = _FakeHttpClient();

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -9,10 +9,10 @@ import '../example_data.dart' as eg;
 import '../model/store_checks.dart';
 
 void main() {
-  TestDataBinding.ensureInitialized();
+  TestZulipBinding.ensureInitialized();
 
   testWidgets('GlobalStoreWidget', (WidgetTester tester) async {
-    addTearDown(TestDataBinding.instance.reset);
+    addTearDown(TestZulipBinding.instance.reset);
 
     GlobalStore? globalStore;
     await tester.pumpWidget(
@@ -29,17 +29,17 @@ void main() {
     await tester.pump();
     // Then after loading, mounts child instead, with provided store.
     check(tester.any(find.byType(CircularProgressIndicator))).isFalse();
-    check(globalStore).identicalTo(TestDataBinding.instance.globalStore);
+    check(globalStore).identicalTo(TestZulipBinding.instance.globalStore);
 
-    await TestDataBinding.instance.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+    await TestZulipBinding.instance.globalStore.add(eg.selfAccount, eg.initialSnapshot());
     check(globalStore).isNotNull()
       .accountEntries.single
       .equals((accountId: eg.selfAccount.id, account: eg.selfAccount));
   });
 
   testWidgets('PerAccountStoreWidget basic', (tester) async {
-    final globalStore = TestDataBinding.instance.globalStore;
-    addTearDown(TestDataBinding.instance.reset);
+    final globalStore = TestZulipBinding.instance.globalStore;
+    addTearDown(TestZulipBinding.instance.reset);
     await globalStore.add(eg.selfAccount, eg.initialSnapshot());
 
     await tester.pumpWidget(
@@ -60,8 +60,8 @@ void main() {
   });
 
   testWidgets('PerAccountStoreWidget immediate data after first loaded', (tester) async {
-    final globalStore = TestDataBinding.instance.globalStore;
-    addTearDown(TestDataBinding.instance.reset);
+    final globalStore = TestZulipBinding.instance.globalStore;
+    addTearDown(TestZulipBinding.instance.reset);
     await globalStore.add(eg.selfAccount, eg.initialSnapshot());
 
     await tester.pumpWidget(


### PR DESCRIPTION
Fixes #71.
Stacked atop #203.

This is a draft. The branch needs some cleanup, but more fundamentally:
* I want to write some tests for this code, because the content parsing in particular gains some complexity of a kind it didn't need before. That turns out to be a bit of a yak shave.
* The way I handle making the links respond both to a tap (to follow the link) and a long-press (to copy the URL) feels like a bit of a hack. I may make some further attempts to clean it up, and should probably also find or start an upstream Flutter discussion of how to do this (i.e. how to have a `TextSpan` respond to two different gestures). I might end up separating the long-press into a separate PR from the main functionality of tapping to follow the link.

But from a user perspective, this version already works nicely. And between the two points above, plus just iterating on refactorings to get this code to be as clean as it is (at the end of the branch) in this version, it's been a bit over a week since I sat down and wrote up a version that works nicely from a user perspective. So I figured it'd be good to share this branch as a demo, and a preview of what the resulting code will look like.

I also have a draft branch that does much of the yak shave to be able to write tests for content parsing. I might send a PR first that lays that groundwork, and also adds tests for some of the existing content-parsing code, and then return to this after that.
