### PR TITLE
model: Add `Reactions` data structure, for efficient access in UI

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -352,7 +352,9 @@ sealed class Message {
   bool isMeMessage;
   int? lastEditTimestamp;
 
-  final List<Reaction> reactions;
+  @JsonKey(fromJson: _reactionsFromJson, toJson: _reactionsToJson)
+  Reactions? reactions; // null is equivalent to an empty [Reactions]
+
   final int recipientId;
   final String senderEmail;
   final String senderFullName;
@@ -369,6 +371,15 @@ sealed class Message {
   List<MessageFlag> flags; // Unrecognized flags won't roundtrip through {to,from}Json.
   final String? matchContent;
   final String? matchSubject;
+
+  static Reactions? _reactionsFromJson(dynamic json) {
+    final list = (json as List<dynamic>);
+    return list.isNotEmpty ? Reactions.fromJson(list) : null;
+  }
+
+  static Object _reactionsToJson(Reactions? value) {
+    return value ?? [];
+  }
 
   static List<MessageFlag> _flagsFromJson(dynamic json) {
     final list = json as List<dynamic>;

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1,5 +1,9 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'reaction.dart';
+
+export 'reaction.dart';
+
 part 'model.g.dart';
 
 /// As in [InitialSnapshot.customProfileFields].
@@ -564,39 +568,4 @@ class DmMessage extends Message {
 
   @override
   Map<String, dynamic> toJson() => _$DmMessageToJson(this);
-}
-
-/// As in [Message.reactions].
-@JsonSerializable(fieldRename: FieldRename.snake)
-class Reaction {
-  final String emojiName;
-  final String emojiCode;
-  final ReactionType reactionType;
-  final int userId;
-  // final Map<String, dynamic> user; // deprecated; ignore
-
-  Reaction({
-    required this.emojiName,
-    required this.emojiCode,
-    required this.reactionType,
-    required this.userId,
-  });
-
-  factory Reaction.fromJson(Map<String, dynamic> json) =>
-    _$ReactionFromJson(json);
-
-  Map<String, dynamic> toJson() => _$ReactionToJson(this);
-
-  @override
-  String toString() => 'Reaction(emojiName: $emojiName, emojiCode: $emojiCode, reactionType: $reactionType, userId: $userId)';
-}
-
-/// As in [Reaction.reactionType].
-@JsonEnum(fieldRename: FieldRename.snake)
-enum ReactionType {
-  unicodeEmoji,
-  realmEmoji,
-  zulipExtraEmoji;
-
-  String toJson() => _$ReactionTypeEnumMap[this]!;
 }

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -236,9 +236,7 @@ StreamMessage _$StreamMessageFromJson(Map<String, dynamic> json) =>
       id: json['id'] as int,
       isMeMessage: json['is_me_message'] as bool,
       lastEditTimestamp: json['last_edit_timestamp'] as int?,
-      reactions: (json['reactions'] as List<dynamic>)
-          .map((e) => Reaction.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      reactions: Message._reactionsFromJson(json['reactions']),
       recipientId: json['recipient_id'] as int,
       senderEmail: json['sender_email'] as String,
       senderFullName: json['sender_full_name'] as String,
@@ -261,7 +259,7 @@ Map<String, dynamic> _$StreamMessageToJson(StreamMessage instance) =>
       'id': instance.id,
       'is_me_message': instance.isMeMessage,
       'last_edit_timestamp': instance.lastEditTimestamp,
-      'reactions': instance.reactions,
+      'reactions': Message._reactionsToJson(instance.reactions),
       'recipient_id': instance.recipientId,
       'sender_email': instance.senderEmail,
       'sender_full_name': instance.senderFullName,
@@ -297,9 +295,7 @@ DmMessage _$DmMessageFromJson(Map<String, dynamic> json) => DmMessage(
       id: json['id'] as int,
       isMeMessage: json['is_me_message'] as bool,
       lastEditTimestamp: json['last_edit_timestamp'] as int?,
-      reactions: (json['reactions'] as List<dynamic>)
-          .map((e) => Reaction.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      reactions: Message._reactionsFromJson(json['reactions']),
       recipientId: json['recipient_id'] as int,
       senderEmail: json['sender_email'] as String,
       senderFullName: json['sender_full_name'] as String,
@@ -321,7 +317,7 @@ Map<String, dynamic> _$DmMessageToJson(DmMessage instance) => <String, dynamic>{
       'id': instance.id,
       'is_me_message': instance.isMeMessage,
       'last_edit_timestamp': instance.lastEditTimestamp,
-      'reactions': instance.reactions,
+      'reactions': Message._reactionsToJson(instance.reactions),
       'recipient_id': instance.recipientId,
       'sender_email': instance.senderEmail,
       'sender_full_name': instance.senderFullName,

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -337,26 +337,6 @@ Map<String, dynamic> _$DmMessageToJson(DmMessage instance) => <String, dynamic>{
           const DmRecipientListConverter().toJson(instance.displayRecipient),
     };
 
-Reaction _$ReactionFromJson(Map<String, dynamic> json) => Reaction(
-      emojiName: json['emoji_name'] as String,
-      emojiCode: json['emoji_code'] as String,
-      reactionType: $enumDecode(_$ReactionTypeEnumMap, json['reaction_type']),
-      userId: json['user_id'] as int,
-    );
-
-Map<String, dynamic> _$ReactionToJson(Reaction instance) => <String, dynamic>{
-      'emoji_name': instance.emojiName,
-      'emoji_code': instance.emojiCode,
-      'reaction_type': instance.reactionType,
-      'user_id': instance.userId,
-    };
-
-const _$ReactionTypeEnumMap = {
-  ReactionType.unicodeEmoji: 'unicode_emoji',
-  ReactionType.realmEmoji: 'realm_emoji',
-  ReactionType.zulipExtraEmoji: 'zulip_extra_emoji',
-};
-
 const _$MessageFlagEnumMap = {
   MessageFlag.read: 'read',
   MessageFlag.starred: 'starred',

--- a/lib/api/model/reaction.dart
+++ b/lib/api/model/reaction.dart
@@ -1,8 +1,148 @@
+import 'dart:collection';
+
+import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'reaction.g.dart';
 
-/// As in [Message.reactions].
+/// A message's reactions, in a convenient data structure.
+class Reactions {
+  int get total => _total;
+  int _total;
+
+  /// A list of [ReactionWithVotes] objects.
+  ///
+  /// There won't be two items with the same
+  /// [ReactionWithVotes.reactionType] and [ReactionWithVotes.emojiCode].
+  /// (We don't also key on [ReactionWithVotes.emojiName];
+  /// see [ReactionWithVotes].)
+  ///
+  /// Sorted descending by the size of [ReactionWithVotes.userIds],
+  /// i.e., the number of votes.
+  late final List<ReactionWithVotes> aggregated;
+
+  Reactions._(this.aggregated, this._total);
+
+  factory Reactions(List<Reaction> unaggregated) {
+    final byReaction = LinkedHashMap<Reaction, ReactionWithVotes>(
+      equals: (a, b) => a.reactionType == b.reactionType && a.emojiCode == b.emojiCode,
+      hashCode: (r) => Object.hash(r.reactionType, r.emojiCode),
+    );
+    for (final reaction in unaggregated) {
+      final current = byReaction[reaction] ??= ReactionWithVotes.empty(reaction);
+      current.userIds.add(reaction.userId);
+    }
+
+    return Reactions._(
+      byReaction.values.sorted(
+        // Descending by number of votes
+        (a, b) => -a.userIds.length.compareTo(b.userIds.length),
+      ),
+      unaggregated.length,
+    );
+  }
+
+  factory Reactions.fromJson(List<dynamic> json) {
+    return Reactions(
+      json.map((r) => Reaction.fromJson(r as Map<String, dynamic>)).toList(),
+    );
+  }
+
+  List<dynamic> toJson() {
+    final result = <Reaction>[];
+    for (final reactionWithVotes in aggregated) {
+      result.addAll(reactionWithVotes.userIds.map((userId) => Reaction(
+        reactionType: reactionWithVotes.reactionType,
+        emojiCode: reactionWithVotes.emojiCode,
+        emojiName: reactionWithVotes.emojiName,
+        userId: userId,
+      )));
+    }
+    return result;
+  }
+
+  void add(Reaction reaction) {
+    final currentIndex = aggregated.indexWhere((r) {
+      return r.reactionType == reaction.reactionType && r.emojiCode == reaction.emojiCode;
+    });
+    if (currentIndex == -1) {
+      final newItem = ReactionWithVotes.empty(reaction);
+      newItem.userIds.add(reaction.userId);
+      aggregated.add(newItem);
+    } else {
+      final current = aggregated[currentIndex];
+      current.userIds.add(reaction.userId);
+
+      // Reposition `current` in list to keep it sorted by number of votes
+      final newIndex = 1 + aggregated.lastIndexWhere(
+        (item) => item.userIds.length >= current.userIds.length,
+        currentIndex - 1,
+      );
+      if (newIndex < currentIndex) {
+        aggregated
+          ..setRange(newIndex + 1, currentIndex + 1, aggregated, newIndex)
+          ..[newIndex] = current;
+      }
+    }
+    _total++;
+  }
+
+  void remove({
+    required ReactionType reactionType,
+    required String emojiCode,
+    required int userId,
+  }) {
+    final currentIndex = aggregated.indexWhere((r) {
+      return r.reactionType == reactionType && r.emojiCode == emojiCode;
+    });
+    if (currentIndex == -1) { // TODO(log)
+      return;
+    }
+    final current = aggregated[currentIndex];
+    current.userIds.remove(userId);
+    if (current.userIds.isEmpty) {
+      aggregated.removeAt(currentIndex);
+    } else {
+      final lteIndex = aggregated.indexWhere(
+        (item) => item.userIds.length <= current.userIds.length,
+        currentIndex + 1,
+      );
+      final newIndex = lteIndex == -1 ? aggregated.length - 1 : lteIndex - 1;
+      if (newIndex > currentIndex) {
+        aggregated
+          ..setRange(currentIndex, newIndex, aggregated, currentIndex + 1)
+          ..[newIndex] = current;
+      }
+    }
+    _total--;
+  }
+}
+
+/// A data structure identifying a reaction and who has voted for it.
+///
+/// [emojiName] is not part of the key identifying the reaction.
+/// Servers don't key on it (only user, message, reaction type, and emoji code),
+/// and we mimic that behavior:
+///   https://github.com/zulip/zulip-flutter/pull/256#discussion_r1284865099
+/// It's included here so we can display it in UI.
+class ReactionWithVotes {
+  final ReactionType reactionType;
+  final String emojiCode;
+  final String emojiName;
+  final Set<int> userIds = {};
+
+  ReactionWithVotes.empty(Reaction reaction)
+    : reactionType = reaction.reactionType,
+      emojiCode    = reaction.emojiCode,
+      emojiName    = reaction.emojiName;
+
+  @override
+  String toString() => 'ReactionWithVotes(reactionType: $reactionType, emojiCode: $emojiCode, emojiName: $emojiName, userIds: $userIds)';
+}
+
+/// A reaction object found inside message objects in the Zulip API.
+///
+/// E.g., under "reactions:" in <https://zulip.com/api/get-message>.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class Reaction {
   final String emojiName;

--- a/lib/api/model/reaction.dart
+++ b/lib/api/model/reaction.dart
@@ -1,0 +1,38 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'reaction.g.dart';
+
+/// As in [Message.reactions].
+@JsonSerializable(fieldRename: FieldRename.snake)
+class Reaction {
+  final String emojiName;
+  final String emojiCode;
+  final ReactionType reactionType;
+  final int userId;
+  // final Map<String, dynamic> user; // deprecated; ignore
+
+  Reaction({
+    required this.emojiName,
+    required this.emojiCode,
+    required this.reactionType,
+    required this.userId,
+  });
+
+  factory Reaction.fromJson(Map<String, dynamic> json) =>
+    _$ReactionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ReactionToJson(this);
+
+  @override
+  String toString() => 'Reaction(emojiName: $emojiName, emojiCode: $emojiCode, reactionType: $reactionType, userId: $userId)';
+}
+
+/// As in [Reaction.reactionType].
+@JsonEnum(fieldRename: FieldRename.snake)
+enum ReactionType {
+  unicodeEmoji,
+  realmEmoji,
+  zulipExtraEmoji;
+
+  String toJson() => _$ReactionTypeEnumMap[this]!;
+}

--- a/lib/api/model/reaction.g.dart
+++ b/lib/api/model/reaction.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: unnecessary_cast
+
+part of 'reaction.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Reaction _$ReactionFromJson(Map<String, dynamic> json) => Reaction(
+      emojiName: json['emoji_name'] as String,
+      emojiCode: json['emoji_code'] as String,
+      reactionType: $enumDecode(_$ReactionTypeEnumMap, json['reaction_type']),
+      userId: json['user_id'] as int,
+    );
+
+Map<String, dynamic> _$ReactionToJson(Reaction instance) => <String, dynamic>{
+      'emoji_name': instance.emojiName,
+      'emoji_code': instance.emojiCode,
+      'reaction_type': instance.reactionType,
+      'user_id': instance.userId,
+    };
+
+const _$ReactionTypeEnumMap = {
+  ReactionType.unicodeEmoji: 'unicode_emoji',
+  ReactionType.realmEmoji: 'realm_emoji',
+  ReactionType.zulipExtraEmoji: 'zulip_extra_emoji',
+};

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -350,18 +350,21 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     final message = messages[index];
     switch (event.op) {
       case ReactionOp.add:
-        message.reactions.add(Reaction(
+        (message.reactions ??= Reactions([])).add(Reaction(
           emojiName: event.emojiName,
           emojiCode: event.emojiCode,
           reactionType: event.reactionType,
           userId: event.userId,
         ));
       case ReactionOp.remove:
-        message.reactions.removeWhere((r) {
-          return r.emojiCode == event.emojiCode
-            && r.reactionType == event.reactionType
-            && r.userId == event.userId;
-        });
+        if (message.reactions == null) { // TODO(log)
+          return;
+        }
+        message.reactions!.remove(
+          reactionType: event.reactionType,
+          emojiCode: event.emojiCode,
+          userId: event.userId,
+        );
     }
 
     notifyListeners();

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -15,7 +15,7 @@ void main() {
     MessageEvent mkEvent(List<MessageFlag> flags) => Event.fromJson({
       'type': 'message',
       'id': 1,
-      'message': message.toJson()..remove('flags'),
+      'message': (deepToJson(message) as Map<String, dynamic>)..remove('flags'),
       'flags': flags.map((f) => f.toJson()).toList(),
     }) as MessageEvent;
     check(mkEvent(message.flags)).message.jsonEquals(message);

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -5,15 +5,41 @@ extension MessageChecks on Subject<Message> {
   Subject<String> get content => has((e) => e.content, 'content');
   Subject<bool> get isMeMessage => has((e) => e.isMeMessage, 'isMeMessage');
   Subject<int?> get lastEditTimestamp => has((e) => e.lastEditTimestamp, 'lastEditTimestamp');
-  Subject<List<Reaction>> get reactions => has((e) => e.reactions, 'reactions');
+  Subject<Reactions?> get reactions => has((e) => e.reactions, 'reactions');
   Subject<List<MessageFlag>> get flags => has((e) => e.flags, 'flags');
 
   // TODO accessors for other fields
 }
 
-extension ReactionsChecks on Subject<List<Reaction>> {
-  void deepEquals(_) {
-    throw UnimplementedError('Tried to call [Subject<List<Reaction>>.deepEquals]. Use jsonEquals instead.');
+extension ReactionsChecks on Subject<Reactions> {
+  Subject<int> get total => has((e) => e.total, 'total');
+  Subject<List<ReactionWithVotes>> get aggregated => has((e) => e.aggregated, 'aggregated');
+}
+
+extension ReactionWithVotesChecks on Subject<ReactionWithVotes> {
+  Subject<ReactionType> get reactionType => has((r) => r.reactionType, 'reactionType');
+  Subject<String> get emojiCode => has((r) => r.emojiCode, 'emojiCode');
+  Subject<String> get emojiName => has((r) => r.emojiName, 'emojiName');
+  Subject<Set<int>> get userIds => has((r) => r.userIds, 'userIds');
+
+  /// Whether this [ReactionWithVotes] corresponds to the given same-emoji [reactions].
+  void matchesReactions(List<Reaction> reactions) {
+    assert(reactions.isNotEmpty);
+    final first = reactions.first;
+
+    // Same emoji for all reactions
+    assert(reactions.every((r) => r.reactionType == first.reactionType && r.emojiCode == first.emojiCode));
+
+    final userIds = Set.from(reactions.map((r) => r.userId));
+
+    // No double-votes from one person (we don't expect this from servers)
+    assert(userIds.length == reactions.length);
+
+    return which(it()
+      ..reactionType.equals(first.reactionType)
+      ..emojiCode.equals(first.emojiCode)
+      ..userIds.deepEquals(userIds)
+    );
   }
 }
 

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -82,8 +82,9 @@ void main() {
   });
 
   group('DmMessage', () {
-    final Map<String, dynamic> baseJson = Map.unmodifiable(
-      eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]).toJson());
+    final Map<String, dynamic> baseJson = Map.unmodifiable(deepToJson(
+      eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
+    ) as Map<String, dynamic>);
 
     DmMessage parse(Map<String, dynamic> specialJson) {
       return DmMessage.fromJson({ ...baseJson, ...specialJson });

--- a/test/api/model/reaction_test.dart
+++ b/test/api/model/reaction_test.dart
@@ -1,0 +1,207 @@
+import 'package:checks/checks.dart';
+import 'package:checks/context.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/reaction.dart';
+
+import 'model_checks.dart';
+
+void main() {
+  group('Reactions', () {
+    // helper to cut out "it()..isA<ReactionWithVotes>()" goo for callers
+    ConditionSubject matchesReactions(List<Reaction> reactions) {
+      return it()..isA<ReactionWithVotes>().matchesReactions(reactions);
+    }
+
+    test('fromJson', () {
+      final reaction1Json = {'emoji_name': 'thumbs_up', 'emoji_code': '1f44d', 'reaction_type': 'unicode_emoji',     'user_id': 1};
+      final reaction2Json = {'emoji_name': 'thumbs_up', 'emoji_code': '1f44d', 'reaction_type': 'unicode_emoji',     'user_id': 2};
+      final reaction3Json = {'emoji_name': '+1',        'emoji_code': '1f44d', 'reaction_type': 'unicode_emoji',     'user_id': 3};
+
+      final reaction4Json = {'emoji_name': 'twocents',  'emoji_code': '181',   'reaction_type': 'realm_emoji',       'user_id': 1};
+      final reaction5Json = {'emoji_name': 'twocents',  'emoji_code': '181',   'reaction_type': 'realm_emoji',       'user_id': 2};
+
+      final reaction6Json = {'emoji_name': 'zulip',     'emoji_code': 'zulip', 'reaction_type': 'zulip_extra_emoji', 'user_id': 4};
+      final reaction7Json = {'emoji_name': 'zulip',     'emoji_code': 'zulip', 'reaction_type': 'zulip_extra_emoji', 'user_id': 5};
+      final reaction8Json = {'emoji_name': 'zulip',     'emoji_code': 'zulip', 'reaction_type': 'zulip_extra_emoji', 'user_id': 6};
+      final reaction9Json = {'emoji_name': 'zulip',     'emoji_code': 'zulip', 'reaction_type': 'zulip_extra_emoji', 'user_id': 7};
+
+      final reaction1 = Reaction.fromJson(reaction1Json);
+      final reaction2 = Reaction.fromJson(reaction2Json);
+      final reaction3 = Reaction.fromJson(reaction3Json);
+      final reaction4 = Reaction.fromJson(reaction4Json);
+      final reaction5 = Reaction.fromJson(reaction5Json);
+      final reaction6 = Reaction.fromJson(reaction6Json);
+      final reaction7 = Reaction.fromJson(reaction7Json);
+      final reaction8 = Reaction.fromJson(reaction8Json);
+      final reaction9 = Reaction.fromJson(reaction9Json);
+
+      check(Reactions.fromJson([
+        reaction1Json, reaction2Json, reaction3Json, reaction4Json, reaction5Json,
+        reaction6Json, reaction7Json, reaction8Json, reaction9Json
+      ]))
+        ..aggregated.deepEquals([
+            matchesReactions([reaction6, reaction7, reaction8, reaction9]),
+            matchesReactions([reaction1, reaction2, reaction3]),
+            matchesReactions([reaction4, reaction5]),
+          ])
+        ..total.equals(9);
+    });
+
+    test('add', () {
+      final reaction0 = Reaction(
+        reactionType: ReactionType.unicodeEmoji, emojiCode: '1f44d', emojiName: 'thumbs_up', userId: 1);
+      final reactions = Reactions([reaction0]);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction0])
+          ])
+        ..total.equals(1);
+
+      // …Different reactionType
+      final reaction1 = Reaction(
+        reactionType: ReactionType.realmEmoji, emojiCode: '181', emojiName: 'twocents', userId: 1);
+      reactions.add(reaction1);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction0]),
+            matchesReactions([reaction1]),
+          ])
+        ..total.equals(2);
+
+      // …Same reactionType, different emojiCode
+      final reaction2 = Reaction(
+        reactionType: ReactionType.realmEmoji, emojiCode: '2049', emojiName: 'something', userId: 1);
+      reactions.add(reaction2);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction0]),
+            matchesReactions([reaction1]),
+            matchesReactions([reaction2]),
+          ])
+        ..total.equals(3);
+
+      // …Same emojiCode, different reactionType
+      final reaction3 = Reaction(
+        reactionType: ReactionType.unicodeEmoji, emojiCode: '2049', emojiName: 'nuclear', userId: 1);
+      reactions.add(reaction3);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction0]),
+            matchesReactions([reaction1]),
+            matchesReactions([reaction2]),
+            matchesReactions([reaction3]),
+          ])
+        ..total.equals(4);
+
+      // …Same reaction, different user
+      final reaction4 = Reaction(
+        reactionType: ReactionType.unicodeEmoji, emojiCode: '2049', emojiName: 'nuclear', userId: 2);
+      reactions.add(reaction4);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction3, reaction4]), // reordered to sort by number of votes
+            matchesReactions([reaction0]),
+            matchesReactions([reaction1]),
+            matchesReactions([reaction2]),
+          ])
+        ..total.equals(5);
+
+      final reaction5 = Reaction(
+        reactionType: ReactionType.unicodeEmoji, emojiCode: '1f6e0', emojiName: 'working_on_it', userId: 2);
+      reactions.add(reaction5);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction3, reaction4]),
+            matchesReactions([reaction0]),
+            matchesReactions([reaction1]),
+            matchesReactions([reaction2]),
+            matchesReactions([reaction5]),
+          ])
+        ..total.equals(6);
+
+      // …Same reactionType and emojiCode, different emojiName
+      final reaction6 = Reaction(
+        reactionType: ReactionType.unicodeEmoji, emojiCode: '1f6e0', emojiName: 'tools', userId: 3);
+      reactions.add(reaction6);
+      check(reactions)
+        ..aggregated.deepEquals([
+          matchesReactions([reaction3, reaction4]),
+          matchesReactions([reaction5, reaction6]), // reordered to sort by number of votes
+          matchesReactions([reaction0]),
+          matchesReactions([reaction1]),
+          matchesReactions([reaction2]),
+        ])
+        ..total.equals(7);
+    });
+
+    test('remove', () {
+      final reaction1 = Reaction(emojiName: 'thumbs_up', emojiCode: '1f44d', reactionType: ReactionType.unicodeEmoji,    userId: 1);
+      final reaction2 = Reaction(emojiName: 'thumbs_up', emojiCode: '1f44d', reactionType: ReactionType.unicodeEmoji,    userId: 2);
+      final reaction3 = Reaction(emojiName: 'thumbs_up', emojiCode: '1f44d', reactionType: ReactionType.unicodeEmoji,    userId: 3);
+
+      final reaction4 = Reaction(emojiName: 'twocents',  emojiCode: '181',   reactionType: ReactionType.realmEmoji,      userId: 1);
+      final reaction5 = Reaction(emojiName: 'twocents',  emojiCode: '181',   reactionType: ReactionType.realmEmoji,      userId: 2);
+
+      final reaction6 = Reaction(emojiName: 'zulip',     emojiCode: 'zulip', reactionType: ReactionType.zulipExtraEmoji, userId: 4);
+      final reaction7 = Reaction(emojiName: 'zulip',     emojiCode: 'zulip', reactionType: ReactionType.zulipExtraEmoji, userId: 5);
+      final reaction8 = Reaction(emojiName: 'zulip',     emojiCode: 'zulip', reactionType: ReactionType.zulipExtraEmoji, userId: 6);
+      final reaction9 = Reaction(emojiName: 'zulip',     emojiCode: 'zulip', reactionType: ReactionType.zulipExtraEmoji, userId: 7);
+
+      final reactions = Reactions([reaction1, reaction2, reaction3, reaction4,
+        reaction5, reaction6, reaction7, reaction8, reaction9]);
+
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction6, reaction7, reaction8, reaction9]),
+            matchesReactions([reaction1, reaction2, reaction3]),
+            matchesReactions([reaction4, reaction5]),
+          ])
+        ..total.equals(9);
+
+      reactions.remove(reactionType: reaction6.reactionType, emojiCode: reaction6.emojiCode, userId: reaction6.userId);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction7, reaction8, reaction9]),
+            matchesReactions([reaction1, reaction2, reaction3]),
+            matchesReactions([reaction4, reaction5]),
+          ])
+        ..total.equals(8);
+
+      reactions.remove(reactionType: reaction8.reactionType, emojiCode: reaction8.emojiCode, userId: reaction8.userId);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction1, reaction2, reaction3]),
+            matchesReactions([reaction7, reaction9]), // reordered to sort by number of votes
+            matchesReactions([reaction4, reaction5]),
+          ])
+        ..total.equals(7);
+
+      reactions.remove(reactionType: reaction7.reactionType, emojiCode: reaction7.emojiCode, userId: reaction7.userId);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction1, reaction2, reaction3]),
+            matchesReactions([reaction4, reaction5]),
+            matchesReactions([reaction9]), // reordered to sort by number of votes
+          ])
+        ..total.equals(6);
+
+      reactions.remove(reactionType: reaction5.reactionType, emojiCode: reaction5.emojiCode, userId: reaction5.userId);
+      check(reactions)
+        ..aggregated.deepEquals([
+            matchesReactions([reaction1, reaction2, reaction3]),
+            matchesReactions([reaction4]),
+            matchesReactions([reaction9]),
+          ])
+        ..total.equals(5);
+
+      reactions.remove(reactionType: reaction1.reactionType, emojiCode: reaction1.emojiCode, userId: reaction1.userId);
+      reactions.remove(reactionType: reaction2.reactionType, emojiCode: reaction2.emojiCode, userId: reaction2.userId);
+      reactions.remove(reactionType: reaction3.reactionType, emojiCode: reaction3.emojiCode, userId: reaction3.userId);
+      reactions.remove(reactionType: reaction4.reactionType, emojiCode: reaction4.emojiCode, userId: reaction4.userId);
+      reactions.remove(reactionType: reaction9.reactionType, emojiCode: reaction9.emojiCode, userId: reaction9.userId);
+      check(reactions)
+        ..aggregated.deepEquals([])
+        ..total.equals(0);
+    });
+  });
+}

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -3,6 +3,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/store.dart';
 
 import 'api/fake_api.dart';
