### PR TITLE
login: Implement browser login

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,14 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="zulip" android:host="login" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -29,9 +29,31 @@ Future<GetServerSettingsResult> getServerSettings({
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
+class ExternalAuthenticationMethod {
+  final String name;
+  final String displayName;
+  final String? displayIcon;
+  final String loginUrl;
+  final String signupUrl;
+
+  ExternalAuthenticationMethod({
+    required this.name,
+    required this.displayName,
+    this.displayIcon,
+    required this.loginUrl,
+    required this.signupUrl,
+  });
+
+  factory ExternalAuthenticationMethod.fromJson(Map<String, dynamic> json) =>
+    _$ExternalAuthenticationMethodFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ExternalAuthenticationMethodToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
 class GetServerSettingsResult {
   final Map<String, bool> authenticationMethods;
-  // final List<ExternalAuthenticationMethod> external_authentication_methods; // TODO handle
+  final List<ExternalAuthenticationMethod> externalAuthenticationMethods;
 
   final int zulipFeatureLevel;
   final String zulipVersion;
@@ -44,12 +66,13 @@ class GetServerSettingsResult {
   final bool requireEmailFormatUsernames;
   final Uri realmUri;
   final String realmName;
-  final String realmIcon;
+  final Uri? realmIcon;
   final String realmDescription;
   final bool? realmWebPublicAccessEnabled; // TODO(server-5)
 
   GetServerSettingsResult({
     required this.authenticationMethods,
+    required this.externalAuthenticationMethods,
     required this.zulipFeatureLevel,
     required this.zulipVersion,
     this.zulipMergeBase,

--- a/lib/api/route/realm.g.dart
+++ b/lib/api/route/realm.g.dart
@@ -8,11 +8,36 @@ part of 'realm.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+ExternalAuthenticationMethod _$ExternalAuthenticationMethodFromJson(
+        Map<String, dynamic> json) =>
+    ExternalAuthenticationMethod(
+      name: json['name'] as String,
+      displayName: json['display_name'] as String,
+      displayIcon: json['display_icon'] as String?,
+      loginUrl: json['login_url'] as String,
+      signupUrl: json['signup_url'] as String,
+    );
+
+Map<String, dynamic> _$ExternalAuthenticationMethodToJson(
+        ExternalAuthenticationMethod instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'display_name': instance.displayName,
+      'display_icon': instance.displayIcon,
+      'login_url': instance.loginUrl,
+      'signup_url': instance.signupUrl,
+    };
+
 GetServerSettingsResult _$GetServerSettingsResultFromJson(
         Map<String, dynamic> json) =>
     GetServerSettingsResult(
       authenticationMethods:
           Map<String, bool>.from(json['authentication_methods'] as Map),
+      externalAuthenticationMethods: (json['external_authentication_methods']
+              as List<dynamic>)
+          .map((e) =>
+              ExternalAuthenticationMethod.fromJson(e as Map<String, dynamic>))
+          .toList(),
       zulipFeatureLevel: json['zulip_feature_level'] as int,
       zulipVersion: json['zulip_version'] as String,
       zulipMergeBase: json['zulip_merge_base'] as String?,
@@ -23,7 +48,9 @@ GetServerSettingsResult _$GetServerSettingsResultFromJson(
           json['require_email_format_usernames'] as bool,
       realmUri: Uri.parse(json['realm_uri'] as String),
       realmName: json['realm_name'] as String,
-      realmIcon: json['realm_icon'] as String,
+      realmIcon: json['realm_icon'] == null
+          ? null
+          : Uri.parse(json['realm_icon'] as String),
       realmDescription: json['realm_description'] as String,
       realmWebPublicAccessEnabled:
           json['realm_web_public_access_enabled'] as bool?,
@@ -33,6 +60,7 @@ Map<String, dynamic> _$GetServerSettingsResultToJson(
         GetServerSettingsResult instance) =>
     <String, dynamic>{
       'authentication_methods': instance.authenticationMethods,
+      'external_authentication_methods': instance.externalAuthenticationMethods,
       'zulip_feature_level': instance.zulipFeatureLevel,
       'zulip_version': instance.zulipVersion,
       'zulip_merge_base': instance.zulipMergeBase,
@@ -42,7 +70,7 @@ Map<String, dynamic> _$GetServerSettingsResultToJson(
       'require_email_format_usernames': instance.requireEmailFormatUsernames,
       'realm_uri': instance.realmUri.toString(),
       'realm_name': instance.realmName,
-      'realm_icon': instance.realmIcon,
+      'realm_icon': instance.realmIcon?.toString(),
       'realm_description': instance.realmDescription,
       'realm_web_public_access_enabled': instance.realmWebPublicAccessEnabled,
     };

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../model/narrow.dart';
 import 'about_zulip.dart';
 import 'login.dart';
+import 'login/browser_login.dart';
 import 'message_list.dart';
 import 'page.dart';
 import 'recent_dm_conversations.dart';
@@ -25,10 +26,29 @@ class ZulipApp extends StatelessWidget {
       //   https://m3.material.io/theme-builder#/custom
       colorScheme: ColorScheme.fromSeed(seedColor: kZulipBrandColor));
     return GlobalStoreWidget(
-      child: MaterialApp(
-        title: 'Zulip',
-        theme: theme,
-        home: const ChooseAccountPage()));
+      child: BrowserLoginWidget(
+        child: Builder(
+          builder: (context) => MaterialApp(
+            title: 'Zulip',
+            theme: theme,
+            home: const ChooseAccountPage(),
+            navigatorKey: BrowserLoginWidget.of(context).navigatorKey,
+            // TODO: Migrate to `MaterialApp.router` & `Router`, so that we can receive
+            //       a full Uri instead of just path+query components and also maybe
+            //       remove the InheritedWidget + navigatorKey hack.
+            // See docs:
+            //   https://api.flutter.dev/flutter/widgets/Router-class.html
+            onGenerateRoute: (settings) {
+              if (settings.name == null) return null;
+              final uri = Uri.parse(settings.name!);
+              if (uri.queryParameters.containsKey('otp_encrypted_api_key')) {
+                BrowserLoginWidget.of(context).loginFromExternalRoute(context, uri);
+                return null;
+              }
+              return null;
+            })),
+      ),
+    );
   }
 }
 

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -9,11 +9,12 @@ import '../model/store.dart';
 import 'app.dart';
 import 'dialog.dart';
 import 'input.dart';
+import 'login/browser_login.dart';
 import 'page.dart';
 import 'store.dart';
 
-class _LoginSequenceRoute extends MaterialWidgetRoute<void> {
-  _LoginSequenceRoute({
+class LoginSequenceRoute extends MaterialWidgetRoute<void> {
+  LoginSequenceRoute({
     required super.page,
   });
 }
@@ -102,7 +103,7 @@ class AddAccountPage extends StatefulWidget {
   const AddAccountPage({super.key});
 
   static Route<void> buildRoute() {
-    return _LoginSequenceRoute(page: const AddAccountPage());
+    return LoginSequenceRoute(page: const AddAccountPage());
   }
 
   @override
@@ -230,7 +231,7 @@ class AuthMethodsPage extends StatefulWidget {
   final GetServerSettingsResult serverSettings;
 
   static Route<void> buildRoute({required GetServerSettingsResult serverSettings}) {
-    return _LoginSequenceRoute(
+    return LoginSequenceRoute(
       page: AuthMethodsPage(serverSettings: serverSettings));
   }
 
@@ -243,10 +244,12 @@ class _AuthMethodsPageState extends State<AuthMethodsPage> {
   //       or update to add a new method.
   static const Set<String> _testedAuthMethods = {
     'github',
+    'gitlab',
     'google',
   };
 
-  Future<void> _openBrowserLogin(ExternalAuthenticationMethod method) async {}
+  Future<void> _openBrowserLogin(ExternalAuthenticationMethod method) =>
+    BrowserLoginWidget.of(context).openLoginUrl(widget.serverSettings, method.loginUrl);
 
   @override
   Widget build(BuildContext context) {
@@ -304,7 +307,7 @@ class PasswordLoginPage extends StatefulWidget {
   final GetServerSettingsResult serverSettings;
 
   static Route<void> buildRoute({required GetServerSettingsResult serverSettings}) {
-    return _LoginSequenceRoute(
+    return LoginSequenceRoute(
       page: PasswordLoginPage(serverSettings: serverSettings));
   }
 
@@ -396,7 +399,7 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
 
       Navigator.of(context).pushAndRemoveUntil(
         HomePage.buildRoute(accountId: accountId),
-        (route) => (route is! _LoginSequenceRoute),
+        (route) => (route is! LoginSequenceRoute),
       );
     } finally {
       setState(() {

--- a/lib/widgets/login/browser_login.dart
+++ b/lib/widgets/login/browser_login.dart
@@ -1,0 +1,181 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:convert/convert.dart';
+import 'package:drift/drift.dart';
+import 'package:flutter/widgets.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../api/route/realm.dart';
+import '../../log.dart';
+import '../../model/store.dart';
+import '../app.dart';
+import '../login.dart';
+import '../store.dart';
+
+/// An InheritedWidget to co-ordinate the browser auth flow
+///
+/// The provided [navigatorKey] by this object should be attached to
+/// the main app widget so that when the browser redirects to the app
+/// using the universal link this widget can use it to access the current
+/// navigator instance.
+///
+/// This object also stores the temporarily generated OTP required for
+/// the completion of the flow.
+class BrowserLoginWidget extends InheritedWidget {
+  BrowserLoginWidget({super.key, required super.child});
+
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+  // TODO: Maybe store these on local DB too, because OS can close the
+  //       app while user is using the browser during the auth flow.
+
+  // Temporary mobile_flow_otp, that was generated while initiating a browser auth flow.
+  final Map<Uri, String> _tempAuthOtp = {};
+  // Temporary server settngs, that was stored while initiating a browser auth flow.
+  final Map<Uri, GetServerSettingsResult> _tempServerSettings = {};
+
+  @override
+  bool updateShouldNotify(covariant BrowserLoginWidget oldWidget) =>
+    !identical(oldWidget.navigatorKey, navigatorKey)
+    && !identical(oldWidget._tempAuthOtp, _tempAuthOtp)
+    && !identical(oldWidget._tempServerSettings, _tempServerSettings);
+
+  static BrowserLoginWidget of(BuildContext context) {
+    final widget = context.dependOnInheritedWidgetOfExactType<BrowserLoginWidget>();
+    assert(widget != null, 'No BrowserLogin ancestor');
+    return widget!;
+  }
+
+  Future<void> openLoginUrl(GetServerSettingsResult serverSettings, String loginUrl) async {
+    // Generate a temporary otp and store it for later use - for decoding the
+    // api key returned by server which will be XOR-ed with this otp.
+    final otp = _generateMobileFlowOtp();
+    _tempAuthOtp[serverSettings.realmUri] = otp;
+    _tempServerSettings[serverSettings.realmUri] = serverSettings;
+
+    // Open the browser
+    await launchUrl(serverSettings.realmUri.replace(
+      path: loginUrl,
+      queryParameters: {'mobile_flow_otp': otp},
+    ));
+  }
+
+  Future<void> loginFromExternalRoute(BuildContext context, Uri uri) async {
+    final globalStore = GlobalStoreWidget.of(context);
+
+    // Parse the query params from the browser redirect url
+    final String otpEncryptedApiKey;
+    final String email;
+    final int userId;
+    final Uri realm;
+    try {
+      if (uri.queryParameters case {
+        'otp_encrypted_api_key': final String otpEncryptedApiKeyStr,
+        'email': final String emailStr,
+        'user_id': final String userIdStr,
+        'realm': final String realmStr,
+      }) {
+        if (otpEncryptedApiKeyStr.isEmpty || emailStr.isEmpty || userIdStr.isEmpty || realmStr.isEmpty) {
+          throw 'Got invalid query params from browser redirect url';
+        }
+        otpEncryptedApiKey = otpEncryptedApiKeyStr;
+        realm = Uri.parse(realmStr);
+        userId = int.parse(userIdStr);
+        email = emailStr;
+      } else {
+        throw 'Got invalid query params from browser redirect url';
+      }
+    } catch (e, st) {
+      // TODO: Log error to Sentry
+      debugLog('$e\n$st');
+      return;
+    }
+
+    // Get the previously temporarily stored otp & serverSettings.
+    final GetServerSettingsResult serverSettings;
+    final String apiKey;
+    try {
+      final otp = _tempAuthOtp[realm];
+      _tempAuthOtp.clear();
+      final settings = _tempServerSettings[realm];
+      _tempServerSettings.clear();
+      if (otp == null) {
+        throw 'Failed to find the previously generated mobile_auth_otp';
+      }
+      if (settings == null) {
+        // TODO: Maybe try refetching instead of error-ing out.
+        throw 'Failed to find the previously stored serverSettings';
+      }
+
+      // Decode the otp XOR-ed api key
+      apiKey = _decodeApiKey(otp, otpEncryptedApiKey);
+      serverSettings = settings;
+    } catch (e, st) {
+      // TODO: Log error to Sentry
+      debugLog('$e\n$st');
+      return;
+    }
+
+    // TODO(#108): give feedback to user on SQL exception, like dupe realm+user
+    final accountId = await globalStore.insertAccount(AccountsCompanion.insert(
+      realmUrl: serverSettings.realmUri,
+      email: email,
+      apiKey: apiKey,
+      userId: userId,
+      zulipFeatureLevel: serverSettings.zulipFeatureLevel,
+      zulipVersion: serverSettings.zulipVersion,
+      zulipMergeBase: Value(serverSettings.zulipMergeBase),
+    ));
+
+    if (!context.mounted) {
+      return;
+    }
+    navigatorKey.currentState?.pushAndRemoveUntil(
+      HomePage.buildRoute(accountId: accountId),
+      (route) => (route is! LoginSequenceRoute),
+    );
+  }
+}
+
+/// Generates a `mobile_flow_otp` to be used by the server for
+/// mobile login flow, server XOR's the api key with the otp hex
+/// and returns the resulting value. So, the same otp that was passed
+/// to the server can be used again to decode the actual api key.
+String _generateMobileFlowOtp() {
+  final rand = Random.secure();
+  return hex.encode(rand.nextBytes(32));
+}
+
+String _decodeApiKey(String otp, String otpEncryptedApiKey) {
+  final otpHex = hex.decode(otp);
+  final otpEncryptedApiKeyHex = hex.decode(otpEncryptedApiKey);
+  return String.fromCharCodes(otpHex ^ otpEncryptedApiKeyHex);
+}
+
+// TODO: Remove this when upstream issue is fixed
+//  https://github.com/dart-lang/sdk/issues/53339
+extension _RandomNextBytes on Random {
+  static const int _pow2_32 = 0x100000000;
+  Uint8List nextBytes(int length) {
+    if ((length % 4) != 0) {
+      throw ArgumentError('\'length\' must be a multiple of 4');
+    }
+    final result = Uint32List(length);
+    for (int i = 0; i < length; i++) {
+      result[i] = nextInt(_pow2_32);
+    }
+    return result.buffer.asUint8List(0, length);
+  }
+}
+
+extension _IntListOpXOR on List<int> {
+  Iterable<int> operator ^(List<int> other) sync* {
+    if (length != other.length) {
+      throw ArgumentError('Both lists must have the same length');
+    }
+    for (var i = 0; i < length; i++) {
+      yield this[i] ^ other[i];
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,7 +186,7 @@ packages:
     source: hosted
     version: "1.18.0"
   convert:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: convert
       sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
@@ -921,18 +921,18 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "781bd58a1eb16069412365c98597726cd8810ae27435f04b3b4d3a470bacd61e"
+      sha256: "47e208a6711459d813ba18af120d9663c20bdf6985d6ad39fe165d2538378d27"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.12"
+    version: "6.1.14"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3dd2388cc0c42912eee04434531a26a82512b9cb1827e0214430c9bcbddfe025"
+      sha256: b04af59516ab45762b2ca6da40fa830d72d0f6045cd97744450b73493fa76330
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.38"
+    version: "6.1.0"
   url_launcher_ios:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,8 @@ dependencies:
   image_picker: ^1.0.0
   package_info_plus: ^4.0.1
   collection: ^1.17.2
-  url_launcher: ^6.1.11
+  url_launcher: ^6.1.14
+  convert: ^3.1.1
 
 dev_dependencies:
   flutter_test:

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1,5 +1,6 @@
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/model/store.dart';
 
 import 'api/fake_api.dart';
@@ -275,5 +276,55 @@ PerAccountStore store() {
     account: selfAccount,
     connection: FakeApiConnection.fromAccount(selfAccount),
     initialSnapshot: initialSnapshot(),
+  );
+}
+
+GetServerSettingsResult serverSettings({
+  Map<String, bool>? authenticationMethods,
+  List<ExternalAuthenticationMethod>? externalAuthenticationMethods,
+  int? zulipFeatureLevel,
+  String? zulipVersion,
+  String? zulipMergeBase,
+  bool? pushNotificationsEnabled,
+  bool? isIncompatible,
+  bool? emailAuthEnabled,
+  bool? requireEmailFormatUsernames,
+  Uri? realmUri,
+  String? realmName,
+  Uri? realmIcon,
+  String? realmDescription,
+  bool? realmWebPublicAccessEnabled,
+  }) {
+  return GetServerSettingsResult(
+    authenticationMethods: authenticationMethods ?? {},
+    externalAuthenticationMethods: externalAuthenticationMethods ?? [],
+    zulipFeatureLevel: zulipFeatureLevel ?? recentZulipFeatureLevel,
+    zulipVersion: zulipVersion ?? recentZulipVersion,
+    zulipMergeBase: zulipMergeBase ?? recentZulipVersion,
+    pushNotificationsEnabled: pushNotificationsEnabled ?? false,
+    isIncompatible: isIncompatible ?? false,
+    emailAuthEnabled: emailAuthEnabled ?? true,
+    requireEmailFormatUsernames: requireEmailFormatUsernames ?? true,
+    realmUri: realmUri ?? realmUrl,
+    realmName: realmName ?? '',
+    realmIcon: realmIcon,
+    realmDescription: realmDescription ?? '',
+    realmWebPublicAccessEnabled: realmWebPublicAccessEnabled ?? false,
+  );
+}
+
+ExternalAuthenticationMethod externalAuthenticationMethod({
+  String? name,
+  String? displayName,
+  String? displayIcon,
+  String? loginUrl,
+  String? signupUrl,
+}) {
+  return ExternalAuthenticationMethod(
+    name: name ?? '',
+    displayName: displayName ?? '',
+    displayIcon: displayIcon,
+    loginUrl: loginUrl ?? '',
+    signupUrl: signupUrl ?? '',
   );
 }

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -1,10 +1,108 @@
 import 'package:checks/checks.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/widgets/login.dart';
 
+import '../model/binding.dart';
 import '../stdlib_checks.dart';
+import '../example_data.dart' as eg;
 
 void main() {
+  TestZulipBinding.ensureInitialized();
+
+  group('AuthMethodsPage', () {
+    Future<void> setupPage(WidgetTester tester, {
+      required GetServerSettingsResult serverSettings,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AuthMethodsPage(serverSettings: serverSettings)));
+    }
+
+    testWidgets('shows all the external methods', (tester) async {
+      final methods = <ExternalAuthenticationMethod>[
+        eg.externalAuthenticationMethod(
+          name: 'some_new_method',
+          displayName: 'Some new method',
+        ),
+        eg.externalAuthenticationMethod(
+          name: 'github',
+          displayName: 'Github',
+        ),
+      ];
+      await setupPage(
+        tester,
+        serverSettings: eg.serverSettings(
+          emailAuthEnabled: false, // don't show password method
+          externalAuthenticationMethods: methods));
+
+      final widgets = tester.widgetList<OutlinedButton>(
+        find.ancestor(
+          of: find.textContaining('Sign in with'),
+          matching: find.byType(OutlinedButton))
+      );
+      check(widgets.length).equals(methods.length);
+    });
+
+    testWidgets('shows all the methods', (tester) async {
+      final methods = <ExternalAuthenticationMethod>[
+        eg.externalAuthenticationMethod(
+          name: 'some_new_method',
+          displayName: 'Some new method',
+        ),
+        eg.externalAuthenticationMethod(
+          name: 'github',
+          displayName: 'Github',
+        ),
+      ];
+      await setupPage(
+        tester,
+        serverSettings: eg.serverSettings(
+          emailAuthEnabled: true, // show password method
+          externalAuthenticationMethods: methods));
+
+      final widgets = tester.widgetList<OutlinedButton>(
+        find.ancestor(
+          of: find.textContaining('Sign in with'),
+          matching: find.byType(OutlinedButton))
+      );
+      check(widgets.length).equals(methods.length + 1);
+    });
+
+    testWidgets('untested methods disabled', (tester) async {
+      final untestedMethod = eg.externalAuthenticationMethod(
+        name: 'some_new_method',
+        displayName: 'Some new method',
+      );
+      await setupPage(
+        tester,
+        serverSettings: eg.serverSettings(externalAuthenticationMethods: [untestedMethod]));
+
+      final button = tester.widget<OutlinedButton>(
+        find.ancestor(
+          of: find.text('Sign in with ${untestedMethod.displayName}'),
+          matching: find.byType(OutlinedButton)));
+      check(button.enabled).isFalse();
+    });
+
+    testWidgets('tested methods enabled', (tester) async {
+      final testedMethod = eg.externalAuthenticationMethod(
+        name: 'github',
+        displayName: 'Github',
+      );
+      await setupPage(
+        tester,
+        serverSettings: eg.serverSettings(externalAuthenticationMethods: [testedMethod]));
+
+      final button = tester.firstWidget<OutlinedButton>(
+        find.ancestor(
+          of: find.text('Sign in with ${testedMethod.displayName}'),
+          matching: find.byType(OutlinedButton)));
+      check(button.enabled).isTrue();
+    });
+  });
+
   group('ServerUrlTextEditingController.tryParse', () {
     final controller = ServerUrlTextEditingController();
 


### PR DESCRIPTION
Fixes #36

Implement authentication using browser auth methods, currently only tested and implemented on Android, but I doubt getting it to work on iOS would be an extensive - in theory should only require [enabling universal link support in Flutter](https://docs.flutter.dev/cookbook/navigation/set-up-universal-links).

Testing this locally will require the zulip-mobile app uninstalled, because the redirect url from the browser 'zulip://login' will also be handled by zulip-mobile and if that happens the behavior will UB.

Also only some `external_methods` are tested and only those are enabled currently (google, github, gitlab).

| Preview |
| - |
| [output.webm](https://github.com/zulip/zulip-flutter/assets/36819268/a6011869-265d-4a4c-936d-6fdb6a6c75a9) |

