### PR TITLE
sticky_header: Rewrite sticky headers completely; write tests

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -382,7 +382,7 @@ class MessageItem extends StatelessWidget {
       shape: Border(
         left: recipientBorder, bottom: restBorder, right: restBorder));
 
-    return StickyHeader(
+    return StickyHeaderItem(
       header: RecipientHeader(message: message),
       content: Column(children: [
         DecoratedBox(

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -322,6 +322,27 @@ class ScrollToBottomButton extends StatelessWidget {
   }
 }
 
+class RecipientHeader extends StatelessWidget {
+  const RecipientHeader({super.key, required this.message});
+
+  final Message message;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO recipient headings depend on narrow
+    final message = this.message;
+    switch (message) {
+      case StreamMessage():
+        final store = PerAccountStoreWidget.of(context);
+        final subscription = store.subscriptions[message.streamId];
+        return StreamTopicRecipientHeader(
+          message: message, streamColor: colorForStream(subscription));
+      case DmMessage():
+        return DmRecipientHeader(message: message);
+    }
+  }
+}
+
 class MessageItem extends StatelessWidget {
   const MessageItem({
     super.key,
@@ -334,24 +355,18 @@ class MessageItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO recipient headings depend on narrow
-
     final store = PerAccountStoreWidget.of(context);
     final message = item.message;
 
     Color highlightBorderColor;
     Color restBorderColor;
-    Widget recipientHeader;
     if (message is StreamMessage) {
       final subscription = store.subscriptions[message.streamId];
       highlightBorderColor = colorForStream(subscription);
       restBorderColor = _kStreamMessageBorderColor;
-      recipientHeader = StreamTopicRecipientHeader(
-        message: message, streamColor: highlightBorderColor);
     } else if (message is DmMessage) {
       highlightBorderColor = _kDmRecipientHeaderColor;
       restBorderColor = _kDmRecipientHeaderColor;
-      recipientHeader = DmRecipientHeader(message: message);
     } else {
       throw Exception("impossible message type: ${message.runtimeType}");
     }
@@ -368,7 +383,7 @@ class MessageItem extends StatelessWidget {
         left: recipientBorder, bottom: restBorder, right: restBorder));
 
     return StickyHeader(
-      header: recipientHeader,
+      header: RecipientHeader(message: message),
       content: Column(children: [
         DecoratedBox(
           decoration: borderDecoration,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -382,9 +382,11 @@ class MessageItem extends StatelessWidget {
       shape: Border(
         left: recipientBorder, bottom: restBorder, right: restBorder));
 
+    final recipientHeader = RecipientHeader(message: message);
     return StickyHeaderItem(
-      header: RecipientHeader(message: message),
-      content: Column(children: [
+      header: recipientHeader,
+      child: Column(children: [
+        recipientHeader,
         DecoratedBox(
           decoration: borderDecoration,
           child: MessageWithSender(message: message, content: item.content)),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -280,11 +280,10 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
               child: Padding(
                 padding: EdgeInsets.symmetric(vertical: 16.0),
                 child: CircularProgressIndicator())), // TODO perhaps a different indicator
-          MessageListMessageItem(:var message, :var content) =>
+          MessageListMessageItem() =>
             MessageItem(
               trailing: i == 0 ? const SizedBox(height: 8) : const SizedBox(height: 11),
-              message: message,
-              content: content)
+              item: data),
         };
       });
   }
@@ -326,13 +325,11 @@ class ScrollToBottomButton extends StatelessWidget {
 class MessageItem extends StatelessWidget {
   const MessageItem({
     super.key,
-    required this.message,
-    required this.content,
+    required this.item,
     this.trailing,
   });
 
-  final Message message;
-  final ZulipContent content;
+  final MessageListMessageItem item;
   final Widget? trailing;
 
   @override
@@ -340,22 +337,21 @@ class MessageItem extends StatelessWidget {
     // TODO recipient headings depend on narrow
 
     final store = PerAccountStoreWidget.of(context);
+    final message = item.message;
 
     Color highlightBorderColor;
     Color restBorderColor;
     Widget recipientHeader;
     if (message is StreamMessage) {
-      final msg = (message as StreamMessage);
-      final subscription = store.subscriptions[msg.streamId];
+      final subscription = store.subscriptions[message.streamId];
       highlightBorderColor = colorForStream(subscription);
       restBorderColor = _kStreamMessageBorderColor;
       recipientHeader = StreamTopicRecipientHeader(
-        message: msg, streamColor: highlightBorderColor);
+        message: message, streamColor: highlightBorderColor);
     } else if (message is DmMessage) {
-      final msg = (message as DmMessage);
       highlightBorderColor = _kDmRecipientHeaderColor;
       restBorderColor = _kDmRecipientHeaderColor;
-      recipientHeader = DmRecipientHeader(message: msg);
+      recipientHeader = DmRecipientHeader(message: message);
     } else {
       throw Exception("impossible message type: ${message.runtimeType}");
     }
@@ -376,7 +372,7 @@ class MessageItem extends StatelessWidget {
       content: Column(children: [
         DecoratedBox(
           decoration: borderDecoration,
-          child: MessageWithSender(message: message, content: content)),
+          child: MessageWithSender(message: message, content: item.content)),
         if (trailing != null) trailing!,
       ]));
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -187,7 +187,7 @@ class RenderSliverStickyHeaderList extends RenderSliverList {
       while (innerChild is RenderProxyBox) {
         innerChild = innerChild.child;
       }
-      if (innerChild is! RenderStickyHeader) {
+      if (innerChild is! RenderStickyHeaderItem) {
         continue;
       }
       assert(axisDirectionToAxis(innerChild.direction) == constraints.axis);
@@ -210,8 +210,8 @@ class RenderSliverStickyHeaderList extends RenderSliverList {
 
 enum StickyHeaderSlot { header, content }
 
-class StickyHeader extends SlottedMultiChildRenderObjectWidget<StickyHeaderSlot, RenderBox> {
-  const StickyHeader({
+class StickyHeaderItem extends SlottedMultiChildRenderObjectWidget<StickyHeaderSlot, RenderBox> {
+  const StickyHeaderItem({
     super.key,
     this.direction = AxisDirection.down,
     this.header,
@@ -238,12 +238,12 @@ class StickyHeader extends SlottedMultiChildRenderObjectWidget<StickyHeaderSlot,
   @override
   SlottedContainerRenderObjectMixin<StickyHeaderSlot, RenderBox> createRenderObject(
       BuildContext context) {
-    return RenderStickyHeader(direction: direction);
+    return RenderStickyHeaderItem(direction: direction);
   }
 }
 
-class RenderStickyHeader extends RenderBox with SlottedContainerRenderObjectMixin<StickyHeaderSlot, RenderBox> {
-  RenderStickyHeader({required AxisDirection direction})
+class RenderStickyHeaderItem extends RenderBox with SlottedContainerRenderObjectMixin<StickyHeaderSlot, RenderBox> {
+  RenderStickyHeaderItem({required AxisDirection direction})
     : _direction = direction;
 
   RenderBox? get _header => childForSlot(StickyHeaderSlot.header);

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -356,6 +356,13 @@ class RenderStickyHeaderItem extends RenderBox with SlottedContainerRenderObject
   BoxParentData _parentData(RenderBox child) => child.parentData! as BoxParentData;
 }
 
+extension AxisCoordinateDirection on Axis {
+  AxisDirection get coordinateDirection => switch (this) {
+    Axis.horizontal => AxisDirection.right,
+    Axis.vertical => AxisDirection.down,
+  };
+}
+
 Size sizeOn(Axis axis, {double main = 0, double cross = 0}) {
   switch (axis) {
     case Axis.horizontal:
@@ -386,6 +393,17 @@ extension SizeOnAxis on Size {
       case Axis.vertical:
         return height;
     }
+  }
+}
+
+extension OffsetInDirection on Offset {
+  double inDirection(AxisDirection direction) {
+    return switch (direction) {
+      AxisDirection.right =>  dx,
+      AxisDirection.left  => -dx,
+      AxisDirection.down  =>  dy,
+      AxisDirection.up    => -dy,
+    };
   }
 }
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -112,7 +112,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1));
       await tester.pump(Duration.zero);
       check(itemCount(tester)).equals(300);
-    });
+    }, skip: true); // TODO this still reproduces manually, still needs debugging,
+                    // but has become harder to reproduce in a test.
   });
 
   group('ScrollToBottomButton interactions', () {

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -1,0 +1,189 @@
+import 'dart:math' as math;
+
+import 'package:checks/checks.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/widgets/sticky_header.dart';
+
+void main() {
+  testWidgets('sticky headers: scroll up, headers bounded by items, semi-explicit version', (tester) async {
+    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr,
+      child: StickyHeaderListView(
+        reverse: true,
+        children: List.generate(100, (i) => StickyHeaderItem(
+          header: _Header(i, height: 20),
+          content: _Item(i, height: 80))))));
+
+    void checkState(int index, {required double item, required double header}) =>
+      _checkHeader(tester, index, first: false,
+        item: Offset(0, item), header: Offset(0, header));
+
+    checkState(5, item:  20, header:   0);
+
+    await _drag(tester, const Offset(0, 5));
+    checkState(6, item: -75, header: -15);
+
+    await _drag(tester, const Offset(0, 75));
+    checkState(6, item:   0, header:   0);
+
+    await _drag(tester, const Offset(0, 20));
+    checkState(6, item:  20, header:   0);
+  });
+
+  for (final reverse in [true, false]) {
+    for (final reverseHeader in [true, false]) {
+      final name = 'sticky headers: '
+        'scroll ${reverse ? 'up' : 'down'}, '
+        'header at ${reverseHeader ? 'bottom' : 'top'}';
+      testWidgets(name, (tester) =>
+        _checkSequence(tester,
+          Axis.vertical,
+          reverse: reverse,
+          reverseHeader: reverseHeader,
+        ));
+    }
+  }
+
+  for (final reverse in [true, false]) {
+    for (final reverseHeader in [true, false]) {
+      for (final textDirection in TextDirection.values) {
+        final name = 'sticky headers: '
+          '${textDirection.name.toUpperCase()} '
+          'scroll ${reverse ? 'backward' : 'forward'}, '
+          'header at ${reverseHeader ? 'end' : 'start'}';
+        testWidgets(name, (tester) =>
+          _checkSequence(tester,
+            Axis.horizontal, textDirection: textDirection,
+            reverse: reverse,
+            reverseHeader: reverseHeader,
+          ));
+      }
+    }
+  }
+}
+
+Future<void> _checkSequence(
+  WidgetTester tester,
+  Axis axis, {
+  TextDirection? textDirection,
+  bool reverse = false,
+  bool reverseHeader = false,
+}) async {
+  assert(textDirection != null || axis == Axis.vertical);
+  final headerAtCoordinateEnd = switch (axis) {
+    Axis.horizontal => reverseHeader ^ (textDirection == TextDirection.rtl),
+    Axis.vertical   => reverseHeader,
+  };
+
+  final controller = ScrollController();
+  await tester.pumpWidget(Directionality(
+    textDirection: textDirection ?? TextDirection.rtl,
+    child: StickyHeaderListView(
+      controller: controller,
+      scrollDirection: axis,
+      reverse: reverse,
+      children: List.generate(100, (i) => StickyHeaderItem(
+        direction: switch ((axis, headerAtCoordinateEnd)) {
+          (Axis.horizontal, true ) => AxisDirection.left,
+          (Axis.horizontal, false) => AxisDirection.right,
+          (Axis.vertical,   true ) => AxisDirection.up,
+          (Axis.vertical,   false) => AxisDirection.down,
+        },
+        header: _Header(i, height: 20),
+        content: _Item(i, height: 80))))));
+
+  final extent = tester.getSize(find.byType(StickyHeaderListView)).onAxis(axis);
+  assert(extent % 100 == 0);
+
+  final first = !(reverse ^ reverseHeader);
+
+  final itemFinder = first ? find.byType(_Item).first : find.byType(_Item).last;
+  final headerFinder = first ? find.byType(_Header).first : find.byType(_Header).last;
+
+  double insetExtent(Finder finder) {
+    return headerAtCoordinateEnd
+      ? extent - tester.getTopLeft(finder).inDirection(axis.coordinateDirection)
+      : tester.getBottomRight(finder).inDirection(axis.coordinateDirection);
+  }
+
+  void checkState() {
+    final scrollOffset = controller.position.pixels;
+    final expectedHeaderIndex = first
+      ? (scrollOffset / 100).floor()
+      : (extent ~/ 100 - 1) + (scrollOffset / 100).ceil();
+    check(tester.widget<_Item>(itemFinder).index).equals(expectedHeaderIndex);
+    check(tester.widget<_Header>(headerFinder).index).equals(expectedHeaderIndex);
+
+    final expectedItemInsetExtent =
+      100 - (first ? scrollOffset % 100 : (-scrollOffset) % 100);
+    check(insetExtent(itemFinder)).equals(expectedItemInsetExtent);
+    check(insetExtent(headerFinder)).equals(
+      math.min(20, expectedItemInsetExtent));
+  }
+
+  Future<void> jumpAndCheck(double position) async {
+    controller.jumpTo(position);
+    await tester.pump();
+    checkState();
+  }
+
+  checkState();
+  await jumpAndCheck(5);
+  await jumpAndCheck(10);
+  await jumpAndCheck(20);
+  await jumpAndCheck(50);
+  await jumpAndCheck(80);
+  await jumpAndCheck(90);
+  await jumpAndCheck(95);
+  await jumpAndCheck(100);
+}
+
+Future<void> _drag(WidgetTester tester, Offset offset) async {
+  await tester.drag(find.byType(StickyHeaderListView), offset);
+  await tester.pump();
+}
+
+void _checkHeader(
+  WidgetTester tester,
+  int index, {
+  required bool first,
+  required Offset item,
+  required Offset header,
+}) {
+  final itemFinder = first ? find.byType(_Item).first : find.byType(_Item).last;
+  final headerFinder = first ? find.byType(_Header).first : find.byType(_Header).last;
+  check(tester.widget<_Item>(itemFinder).index).equals(index);
+  check(tester.widget<_Header>(headerFinder).index).equals(index);
+  check(tester.getTopLeft(itemFinder)).equals(item);
+  check(tester.getTopLeft(headerFinder)).equals(header);
+}
+
+class _Header extends StatelessWidget {
+  const _Header(this.index, {required this.height});
+
+  final int index;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      width: height, // TODO clean up
+      child: Text("Header $index"));
+  }
+}
+
+class _Item extends StatelessWidget {
+  const _Item(this.index, {required this.height});
+
+  final int index;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      width: height,
+      child: Text("Item $index"));
+  }
+}

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -6,57 +6,100 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/sticky_header.dart';
 
 void main() {
+  testWidgets('sticky headers: scroll up, headers overflow items, explicit version', (tester) async {
+    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr,
+      child: StickyHeaderListView(
+        reverse: true,
+        children: List.generate(100, (i) => StickyHeaderItem(
+          allowOverflow: true,
+          header: _Header(i, height: 20),
+          child: _Item(i, height: 100))))));
+    check(_itemIndexes(tester)).deepEquals([0, 1, 2, 3, 4, 5]);
+    check(_headerIndex(tester)).equals(5);
+    check(tester.getTopLeft(find.byType(_Item).last)).equals(const Offset(0, 0));
+    check(tester.getTopLeft(find.byType(_Header))).equals(const Offset(0, 0));
+
+    await tester.drag(find.byType(StickyHeaderListView), const Offset(0, 5));
+    await tester.pump();
+    check(_itemIndexes(tester)).deepEquals([0, 1, 2, 3, 4, 5, 6]);
+    check(_headerIndex(tester)).equals(6);
+    check(tester.getTopLeft(find.byType(_Item).last)).equals(const Offset(0, -95));
+    check(tester.getTopLeft(find.byType(_Header))).equals(const Offset(0, 0));
+
+    await tester.drag(find.byType(StickyHeaderListView), const Offset(0, 75));
+    await tester.pump();
+    check(_itemIndexes(tester)).deepEquals([0, 1, 2, 3, 4, 5, 6]);
+    check(_headerIndex(tester)).equals(6);
+    check(tester.getTopLeft(find.byType(_Item).last)).equals(const Offset(0, -20));
+    check(tester.getTopLeft(find.byType(_Header))).equals(const Offset(0, 0));
+
+    await tester.drag(find.byType(StickyHeaderListView), const Offset(0, 20));
+    await tester.pump();
+    check(_itemIndexes(tester)).deepEquals([1, 2, 3, 4, 5, 6]);
+    check(_headerIndex(tester)).equals(6);
+    check(tester.getTopLeft(find.byType(_Item).last)).equals(const Offset(0, 0));
+    check(tester.getTopLeft(find.byType(_Header))).equals(const Offset(0, 0));
+  });
+
   testWidgets('sticky headers: scroll up, headers bounded by items, semi-explicit version', (tester) async {
     await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr,
       child: StickyHeaderListView(
         reverse: true,
         children: List.generate(100, (i) => StickyHeaderItem(
           header: _Header(i, height: 20),
-          content: _Item(i, height: 80))))));
+          child: _Item(i, height: 100))))));
 
     void checkState(int index, {required double item, required double header}) =>
       _checkHeader(tester, index, first: false,
         item: Offset(0, item), header: Offset(0, header));
 
