### PR TITLE
choose-account [nfc]: Remove redundant InkWell

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -47,10 +47,11 @@ class ChooseAccountPage extends StatelessWidget {
   }) {
     return Card(
       clipBehavior: Clip.hardEdge,
-      child: InkWell(
+      child: ListTile(
+        title: title,
+        subtitle: subtitle,
         onTap: () => Navigator.push(context,
-          HomePage.buildRoute(accountId: accountId)),
-        child: ListTile(title: title, subtitle: subtitle)));
+          HomePage.buildRoute(accountId: accountId))));
   }
 
   @override


### PR DESCRIPTION
The ink effect is already provided when you pass onTap to ListTile; see example:
  https://api.flutter.dev/flutter/material/ListTile-class.html#material.ListTile.8

Tested on my iPhone.