### PR TITLE
msglist test: Backfill tests for rest of model; overhaul test setup

### DIFF
--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -9,17 +9,12 @@ import 'package:zulip/model/narrow.dart';
 import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
 import '../example_data.dart' as eg;
-import '../model/binding.dart';
 import '../model/test_store.dart';
 
 const int userId = 1;
 
 Future<MessageListView> messageListViewWithMessages(List<Message> messages, ZulipStream stream, Narrow narrow) async {
-  addTearDown(TestZulipBinding.instance.reset);
-
-  await TestZulipBinding.instance.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-
-  final store = await TestZulipBinding.instance.globalStore.perAccount(eg.selfAccount.id);
+  final store = eg.store();
   store.addUser(eg.user(userId: userId));
   store.addStream(stream);
 
@@ -40,8 +35,6 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, Zuli
 }
 
 void main() async {
-  TestZulipBinding.ensureInitialized();
-
   final stream = eg.stream();
   final narrow = StreamNarrow(stream.streamId);
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -9,15 +9,11 @@ import 'package:zulip/model/narrow.dart';
 import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
 import '../example_data.dart' as eg;
-import '../model/test_store.dart';
 
 const int userId = 1;
 
-Future<MessageListView> messageListViewWithMessages(List<Message> messages, ZulipStream stream, Narrow narrow) async {
+Future<MessageListView> messageListViewWithMessages(List<Message> messages, Narrow narrow) async {
   final store = eg.store();
-  store.addUser(eg.user(userId: userId));
-  store.addStream(stream);
-
   final messageList = MessageListView.init(store: store, narrow: narrow);
 
   final connection = store.connection as FakeApiConnection;
@@ -42,7 +38,7 @@ void main() async {
     final m1 = eg.streamMessage(id: 2, stream: stream);
     final m2 = eg.streamMessage(id: 4, stream: stream);
     final m3 = eg.streamMessage(id: 6, stream: stream);
-    final messageList = await messageListViewWithMessages([m1, m2, m3], stream, narrow);
+    final messageList = await messageListViewWithMessages([m1, m2, m3], narrow);
 
     // Exercise the binary search before, at, and after each element of the list.
     check(messageList.findMessageWithId(1)).equals(-1);
@@ -70,7 +66,7 @@ void main() async {
         renderingOnly: false,
       );
 
-      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+      final messageList = await messageListViewWithMessages([originalMessage], narrow);
       bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
 
@@ -105,7 +101,7 @@ void main() async {
         renderingOnly: false,
       );
 
-      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+      final messageList = await messageListViewWithMessages([originalMessage], narrow);
       bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
 
@@ -132,7 +128,7 @@ void main() async {
         userId: null,
       );
 
-      final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+      final messageList = await messageListViewWithMessages([originalMessage], narrow);
       bool listenersNotified = false;
       messageList.addListener(() { listenersNotified = true; });
 
@@ -171,7 +167,7 @@ void main() async {
 
       test('add reaction', () async {
         final originalMessage = eg.streamMessage(stream: stream, reactions: []);
-        final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+        final messageList = await messageListViewWithMessages([originalMessage], narrow);
 
         final message = messageList.messages.single;
 
@@ -189,7 +185,7 @@ void main() async {
 
       test('add reaction; message is not in list', () async {
         final someMessage = eg.streamMessage(id: 1, reactions: []);
-        final messageList = await messageListViewWithMessages([someMessage], stream, narrow);
+        final messageList = await messageListViewWithMessages([someMessage], narrow);
 
         bool listenersNotified = false;
         messageList.addListener(() { listenersNotified = true; });
@@ -223,7 +219,7 @@ void main() async {
 
         final originalMessage = eg.streamMessage(stream: stream,
           reactions: [reaction2, reaction3, reaction4]);
-        final messageList = await messageListViewWithMessages([originalMessage], stream, narrow);
+        final messageList = await messageListViewWithMessages([originalMessage], narrow);
 
         final message = messageList.messages.single;
 
@@ -241,7 +237,7 @@ void main() async {
 
       test('remove reaction; message is not in list', () async {
         final someMessage = eg.streamMessage(id: 1, reactions: [eg.unicodeEmojiReaction]);
-        final messageList = await messageListViewWithMessages([someMessage], stream, narrow);
+        final messageList = await messageListViewWithMessages([someMessage], narrow);
 
         bool listenersNotified = false;
         messageList.addListener(() { listenersNotified = true; });

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -10,7 +10,7 @@ import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
 import '../example_data.dart' as eg;
 
-Future<MessageListView> messageListViewWithMessages(List<Message> messages, Narrow narrow) async {
+Future<MessageListView> messageListViewWithMessages(List<Message> messages, [Narrow narrow = const AllMessagesNarrow()]) async {
   final store = eg.store();
   final model = MessageListView.init(store: store, narrow: narrow);
 
@@ -30,13 +30,12 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, Narr
 
 void main() async {
   final stream = eg.stream();
-  final narrow = StreamNarrow(stream.streamId);
 
   test('findMessageWithId', () async {
     final m1 = eg.streamMessage(id: 2, stream: stream);
     final m2 = eg.streamMessage(id: 4, stream: stream);
     final m3 = eg.streamMessage(id: 6, stream: stream);
-    final model = await messageListViewWithMessages([m1, m2, m3], narrow);
+    final model = await messageListViewWithMessages([m1, m2, m3]);
 
     // Exercise the binary search before, at, and after each element of the list.
     check(model.findMessageWithId(1)).equals(-1);
@@ -64,7 +63,7 @@ void main() async {
         renderingOnly: false,
       );
 
-      final model = await messageListViewWithMessages([originalMessage], narrow);
+      final model = await messageListViewWithMessages([originalMessage]);
       bool listenersNotified = false;
       model.addListener(() { listenersNotified = true; });
 
@@ -99,7 +98,7 @@ void main() async {
         renderingOnly: false,
       );
 
-      final model = await messageListViewWithMessages([originalMessage], narrow);
+      final model = await messageListViewWithMessages([originalMessage]);
       bool listenersNotified = false;
       model.addListener(() { listenersNotified = true; });
 
@@ -126,7 +125,7 @@ void main() async {
         userId: null,
       );
 
-      final model = await messageListViewWithMessages([originalMessage], narrow);
+      final model = await messageListViewWithMessages([originalMessage]);
       bool listenersNotified = false;
       model.addListener(() { listenersNotified = true; });
 
@@ -165,7 +164,7 @@ void main() async {
 
       test('add reaction', () async {
         final originalMessage = eg.streamMessage(stream: stream, reactions: []);
-        final model = await messageListViewWithMessages([originalMessage], narrow);
+        final model = await messageListViewWithMessages([originalMessage]);
 
         final message = model.messages.single;
 
@@ -183,7 +182,7 @@ void main() async {
 
       test('add reaction; message is not in list', () async {
         final someMessage = eg.streamMessage(id: 1, reactions: []);
-        final model = await messageListViewWithMessages([someMessage], narrow);
+        final model = await messageListViewWithMessages([someMessage]);
 
         bool listenersNotified = false;
         model.addListener(() { listenersNotified = true; });
@@ -217,7 +216,7 @@ void main() async {
 
         final originalMessage = eg.streamMessage(stream: stream,
           reactions: [reaction2, reaction3, reaction4]);
-        final model = await messageListViewWithMessages([originalMessage], narrow);
+        final model = await messageListViewWithMessages([originalMessage]);
 
         final message = model.messages.single;
 
@@ -235,7 +234,7 @@ void main() async {
 
       test('remove reaction; message is not in list', () async {
         final someMessage = eg.streamMessage(id: 1, reactions: [eg.unicodeEmojiReaction]);
-        final model = await messageListViewWithMessages([someMessage], narrow);
+        final model = await messageListViewWithMessages([someMessage]);
 
         bool listenersNotified = false;
         model.addListener(() { listenersNotified = true; });

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -10,8 +10,6 @@ import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
 import '../example_data.dart' as eg;
 
-const int userId = 1;
-
 Future<MessageListView> messageListViewWithMessages(List<Message> messages, Narrow narrow) async {
   final store = eg.store();
   final messageList = MessageListView.init(store: store, narrow: narrow);
@@ -62,7 +60,7 @@ void main() async {
         renderedContent: "<p>Hello, edited</p>",
         editTimestamp: 99999,
         isMeMessage: true,
-        userId: userId,
+        userId: 1,
         renderingOnly: false,
       );
 
@@ -97,7 +95,7 @@ void main() async {
         flags: originalMessage.flags,
         renderedContent: "<p>Hello, edited</p>",
         editTimestamp: 99999,
-        userId: userId,
+        userId: 1,
         renderingOnly: false,
       );
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -29,12 +29,10 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, [Nar
 }
 
 void main() async {
-  final stream = eg.stream();
-
   test('findMessageWithId', () async {
-    final m1 = eg.streamMessage(id: 2, stream: stream);
-    final m2 = eg.streamMessage(id: 4, stream: stream);
-    final m3 = eg.streamMessage(id: 6, stream: stream);
+    final m1 = eg.streamMessage(id: 2);
+    final m2 = eg.streamMessage(id: 4);
+    final m3 = eg.streamMessage(id: 6);
     final model = await messageListViewWithMessages([m1, m2, m3]);
 
     // Exercise the binary search before, at, and after each element of the list.
@@ -49,7 +47,7 @@ void main() async {
 
   group('maybeUpdateMessage', () {
     test('update a message', () async {
-      final originalMessage = eg.streamMessage(id: 243, stream: stream,
+      final originalMessage = eg.streamMessage(id: 243,
         content: "<p>Hello, world</p>");
       final updateEvent = UpdateMessageEvent(
         id: 1,
@@ -85,7 +83,7 @@ void main() async {
     });
 
     test('ignore when message not present', () async {
-      final originalMessage = eg.streamMessage(id: 243, stream: stream,
+      final originalMessage = eg.streamMessage(id: 243,
         content: "<p>Hello, world</p>");
       final updateEvent = UpdateMessageEvent(
         id: 1,
@@ -111,7 +109,7 @@ void main() async {
 
     // TODO(server-5): Cut legacy case for rendering-only message update
     Future<void> checkRenderingOnly({required bool legacy}) async {
-      final originalMessage = eg.streamMessage(id: 972, stream: stream,
+      final originalMessage = eg.streamMessage(id: 972,
         lastEditTimestamp: 78492,
         content: "<p>Hello, world</p>");
       final updateEvent = UpdateMessageEvent(
@@ -163,7 +161,7 @@ void main() async {
       }
 
       test('add reaction', () async {
-        final originalMessage = eg.streamMessage(stream: stream, reactions: []);
+        final originalMessage = eg.streamMessage(reactions: []);
         final model = await messageListViewWithMessages([originalMessage]);
 
         final message = model.messages.single;
@@ -214,7 +212,7 @@ void main() async {
         final reaction4 = Reaction.fromJson(eventReaction.toJson()
           ..['emoji_name'] = 'hello');
 
-        final originalMessage = eg.streamMessage(stream: stream,
+        final originalMessage = eg.streamMessage(
           reactions: [reaction2, reaction3, reaction4]);
         final model = await messageListViewWithMessages([originalMessage]);
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -3,8 +3,10 @@ import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/messages.dart';
+import 'package:zulip/model/content.dart';
 import 'package:zulip/model/message_list.dart';
 import 'package:zulip/model/narrow.dart';
+import 'package:zulip/model/store.dart';
 
 import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
@@ -75,7 +77,7 @@ void main() async {
 
       model.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isTrue();
-      check(model.messages.single)
+      check(model).messages.single
         ..identicalTo(message)
         ..content.equals(updateEvent.renderedContent!)
         ..lastEditTimestamp.equals(updateEvent.editTimestamp)
@@ -103,7 +105,7 @@ void main() async {
 
       model.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isFalse();
-      check(model.messages.single)
+      check(model).messages.single
         ..content.equals(originalMessage.content)
         ..content.not(it()..equals(updateEvent.renderedContent!));
     });
@@ -131,7 +133,7 @@ void main() async {
       final message = model.messages.single;
       model.maybeUpdateMessage(updateEvent);
       check(listenersNotified).isTrue();
-      check(model.messages.single)
+      check(model).messages.single
         ..identicalTo(message)
         // Content is updated...
         ..content.equals(updateEvent.renderedContent!)
@@ -174,7 +176,7 @@ void main() async {
           mkEvent(eg.unicodeEmojiReaction, ReactionOp.add, originalMessage.id));
 
         check(listenersNotified).isTrue();
-        check(model.messages.single)
+        check(model).messages.single
           ..identicalTo(message)
           ..reactions.jsonEquals([eg.unicodeEmojiReaction]);
       });
@@ -190,7 +192,7 @@ void main() async {
           mkEvent(eg.unicodeEmojiReaction, ReactionOp.add, 1000));
 
         check(listenersNotified).isFalse();
-        check(model.messages.single).reactions.jsonEquals([]);
+        check(model).messages.single.reactions.jsonEquals([]);
       });
 
       test('remove reaction', () async {
@@ -226,7 +228,7 @@ void main() async {
           mkEvent(eventReaction, ReactionOp.remove, originalMessage.id));
 
         check(listenersNotified).isTrue();
-        check(model.messages.single)
+        check(model).messages.single
           ..identicalTo(message)
           ..reactions.jsonEquals([reaction2, reaction3]);
       });
@@ -242,8 +244,16 @@ void main() async {
           mkEvent(eg.unicodeEmojiReaction, ReactionOp.remove, 1000));
 
         check(listenersNotified).isFalse();
-        check(model.messages.single).reactions.jsonEquals([eg.unicodeEmojiReaction]);
+        check(model).messages.single.reactions.jsonEquals([eg.unicodeEmojiReaction]);
       });
     });
   });
+}
+
+extension MessageListViewChecks on Subject<MessageListView> {
+  Subject<PerAccountStore> get store => has((x) => x.store, 'store');
+  Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
+  Subject<List<Message>> get messages => has((x) => x.messages, 'messages');
+  Subject<List<ZulipContent>> get contents => has((x) => x.contents, 'contents');
+  Subject<bool> get fetched => has((x) => x.fetched, 'fetched');
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -17,14 +17,8 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, [Nar
   final model = MessageListView.init(store: store, narrow: narrow);
 
   final connection = store.connection as FakeApiConnection;
-  connection.prepare(json: GetMessagesResult(
-    anchor: messages.first.id,
-    foundNewest: true,
-    foundOldest: true,
-    foundAnchor: true,
-    historyLimited: false,
-    messages: messages,
-  ).toJson());
+  connection.prepare(json:
+    newestResult(foundOldest: true, messages: messages).toJson());
   await model.fetch();
 
   return model;
@@ -256,4 +250,23 @@ extension MessageListViewChecks on Subject<MessageListView> {
   Subject<List<Message>> get messages => has((x) => x.messages, 'messages');
   Subject<List<ZulipContent>> get contents => has((x) => x.contents, 'contents');
   Subject<bool> get fetched => has((x) => x.fetched, 'fetched');
+}
+
+/// A GetMessagesResult the server might return on an `anchor=newest` request.
+GetMessagesResult newestResult({
+  required bool foundOldest,
+  bool historyLimited = false,
+  required List<Message> messages,
+}) {
+  return GetMessagesResult(
+    // These anchor, foundAnchor, and foundNewest values are what the server
+    // appears to always return when the request had `anchor=newest`.
+    anchor: 10000000000000000, // that's 16 zeros
+    foundAnchor: false,
+    foundNewest: true,
+
+    foundOldest: foundOldest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -30,10 +30,11 @@ Future<MessageListView> messageListViewWithMessages(List<Message> messages, [Nar
 
 void main() async {
   test('findMessageWithId', () async {
-    final m1 = eg.streamMessage(id: 2);
-    final m2 = eg.streamMessage(id: 4);
-    final m3 = eg.streamMessage(id: 6);
-    final model = await messageListViewWithMessages([m1, m2, m3]);
+    final model = await messageListViewWithMessages([
+      eg.streamMessage(id: 2),
+      eg.streamMessage(id: 4),
+      eg.streamMessage(id: 6),
+    ]);
 
     // Exercise the binary search before, at, and after each element of the list.
     check(model.findMessageWithId(1)).equals(-1);


### PR DESCRIPTION
This is part of #78. That issue will involve substantial refactoring on MessageListView, which makes it a good time to have tests in place.

The final commit here adds tests for all the exposed methods of MessageListView that lack them, namely `fetch`, `maybeAddMessage`, and `reassemble`. That was in fact the origin of this PR — I wrote those tests a few weeks ago as part of my draft branch for #78. (Which I've now picked back up to bring toward merge, after having held off for a while because its changes in `lib/` conflicted with other PRs and I wanted to handle the conflicts myself rather than pushing them to those PRs' authors to deal with.) The 11 preceding commits convert all the existing tests in this file to work the same way as those new tests.

In particular the first 9 of these 12 commits are a sort of followup to #258, making further cleanups and simplifications to those existing tests, compared to the patterns that were set in #238.

The remaining two commits make deeper changes:

---

msglist test: Overhaul setup of tests, with shared helpers

All the tests in this file are going to have a common structure
to the objects they operate on: chiefly, a MessageListView.
So we can hoist those up to the level of `main`, which enables
the tests to share helper functions that act on those objects.

In principle this means a state leak between tests.  We mitigate
that by resetting all the shared variables at the same time,
in the `prepare` function that each test calls at the outset.

We could get a similar effect by putting these shared variables and
helpers as fields and methods on a class, and having each test case
make its own instance of the class -- its own "tester" object, akin to
the WidgetTester object that `testWidgets` provides to its test body.
That'd provide more encapsulation, and would be a good strategy if
for example this logic were to be shared across several test files.
But I think this test file can get away without it.

The immediate payoff of the shared helpers is that they let us
centralize the logic for checking that the view-model has, or hasn't,
notified its listeners.  That simplifies each test case, plus it
lets us make that logic slightly more sophisticated (at O(1) rather
than O(n) cost in the source code): we now detect duplicate calls too.

Coming up, we'll add further centralized useful logic to these helpers,
and add some tests that benefit from the split between `prepare`
and `prepareMessages`.

---

msglist test: Systematically check invariants of MessageListView

This takes further advantage of having these centralized helpers.
