### PR TITLE
model: Start tracking a few `user_settings`, including `display_emoji_reaction_users`

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -107,6 +107,7 @@ class UserSettingsUpdateEvent extends Event {
   static Object? _readValue(Map json, String key) {
     final value = json['value'];
     switch (UserSettingName.fromRawString(json['property'] as String)) {
+      case UserSettingName.twentyFourHourTime:
       case UserSettingName.displayEmojiReactionUsers:
         return value as bool;
       case null:

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -43,6 +43,7 @@ Map<String, dynamic> _$UserSettingsUpdateEventToJson(
     };
 
 const _$UserSettingNameEnumMap = {
+  UserSettingName.twentyFourHourTime: 'twenty_four_hour_time',
   UserSettingName.displayEmojiReactionUsers: 'display_emoji_reaction_users',
 };
 

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -23,6 +23,29 @@ Map<String, dynamic> _$AlertWordsEventToJson(AlertWordsEvent instance) =>
       'alert_words': instance.alertWords,
     };
 
+UserSettingsUpdateEvent _$UserSettingsUpdateEventFromJson(
+        Map<String, dynamic> json) =>
+    UserSettingsUpdateEvent(
+      id: json['id'] as int,
+      property: $enumDecodeNullable(_$UserSettingNameEnumMap, json['property'],
+          unknownValue: JsonKey.nullForUndefinedEnumValue),
+      value: UserSettingsUpdateEvent._readValue(json, 'value'),
+    );
+
+Map<String, dynamic> _$UserSettingsUpdateEventToJson(
+        UserSettingsUpdateEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'op': instance.op,
+      'property': _$UserSettingNameEnumMap[instance.property],
+      'value': instance.value,
+    };
+
+const _$UserSettingNameEnumMap = {
+  UserSettingName.displayEmojiReactionUsers: 'display_emoji_reaction_users',
+};
+
 RealmUserAddEvent _$RealmUserAddEventFromJson(Map<String, dynamic> json) =>
     RealmUserAddEvent(
       id: json['id'] as int,

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -30,6 +30,14 @@ class InitialSnapshot {
 
   final List<ZulipStream> streams;
 
+  // Servers pre-5.0 don't have `user_settings`, and instead provide whatever
+  // user settings they support at toplevel in the initial snapshot. Since we're
+  // likely to desupport pre-5.0 servers before wide release, we prefer to
+  // ignore the toplevel fields and use `user_settings` where present instead,
+  // even at the expense of functionality with pre-5.0 servers.
+  // TODO(server-5) remove pre-5.0 comment
+  final UserSettings? userSettings; // TODO(server-5)
+
   final int maxFileUploadSizeMib;
 
   @JsonKey(readValue: _readUsersIsActiveFallbackTrue)
@@ -71,6 +79,7 @@ class InitialSnapshot {
     required this.recentPrivateConversations,
     required this.subscriptions,
     required this.streams,
+    required this.userSettings,
     required this.maxFileUploadSizeMib,
     required this.realmUsers,
     required this.realmNonActiveUsers,
@@ -101,4 +110,24 @@ class RecentDmConversation {
     _$RecentDmConversationFromJson(json);
 
   Map<String, dynamic> toJson() => _$RecentDmConversationToJson(this);
+}
+
+/// The `user_settings` dictionary.
+///
+/// For docs, search for "user_settings:"
+/// in <https://zulip.com/api/register-queue>.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UserSettings {
+  final bool? displayEmojiReactionUsers; // TODO(server-6)
+
+  // TODO more, as needed
+
+  UserSettings({
+    required this.displayEmojiReactionUsers,
+  });
+
+  factory UserSettings.fromJson(Map<String, dynamic> json) =>
+    _$UserSettingsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserSettingsToJson(this);
 }

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -119,6 +119,7 @@ class RecentDmConversation {
 /// in <https://zulip.com/api/register-queue>.
 @JsonSerializable(fieldRename: FieldRename.snake, createFieldMap: true)
 class UserSettings {
+  bool twentyFourHourTime;
   bool? displayEmojiReactionUsers; // TODO(server-6)
 
   // TODO more, as needed. When adding a setting here, please also:
@@ -127,6 +128,7 @@ class UserSettings {
   // (3) handle the event that signals an update to the setting
 
   UserSettings({
+    required this.twentyFourHourTime,
     required this.displayEmojiReactionUsers,
   });
 
@@ -148,6 +150,7 @@ class UserSettings {
 /// to ensure that every setting in [UserSettings] responds to the event.
 @JsonEnum(fieldRename: FieldRename.snake, alwaysCreate: true)
 enum UserSettingName {
+  twentyFourHourTime,
   displayEmojiReactionUsers;
 
   /// Get a [UserSettingName] from a raw, snake-case string we recognize, else null.

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -89,7 +89,15 @@ UserSettings _$UserSettingsFromJson(Map<String, dynamic> json) => UserSettings(
       displayEmojiReactionUsers: json['display_emoji_reaction_users'] as bool?,
     );
 
+const _$UserSettingsFieldMap = <String, String>{
+  'displayEmojiReactionUsers': 'display_emoji_reaction_users',
+};
+
 Map<String, dynamic> _$UserSettingsToJson(UserSettings instance) =>
     <String, dynamic>{
       'display_emoji_reaction_users': instance.displayEmojiReactionUsers,
     };
+
+const _$UserSettingNameEnumMap = {
+  UserSettingName.displayEmojiReactionUsers: 'display_emoji_reaction_users',
+};

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -31,6 +31,10 @@ InitialSnapshot _$InitialSnapshotFromJson(Map<String, dynamic> json) =>
       streams: (json['streams'] as List<dynamic>)
           .map((e) => ZulipStream.fromJson(e as Map<String, dynamic>))
           .toList(),
+      userSettings: json['user_settings'] == null
+          ? null
+          : UserSettings.fromJson(
+              json['user_settings'] as Map<String, dynamic>),
       maxFileUploadSizeMib: json['max_file_upload_size_mib'] as int,
       realmUsers:
           (InitialSnapshot._readUsersIsActiveFallbackTrue(json, 'realm_users')
@@ -59,6 +63,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
       'recent_private_conversations': instance.recentPrivateConversations,
       'subscriptions': instance.subscriptions,
       'streams': instance.streams,
+      'user_settings': instance.userSettings,
       'max_file_upload_size_mib': instance.maxFileUploadSizeMib,
       'realm_users': instance.realmUsers,
       'realm_non_active_users': instance.realmNonActiveUsers,
@@ -78,4 +83,13 @@ Map<String, dynamic> _$RecentDmConversationToJson(
     <String, dynamic>{
       'max_message_id': instance.maxMessageId,
       'user_ids': instance.userIds,
+    };
+
+UserSettings _$UserSettingsFromJson(Map<String, dynamic> json) => UserSettings(
+      displayEmojiReactionUsers: json['display_emoji_reaction_users'] as bool?,
+    );
+
+Map<String, dynamic> _$UserSettingsToJson(UserSettings instance) =>
+    <String, dynamic>{
+      'display_emoji_reaction_users': instance.displayEmojiReactionUsers,
     };

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -86,18 +86,22 @@ Map<String, dynamic> _$RecentDmConversationToJson(
     };
 
 UserSettings _$UserSettingsFromJson(Map<String, dynamic> json) => UserSettings(
+      twentyFourHourTime: json['twenty_four_hour_time'] as bool,
       displayEmojiReactionUsers: json['display_emoji_reaction_users'] as bool?,
     );
 
 const _$UserSettingsFieldMap = <String, String>{
+  'twentyFourHourTime': 'twenty_four_hour_time',
   'displayEmojiReactionUsers': 'display_emoji_reaction_users',
 };
 
 Map<String, dynamic> _$UserSettingsToJson(UserSettings instance) =>
     <String, dynamic>{
+      'twenty_four_hour_time': instance.twentyFourHourTime,
       'display_emoji_reaction_users': instance.displayEmojiReactionUsers,
     };
 
 const _$UserSettingNameEnumMap = {
+  UserSettingName.twentyFourHourTime: 'twenty_four_hour_time',
   UserSettingName.displayEmojiReactionUsers: 'display_emoji_reaction_users',
 };

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -174,7 +174,7 @@ class PerAccountStore extends ChangeNotifier {
   final int maxFileUploadSizeMib; // No event for this.
 
   // Data attached to the self-account on the realm.
-  final UserSettings? userSettings; // TODO(#135) update with user_settings/update event
+  final UserSettings? userSettings; // TODO(server-5)
 
   // Users and data about them.
   final Map<int, User> users;
@@ -219,6 +219,17 @@ class PerAccountStore extends ChangeNotifier {
     } else if (event is AlertWordsEvent) {
       assert(debugLog("server event: alert_words"));
       // We don't yet store this data, so there's nothing to update.
+    } else if (event is UserSettingsUpdateEvent) {
+      assert(debugLog("server event: user_settings/update ${event.property?.name ?? '[unrecognized]'}"));
+      if (event.property == null) {
+        // unrecognized setting; do nothing
+        return;
+      }
+      switch (event.property!) {
+        case UserSettingName.displayEmojiReactionUsers:
+          userSettings?.displayEmojiReactionUsers = event.value as bool;
+      }
+      notifyListeners();
     } else if (event is RealmUserAddEvent) {
       assert(debugLog("server event: realm_user/add"));
       users[event.person.userId] = event.person;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -151,6 +151,7 @@ class PerAccountStore extends ChangeNotifier {
     required InitialSnapshot initialSnapshot,
   }) : zulipVersion = initialSnapshot.zulipVersion,
        maxFileUploadSizeMib = initialSnapshot.maxFileUploadSizeMib,
+       userSettings = initialSnapshot.userSettings,
        users = Map.fromEntries(
          initialSnapshot.realmUsers
          .followedBy(initialSnapshot.realmNonActiveUsers)
@@ -171,6 +172,9 @@ class PerAccountStore extends ChangeNotifier {
   // Data attached to the realm or the server.
   final String zulipVersion; // TODO get from account; update there on initial snapshot
   final int maxFileUploadSizeMib; // No event for this.
+
+  // Data attached to the self-account on the realm.
+  final UserSettings? userSettings; // TODO(#135) update with user_settings/update event
 
   // Users and data about them.
   final Map<int, User> users;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -226,6 +226,8 @@ class PerAccountStore extends ChangeNotifier {
         return;
       }
       switch (event.property!) {
+        case UserSettingName.twentyFourHourTime:
+          userSettings?.twentyFourHourTime        = event.value as bool;
         case UserSettingName.displayEmojiReactionUsers:
           userSettings?.displayEmojiReactionUsers = event.value as bool;
       }

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -1,6 +1,7 @@
 import 'package:checks/checks.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/events.dart';
+import 'package:zulip/api/model/initial_snapshot.dart';
 
 import '../../example_data.dart' as eg;
 import '../../stdlib_checks.dart';
@@ -19,5 +20,25 @@ void main() {
     check(mkEvent(message.flags)).message.jsonEquals(message);
     check(mkEvent([])).message.flags.deepEquals([]);
     check(mkEvent(['read'])).message.flags.deepEquals(['read']);
+  });
+
+  test('user_settings: all known settings have event handling', () {
+    final dataClassFieldNames = UserSettings.debugKnownNames;
+    final enumNames = UserSettingName.values.map((n) => n.name);
+    final missingEnumNames = dataClassFieldNames.where((key) => !enumNames.contains(key)).toList();
+    check(
+      missingEnumNames,
+      because:
+        'You have added these fields to [UserSettings]\n'
+        'without handling the corresponding forms of the\n'
+        'user_settings/update event in [PerAccountStore]:\n'
+        '  $missingEnumNames\n'
+        'To do that, please follow these steps:\n'
+        '  (1) Add corresponding members to the [UserSettingName] enum.\n'
+        '  (2) Then, re-run the command to refresh the .g.dart files.\n'
+        '  (3) Resolve the Dart analysis errors about not exhaustively\n'
+        '      matching on that enum, by adding new `switch` cases\n'
+        '      on the pattern of the existing cases.'
+    ).isEmpty();
   });
 }

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -208,6 +208,7 @@ InitialSnapshot initialSnapshot({
   List<RecentDmConversation>? recentPrivateConversations,
   List<Subscription>? subscriptions,
   List<ZulipStream>? streams,
+  UserSettings? userSettings,
   int? maxFileUploadSizeMib,
   List<User>? realmUsers,
   List<User>? realmNonActiveUsers,
@@ -224,6 +225,7 @@ InitialSnapshot initialSnapshot({
     recentPrivateConversations: recentPrivateConversations ?? [],
     subscriptions: subscriptions ?? [], // TODO add subscriptions to default
     streams: streams ?? [], // TODO add streams to default
+    userSettings: userSettings, // TODO add userSettings to default
     maxFileUploadSizeMib: maxFileUploadSizeMib ?? 25,
     realmUsers: realmUsers ?? [],
     realmNonActiveUsers: realmNonActiveUsers ?? [],


### PR DESCRIPTION
As mentioned in the last two commits:

f662a0176 api: Add user_settings/update events, with a test for exhaustiveness
815a34730 api: Add UserSettings.twentyFourHourTime

I'm not sure about the system I've set up for type-checking the `user_settings/update` event at the edge, and verifying that all settings in the initial snapshot get updated with that event. I'd be curious to hear thoughts on that. 🙂

Related: #121