### PR TITLE
nav [nfc]: Make navigation more cleanly testable, with WidgetRoute

### DIFF
--- a/lib/widgets/about_zulip.dart
+++ b/lib/widgets/about_zulip.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+import 'page.dart';
+
 class AboutZulipPage extends StatefulWidget {
   const AboutZulipPage({super.key});
 
   static Route<void> buildRoute(BuildContext context) {
-    return MaterialPageRoute(builder: (context) => const AboutZulipPage());
+    return MaterialWidgetRoute(page: const AboutZulipPage());
   }
 
   @override

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -4,6 +4,7 @@ import '../model/narrow.dart';
 import 'about_zulip.dart';
 import 'login.dart';
 import 'message_list.dart';
+import 'page.dart';
 import 'recent_dm_conversations.dart';
 import 'store.dart';
 
@@ -110,8 +111,8 @@ class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   static Route<void> buildRoute({required int accountId}) {
-    return MaterialPageRoute(builder: (context) =>
-      PerAccountStoreWidget(accountId: accountId,
+    return MaterialWidgetRoute(
+      page: PerAccountStoreWidget(accountId: accountId,
         child: const HomePage()));
   }
 

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -9,11 +9,12 @@ import '../model/store.dart';
 import 'app.dart';
 import 'dialog.dart';
 import 'input.dart';
+import 'page.dart';
 import 'store.dart';
 
-class _LoginSequenceRoute extends MaterialPageRoute<void> {
+class _LoginSequenceRoute extends MaterialWidgetRoute<void> {
   _LoginSequenceRoute({
-    required super.builder,
+    required super.page,
   });
 }
 
@@ -101,8 +102,7 @@ class AddAccountPage extends StatefulWidget {
   const AddAccountPage({super.key});
 
   static Route<void> buildRoute() {
-    return _LoginSequenceRoute(builder: (context) =>
-      const AddAccountPage());
+    return _LoginSequenceRoute(page: const AddAccountPage());
   }
 
   @override
@@ -231,8 +231,8 @@ class PasswordLoginPage extends StatefulWidget {
   final GetServerSettingsResult serverSettings;
 
   static Route<void> buildRoute({required GetServerSettingsResult serverSettings}) {
-    return _LoginSequenceRoute(builder: (context) =>
-      PasswordLoginPage(serverSettings: serverSettings));
+    return _LoginSequenceRoute(
+      page: PasswordLoginPage(serverSettings: serverSettings));
   }
 
   @override

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -20,9 +20,8 @@ class MessageListPage extends StatefulWidget {
   const MessageListPage({super.key, required this.narrow});
 
   static Route<void> buildRoute({required BuildContext context, required Narrow narrow}) {
-    return MaterialAccountPageRoute(context: context,
-      settings: RouteSettings(name: 'message_list', arguments: narrow), // for testing
-      builder: (context) => MessageListPage(narrow: narrow));
+    return MaterialAccountWidgetRoute(context: context,
+      page: MessageListPage(narrow: narrow));
   }
 
   /// A [ComposeBoxController], if this [MessageListPage] offers a compose box.

--- a/lib/widgets/page.dart
+++ b/lib/widgets/page.dart
@@ -3,6 +3,30 @@ import 'package:flutter/material.dart';
 
 import 'store.dart';
 
+/// A page route that always builds the same widget.
+///
+/// This is useful for making the route more transparent for a test to inspect.
+abstract class WidgetRoute<T> extends PageRoute<T> {
+  /// The widget that this page route always builds.
+  Widget get page;
+}
+
+/// A [MaterialPageRoute] that always builds the same widget.
+///
+/// This is useful for making the route more transparent for a test to inspect.
+class MaterialWidgetRoute<T> extends MaterialPageRoute<T> implements WidgetRoute<T> {
+  MaterialWidgetRoute({
+    required this.page,
+    super.settings,
+    super.maintainState,
+    super.fullscreenDialog,
+    super.allowSnapshotting,
+  }) : super(builder: (context) => page);
+
+  @override
+  final Widget page;
+}
+
 mixin AccountPageRouteMixin<T> on PageRoute<T> {
   int get accountId;
 
@@ -26,6 +50,23 @@ class MaterialAccountPageRoute<T> extends MaterialPageRoute<T> with AccountPageR
 
   @override
   final int accountId;
+}
+
+/// A [MaterialAccountPageRoute] that always builds the same widget.
+///
+/// This is useful for making the route more transparent for a test to inspect.
+class MaterialAccountWidgetRoute<T> extends MaterialAccountPageRoute<T> implements WidgetRoute<T> {
+  MaterialAccountWidgetRoute({
+    required super.context,
+    required this.page,
+    super.settings,
+    super.maintainState,
+    super.fullscreenDialog,
+    super.allowSnapshotting,
+  }) : super(builder: (context) => page);
+
+  @override
+  final Widget page;
 }
 
 class AccountPageRouteBuilder<T> extends PageRouteBuilder<T> with AccountPageRouteMixin<T> {

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -13,8 +13,8 @@ class RecentDmConversationsPage extends StatefulWidget {
   const RecentDmConversationsPage({super.key});
 
   static Route<void> buildRoute({required BuildContext context}) {
-    return MaterialAccountPageRoute(context: context,
-      builder: (context) => const RecentDmConversationsPage());
+    return MaterialAccountWidgetRoute(context: context,
+      page: const RecentDmConversationsPage());
   }
 
   @override

--- a/test/widgets/message_list_checks.dart
+++ b/test/widgets/message_list_checks.dart
@@ -1,0 +1,7 @@
+import 'package:checks/checks.dart';
+import 'package:zulip/model/narrow.dart';
+import 'package:zulip/widgets/message_list.dart';
+
+extension MessageListPageChecks on Subject<MessageListPage> {
+  Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
+}

--- a/test/widgets/page_checks.dart
+++ b/test/widgets/page_checks.dart
@@ -1,0 +1,7 @@
+import 'package:checks/checks.dart';
+import 'package:flutter/widgets.dart';
+import 'package:zulip/widgets/page.dart';
+
+extension WidgetRouteChecks on Subject<WidgetRoute> {
+  Subject<Widget> get page => has((x) => x.page, 'page');
+}

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -7,15 +7,18 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/icons.dart';
+import 'package:zulip/widgets/message_list.dart';
+import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/recent_dm_conversations.dart';
 import 'package:zulip/widgets/store.dart';
 
 import '../example_data.dart' as eg;
-import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/test_store.dart';
 import '../test_navigation.dart';
 import 'content_checks.dart';
+import 'message_list_checks.dart';
+import 'page_checks.dart';
 
 Future<void> setupPage(WidgetTester tester, {
   required List<DmMessage> dmMessages,
@@ -275,9 +278,9 @@ void main() {
         await tester.tap(find.byType(RecentDmConversationsItem));
         // no `tester.pump`, to avoid having to mock API response for [MessageListPage]
 
-        check(pushedRoutes).last.settings
-          ..name.equals('message_list')
-          ..arguments.equals(expectedNarrow);
+        check(pushedRoutes).last.isA<WidgetRoute>().page
+          .isA<MessageListPage>()
+          .narrow.equals(expectedNarrow);
       }
 
       testWidgets('1:1', (WidgetTester tester) async {


### PR DESCRIPTION
As discussed when we added this first test of this kind: https://github.com/zulip/zulip-flutter/pull/249#discussion_r1289230559
