### PR TITLE
Test content parsing; use Diagnosticable; write docs for ContentNode etc.

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -20,6 +20,7 @@ import 'package:html/parser.dart';
 /// When modifying subclasses:
 ///  * Always check the following places to see if they need a matching update:
 ///    * [==] and [hashCode], if overridden.
+///    * `equalsNode` in test/model/content_checks.dart .
 @immutable
 sealed class ContentNode {
   const ContentNode({this.debugHtmlNode});

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -198,9 +198,13 @@ class UserMentionNode extends InlineContainerNode {
     // required this.isSilent,
   });
 
-  // We don't actually seem to need this information.
-  //  final UserMentionType mentionType;
-  //  final bool isSilent;
+  // We don't currently seem to need this information in code.  Instead,
+  // the inner text already shows how to communicate it to the user
+  // (e.g., silent mentions' text lacks a leading "@"),
+  // and we show that text in the same style for all types of @-mention.
+  // If we need this information in the future, go ahead and add it here.
+  //   final UserMentionType mentionType;
+  //   final bool isSilent;
 }
 
 abstract class EmojiNode extends InlineContentNode {

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -7,10 +7,8 @@ import 'package:html/parser.dart';
 // TODO: Implement toString for all these classes, for testing/debugging; or
 //   perhaps Diagnosticable instead?
 
-// This should have no subclasses except the ones defined in this file.
-// TODO mark as sealed: https://github.com/dart-lang/language/blob/a374667bc/accepted/future-releases/sealed-types/feature-specification.md
 @immutable
-abstract class ContentNode {
+sealed class ContentNode {
   const ContentNode({this.debugHtmlNode});
 
   final dom.Node? debugHtmlNode;

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -131,15 +131,6 @@ class ParagraphNode extends BlockInlineContainerNode {
   String toString() => '${objectRuntimeType(this, 'ParagraphNode')}(wasImplicit: $wasImplicit, $nodes)';
 }
 
-enum ListStyle { ordered, unordered }
-
-class ListNode extends BlockContentNode {
-  const ListNode(this.style, this.items, {super.debugHtmlNode});
-
-  final ListStyle style;
-  final List<List<BlockContentNode>> items;
-}
-
 enum HeadingLevel { h1, h2, h3, h4, h5, h6 }
 
 class HeadingNode extends BlockInlineContainerNode {
@@ -150,6 +141,15 @@ class HeadingNode extends BlockInlineContainerNode {
   });
 
   final HeadingLevel level;
+}
+
+enum ListStyle { ordered, unordered }
+
+class ListNode extends BlockContentNode {
+  const ListNode(this.style, this.items, {super.debugHtmlNode});
+
+  final ListStyle style;
+  final List<List<BlockContentNode>> items;
 }
 
 class QuotationNode extends BlockContentNode {
@@ -540,10 +540,6 @@ BlockContentNode parseBlockContent(dom.Node node) {
     return ParagraphNode(nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
   }
 
-  if ((localName == 'ol' || localName == 'ul') && classes.isEmpty) {
-    return parseListNode(element);
-  }
-
   HeadingLevel? headingLevel;
   switch (localName) {
     case 'h1': headingLevel = HeadingLevel.h1; break;
@@ -557,6 +553,10 @@ BlockContentNode parseBlockContent(dom.Node node) {
     // TODO(#192) handle h1, h2, h3, h4, h5
     return HeadingNode(
       level: headingLevel!, nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
+  }
+
+  if ((localName == 'ol' || localName == 'ul') && classes.isEmpty) {
+    return parseListNode(element);
   }
 
   if (localName == 'blockquote' && classes.isEmpty) {

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -79,8 +79,6 @@ class BlockContentNodeWidget extends StatelessWidget {
       return const Text('');
     } else if (node is ParagraphNode) {
       return Paragraph(node: node);
-    } else if (node is ListNode) {
-      return ListNodeWidget(node: node);
     } else if (node is HeadingNode) {
       // TODO(#192) h1, h2, h3, h4, h5 -- same as h6 except font size
       assert(node.level == HeadingLevel.h6);
@@ -89,6 +87,8 @@ class BlockContentNodeWidget extends StatelessWidget {
         child: Text.rich(TextSpan(
           style: const TextStyle(fontWeight: FontWeight.w600, height: 1.4),
           children: _buildInlineList(node.nodes))));
+    } else if (node is ListNode) {
+      return ListNodeWidget(node: node);
     } else if (node is QuotationNode) {
       return Padding(
         padding: const EdgeInsets.only(left: 10),

--- a/test/model/content_checks.dart
+++ b/test/model/content_checks.dart
@@ -5,28 +5,68 @@ extension ContentNodeChecks on Subject<ContentNode> {
   void equalsNode(ContentNode expected) {
     if (expected is ZulipContent) {
       isA<ZulipContent>()
-        .nodes.deepEquals(expected.nodes.map(
-          (e) => it()..isA<BlockContentNode>().equalsNode(e)));
-        // A shame we need the dynamic `isA` there.  This
-        // version hits a runtime type error:
-        //   .nodes.deepEquals(expected.nodes.map(
-        //     (e) => it<BlockContentNode>()..equalsNode(e)));
-        // and with `it()` with no type argument, it doesn't type-check.
-        // TODO: report that as API feedback on deepEquals
+        .nodes.equalsNodes(expected.nodes);
+    } else if (expected is UnimplementedBlockContentNode) {
+      isA<UnimplementedBlockContentNode>()
+        .debugHtmlText.equals(expected.debugHtmlText);
     } else if (expected is ParagraphNode) {
       isA<ParagraphNode>()
         ..wasImplicit.equals(expected.wasImplicit)
-        ..nodes.deepEquals(expected.nodes.map(
-          (e) => it()..isA<InlineContentNode>().equalsNode(e)));
+        ..nodes.equalsNodes(expected.nodes);
+    } else if (expected is ListNode) {
+      isA<ListNode>()
+        ..style.equals(expected.style)
+        ..items.deepEquals(expected.items.map(
+          (item) => it()..isA<List<BlockContentNode>>().equalsNodes(item)));
+    } else if (expected is HeadingNode) {
+      isA<HeadingNode>()
+        ..level.equals(expected.level)
+        ..nodes.equalsNodes(expected.nodes);
+    } else if (expected is QuotationNode) {
+      isA<QuotationNode>()
+        .nodes.equalsNodes(expected.nodes);
+    } else if (expected is UnimplementedInlineContentNode) {
+      isA<UnimplementedInlineContentNode>()
+        .debugHtmlText.equals(expected.debugHtmlText);
+    } else if (expected is StrongNode) {
+      isA<StrongNode>()
+        .nodes.equalsNodes(expected.nodes);
+    } else if (expected is EmphasisNode) {
+      isA<EmphasisNode>()
+        .nodes.equalsNodes(expected.nodes);
+    } else if (expected is InlineCodeNode) {
+      isA<InlineCodeNode>()
+        .nodes.equalsNodes(expected.nodes);
+    } else if (expected is LinkNode) {
+      isA<LinkNode>()
+        .nodes.equalsNodes(expected.nodes);
+    } else if (expected is UserMentionNode) {
+      isA<UserMentionNode>()
+        .nodes.equalsNodes(expected.nodes);
     } else {
-      // TODO handle remaining ContentNode subclasses that lack structural ==
+      // The remaining node types have structural `==`.  Use that.
       equals(expected);
     }
   }
+
+  Subject<String> get debugHtmlText => has((n) => n.debugHtmlText, 'debugHtmlText');
 }
 
 extension ZulipContentChecks on Subject<ZulipContent> {
   Subject<List<BlockContentNode>> get nodes => has((n) => n.nodes, 'nodes');
+}
+
+extension BlockContentNodeListChecks on Subject<List<BlockContentNode>> {
+  void equalsNodes(List<BlockContentNode> expected) {
+    deepEquals(expected.map(
+      (e) => it()..isA<BlockContentNode>().equalsNode(e)));
+    // A shame we need the dynamic `isA` there.  This
+    // version hits a runtime type error:
+    //   .nodes.deepEquals(expected.nodes.map(
+    //     (e) => it<BlockContentNode>()..equalsNode(e)));
+    // and with `it()` with no type argument, it doesn't type-check.
+    // TODO(checks): report that as API feedback on deepEquals
+  }
 }
 
 extension ParagraphNodeChecks on Subject<ParagraphNode> {
@@ -34,8 +74,27 @@ extension ParagraphNodeChecks on Subject<ParagraphNode> {
   Subject<List<InlineContentNode>> get nodes => has((n) => n.nodes, 'nodes');
 }
 
-extension TextNodeChecks on Subject<TextNode> {
-  Subject<String> get text => has((n) => n.text, 'text');
+extension ListNodeChecks on Subject<ListNode> {
+  Subject<ListStyle> get style => has((n) => n.style, 'style');
+  Subject<List<List<BlockContentNode>>> get items => has((n) => n.items, 'items');
 }
 
-// TODO write similar extensions for the rest of the content node classes
+extension HeadingNodeChecks on Subject<HeadingNode> {
+  Subject<HeadingLevel> get level => has((n) => n.level, 'level');
+  Subject<List<InlineContentNode>> get nodes => has((n) => n.nodes, 'nodes');
+}
+
+extension QuotationNodeChecks on Subject<QuotationNode> {
+  Subject<List<BlockContentNode>> get nodes => has((n) => n.nodes, 'nodes');
+}
+
+extension InlineContentNodeListChecks on Subject<List<InlineContentNode>> {
+  void equalsNodes(List<InlineContentNode> expected) {
+    deepEquals(expected.map(
+      (e) => it()..isA<InlineContentNode>().equalsNode(e)));
+  }
+}
+
+extension InlineContainerNodeChecks on Subject<InlineContainerNode> {
+  Subject<List<InlineContentNode>> get nodes => has((n) => n.nodes, 'nodes');
+}

--- a/test/model/content_checks.dart
+++ b/test/model/content_checks.dart
@@ -69,9 +69,12 @@ extension BlockContentNodeListChecks on Subject<List<BlockContentNode>> {
   }
 }
 
+extension BlockInlineContainerNodeChecks on Subject<BlockInlineContainerNode> {
+  Subject<List<InlineContentNode>> get nodes => has((n) => n.nodes, 'nodes');
+}
+
 extension ParagraphNodeChecks on Subject<ParagraphNode> {
   Subject<bool> get wasImplicit => has((n) => n.wasImplicit, 'wasImplicit');
-  Subject<List<InlineContentNode>> get nodes => has((n) => n.nodes, 'nodes');
 }
 
 extension ListNodeChecks on Subject<ListNode> {
@@ -81,7 +84,6 @@ extension ListNodeChecks on Subject<ListNode> {
 
 extension HeadingNodeChecks on Subject<HeadingNode> {
   Subject<HeadingLevel> get level => has((n) => n.level, 'level');
-  Subject<List<InlineContentNode>> get nodes => has((n) => n.nodes, 'nodes');
 }
 
 extension QuotationNodeChecks on Subject<QuotationNode> {

--- a/test/model/content_checks.dart
+++ b/test/model/content_checks.dart
@@ -13,15 +13,15 @@ extension ContentNodeChecks on Subject<ContentNode> {
       isA<ParagraphNode>()
         ..wasImplicit.equals(expected.wasImplicit)
         ..nodes.equalsNodes(expected.nodes);
+    } else if (expected is HeadingNode) {
+      isA<HeadingNode>()
+        ..level.equals(expected.level)
+        ..nodes.equalsNodes(expected.nodes);
     } else if (expected is ListNode) {
       isA<ListNode>()
         ..style.equals(expected.style)
         ..items.deepEquals(expected.items.map(
           (item) => it()..isA<List<BlockContentNode>>().equalsNodes(item)));
-    } else if (expected is HeadingNode) {
-      isA<HeadingNode>()
-        ..level.equals(expected.level)
-        ..nodes.equalsNodes(expected.nodes);
     } else if (expected is QuotationNode) {
       isA<QuotationNode>()
         .nodes.equalsNodes(expected.nodes);
@@ -77,13 +77,13 @@ extension ParagraphNodeChecks on Subject<ParagraphNode> {
   Subject<bool> get wasImplicit => has((n) => n.wasImplicit, 'wasImplicit');
 }
 
+extension HeadingNodeChecks on Subject<HeadingNode> {
+  Subject<HeadingLevel> get level => has((n) => n.level, 'level');
+}
+
 extension ListNodeChecks on Subject<ListNode> {
   Subject<ListStyle> get style => has((n) => n.style, 'style');
   Subject<List<List<BlockContentNode>>> get items => has((n) => n.items, 'items');
-}
-
-extension HeadingNodeChecks on Subject<HeadingNode> {
-  Subject<HeadingLevel> get level => has((n) => n.level, 'level');
 }
 
 extension QuotationNodeChecks on Subject<QuotationNode> {

--- a/test/model/content_checks.dart
+++ b/test/model/content_checks.dart
@@ -3,6 +3,12 @@ import 'package:zulip/model/content.dart';
 
 extension ContentNodeChecks on Subject<ContentNode> {
   void equalsNode(ContentNode expected) {
+    // TODO: Make equalsNode output clearer on failure, applying Diagnosticable.
+    //   In particular (a) show the top-level expected node in one piece
+    //   (as well as the actual); (a') ideally, suppress on the "expected" side
+    //   the various predicates below, which should be redundant with just
+    //   the expected node; (b) show expected for the specific `equals` leaf.
+    //   See also comment on [ContentNode.toString].
     if (expected is ZulipContent) {
       isA<ZulipContent>()
         .nodes.equalsNodes(expected.nodes);

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -194,5 +194,48 @@ void main() {
       ]);
   });
 
+  group('parse lists', () {
+    testParse('<ol>',
+      // "1. first\n2. then"
+      '<ol>\n<li>first</li>\n<li>then</li>\n</ol>', const [
+        ListNode(ListStyle.ordered, [
+          [ParagraphNode(wasImplicit: true, nodes: [TextNode('first')])],
+          [ParagraphNode(wasImplicit: true, nodes: [TextNode('then')])],
+        ]),
+      ]);
+
+    testParse('<ul>',
+      // "* something\n* another"
+      '<ul>\n<li>something</li>\n<li>another</li>\n</ul>', const [
+        ListNode(ListStyle.unordered, [
+          [ParagraphNode(wasImplicit: true, nodes: [TextNode('something')])],
+          [ParagraphNode(wasImplicit: true, nodes: [TextNode('another')])],
+        ]),
+      ]);
+
+    testParse('implicit paragraph with internal <br>',
+      // "* a\n  b"
+      '<ul>\n<li>a<br>\n  b</li>\n</ul>', const [
+        ListNode(ListStyle.unordered, [
+          [ParagraphNode(wasImplicit: true, nodes: [
+            TextNode('a'),
+            LineBreakInlineNode(),
+            TextNode('\n  b'), // TODO: this renders misaligned
+          ])],
+        ])
+      ]);
+
+    testParse('explicit paragraphs',
+      // "* a\n\n  b"
+      '<ul>\n<li>\n<p>a</p>\n<p>b</p>\n</li>\n</ul>', const [
+        ListNode(ListStyle.unordered, [
+          [
+            ParagraphNode(nodes: [TextNode('a')]),
+            ParagraphNode(nodes: [TextNode('b')]),
+          ],
+        ]),
+      ]);
+  });
+
   // TODO write more tests for this code
 }

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -12,13 +12,39 @@ void testParse(String name, String html, List<BlockContentNode> nodes) {
 }
 
 void main() {
+  // When writing test cases in this file:
+  //
+  //  * Try to use actual HTML emitted by a Zulip server.
+  //    Record the corresponding Markdown source in a comment.
+  //
+  //  * Here's a handy `curl` command for getting the server's HTML.
+  //    First, as one-time setup, create a file with a test account's
+  //    Zulip credentials in "netrc" format, meaning one line that looks like:
+  //       machine HOSTNAME login EMAIL password API_KEY
+  //
+  //  * Then send some test messages, and fetch with a command like this.
+  //    (Change "sender" operand to your user ID, and "topic" etc. as desired.)
+  /*    $ curl -sS --netrc-file ../.netrc -G https://chat.zulip.org/api/v1/messages \
+            --data-urlencode 'narrow=[{"operator":"sender", "operand":2187},
+                                      {"operator":"stream", "operand":"test here"},
+                                      {"operator":"topic",  "operand":"content"}]' \
+            --data-urlencode anchor=newest --data-urlencode num_before=10 --data-urlencode num_after=0 \
+            --data-urlencode apply_markdown=true \
+          | jq '.messages[] | .content'
+   */
+  //
+  //  * To get the corresponding Markdown source, use the same command
+  //    with `apply_markdown` changed to `false`.
+
   testParse('parse a plain-text paragraph',
+    // "hello world"
     '<p>hello world</p>', const [
       ParagraphNode(nodes: [TextNode('hello world')]),
     ]);
 
   testParse('parse two plain-text paragraphs',
-    '<p>hello</p><p>world</p>', const [
+    // "hello\n\nworld"
+    '<p>hello</p>\n<p>world</p>', const [
       ParagraphNode(nodes: [TextNode('hello')]),
       ParagraphNode(nodes: [TextNode('world')]),
     ]);

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -4,21 +4,24 @@ import 'package:zulip/model/content.dart';
 
 import 'content_checks.dart';
 
-void main() {
-  test('parse a plain-text paragraph', () {
-    check(parseContent('<p>hello world</p>'))
-      .equalsNode(const ZulipContent(nodes: [
-        ParagraphNode(nodes: [TextNode('hello world')]),
-      ]));
+void testParse(String name, String html, List<BlockContentNode> nodes) {
+  test(name, () {
+    check(parseContent(html))
+      .equalsNode(ZulipContent(nodes: nodes));
   });
+}
 
-  test('parse two plain-text paragraphs', () {
-    check(parseContent('<p>hello</p><p>world</p>'))
-      .equalsNode(const ZulipContent(nodes: [
-        ParagraphNode(nodes: [TextNode('hello')]),
-        ParagraphNode(nodes: [TextNode('world')]),
-      ]));
-  });
+void main() {
+  testParse('parse a plain-text paragraph',
+    '<p>hello world</p>', const [
+      ParagraphNode(nodes: [TextNode('hello world')]),
+    ]);
+
+  testParse('parse two plain-text paragraphs',
+    '<p>hello</p><p>world</p>', const [
+      ParagraphNode(nodes: [TextNode('hello')]),
+      ParagraphNode(nodes: [TextNode('world')]),
+    ]);
 
   // TODO write more tests for this code
 }

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -36,11 +36,109 @@ void main() {
   //  * To get the corresponding Markdown source, use the same command
   //    with `apply_markdown` changed to `false`.
 
+  //
+  // Inline content.
+  //
+
+  void testParseInline(String name, String html, InlineContentNode node) {
+    testParse(name, html, [ParagraphNode(nodes: [node])]);
+  }
+
   testParse('parse a plain-text paragraph',
     // "hello world"
-    '<p>hello world</p>', const [
-      ParagraphNode(nodes: [TextNode('hello world')]),
-    ]);
+    '<p>hello world</p>', const [ParagraphNode(nodes: [
+      TextNode('hello world'),
+    ])]);
+
+  testParse('parse <br> inside a paragraph',
+    // "a\nb"
+    '<p>a<br>\nb</p>', const [ParagraphNode(nodes: [
+      TextNode('a'),
+      LineBreakInlineNode(),
+      TextNode('\nb'),
+    ])]);
+
+  testParseInline('parse strong/bold',
+    // "**bold**"
+    '<p><strong>bold</strong></p>',
+    const StrongNode(nodes: [TextNode('bold')]));
+
+  testParseInline('parse emphasis/italic',
+    // "*italic*"
+    '<p><em>italic</em></p>',
+    const EmphasisNode(nodes: [TextNode('italic')]));
+
+  testParseInline('parse inline code',
+    // "`inline code`"
+    '<p><code>inline code</code></p>',
+    const InlineCodeNode(nodes: [TextNode('inline code')]));
+
+  testParseInline('parse nested strong, em, code',
+    // "***`word`***"
+    '<p><strong><em><code>word</code></em></strong></p>',
+    const StrongNode(nodes: [EmphasisNode(nodes: [InlineCodeNode(nodes: [
+      TextNode('word')])])]));
+
+  testParseInline('parse link',
+    // "[text](https://example/)"
+    '<p><a href="https://example/">text</a></p>',
+    const LinkNode(nodes: [TextNode('text')]));
+
+  testParseInline('parse #-mention of stream',
+    // "#**general**"
+    '<p><a class="stream" data-stream-id="2" href="/#narrow/stream/2-general">'
+        '#general</a></p>',
+    const LinkNode(nodes: [TextNode('#general')]));
+
+  testParseInline('parse #-mention of topic',
+    // "#**mobile-team>zulip-flutter**"
+    '<p><a class="stream-topic" data-stream-id="243" '
+        'href="/#narrow/stream/243-mobile-team/topic/zulip-flutter">'
+        '#mobile-team &gt; zulip-flutter</a></p>',
+    const LinkNode(nodes: [TextNode('#mobile-team > zulip-flutter')]));
+
+  testParseInline('parse nested link, strong, em, code',
+    // "[***`word`***](https://example/)"
+    '<p><a href="https://example/"><strong><em><code>word'
+        '</code></em></strong></a></p>',
+    const LinkNode(nodes: [StrongNode(nodes: [
+      EmphasisNode(nodes: [InlineCodeNode(nodes: [
+        TextNode('word')])])])]));
+
+  group('parse @-mentions', () {
+    testParseInline('plain user @-mention',
+      // "@**Greg Price**"
+      '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>',
+      const UserMentionNode(nodes: [TextNode('@Greg Price')]));
+
+    testParseInline('silent user @-mention',
+      // "@_**Greg Price**"
+      '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>',
+      const UserMentionNode(nodes: [TextNode('Greg Price')]));
+
+    // TODO test group mentions and wildcard mentions
+  });
+
+  testParseInline('parse Unicode emoji',
+    // ":thumbs_up:"
+    '<p><span aria-label="thumbs up" class="emoji emoji-1f44d" role="img" title="thumbs up">:thumbs_up:</span></p>',
+    const UnicodeEmojiNode(text: ':thumbs_up:'));
+
+  testParseInline('parse custom emoji',
+    // ":flutter:"
+    '<p><img alt=":flutter:" class="emoji" src="/user_avatars/2/emoji/images/204.png" title="flutter"></p>',
+    const ImageEmojiNode(
+      src: '/user_avatars/2/emoji/images/204.png', alt: ':flutter:'));
+
+  testParseInline('parse Zulip extra emoji',
+    // ":zulip:"
+    '<p><img alt=":zulip:" class="emoji" src="/static/generated/emoji/images/emoji/unicode/zulip.png" title="zulip"></p>',
+    const ImageEmojiNode(
+      src: '/static/generated/emoji/images/emoji/unicode/zulip.png', alt: ':zulip:'));
+
+  //
+  // Block content.
+  //
 
   testParse('parse two plain-text paragraphs',
     // "hello\n\nworld"


### PR DESCRIPTION
This lays all the foundations we need in order to write tests for our content-parsing code, and then does so for all the existing code.

We'll want such tests for #71, which will add a new form of complication to that code. We'll also want it as we implement more features in the content parsing in general.

To get helpful debugging output when tests fail, we use the Diagnosticable class from Flutter to produce readable printouts of the content nodes:
https://api.flutter.dev/flutter/foundation/Diagnosticable-mixin.html
https://api.flutter.dev/flutter/foundation/Diagnosticable/debugFillProperties.html
