### PR TITLE
Record links when parsing content

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -375,8 +375,16 @@ class InlineCodeNode extends InlineContainerNode {
 }
 
 class LinkNode extends InlineContainerNode {
-  const LinkNode({super.debugHtmlNode, required super.nodes});
-  // TODO: final String hrefUrl;
+  const LinkNode({super.debugHtmlNode, required super.nodes, required this.url});
+
+  // TODO(#71): Use [LinkNode.url] to open links
+  final String url; // Left as a string, to defer parsing until link actually followed.
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('url', url));
+  }
 }
 
 enum UserMentionType { user, userGroup }
@@ -484,8 +492,9 @@ InlineContentNode parseInlineContent(dom.Node node) {
           || (classes.length == 1
               && (classes.contains('stream-topic')
                   || classes.contains('stream'))))) {
-    // TODO parse link's href
-    return LinkNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
+    final href = element.attributes['href'];
+    if (href == null) return unimplemented();
+    return LinkNode(nodes: nodes(), url: href, debugHtmlNode: debugHtmlNode);
   }
 
   if (localName == 'span'

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -646,14 +646,14 @@ class _ZulipContentParser {
     final localName = element.localName;
     final classes = element.classes;
     List<BlockContentNode> blockNodes() => parseBlockContentList(element.nodes);
-    List<InlineContentNode> inlineNodes() => parseInlineContentList(element.nodes);
 
     if (localName == 'br' && classes.isEmpty) {
       return LineBreakNode(debugHtmlNode: debugHtmlNode);
     }
 
     if (localName == 'p' && classes.isEmpty) {
-      return ParagraphNode(nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
+      return ParagraphNode(debugHtmlNode: debugHtmlNode,
+        nodes: parseInlineContentList(element.nodes));
     }
 
     HeadingLevel? headingLevel;
@@ -667,8 +667,9 @@ class _ZulipContentParser {
     }
     if (headingLevel == HeadingLevel.h6 && classes.isEmpty) {
       // TODO(#192) handle h1, h2, h3, h4, h5
-      return HeadingNode(
-        level: headingLevel!, nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
+      return HeadingNode(debugHtmlNode: debugHtmlNode,
+        level: headingLevel!,
+        nodes: parseInlineContentList(element.nodes));
     }
 
     if ((localName == 'ol' || localName == 'ul') && classes.isEmpty) {

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -471,9 +471,7 @@ class _ZulipContentParser {
     final element = node;
     final localName = element.localName;
     final classes = element.classes;
-    List<InlineContentNode> nodes() {
-      return element.nodes.map(parseInlineContent).toList(growable: false);
-    }
+    List<InlineContentNode> nodes() => parseInlineContentList(element.nodes);
 
     if (localName == 'br' && classes.isEmpty) {
       return LineBreakInlineNode(debugHtmlNode: debugHtmlNode);
@@ -525,6 +523,10 @@ class _ZulipContentParser {
 
     // TODO more types of node
     return unimplemented();
+  }
+
+  List<InlineContentNode> parseInlineContentList(List<dom.Node> nodes) {
+    return nodes.map(parseInlineContent).toList(growable: false);
   }
 
   BlockContentNode parseListNode(dom.Element element) {
@@ -644,9 +646,7 @@ class _ZulipContentParser {
     final localName = element.localName;
     final classes = element.classes;
     List<BlockContentNode> blockNodes() => parseBlockContentList(element.nodes);
-    List<InlineContentNode> inlineNodes() {
-      return element.nodes.map(parseInlineContent).toList(growable: false);
-    }
+    List<InlineContentNode> inlineNodes() => parseInlineContentList(element.nodes);
 
     if (localName == 'br' && classes.isEmpty) {
       return LineBreakNode(debugHtmlNode: debugHtmlNode);
@@ -724,7 +724,7 @@ class _ZulipContentParser {
     void consumeParagraph() {
       result.add(ParagraphNode(
         wasImplicit: true,
-        nodes: currentParagraph.map(parseInlineContent).toList(growable: false)));
+        nodes: parseInlineContentList(currentParagraph)));
       currentParagraph.clear();
     }
 

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -454,306 +454,312 @@ class ImageEmojiNode extends EmojiNode {
 
 ////////////////////////////////////////////////////////////////
 
-final _emojiClassRegexp = RegExp(r"^emoji(-[0-9a-f]+)?$");
+class _ZulipContentParser {
+  static final _emojiClassRegexp = RegExp(r"^emoji(-[0-9a-f]+)?$");
 
-InlineContentNode parseInlineContent(dom.Node node) {
-  final debugHtmlNode = kDebugMode ? node : null;
-  InlineContentNode unimplemented() => UnimplementedInlineContentNode(htmlNode: node);
+  InlineContentNode parseInlineContent(dom.Node node) {
+    final debugHtmlNode = kDebugMode ? node : null;
+    InlineContentNode unimplemented() => UnimplementedInlineContentNode(htmlNode: node);
 
-  if (node is dom.Text) {
-    return TextNode(node.text, debugHtmlNode: debugHtmlNode);
-  }
-  if (node is! dom.Element) {
+    if (node is dom.Text) {
+      return TextNode(node.text, debugHtmlNode: debugHtmlNode);
+    }
+    if (node is! dom.Element) {
+      return unimplemented();
+    }
+
+    final element = node;
+    final localName = element.localName;
+    final classes = element.classes;
+    List<InlineContentNode> nodes() {
+      return element.nodes.map(parseInlineContent).toList(growable: false);
+    }
+
+    if (localName == 'br' && classes.isEmpty) {
+      return LineBreakInlineNode(debugHtmlNode: debugHtmlNode);
+    }
+    if (localName == 'strong' && classes.isEmpty) {
+      return StrongNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
+    }
+    if (localName == 'em' && classes.isEmpty) {
+      return EmphasisNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
+    }
+    if (localName == 'code' && classes.isEmpty) {
+      return InlineCodeNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'a'
+        && (classes.isEmpty
+            || (classes.length == 1
+                && (classes.contains('stream-topic')
+                    || classes.contains('stream'))))) {
+      final href = element.attributes['href'];
+      if (href == null) return unimplemented();
+      return LinkNode(nodes: nodes(), url: href, debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'span'
+        && (classes.contains('user-mention')
+            || classes.contains('user-group-mention'))
+        && (classes.length == 1
+            || (classes.length == 2 && classes.contains('silent')))) {
+      return UserMentionNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'span'
+        && classes.length == 2
+        && classes.contains('emoji')
+        && classes.every(_emojiClassRegexp.hasMatch)) {
+      return UnicodeEmojiNode(text: element.text, debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'img'
+        && classes.contains('emoji')
+        && classes.length == 1) {
+      final alt = element.attributes['alt'];
+      if (alt == null) return unimplemented();
+      final src = element.attributes['src'];
+      if (src == null) return unimplemented();
+      return ImageEmojiNode(src: src, alt: alt, debugHtmlNode: debugHtmlNode);
+    }
+
+    // TODO more types of node
     return unimplemented();
   }
 
-  final element = node;
-  final localName = element.localName;
-  final classes = element.classes;
-  List<InlineContentNode> nodes() {
-    return element.nodes.map(parseInlineContent).toList(growable: false);
-  }
-
-  if (localName == 'br' && classes.isEmpty) {
-    return LineBreakInlineNode(debugHtmlNode: debugHtmlNode);
-  }
-  if (localName == 'strong' && classes.isEmpty) {
-    return StrongNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
-  }
-  if (localName == 'em' && classes.isEmpty) {
-    return EmphasisNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
-  }
-  if (localName == 'code' && classes.isEmpty) {
-    return InlineCodeNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
-  }
-
-  if (localName == 'a'
-      && (classes.isEmpty
-          || (classes.length == 1
-              && (classes.contains('stream-topic')
-                  || classes.contains('stream'))))) {
-    final href = element.attributes['href'];
-    if (href == null) return unimplemented();
-    return LinkNode(nodes: nodes(), url: href, debugHtmlNode: debugHtmlNode);
-  }
-
-  if (localName == 'span'
-      && (classes.contains('user-mention')
-          || classes.contains('user-group-mention'))
-      && (classes.length == 1
-          || (classes.length == 2 && classes.contains('silent')))) {
-    return UserMentionNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
-  }
-
-  if (localName == 'span'
-      && classes.length == 2
-      && classes.contains('emoji')
-      && classes.every(_emojiClassRegexp.hasMatch)) {
-    return UnicodeEmojiNode(text: element.text, debugHtmlNode: debugHtmlNode);
-  }
-
-  if (localName == 'img'
-      && classes.contains('emoji')
-      && classes.length == 1) {
-    final alt = element.attributes['alt'];
-    if (alt == null) return unimplemented();
-    final src = element.attributes['src'];
-    if (src == null) return unimplemented();
-    return ImageEmojiNode(src: src, alt: alt, debugHtmlNode: debugHtmlNode);
-  }
-
-  // TODO more types of node
-  return unimplemented();
-}
-
-BlockContentNode parseListNode(dom.Element element) {
-  ListStyle? listStyle;
-  switch (element.localName) {
-    case 'ol': listStyle = ListStyle.ordered; break;
-    case 'ul': listStyle = ListStyle.unordered; break;
-  }
-  assert(listStyle != null);
-  assert(element.classes.isEmpty);
-
-  final debugHtmlNode = kDebugMode ? element : null;
-  final List<List<BlockContentNode>> items = [];
-  for (final item in element.nodes) {
-    if (item is dom.Text && item.text == '\n') continue;
-    if (item is! dom.Element || item.localName != 'li' || item.classes.isNotEmpty) {
-      items.add([UnimplementedBlockContentNode(htmlNode: item)]);
+  BlockContentNode parseListNode(dom.Element element) {
+    ListStyle? listStyle;
+    switch (element.localName) {
+      case 'ol': listStyle = ListStyle.ordered; break;
+      case 'ul': listStyle = ListStyle.unordered; break;
     }
-    items.add(parseImplicitParagraphBlockContentList(item.nodes));
-  }
+    assert(listStyle != null);
+    assert(element.classes.isEmpty);
 
-  return ListNode(listStyle!, items, debugHtmlNode: debugHtmlNode);
-}
-
-BlockContentNode parseCodeBlock(dom.Element divElement) {
-  final mainElement = () {
-    assert(divElement.localName == 'div'
-        && divElement.classes.length == 1
-        && divElement.classes.contains("codehilite"));
-
-    if (divElement.nodes.length != 1) return null;
-    final child = divElement.nodes[0];
-    if (child is! dom.Element) return null;
-    if (child.localName != 'pre') return null;
-
-    if (child.nodes.length > 2) return null;
-    if (child.nodes.length == 2) {
-      final first = child.nodes[0];
-      if (first is! dom.Element
-          || first.localName != 'span'
-          || first.nodes.isNotEmpty) return null;
-    }
-    final grandchild = child.nodes[child.nodes.length - 1];
-    if (grandchild is! dom.Element) return null;
-    if (grandchild.localName != 'code') return null;
-
-    return grandchild;
-  }();
-
-  final debugHtmlNode = kDebugMode ? divElement : null;
-  if (mainElement == null) {
-    return UnimplementedBlockContentNode(htmlNode: divElement);
-  }
-
-  final buffer = StringBuffer();
-  for (int i = 0; i < mainElement.nodes.length; i++) {
-    final child = mainElement.nodes[i];
-    if (child is dom.Text) {
-      String text = child.text;
-      if (i == mainElement.nodes.length - 1) {
-        // The HTML tends to have a final newline here.  If included in the
-        // [Text] widget, that would make a trailing blank line.  So cut it out.
-        text = text.replaceFirst(RegExp(r'\n$'), '');
+    final debugHtmlNode = kDebugMode ? element : null;
+    final List<List<BlockContentNode>> items = [];
+    for (final item in element.nodes) {
+      if (item is dom.Text && item.text == '\n') continue;
+      if (item is! dom.Element || item.localName != 'li' || item.classes.isNotEmpty) {
+        items.add([UnimplementedBlockContentNode(htmlNode: item)]);
       }
-      buffer.write(text);
-    } else if (child is dom.Element && child.localName == 'span') {
-      // TODO(#191) parse the code-highlighting spans, to style them
-      buffer.write(child.text);
-    } else {
+      items.add(parseImplicitParagraphBlockContentList(item.nodes));
+    }
+
+    return ListNode(listStyle!, items, debugHtmlNode: debugHtmlNode);
+  }
+
+  BlockContentNode parseCodeBlock(dom.Element divElement) {
+    final mainElement = () {
+      assert(divElement.localName == 'div'
+          && divElement.classes.length == 1
+          && divElement.classes.contains("codehilite"));
+
+      if (divElement.nodes.length != 1) return null;
+      final child = divElement.nodes[0];
+      if (child is! dom.Element) return null;
+      if (child.localName != 'pre') return null;
+
+      if (child.nodes.length > 2) return null;
+      if (child.nodes.length == 2) {
+        final first = child.nodes[0];
+        if (first is! dom.Element
+            || first.localName != 'span'
+            || first.nodes.isNotEmpty) return null;
+      }
+      final grandchild = child.nodes[child.nodes.length - 1];
+      if (grandchild is! dom.Element) return null;
+      if (grandchild.localName != 'code') return null;
+
+      return grandchild;
+    }();
+
+    final debugHtmlNode = kDebugMode ? divElement : null;
+    if (mainElement == null) {
       return UnimplementedBlockContentNode(htmlNode: divElement);
     }
-  }
-  final text = buffer.toString();
 
-  return CodeBlockNode(text: text, debugHtmlNode: debugHtmlNode);
-}
+    final buffer = StringBuffer();
+    for (int i = 0; i < mainElement.nodes.length; i++) {
+      final child = mainElement.nodes[i];
+      if (child is dom.Text) {
+        String text = child.text;
+        if (i == mainElement.nodes.length - 1) {
+          // The HTML tends to have a final newline here.  If included in the
+          // [Text] widget, that would make a trailing blank line.  So cut it out.
+          text = text.replaceFirst(RegExp(r'\n$'), '');
+        }
+        buffer.write(text);
+      } else if (child is dom.Element && child.localName == 'span') {
+        // TODO(#191) parse the code-highlighting spans, to style them
+        buffer.write(child.text);
+      } else {
+        return UnimplementedBlockContentNode(htmlNode: divElement);
+      }
+    }
+    final text = buffer.toString();
 
-BlockContentNode parseImageNode(dom.Element divElement) {
-  final imgElement = () {
-    assert(divElement.localName == 'div'
-        && divElement.classes.length == 1
-        && divElement.classes.contains('message_inline_image'));
-
-    if (divElement.nodes.length != 1) return null;
-    final child = divElement.nodes[0];
-    if (child is! dom.Element) return null;
-    if (child.localName != 'a') return null;
-    if (child.classes.isNotEmpty) return null;
-
-    if (child.nodes.length != 1) return null;
-    final grandchild = child.nodes[0];
-    if (grandchild is! dom.Element) return null;
-    if (grandchild.localName != 'img') return null;
-    if (grandchild.classes.isNotEmpty) return null;
-    return grandchild;
-  }();
-
-  final debugHtmlNode = kDebugMode ? divElement : null;
-  if (imgElement == null) {
-    return UnimplementedBlockContentNode(htmlNode: divElement);
+    return CodeBlockNode(text: text, debugHtmlNode: debugHtmlNode);
   }
 
-  final src = imgElement.attributes['src'];
-  if (src == null) {
-    return UnimplementedBlockContentNode(htmlNode: divElement);
+  BlockContentNode parseImageNode(dom.Element divElement) {
+    final imgElement = () {
+      assert(divElement.localName == 'div'
+          && divElement.classes.length == 1
+          && divElement.classes.contains('message_inline_image'));
+
+      if (divElement.nodes.length != 1) return null;
+      final child = divElement.nodes[0];
+      if (child is! dom.Element) return null;
+      if (child.localName != 'a') return null;
+      if (child.classes.isNotEmpty) return null;
+
+      if (child.nodes.length != 1) return null;
+      final grandchild = child.nodes[0];
+      if (grandchild is! dom.Element) return null;
+      if (grandchild.localName != 'img') return null;
+      if (grandchild.classes.isNotEmpty) return null;
+      return grandchild;
+    }();
+
+    final debugHtmlNode = kDebugMode ? divElement : null;
+    if (imgElement == null) {
+      return UnimplementedBlockContentNode(htmlNode: divElement);
+    }
+
+    final src = imgElement.attributes['src'];
+    if (src == null) {
+      return UnimplementedBlockContentNode(htmlNode: divElement);
+    }
+
+    return ImageNode(srcUrl: src, debugHtmlNode: debugHtmlNode);
   }
 
-  return ImageNode(srcUrl: src, debugHtmlNode: debugHtmlNode);
-}
+  BlockContentNode parseBlockContent(dom.Node node) {
+    final debugHtmlNode = kDebugMode ? node : null;
+    if (node is! dom.Element) {
+      return UnimplementedBlockContentNode(htmlNode: node);
+    }
+    final element = node;
+    final localName = element.localName;
+    final classes = element.classes;
+    List<BlockContentNode> blockNodes() => parseBlockContentList(element.nodes);
+    List<InlineContentNode> inlineNodes() {
+      return element.nodes.map(parseInlineContent).toList(growable: false);
+    }
 
-BlockContentNode parseBlockContent(dom.Node node) {
-  final debugHtmlNode = kDebugMode ? node : null;
-  if (node is! dom.Element) {
+    if (localName == 'br' && classes.isEmpty) {
+      return LineBreakNode(debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'p' && classes.isEmpty) {
+      return ParagraphNode(nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
+    }
+
+    HeadingLevel? headingLevel;
+    switch (localName) {
+      case 'h1': headingLevel = HeadingLevel.h1; break;
+      case 'h2': headingLevel = HeadingLevel.h2; break;
+      case 'h3': headingLevel = HeadingLevel.h3; break;
+      case 'h4': headingLevel = HeadingLevel.h4; break;
+      case 'h5': headingLevel = HeadingLevel.h5; break;
+      case 'h6': headingLevel = HeadingLevel.h6; break;
+    }
+    if (headingLevel == HeadingLevel.h6 && classes.isEmpty) {
+      // TODO(#192) handle h1, h2, h3, h4, h5
+      return HeadingNode(
+        level: headingLevel!, nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
+    }
+
+    if ((localName == 'ol' || localName == 'ul') && classes.isEmpty) {
+      return parseListNode(element);
+    }
+
+    if (localName == 'blockquote' && classes.isEmpty) {
+      return QuotationNode(blockNodes(), debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'div'
+        && classes.length == 1 && classes.contains('codehilite')) {
+      return parseCodeBlock(element);
+    }
+
+    if (localName == 'div'
+        && classes.length == 1 && classes.contains('message_inline_image')) {
+      return parseImageNode(element);
+    }
+
+    // TODO more types of node
     return UnimplementedBlockContentNode(htmlNode: node);
   }
-  final element = node;
-  final localName = element.localName;
-  final classes = element.classes;
-  List<BlockContentNode> blockNodes() => parseBlockContentList(element.nodes);
-  List<InlineContentNode> inlineNodes() {
-    return element.nodes.map(parseInlineContent).toList(growable: false);
+
+  bool _isPossibleInlineNode(dom.Node node) {
+    // TODO: find a way to assert that this matches parsing, or refactor away
+    if (node is dom.Text) return true;
+    if (node is! dom.Element) return false;
+    switch (node.localName) {
+      case 'p':
+      case 'ol':
+      case 'ul':
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+      case 'blockquote':
+      case 'div':
+        return false;
+      default:
+        return true;
+    }
   }
 
-  if (localName == 'br' && classes.isEmpty) {
-    return LineBreakNode(debugHtmlNode: debugHtmlNode);
-  }
+  /// Parse where block content is expected, but paragraphs may be implicit.
+  ///
+  /// See [ParagraphNode].
+  List<BlockContentNode> parseImplicitParagraphBlockContentList(dom.NodeList nodes) {
+    final List<BlockContentNode> result = [];
+    final List<dom.Node> currentParagraph = [];
+    void consumeParagraph() {
+      result.add(ParagraphNode(
+        wasImplicit: true,
+        nodes: currentParagraph.map(parseInlineContent).toList(growable: false)));
+      currentParagraph.clear();
+    }
 
-  if (localName == 'p' && classes.isEmpty) {
-    return ParagraphNode(nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
-  }
+    for (final node in nodes) {
+      if (node is dom.Text && (node.text == '\n')) continue;
 
-  HeadingLevel? headingLevel;
-  switch (localName) {
-    case 'h1': headingLevel = HeadingLevel.h1; break;
-    case 'h2': headingLevel = HeadingLevel.h2; break;
-    case 'h3': headingLevel = HeadingLevel.h3; break;
-    case 'h4': headingLevel = HeadingLevel.h4; break;
-    case 'h5': headingLevel = HeadingLevel.h5; break;
-    case 'h6': headingLevel = HeadingLevel.h6; break;
-  }
-  if (headingLevel == HeadingLevel.h6 && classes.isEmpty) {
-    // TODO(#192) handle h1, h2, h3, h4, h5
-    return HeadingNode(
-      level: headingLevel!, nodes: inlineNodes(), debugHtmlNode: debugHtmlNode);
-  }
-
-  if ((localName == 'ol' || localName == 'ul') && classes.isEmpty) {
-    return parseListNode(element);
-  }
-
-  if (localName == 'blockquote' && classes.isEmpty) {
-    return QuotationNode(blockNodes(), debugHtmlNode: debugHtmlNode);
-  }
-
-  if (localName == 'div'
-      && classes.length == 1 && classes.contains('codehilite')) {
-    return parseCodeBlock(element);
-  }
-
-  if (localName == 'div'
-      && classes.length == 1 && classes.contains('message_inline_image')) {
-    return parseImageNode(element);
-  }
-
-  // TODO more types of node
-  return UnimplementedBlockContentNode(htmlNode: node);
-}
-
-bool _isPossibleInlineNode(dom.Node node) {
-  // TODO: find a way to assert that this matches parsing, or refactor away
-  if (node is dom.Text) return true;
-  if (node is! dom.Element) return false;
-  switch (node.localName) {
-    case 'p':
-    case 'ol':
-    case 'ul':
-    case 'h1':
-    case 'h2':
-    case 'h3':
-    case 'h4':
-    case 'h5':
-    case 'h6':
-    case 'blockquote':
-    case 'div':
-      return false;
-    default:
-      return true;
-  }
-}
-
-/// Parse where block content is expected, but paragraphs may be implicit.
-///
-/// See [ParagraphNode].
-List<BlockContentNode> parseImplicitParagraphBlockContentList(dom.NodeList nodes) {
-  final List<BlockContentNode> result = [];
-  final List<dom.Node> currentParagraph = [];
-  void consumeParagraph() {
-    result.add(ParagraphNode(
-      wasImplicit: true,
-      nodes: currentParagraph.map(parseInlineContent).toList(growable: false)));
-    currentParagraph.clear();
-  }
-
-  for (final node in nodes) {
-    if (node is dom.Text && (node.text == '\n')) continue;
-
-    if (_isPossibleInlineNode(node)) {
-      currentParagraph.add(node);
-      continue;
+      if (_isPossibleInlineNode(node)) {
+        currentParagraph.add(node);
+        continue;
+      }
+      if (currentParagraph.isNotEmpty) consumeParagraph();
+      result.add(parseBlockContent(node));
     }
     if (currentParagraph.isNotEmpty) consumeParagraph();
-    result.add(parseBlockContent(node));
+
+    return result;
   }
-  if (currentParagraph.isNotEmpty) consumeParagraph();
 
-  return result;
-}
+  List<BlockContentNode> parseBlockContentList(dom.NodeList nodes) {
+    final acceptedNodes = nodes.where((node) {
+      // We get a bunch of newline Text nodes between paragraphs.
+      // A browser seems to ignore these; let's do the same.
+      if (node is dom.Text && (node.text == '\n')) return false;
+      return true;
+    });
+    return acceptedNodes.map(parseBlockContent).toList(growable: false);
+  }
 
-List<BlockContentNode> parseBlockContentList(dom.NodeList nodes) {
-  final acceptedNodes = nodes.where((node) {
-    // We get a bunch of newline Text nodes between paragraphs.
-    // A browser seems to ignore these; let's do the same.
-    if (node is dom.Text && (node.text == '\n')) return false;
-    return true;
-  });
-  return acceptedNodes.map(parseBlockContent).toList(growable: false);
+  ZulipContent parse(String html) {
+    final fragment = HtmlParser(html, parseMeta: false).parseFragment();
+    final nodes = parseBlockContentList(fragment.nodes);
+    return ZulipContent(nodes: nodes, debugHtmlNode: kDebugMode ? fragment : null);
+  }
 }
 
 ZulipContent parseContent(String html) {
-  final fragment = HtmlParser(html, parseMeta: false).parseFragment();
-  final nodes = parseBlockContentList(fragment.nodes);
-  return ZulipContent(nodes: nodes, debugHtmlNode: kDebugMode ? fragment : null);
+  return _ZulipContentParser().parse(html);
 }

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -93,27 +93,29 @@ void main() {
   testParseInline('parse link',
     // "[text](https://example/)"
     '<p><a href="https://example/">text</a></p>',
-    const LinkNode(nodes: [TextNode('text')]));
+    const LinkNode(url: 'https://example/', nodes: [TextNode('text')]));
 
   testParseInline('parse #-mention of stream',
     // "#**general**"
     '<p><a class="stream" data-stream-id="2" href="/#narrow/stream/2-general">'
         '#general</a></p>',
-    const LinkNode(nodes: [TextNode('#general')]));
+    const LinkNode(url: '/#narrow/stream/2-general',
+      nodes: [TextNode('#general')]));
 
   testParseInline('parse #-mention of topic',
     // "#**mobile-team>zulip-flutter**"
     '<p><a class="stream-topic" data-stream-id="243" '
         'href="/#narrow/stream/243-mobile-team/topic/zulip-flutter">'
         '#mobile-team &gt; zulip-flutter</a></p>',
-    const LinkNode(nodes: [TextNode('#mobile-team > zulip-flutter')]));
+    const LinkNode(url: '/#narrow/stream/243-mobile-team/topic/zulip-flutter',
+      nodes: [TextNode('#mobile-team > zulip-flutter')]));
 
   testParseInline('parse nested link, strong, em, code',
     // "[***`word`***](https://example/)"
     '<p><a href="https://example/"><strong><em><code>word'
         '</code></em></strong></a></p>',
-    const LinkNode(nodes: [StrongNode(nodes: [
-      EmphasisNode(nodes: [InlineCodeNode(nodes: [
+    const LinkNode(url: 'https://example/',
+      nodes: [StrongNode(nodes: [EmphasisNode(nodes: [InlineCodeNode(nodes: [
         TextNode('word')])])])]));
 
   group('parse @-mentions', () {
@@ -177,9 +179,9 @@ void main() {
           '</code></em></strong></a></h6>', const [
         HeadingNode(level: HeadingLevel.h6, nodes: [
           TextNode('one '),
-          LinkNode(nodes: [StrongNode(nodes: [
-            EmphasisNode(nodes: [InlineCodeNode(nodes: [
-              TextNode('two')])])])]),
+          LinkNode(url: 'https://example/',
+            nodes: [StrongNode(nodes: [EmphasisNode(nodes: [
+              InlineCodeNode(nodes: [TextNode('two')])])])]),
         ])]);
 
     testParse('amidst paragraphs',


### PR DESCRIPTION
The interesting parts of this are about tracking on each block inline container (notably each `ParagraphNode`) the set of link nodes found in its subtree. We'll need that information for #71, for reasons explained there.

Computing it involves adding a bit of complexity (that we were pretty much bound to eventually need for one reason or another), making the content-parser a stateful object.

This PR doesn't yet go on to have the widgets actually consume this information. I have a draft branch for that (corresponding to part of #204), but want to write some tests for it.
