### PR TITLE
ui: For boring, non-emoji font, use one that iOS recognizes

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -21,7 +21,12 @@ class ZulipApp extends StatelessWidget {
       // Note that specifiying only "Noto Color Emoji" in the fallback list,
       // Flutter tries to use it to draw even the non emoji characters
       // which leads to broken text rendering.
-      fontFamilyFallback: const <String>['sans-serif', 'Noto Color Emoji'],
+      fontFamilyFallback: [
+        // …since apparently iOS doesn't support 'sans-serif', use this instead:
+        //   https://github.com/flutter/flutter/issues/63507#issuecomment-1698504425
+        if (Theme.of(context).platform == TargetPlatform.iOS) '.AppleSystemUIFont' else 'sans-serif',
+        'Noto Color Emoji',
+      ],
       useMaterial3: false, // TODO(#225) fix things and switch to true
       // This applies Material 3's color system to produce a palette of
       // appropriately matching and contrasting colors for use in a UI.


### PR DESCRIPTION
It's strange that iOS really doesn't seem to know what to do with 'sans-serif' here. Nor "SF Pro", "SF-Pro", nor any obvious variation on that, even though it's supposedly the system font:
  https://developer.apple.com/fonts/

But a GitHub comment popped up a few hours ago (linked in the added code), and that's the first thing I've found that seems to work, as a clear pointer to the default system font. Shrug.

Later, we'll want to use Sorce Sans 3 for almost all the text in the app. But we'll want to take more care with that than I have bandwidth for right now (around it being a variable-weight font); see discussion:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20text.20all.20weird/near/1633648

Fixes: #289