-    checkState(5, item:  20, header:   0);
+    checkState(5, item:   0, header:   0);
 
     await _drag(tester, const Offset(0, 5));
-    checkState(6, item: -75, header: -15);
+    checkState(6, item: -95, header: -15);
 
     await _drag(tester, const Offset(0, 75));
-    checkState(6, item:   0, header:   0);
+    checkState(6, item: -20, header:   0);
 
     await _drag(tester, const Offset(0, 20));
-    checkState(6, item:  20, header:   0);
+    checkState(6, item:   0, header:   0);
   });
 
   for (final reverse in [true, false]) {
     for (final reverseHeader in [true, false]) {
-      final name = 'sticky headers: '
-        'scroll ${reverse ? 'up' : 'down'}, '
-        'header at ${reverseHeader ? 'bottom' : 'top'}';
-      testWidgets(name, (tester) =>
-        _checkSequence(tester,
-          Axis.vertical,
-          reverse: reverse,
-          reverseHeader: reverseHeader,
-        ));
+      for (final allowOverflow in [true, false]) {
+        final name = 'sticky headers: '
+          'scroll ${reverse ? 'up' : 'down'}, '
+          'header at ${reverseHeader ? 'bottom' : 'top'}, '
+          'headers ${allowOverflow ? 'overflow' : 'bounded'}';
+        testWidgets(name, (tester) =>
+          _checkSequence(tester,
+            Axis.vertical,
+            reverse: reverse,
+            reverseHeader: reverseHeader,
+            allowOverflow: allowOverflow,
+          ));
+      }
     }
   }
 
   for (final reverse in [true, false]) {
     for (final reverseHeader in [true, false]) {
-      for (final textDirection in TextDirection.values) {
-        final name = 'sticky headers: '
-          '${textDirection.name.toUpperCase()} '
-          'scroll ${reverse ? 'backward' : 'forward'}, '
-          'header at ${reverseHeader ? 'end' : 'start'}';
-        testWidgets(name, (tester) =>
-          _checkSequence(tester,
-            Axis.horizontal, textDirection: textDirection,
-            reverse: reverse,
-            reverseHeader: reverseHeader,
-          ));
+      for (final allowOverflow in [true, false]) {
+        for (final textDirection in TextDirection.values) {
+          final name = 'sticky headers: '
+            '${textDirection.name.toUpperCase()} '
+            'scroll ${reverse ? 'backward' : 'forward'}, '
+            'header at ${reverseHeader ? 'end' : 'start'}, '
+            'headers ${allowOverflow ? 'overflow' : 'bounded'}';
+          testWidgets(name, (tester) =>
+            _checkSequence(tester,
+              Axis.horizontal, textDirection: textDirection,
+              reverse: reverse,
+              reverseHeader: reverseHeader,
+              allowOverflow: allowOverflow,
+            ));
+        }
       }
     }
   }
@@ -68,6 +111,7 @@ Future<void> _checkSequence(
   TextDirection? textDirection,
   bool reverse = false,
   bool reverseHeader = false,
+  required bool allowOverflow,
 }) async {
   assert(textDirection != null || axis == Axis.vertical);
   final headerAtCoordinateEnd = switch (axis) {
@@ -82,15 +126,11 @@ Future<void> _checkSequence(
       controller: controller,
       scrollDirection: axis,
       reverse: reverse,
+      reverseHeader: reverseHeader,
       children: List.generate(100, (i) => StickyHeaderItem(
-        direction: switch ((axis, headerAtCoordinateEnd)) {
-          (Axis.horizontal, true ) => AxisDirection.left,
-          (Axis.horizontal, false) => AxisDirection.right,
-          (Axis.vertical,   true ) => AxisDirection.up,
-          (Axis.vertical,   false) => AxisDirection.down,
-        },
+        allowOverflow: allowOverflow,
         header: _Header(i, height: 20),
-        content: _Item(i, height: 80))))));
+        child: _Item(i, height: 100))))));
 
   final extent = tester.getSize(find.byType(StickyHeaderListView)).onAxis(axis);
   assert(extent % 100 == 0);
