### PR TITLE
model: Use enum for Message.flags[]

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -341,7 +341,7 @@ class UpdateMessageEvent extends Event {
   final bool? renderingOnly; // TODO(server-5)
   final int messageId;
   final List<int> messageIds;
-  final List<String> flags; // TODO enum
+  final List<MessageFlag> flags;
   final int? editTimestamp; // TODO(server-5)
   final String? streamName;
   final int? streamId;

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -166,7 +166,9 @@ UpdateMessageEvent _$UpdateMessageEventFromJson(Map<String, dynamic> json) =>
       messageId: json['message_id'] as int,
       messageIds:
           (json['message_ids'] as List<dynamic>).map((e) => e as int).toList(),
-      flags: (json['flags'] as List<dynamic>).map((e) => e as String).toList(),
+      flags: (json['flags'] as List<dynamic>)
+          .map((e) => $enumDecode(_$MessageFlagEnumMap, e))
+          .toList(),
       editTimestamp: json['edit_timestamp'] as int?,
       streamName: json['stream_name'] as String?,
       streamId: json['stream_id'] as int?,
@@ -203,6 +205,17 @@ Map<String, dynamic> _$UpdateMessageEventToJson(UpdateMessageEvent instance) =>
       'rendered_content': instance.renderedContent,
       'is_me_message': instance.isMeMessage,
     };
