### PR TITLE
test: Fix wrong type in RealmContentNetworkImageChecks

### DIFF
--- a/test/widgets/content_checks.dart
+++ b/test/widgets/content_checks.dart
@@ -2,6 +2,6 @@ import 'package:checks/checks.dart';
 import 'package:zulip/widgets/content.dart';
 
 extension RealmContentNetworkImageChecks on Subject<RealmContentNetworkImage> {
-  Subject<String> get src => has((i) => i.src, 'src');
+  Subject<Uri> get src => has((i) => i.src, 'src');
   // TODO others
 }


### PR DESCRIPTION
This was accidentally clobbered in the merge of #247; see
  https://github.com/zulip/zulip-flutter/pull/247#issuecomment-1664710827