### PR TITLE
Clean up and tighten UpdateMessageEvent tests

### DIFF
--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -94,7 +94,6 @@ ZulipStream stream({
 
 final _messagePropertiesBase = {
   'is_me_message': false,
-  'last_edit_timestamp': null,
   'recipient_id': 32, // obsolescent in API, and ignored
 };
 
@@ -132,6 +131,7 @@ StreamMessage streamMessage({
   String? topic,
   String? content,
   String? contentMarkdown,
+  int? lastEditTimestamp,
   List<String>? flags,
 }) {
   final effectiveStream = stream ?? _stream();
@@ -148,6 +148,7 @@ StreamMessage streamMessage({
     'stream_id': effectiveStream.streamId,
     'flags': flags ?? [],
     'id': id ?? 1234567, // TODO generate example IDs
+    'last_edit_timestamp': lastEditTimestamp,
     'subject': topic ?? 'example topic',
     'timestamp': 1678139636,
     'type': 'stream',
@@ -164,6 +165,7 @@ DmMessage dmMessage({
   required List<User> to,
   String? content,
   String? contentMarkdown,
+  int? lastEditTimestamp,
   List<String>? flags,
 }) {
   assert(!to.any((user) => user.userId == from.userId));
@@ -177,6 +179,7 @@ DmMessage dmMessage({
 
     'flags': flags ?? [],
     'id': id ?? 1234567, // TODO generate example IDs
+    'last_edit_timestamp': lastEditTimestamp,
     'subject': '',
     'timestamp': 1678139636,
     'type': 'private',

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -71,23 +71,22 @@ void main() async {
     test('update a message', () async {
       final store = await setupStore(stream);
 
-      const oldContent = "<p>Hello, world</p>";
-      const newContent = "<p>Hello, edited</p>";
-      const newTimestamp = 99999;
-
-      List<String> oldFlags = [];
-      List<String> newFlags = ["starred"];
-
-      final originalMessage = eg.streamMessage(id: 243, stream: stream, content: oldContent, flags: oldFlags);
+      final originalMessage = eg.streamMessage(id: 243, stream: stream,
+        content: "<p>Hello, world</p>",
+        flags: [],
+      );
       final messageList = await messageListViewWithMessages([originalMessage], store, narrow);
 
+      final newFlags = ["starred"];
+      const newContent = "<p>Hello, edited</p>";
+      const editTimestamp = 99999;
       final updateEvent = UpdateMessageEvent(
         id: 1,
         messageId: originalMessage.id,
         messageIds: [originalMessage.id],
         flags: newFlags,
         renderedContent: newContent,
-        editTimestamp: newTimestamp,
+        editTimestamp: editTimestamp,
         isMeMessage: true,
         userId: userId,
         renderingOnly: false,
@@ -95,8 +94,9 @@ void main() async {
 
       final message = messageList.messages.single;
       check(message)
-        ..content.equals(oldContent)
-        ..flags.deepEquals(oldFlags)
+        ..content.not(it()..equals(newContent))
+        ..lastEditTimestamp.isNull()
+        ..flags.not(it()..deepEquals(newFlags))
         ..isMeMessage.isFalse();
 
       bool listenersNotified = false;
@@ -107,7 +107,7 @@ void main() async {
       check(messageList.messages.single)
         ..identicalTo(message)
         ..content.equals(newContent)
-        ..lastEditTimestamp.equals(newTimestamp)
+        ..lastEditTimestamp.equals(editTimestamp)
         ..flags.equals(newFlags)
         ..isMeMessage.isTrue();
     });

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -141,13 +141,9 @@ void main() async {
     Future<void> checkRenderingOnly({required bool legacy}) async {
       final store = await setupStore(stream);
 
-      const oldContent = "<p>Hello, world</p>";
-      const oldTimestamp = 78492;
-      const newContent = "<p>Hello, world</p> <div>Some link preview</div>";
-      const newTimestamp = 99999;
-
-      final originalMessage = eg.streamMessage(id: 972, stream: stream, content: oldContent);
-      originalMessage.lastEditTimestamp = oldTimestamp;
+      final originalMessage = eg.streamMessage(id: 972, stream: stream,
+        content: "<p>Hello, world</p>");
+      originalMessage.lastEditTimestamp = 78492;
 
       final messageList = await messageListViewWithMessages([originalMessage], store, narrow);
 
@@ -156,17 +152,21 @@ void main() async {
         messageId: originalMessage.id,
         messageIds: [originalMessage.id],
         flags: originalMessage.flags,
-        renderedContent: newContent,
-        editTimestamp: newTimestamp,
+        renderedContent: "<p>Hello, world</p> <div>Some link preview</div>",
+        editTimestamp: 99999,
         renderingOnly: legacy ? null : true,
         userId: null,
       );
 
       final message = messageList.messages.single;
       messageList.maybeUpdateMessage(updateEvent);
-      check(message)
-        ..content.equals(newContent)
-        ..lastEditTimestamp.equals(oldTimestamp);
+      check(messageList.messages.single)
+        ..identicalTo(message)
+        // Content is updated...
+        ..content.equals(updateEvent.renderedContent!)
+        // ... edit timestamp is not.
+        ..lastEditTimestamp.equals(originalMessage.lastEditTimestamp)
+        ..lastEditTimestamp.not(it()..equals(updateEvent.editTimestamp));
     }
 
     test('rendering-only update does not change timestamp', () async {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -77,16 +77,13 @@ void main() async {
       );
       final messageList = await messageListViewWithMessages([originalMessage], store, narrow);
 
-      final newFlags = ["starred"];
-      const newContent = "<p>Hello, edited</p>";
-      const editTimestamp = 99999;
       final updateEvent = UpdateMessageEvent(
         id: 1,
         messageId: originalMessage.id,
         messageIds: [originalMessage.id],
-        flags: newFlags,
-        renderedContent: newContent,
-        editTimestamp: editTimestamp,
+        flags: ["starred"],
+        renderedContent: "<p>Hello, edited</p>",
+        editTimestamp: 99999,
         isMeMessage: true,
         userId: userId,
         renderingOnly: false,
@@ -94,10 +91,10 @@ void main() async {
 
       final message = messageList.messages.single;
       check(message)
-        ..content.not(it()..equals(newContent))
+        ..content.not(it()..equals(updateEvent.renderedContent!))
         ..lastEditTimestamp.isNull()
-        ..flags.not(it()..deepEquals(newFlags))
-        ..isMeMessage.isFalse();
+        ..flags.not(it()..deepEquals(updateEvent.flags))
+        ..isMeMessage.not(it()..equals(updateEvent.isMeMessage!));
 
       bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
@@ -106,10 +103,10 @@ void main() async {
       check(listenersNotified).isTrue();
       check(messageList.messages.single)
         ..identicalTo(message)
-        ..content.equals(newContent)
-        ..lastEditTimestamp.equals(editTimestamp)
-        ..flags.equals(newFlags)
-        ..isMeMessage.isTrue();
+        ..content.equals(updateEvent.renderedContent!)
+        ..lastEditTimestamp.equals(updateEvent.editTimestamp)
+        ..flags.equals(updateEvent.flags)
+        ..isMeMessage.equals(updateEvent.isMeMessage!);
     });
 
     test('ignore when message not present', () async {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -31,7 +31,6 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, PerA
   final messageList = MessageListView.init(store: store, narrow: narrow);
 
   final connection = store.connection as FakeApiConnection;
-
   connection.prepare(json: GetMessagesResult(
     anchor: messages.first.id,
     foundNewest: true,
@@ -40,10 +39,7 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, PerA
     historyLimited: false,
     messages: messages,
   ).toJson());
-
   await messageList.fetch();
-
-  check(messageList.messages.length).equals(messages.length);
 
   return messageList;
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -112,11 +112,8 @@ void main() async {
     test('ignore when message not present', () async {
       final store = await setupStore(stream);
 
-      const oldContent = "<p>Hello, world</p>";
-      const newContent = "<p>Hello, edited</p>";
-      const newTimestamp = 99999;
-
-      final originalMessage = eg.streamMessage(id: 243, stream: stream, content: oldContent);
+      final originalMessage = eg.streamMessage(id: 243, stream: stream,
+        content: "<p>Hello, world</p>");
       final messageList = await messageListViewWithMessages([originalMessage], store, narrow);
 
       final updateEvent = UpdateMessageEvent(
@@ -124,21 +121,20 @@ void main() async {
         messageId: originalMessage.id + 1,
         messageIds: [originalMessage.id + 1],
         flags: originalMessage.flags,
-        renderedContent: newContent,
-        editTimestamp: newTimestamp,
+        renderedContent: "<p>Hello, edited</p>",
+        editTimestamp: 99999,
         userId: userId,
         renderingOnly: false,
       );
-
-      final message = messageList.messages.single;
-      check(message).content.equals(oldContent);
 
       bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
 
       messageList.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isFalse();
-      check(message).content.equals(oldContent);
+      check(messageList.messages.single)
+        ..content.equals(originalMessage.content)
+        ..content.not(it()..equals(updateEvent.renderedContent!));
     });
 
     test('rendering-only update does not change timestamp', () async {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -67,8 +67,8 @@ void main() async {
     check(messageList.findMessageWithId(7)).equals(-1);
   });
 
-  group('update message tests', () {
-    test('update events are correctly applied to message when it is in the stream', () async {
+  group('maybeUpdateMessage', () {
+    test('update a message', () async {
       final store = await setupStore(stream);
 
       const oldContent = "<p>Hello, world</p>";
@@ -114,7 +114,7 @@ void main() async {
         ..isMeMessage.isTrue();
     });
 
-    test('update event is ignored when message is not in the message list', () async {
+    test('ignore when message not present', () async {
       final store = await setupStore(stream);
 
       const oldContent = "<p>Hello, world</p>";

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -9,9 +9,9 @@ import 'package:zulip/model/store.dart';
 
 import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
+import '../example_data.dart' as eg;
 import '../model/binding.dart';
 import '../model/test_store.dart';
-import '../example_data.dart' as eg;
 
 const int userId = 1;
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -104,8 +104,8 @@ void main() async {
 
       messageList.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isTrue();
-      check(message)
-        ..identicalTo(messageList.messages.single)
+      check(messageList.messages.single)
+        ..identicalTo(message)
         ..content.equals(newContent)
         ..lastEditTimestamp.equals(newTimestamp)
         ..flags.equals(newFlags)

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -50,32 +50,24 @@ void main() async {
   final stream = eg.stream();
   final narrow = StreamNarrow(stream.streamId);
 
+  test('findMessageWithId', () async {
+    final store = await setupStore(stream);
+    final m1 = eg.streamMessage(id: 2, stream: stream);
+    final m2 = eg.streamMessage(id: 4, stream: stream);
+    final m3 = eg.streamMessage(id: 6, stream: stream);
+    final messageList = await messageListViewWithMessages([m1, m2, m3], store, narrow);
+
+    // Exercise the binary search before, at, and after each element of the list.
+    check(messageList.findMessageWithId(1)).equals(-1);
+    check(messageList.findMessageWithId(2)).equals(0);
+    check(messageList.findMessageWithId(3)).equals(-1);
+    check(messageList.findMessageWithId(4)).equals(1);
+    check(messageList.findMessageWithId(5)).equals(-1);
+    check(messageList.findMessageWithId(6)).equals(2);
+    check(messageList.findMessageWithId(7)).equals(-1);
+  });
+
   group('update message tests', () {
-
-    test('find message in message list returns index of message', () async {
-      final store = await setupStore(stream);
-
-      final m1 = eg.streamMessage(id: 2, stream: stream);
-      final m2 = eg.streamMessage(id: 4, stream: stream);
-      final m3 = eg.streamMessage(id: 6, stream: stream);
-
-      final messageList = await messageListViewWithMessages([m1, m2, m3], store, narrow);
-      // The implementation of this uses a binary search, so let's test it
-      // a bit more exhaustively.
-
-      check(messageList.findMessageWithId(1)).equals(-1);
-      check(messageList.findMessageWithId(2)).equals(0);
-      check(messageList.findMessageWithId(3)).equals(-1);
-      check(messageList.findMessageWithId(4)).equals(1);
-      check(messageList.findMessageWithId(5)).equals(-1);
-      check(messageList.findMessageWithId(6)).equals(2);
-      check(messageList.findMessageWithId(7)).equals(-1);
-
-      // Invalid IDs
-      check(messageList.findMessageWithId(-8409)).equals(-1);
-      check(messageList.findMessageWithId(0)).equals(-1);
-    });
-
     test('update events are correctly applied to message when it is in the stream', () async {
       final store = await setupStore(stream);
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -99,13 +99,11 @@ void main() async {
         ..flags.deepEquals(oldFlags)
         ..isMeMessage.isFalse();
 
-      var listenersNotified = false;
-
+      bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
+
       messageList.maybeUpdateMessage(updateEvent);
-
       check(listenersNotified).isTrue();
-
       check(message)
         ..identicalTo(messageList.messages.single)
         ..content.equals(newContent)
@@ -138,11 +136,10 @@ void main() async {
       final message = messageList.messages.single;
       check(message).content.equals(oldContent);
 
-      var listenersNotified = false;
-
+      bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
-      messageList.maybeUpdateMessage(updateEvent);
 
+      messageList.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isFalse();
       check(message).content.equals(oldContent);
     });

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -142,9 +142,8 @@ void main() async {
       final store = await setupStore(stream);
 
       final originalMessage = eg.streamMessage(id: 972, stream: stream,
+        lastEditTimestamp: 78492,
         content: "<p>Hello, world</p>");
-      originalMessage.lastEditTimestamp = 78492;
-
       final messageList = await messageListViewWithMessages([originalMessage], store, narrow);
 
       final updateEvent = UpdateMessageEvent(

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -140,9 +140,12 @@ void main() async {
       );
 
       final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+      bool listenersNotified = false;
+      messageList.addListener(() { listenersNotified = true; });
 
       final message = messageList.messages.single;
       messageList.maybeUpdateMessage(updateEvent);
+      check(listenersNotified).isTrue();
       check(messageList.messages.single)
         ..identicalTo(message)
         // Content is updated...

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -137,7 +137,8 @@ void main() async {
         ..content.not(it()..equals(updateEvent.renderedContent!));
     });
 
-    test('rendering-only update does not change timestamp', () async {
+    // TODO(server-5): Cut legacy case for rendering-only message update
+    Future<void> checkRenderingOnly({required bool legacy}) async {
       final store = await setupStore(stream);
 
       const oldContent = "<p>Hello, world</p>";
@@ -157,39 +158,7 @@ void main() async {
         flags: originalMessage.flags,
         renderedContent: newContent,
         editTimestamp: newTimestamp,
-        renderingOnly: true,
-        userId: null,
-      );
-
-      final message = messageList.messages[0];
-      messageList.maybeUpdateMessage(updateEvent);
-      check(message)
-        ..content.equals(newContent)
-        ..lastEditTimestamp.equals(oldTimestamp);
-    });
-
-    // TODO(server-5): Cut this test; rely on renderingOnly from FL 114
-    test('rendering-only update does not change timestamp (for old server versions)', () async {
-      final store = await setupStore(stream);
-
-      const oldContent = "<p>Hello, world</p>";
-      const oldTimestamp = 78492;
-      const newContent = "<p>Hello, world</p> <div>Some link preview</div>";
-      const newTimestamp = 99999;
-
-      final originalMessage = eg.streamMessage(id: 972, stream: stream, content: oldContent);
-      originalMessage.lastEditTimestamp = oldTimestamp;
-
-      final messageList = await messageListViewWithMessages([originalMessage], store, narrow);
-
-      final updateEvent = UpdateMessageEvent(
-        id: 1,
-        messageId: originalMessage.id,
-        messageIds: [originalMessage.id],
-        flags: originalMessage.flags,
-        renderedContent: newContent,
-        editTimestamp: newTimestamp,
-        renderingOnly: null,
+        renderingOnly: legacy ? null : true,
         userId: null,
       );
 
@@ -198,6 +167,14 @@ void main() async {
       check(message)
         ..content.equals(newContent)
         ..lastEditTimestamp.equals(oldTimestamp);
+    }
+
+    test('rendering-only update does not change timestamp', () async {
+      await checkRenderingOnly(legacy: false);
+    });
+
+    test('rendering-only update does not change timestamp (for old server versions)', () async {
+      await checkRenderingOnly(legacy: true);
     });
   });
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -64,11 +64,7 @@ void main() async {
   group('maybeUpdateMessage', () {
     test('update a message', () async {
       final originalMessage = eg.streamMessage(id: 243, stream: stream,
-        content: "<p>Hello, world</p>",
-        flags: [],
-      );
-      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
-
+        content: "<p>Hello, world</p>");
       final updateEvent = UpdateMessageEvent(
         id: 1,
         messageId: originalMessage.id,
@@ -81,15 +77,16 @@ void main() async {
         renderingOnly: false,
       );
 
+      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+      bool listenersNotified = false;
+      messageList.addListener(() { listenersNotified = true; });
+
       final message = messageList.messages.single;
       check(message)
         ..content.not(it()..equals(updateEvent.renderedContent!))
         ..lastEditTimestamp.isNull()
         ..flags.not(it()..deepEquals(updateEvent.flags))
         ..isMeMessage.not(it()..equals(updateEvent.isMeMessage!));
-
-      bool listenersNotified = false;
-      messageList.addListener(() { listenersNotified = true; });
 
       messageList.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isTrue();
@@ -104,8 +101,6 @@ void main() async {
     test('ignore when message not present', () async {
       final originalMessage = eg.streamMessage(id: 243, stream: stream,
         content: "<p>Hello, world</p>");
-      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
-
       final updateEvent = UpdateMessageEvent(
         id: 1,
         messageId: originalMessage.id + 1,
@@ -117,6 +112,7 @@ void main() async {
         renderingOnly: false,
       );
 
+      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
       bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
 
@@ -132,8 +128,6 @@ void main() async {
       final originalMessage = eg.streamMessage(id: 972, stream: stream,
         lastEditTimestamp: 78492,
         content: "<p>Hello, world</p>");
-      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
-
       final updateEvent = UpdateMessageEvent(
         id: 1,
         messageId: originalMessage.id,
@@ -144,6 +138,8 @@ void main() async {
         renderingOnly: legacy ? null : true,
         userId: null,
       );
+
+      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
 
       final message = messageList.messages.single;
       messageList.maybeUpdateMessage(updateEvent);


### PR DESCRIPTION
This makes a number of small improvements to the tests for our recently-added handling of `update_message` events editing messages (in #238), as discussed at https://github.com/zulip/zulip-flutter/pull/256#pullrequestreview-1563589723 .