@@ -98,7 +138,6 @@ Future<void> _checkSequence(
   final first = !(reverse ^ reverseHeader);
 
   final itemFinder = first ? find.byType(_Item).first : find.byType(_Item).last;
-  final headerFinder = first ? find.byType(_Header).first : find.byType(_Header).last;
 
   double insetExtent(Finder finder) {
     return headerAtCoordinateEnd
@@ -112,13 +151,13 @@ Future<void> _checkSequence(
       ? (scrollOffset / 100).floor()
       : (extent ~/ 100 - 1) + (scrollOffset / 100).ceil();
     check(tester.widget<_Item>(itemFinder).index).equals(expectedHeaderIndex);
-    check(tester.widget<_Header>(headerFinder).index).equals(expectedHeaderIndex);
+    check(_headerIndex(tester)).equals(expectedHeaderIndex);
 
     final expectedItemInsetExtent =
       100 - (first ? scrollOffset % 100 : (-scrollOffset) % 100);
     check(insetExtent(itemFinder)).equals(expectedItemInsetExtent);
-    check(insetExtent(headerFinder)).equals(
-      math.min(20, expectedItemInsetExtent));
+    check(insetExtent(find.byType(_Header))).equals(
+      allowOverflow ? 20 : math.min(20, expectedItemInsetExtent));
   }
 
   Future<void> jumpAndCheck(double position) async {
@@ -151,11 +190,18 @@ void _checkHeader(
   required Offset header,
 }) {
   final itemFinder = first ? find.byType(_Item).first : find.byType(_Item).last;
-  final headerFinder = first ? find.byType(_Header).first : find.byType(_Header).last;
   check(tester.widget<_Item>(itemFinder).index).equals(index);
-  check(tester.widget<_Header>(headerFinder).index).equals(index);
+  check(_headerIndex(tester)).equals(index);
   check(tester.getTopLeft(itemFinder)).equals(item);
-  check(tester.getTopLeft(headerFinder)).equals(header);
+  check(tester.getTopLeft(find.byType(_Header))).equals(header);
+}
+
+int _headerIndex(WidgetTester tester) {
+  return tester.widget<_Header>(find.byType(_Header)).index;
+}
+
+Iterable<int> _itemIndexes(WidgetTester tester) {
+  return tester.widgetList<_Item>(find.byType(_Item)).map((w) => w.index);
 }
 
 class _Header extends StatelessWidget {


### PR DESCRIPTION
In particular this gives us two features we'll want in the Zulip
message list when we go to make recipient headers appear only
where needed (#174):

 * An item's header now gets built (and laid out and painted) only if
   the item is actually the one at the relevant edge of the viewport
   such that the stickiness comes into play.  This lets us attach a
   sticky header to every message, even when it shares a recipient
   header with the message that comes before it.

 * An item can now (optionally) allow the header's stickiness at the
   edge of the viewport to take precedence over the header's
   confinement within the item's own bounds.  We'll use this to let
   the header stay pinned when scrolling between items that share a
   recipient header.