+
+const _$MessageFlagEnumMap = {
+  MessageFlag.read: 'read',
+  MessageFlag.starred: 'starred',
+  MessageFlag.collapsed: 'collapsed',
+  MessageFlag.mentioned: 'mentioned',
+  MessageFlag.wildcardMentioned: 'wildcard_mentioned',
+  MessageFlag.hasAlertWord: 'has_alert_word',
+  MessageFlag.historical: 'historical',
+  MessageFlag.unknown: 'unknown',
+};
 
 const _$PropagateModeEnumMap = {
   PropagateMode.changeOne: 'change_one',

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -196,7 +196,7 @@ StreamMessage _$StreamMessageFromJson(Map<String, dynamic> json) =>
       senderRealmStr: json['sender_realm_str'] as String,
       subject: json['subject'] as String,
       timestamp: json['timestamp'] as int,
-      flags: (json['flags'] as List<dynamic>).map((e) => e as String).toList(),
+      flags: Message._flagsFromJson(json['flags']),
       matchContent: json['match_content'] as String?,
       matchSubject: json['match_subject'] as String?,
       displayRecipient: json['display_recipient'] as String,
@@ -257,7 +257,7 @@ DmMessage _$DmMessageFromJson(Map<String, dynamic> json) => DmMessage(
       senderRealmStr: json['sender_realm_str'] as String,
       subject: json['subject'] as String,
       timestamp: json['timestamp'] as int,
-      flags: (json['flags'] as List<dynamic>).map((e) => e as String).toList(),
+      flags: Message._flagsFromJson(json['flags']),
       matchContent: json['match_content'] as String?,
       matchSubject: json['match_subject'] as String?,
       displayRecipient: const DmRecipientListConverter()
@@ -305,4 +305,15 @@ const _$ReactionTypeEnumMap = {
   ReactionType.unicodeEmoji: 'unicode_emoji',
   ReactionType.realmEmoji: 'realm_emoji',
   ReactionType.zulipExtraEmoji: 'zulip_extra_emoji',
+};
+
+const _$MessageFlagEnumMap = {
+  MessageFlag.read: 'read',
+  MessageFlag.starred: 'starred',
+  MessageFlag.collapsed: 'collapsed',
+  MessageFlag.mentioned: 'mentioned',
+  MessageFlag.wildcardMentioned: 'wildcard_mentioned',
+  MessageFlag.hasAlertWord: 'has_alert_word',
+  MessageFlag.historical: 'historical',
+  MessageFlag.unknown: 'unknown',
 };

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -161,6 +161,13 @@ class DmNarrow extends Narrow implements SendableNarrow {
     );
   }
 
+  factory DmNarrow.withUser(int userId, {required int selfUserId}) {
+    return DmNarrow(
+      allRecipientIds: {userId, selfUserId}.toList()..sort(),
+      selfUserId: selfUserId,
+    );
+  }
+
   /// The user IDs of everyone in the conversation, sorted.
   ///
   /// Each message in the conversation is sent by one of these users

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -2,6 +2,7 @@ import 'package:checks/checks.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
+import 'package:zulip/api/model/model.dart';
 
 import '../../example_data.dart' as eg;
 import '../../stdlib_checks.dart';
@@ -11,15 +12,15 @@ import 'model_checks.dart';
 void main() {
   test('message: move flags into message object', () {
     final message = eg.streamMessage();
-    MessageEvent mkEvent(List<String> flags) => Event.fromJson({
+    MessageEvent mkEvent(List<MessageFlag> flags) => Event.fromJson({
       'type': 'message',
       'id': 1,
       'message': message.toJson()..remove('flags'),
-      'flags': flags,
+      'flags': flags.map((f) => f.toJson()).toList(),
     }) as MessageEvent;
     check(mkEvent(message.flags)).message.jsonEquals(message);
     check(mkEvent([])).message.flags.deepEquals([]);
-    check(mkEvent(['read'])).message.flags.deepEquals(['read']);
+    check(mkEvent([MessageFlag.read])).message.flags.deepEquals([MessageFlag.read]);
   });
 
   test('user_settings: all known settings have event handling', () {

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -6,7 +6,7 @@ extension MessageChecks on Subject<Message> {
   Subject<bool> get isMeMessage => has((e) => e.isMeMessage, 'isMeMessage');
   Subject<int?> get lastEditTimestamp => has((e) => e.lastEditTimestamp, 'lastEditTimestamp');
   Subject<List<Reaction>> get reactions => has((e) => e.reactions, 'reactions');
-  Subject<List<String>> get flags => has((e) => e.flags, 'flags');
+  Subject<List<MessageFlag>> get flags => has((e) => e.flags, 'flags');
 
   // TODO accessors for other fields
 }

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -3,6 +3,8 @@ import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/model.dart';
 
 import '../../example_data.dart' as eg;
+import '../../stdlib_checks.dart';
+import 'model_checks.dart';
 
 void main() {
   group('User', () {
@@ -44,6 +46,22 @@ void main() {
       check(mkUser({}).isSystemBot).isNull();
       check(mkUser({'is_cross_realm_bot': true}).isSystemBot).equals(true);
       check(mkUser({'is_system_bot': true}).isSystemBot).equals(true);
+    });
+  });
+
+  group('Message', () {
+    test('no crash on unrecognized flag', () {
+      final m1 = Message.fromJson(
+        (deepToJson(eg.streamMessage()) as Map<String, dynamic>)
+          ..['flags'] = ['read', 'something_unknown'],
+      );
+      check(m1).flags.deepEquals([MessageFlag.read, MessageFlag.unknown]);
+
+      final m2 = Message.fromJson(
+        (deepToJson(eg.dmMessage(from: eg.selfUser, to: [eg.otherUser])) as Map<String, dynamic>)
+          ..['flags'] = ['read', 'something_unknown'],
+      );
+      check(m2).flags.deepEquals([MessageFlag.read, MessageFlag.unknown]);
     });
   });
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -269,7 +269,7 @@ void main() async {
         id: 1,
         messageId: originalMessage.id,
         messageIds: [originalMessage.id],
-        flags: ["starred"],
+        flags: [MessageFlag.starred],
         renderedContent: "<p>Hello, edited</p>",
         editTimestamp: 99999,
         isMeMessage: true,

--- a/test/model/narrow_test.dart
+++ b/test/model/narrow_test.dart
@@ -69,6 +69,27 @@ void main() {
         selfUserId: eg.selfUser.userId));
     });
 
+    test('withUser: same user', () {
+      final actual = DmNarrow.withUser(5, selfUserId: 5);
+      check(actual).equals(DmNarrow(
+        allRecipientIds: [5],
+        selfUserId: 5));
+    });
+
+    test('withUser: user ID less than selfUserId', () {
+      final actual = DmNarrow.withUser(3, selfUserId: 5);
+      check(actual).equals(DmNarrow(
+          allRecipientIds: [3, 5],
+          selfUserId: 5));
+    });
+
+    test('withUser: user ID greater than selfUserId', () {
+      final actual = DmNarrow.withUser(7, selfUserId: 5);
+      check(actual).equals(DmNarrow(
+          allRecipientIds: [5, 7],
+          selfUserId: 5));
+    });
+
     test('otherRecipientIds', () {
       check(DmNarrow(allRecipientIds: [1, 2, 3], selfUserId: 2))
         .otherRecipientIds.deepEquals([1, 3]);

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -57,7 +57,7 @@ Object? deepToJson(Object? object) {
     case List():
       result = object.map((x) => deepToJson(x)).toList();
     case Map() when object.keys.every((k) => k is String):
-      result = object.map((k, v) => MapEntry(k, deepToJson(v)));
+      result = object.map((k, v) => MapEntry<String, dynamic>(k, deepToJson(v)));
     default:
       return (null, false);
   }


### PR DESCRIPTION
This contains commits cherry-picked from other PRs:

From my f59da2ace5201d4139a682c64f7428bd80c2ef46 / #286:
```
test [nfc]: When deepToJson returns Map, don't lose its string-keyed type
```

From @sirpengi's 00bc224853fce8c9eef61ed3ccc479c02ab1d4ba / #287 (thanks @sirpengi!):
```
model: Add DmNarrow.withUser helper
```

Related: #253