+import 'stdlib_checks.dart';
 
 final Uri realmUrl = Uri.parse('https://chat.example/');
 
@@ -162,22 +163,20 @@ StreamMessage streamMessage({
   // of the properties as we're constructing the data.  That's probably OK
   // because (a) this is only for tests; (b) the types do get checked
   // dynamically in the constructor, so any ill-typing won't propagate further.
-  return StreamMessage.fromJson({
+  return StreamMessage.fromJson(deepToJson({
     ..._messagePropertiesBase,
     ..._messagePropertiesFromSender(sender),
     ..._messagePropertiesFromContent(content, contentMarkdown),
     'display_recipient': effectiveStream.name,
     'stream_id': effectiveStream.streamId,
-    'reactions': reactions?.map(
-      (r) => r.toJson()..['reaction_type'] = r.reactionType.toJson(),
-    ).toList() ?? [],
+    'reactions': reactions == null ? [] : Reactions(reactions),
     'flags': flags ?? [],
     'id': id ?? 1234567, // TODO generate example IDs
     'last_edit_timestamp': lastEditTimestamp,
     'subject': topic ?? 'example topic',
     'timestamp': timestamp ?? 1678139636,
     'type': 'stream',
-  });
+  }) as Map<String, dynamic>);
 }
 
 /// Construct an example direct message.

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -381,7 +381,7 @@ void main() async {
         checkNotifiedOnce();
         check(model).messages.single
           ..identicalTo(message)
-          ..reactions.jsonEquals([eg.unicodeEmojiReaction]);
+          ..reactions.isNotNull().jsonEquals([eg.unicodeEmojiReaction]);
       });
 
       test('add reaction; message is not in list', () async {
@@ -391,7 +391,7 @@ void main() async {
         model.maybeUpdateMessageReactions(
           mkEvent(eg.unicodeEmojiReaction, ReactionOp.add, 1000));
         checkNotNotified();
-        check(model).messages.single.reactions.jsonEquals([]);
+        check(model).messages.single.reactions.isNull();
       });
 
       test('remove reaction', () async {
@@ -424,7 +424,7 @@ void main() async {
         checkNotifiedOnce();
         check(model).messages.single
           ..identicalTo(message)
-          ..reactions.jsonEquals([reaction2, reaction3]);
+          ..reactions.isNotNull().jsonEquals([reaction2, reaction3]);
       });
 
       test('remove reaction; message is not in list', () async {
@@ -434,7 +434,7 @@ void main() async {
         model.maybeUpdateMessageReactions(
           mkEvent(eg.unicodeEmojiReaction, ReactionOp.remove, 1000));
         checkNotNotified();
-        check(model).messages.single.reactions.jsonEquals([eg.unicodeEmojiReaction]);
+        check(model).messages.single.reactions.isNotNull().jsonEquals([eg.unicodeEmojiReaction]);
       });
     });
   });


### PR DESCRIPTION
I thought I'd check in with my progress toward keeping an efficient data structure to support the list of reaction buttons on a message in the message list. 🙂

As discussed [in chat](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20view-model.20for.20aggregated.20reactions/near/1624769), this goes directly on `Message` instances.

In this revision, the data structure retains a raw, "unaggregated" list, like the list it gets from the server. That doesn't have to stay, since it takes up space, but it does make it efficient to count reactions for `UserSettings.displayEmojiReactionUsers`, and it supports a nice and efficient `Reactions.toJson` in case the app starts requiring that.

There are TODOs in the tests, but I'll get to those. 🙂

Related: #121