### PR TITLE
Add "Copy to clipboard" button to message action sheet

### DIFF
--- a/lib/widgets/clipboard.dart
+++ b/lib/widgets/clipboard.dart
@@ -1,6 +1,7 @@
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import '../model/binding.dart';
 
 /// Copies [data] to the clipboard and shows a popup on success.
 ///
@@ -17,7 +18,7 @@ void copyWithPopup({
   required Widget successContent,
 }) async {
   await Clipboard.setData(data);
-  final deviceInfo = await DeviceInfoPlugin().deviceInfo;
+  final deviceInfo = await ZulipBinding.instance.deviceInfo();
 
   // https://github.com/dart-lang/linter/issues/4007
   // ignore: use_build_context_synchronously
@@ -27,12 +28,12 @@ void copyWithPopup({
 
   final bool shouldShowSnackbar;
   switch (deviceInfo) {
-    case AndroidDeviceInfo(:var version):
+    case AndroidDeviceInfo(:var sdkInt):
       // Android 13+ shows its own popup on copying to the clipboard,
       // so we suppress ours, following the advice at:
       //   https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
       // TODO(android-sdk-33): Simplify this and dartdoc
-      shouldShowSnackbar = version.sdkInt <= 32;
+      shouldShowSnackbar = sdkInt <= 32;
     default:
       shouldShowSnackbar = true;
   }

--- a/lib/widgets/clipboard.dart
+++ b/lib/widgets/clipboard.dart
@@ -20,11 +20,7 @@ void copyWithPopup({
   await Clipboard.setData(data);
   final deviceInfo = await ZulipBinding.instance.deviceInfo();
 
-  // https://github.com/dart-lang/linter/issues/4007
-  // ignore: use_build_context_synchronously
-  if (!context.mounted) {
-    return;
-  }
+  if (!context.mounted) return;
 
   final bool shouldShowSnackbar;
   switch (deviceInfo) {

--- a/lib/widgets/clipboard.dart
+++ b/lib/widgets/clipboard.dart
@@ -22,18 +22,14 @@ void copyWithPopup({
 
   if (!context.mounted) return;
 
-  final bool shouldShowSnackbar;
-  switch (deviceInfo) {
-    case AndroidDeviceInfo(:var sdkInt):
-      // Android 13+ shows its own popup on copying to the clipboard,
-      // so we suppress ours, following the advice at:
-      //   https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
-      // TODO(android-sdk-33): Simplify this and dartdoc
-      shouldShowSnackbar = sdkInt <= 32;
-    default:
-      shouldShowSnackbar = true;
-  }
-
+  final shouldShowSnackbar = switch (deviceInfo) {
+    // Android 13+ shows its own popup on copying to the clipboard,
+    // so we suppress ours, following the advice at:
+    //   https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
+    // TODO(android-sdk-33): Simplify this and dartdoc
+    AndroidDeviceInfo(:var sdkInt) => sdkInt <= 32,
+    _                              => true,
+  };
   if (shouldShowSnackbar) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(behavior: SnackBarBehavior.floating, content: successContent));

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -4,7 +4,11 @@ import 'dart:ui';
 import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:flutter/services.dart';
 
+extension ClipboardDataChecks on Subject<ClipboardData> {
+  Subject<String?> get text => has((d) => d.text, 'text');
+}
 
 extension ValueNotifierChecks<T> on Subject<ValueNotifier<T>> {
   Subject<T> get value => has((c) => c.value, 'value');

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -59,6 +59,7 @@ class TestZulipBinding extends ZulipBinding {
 
     launchUrlResult = true;
     _launchUrlCalls = null;
+    deviceInfoResult = _defaultDeviceInfoResult;
   }
 
   /// The current global store offered to a [GlobalStoreWidget].
@@ -125,5 +126,16 @@ class TestZulipBinding extends ZulipBinding {
   }) async {
     (_launchUrlCalls ??= []).add((url: url, mode: mode));
     return launchUrlResult;
+  }
+
+  /// The value that `ZulipBinding.instance.deviceInfo()` should return.
+  ///
+  /// See also [takeDeviceInfoCalls].
+  BaseDeviceInfo deviceInfoResult = _defaultDeviceInfoResult;
+  static final _defaultDeviceInfoResult = AndroidDeviceInfo(sdkInt: 33);
+
+  @override
+  Future<BaseDeviceInfo> deviceInfo() {
+    return Future(() => deviceInfoResult);
   }
 }

--- a/test/test_clipboard.dart
+++ b/test/test_clipboard.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/services.dart';
+
+// Inspired by MockClipboard in test code in the Flutter tree:
+//   https://github.com/flutter/flutter/blob/de26ad0a8/packages/flutter/test/widgets/clipboard_utils.dart
+class MockClipboard {
+  MockClipboard();
+
+  dynamic clipboardData;
+
+  Future<Object?> handleMethodCall(MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'Clipboard.getData':
+        return clipboardData;
+      case 'Clipboard.hasStrings':
+        final clipboardDataMap = clipboardData as Map<String, dynamic>?;
+        final text = clipboardDataMap?['text'] as String?;
+        return {'value': text != null && text.isNotEmpty};
+      case 'Clipboard.setData':
+        clipboardData = methodCall.arguments;
+      default:
+        if (methodCall.method.startsWith('Clipboard.')) {
+          throw UnimplementedError();
+        }
+    }
+    return null;
+  }
+}

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -63,6 +63,26 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
 void main() {
   TestZulipBinding.ensureInitialized();
 
+  void prepareRawContentResponseSuccess(PerAccountStore store, {
+    required Message message,
+    required String rawContent,
+  }) {
+    // Prepare fetch-raw-Markdown response
+    // TODO: Message should really only differ from `message`
+    //   in its content / content_type, not in `id` or anything else.
+    (store.connection as FakeApiConnection).prepare(json:
+      GetMessageResult(message: eg.streamMessage(contentMarkdown: rawContent)).toJson());
+  }
+
+  void prepareRawContentResponseError(PerAccountStore store) {
+    final fakeResponseJson = {
+      'code': 'BAD_REQUEST',
+      'msg': 'Invalid message(s)',
+      'result': 'error',
+    };
+    (store.connection as FakeApiConnection).prepare(httpStatus: 400, json: fakeResponseJson);
+  }
+
   group('QuoteAndReplyButton', () {
     ComposeBoxController? findComposeBoxController(WidgetTester tester) {
       return tester.widget<ComposeBox>(find.byType(ComposeBox))
@@ -71,26 +91,6 @@ void main() {
 
     Widget? findQuoteAndReplyButton(WidgetTester tester) {
       return tester.widgetList(find.byIcon(Icons.format_quote_outlined)).singleOrNull;
-    }
-
-    void prepareRawContentResponseSuccess(PerAccountStore store, {
-      required Message message,
-      required String rawContent,
-    }) {
-      // Prepare fetch-raw-Markdown response
-      // TODO: Message should really only differ from `message`
-      //   in its content / content_type, not in `id` or anything else.
-      (store.connection as FakeApiConnection).prepare(json:
-        GetMessageResult(message: eg.streamMessage(contentMarkdown: rawContent)).toJson());
-    }
-
-    void prepareRawContentResponseError(PerAccountStore store) {
-      final fakeResponseJson = {
-        'code': 'BAD_REQUEST',
-        'msg': 'Invalid message(s)',
-        'result': 'error',
-      };
-      (store.connection as FakeApiConnection).prepare(httpStatus: 400, json: fakeResponseJson);
     }
 
     /// Simulates tapping the quote-and-reply button in the message action sheet.

--- a/test/widgets/clipboard_test.dart
+++ b/test/widgets/clipboard_test.dart
@@ -1,0 +1,82 @@
+import 'package:checks/checks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/model/binding.dart';
+import 'package:zulip/widgets/clipboard.dart';
+
+import '../flutter_checks.dart';
+import '../model/binding.dart';
+import '../test_clipboard.dart';
+
+void main() {
+  TestZulipBinding.ensureInitialized();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      MockClipboard().handleMethodCall,
+    );
+  });
+
+  tearDown(() async {
+    TestZulipBinding.instance.reset();
+  });
+
+  group('copyWithPopup', () {
+    Future<void> call(WidgetTester tester, {required String text}) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  // TODO(i18n)
+                  copyWithPopup(context: context, successContent: const Text('Text copied'),
+                    data: ClipboardData(text: text));
+                },
+                child: const Text('Copy'))))),
+        ));
+      await tester.tap(find.text('Copy'));
+      await tester.pump(); // copy
+      await tester.pump(Duration.zero); // await platform info (awkwardly async)
+    }
+
+    Future<void> checkSnackBar(WidgetTester tester, {required bool expected}) async {
+      if (!expected) {
+        check(tester.widgetList(find.byType(SnackBar))).isEmpty();
+        return;
+      }
+      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+      check(snackBar.behavior).equals(SnackBarBehavior.floating);
+      tester.widget(find.descendant(matchRoot: true,
+        of: find.byWidget(snackBar.content), matching: find.text('Text copied')));
+    }
+
+    Future<void> checkClipboardText(String expected) async {
+      check(await Clipboard.getData('text/plain')).isNotNull().text.equals(expected);
+    }
+
+    testWidgets('iOS', (WidgetTester tester) async {
+      TestZulipBinding.instance.deviceInfoResult = IosDeviceInfo(systemVersion: '16.0');
+      await call(tester, text: 'asdf');
+      await checkClipboardText('asdf');
+      await checkSnackBar(tester, expected: true);
+    });
+
+    testWidgets('Android', (WidgetTester tester) async {
+      TestZulipBinding.instance.deviceInfoResult = AndroidDeviceInfo(sdkInt: 33);
+      await call(tester, text: 'asdf');
+      await checkClipboardText('asdf');
+      await checkSnackBar(tester, expected: false);
+    });
+
+    testWidgets('Android <13', (WidgetTester tester) async {
+      TestZulipBinding.instance.deviceInfoResult = AndroidDeviceInfo(sdkInt: 32);
+      await call(tester, text: 'asdf');
+      await checkClipboardText('asdf');
+      await checkSnackBar(tester, expected: true);
+    });
+  });
+}


### PR DESCRIPTION
This leaves some TODOs in the tests, for testing code that calls into a Flutter plugin. Greg is working on a good way to do that; see https://github.com/zulip/zulip-flutter/pull/204#discussion_r1253664445.

Empirically, the relevant calls here return Futures that never resolve, which will be fine until we want to stub out the native-code functionality.

Fixes: #132