### PR TITLE
vscode: Disable reformatting whole swaths of code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+// Visual Studio Code settings for the zulip-flutter repo.
+{
+  // VS Code formats files on save by default.
+  // Like Flutter itself, we don't use the Dart autoformatter,
+  // so disable that VS Code behavior.
+  "[dart]": {
+    // This appears redundant with the all-language setting,
+    // but it's not: if the user's personal config has a Dart-specific
+    // setting, then we need a Dart-specific setting to override it.
+    "editor.formatOnSave": false,
+    "editor.formatOnType": false,
+    "editor.formatOnPaste": false,
+  },
+
+  // For that matter, don't go reformatting whole files in any language.
+  "editor.formatOnSave": false,
+
+  // This much more focused automatic fix is helpful, though.
+  "files.trimTrailingWhitespace": true,
+}


### PR DESCRIPTION
The details here are largely borrowed from the Flutter repo, and in particular the subtleties most recently added there:
  https://github.com/flutter/flutter/pull/122758

This config does the job in my testing.

Note that it doesn't affect any of the things the editor does to simply augment your typing: adding indentation when you hit enter, adding a close-paren when you type an open-parent, and so on. Those are perfectly fine -- most of all because they only affect the code you actually intended to edit, but also because they generally get things right -- and continue operating as usual.

Fixes: #229