### PR TITLE
api: Add update_message_flags events

### DIFF
--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -275,6 +275,75 @@ const _$MessageTypeEnumMap = {
   MessageType.private: 'private',
 };
 
+UpdateMessageFlagsAddEvent _$UpdateMessageFlagsAddEventFromJson(
+        Map<String, dynamic> json) =>
+    UpdateMessageFlagsAddEvent(
+      id: json['id'] as int,
+      flag: $enumDecode(_$MessageFlagEnumMap, json['flag'],
+          unknownValue: MessageFlag.unknown),
+      messages:
+          (json['messages'] as List<dynamic>).map((e) => e as int).toList(),
+      all: json['all'] as bool,
+    );
+
+Map<String, dynamic> _$UpdateMessageFlagsAddEventToJson(
+        UpdateMessageFlagsAddEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'flag': instance.flag,
+      'messages': instance.messages,
+      'all': instance.all,
+    };
+
+UpdateMessageFlagsRemoveEvent _$UpdateMessageFlagsRemoveEventFromJson(
+        Map<String, dynamic> json) =>
+    UpdateMessageFlagsRemoveEvent(
+      id: json['id'] as int,
+      flag: $enumDecode(_$MessageFlagEnumMap, json['flag'],
+          unknownValue: MessageFlag.unknown),
+      messages:
+          (json['messages'] as List<dynamic>).map((e) => e as int).toList(),
+      messageDetails: (json['message_details'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(
+            int.parse(k),
+            UpdateMessageFlagsMessageDetail.fromJson(
+                e as Map<String, dynamic>)),
+      ),
+    );
+
+Map<String, dynamic> _$UpdateMessageFlagsRemoveEventToJson(
+        UpdateMessageFlagsRemoveEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'flag': instance.flag,
+      'messages': instance.messages,
+      'message_details':
+          instance.messageDetails?.map((k, e) => MapEntry(k.toString(), e)),
+    };
+
+UpdateMessageFlagsMessageDetail _$UpdateMessageFlagsMessageDetailFromJson(
+        Map<String, dynamic> json) =>
+    UpdateMessageFlagsMessageDetail(
+      type: $enumDecode(_$MessageTypeEnumMap, json['type']),
+      mentioned: json['mentioned'] as bool?,
+      userIds:
+          (json['user_ids'] as List<dynamic>?)?.map((e) => e as int).toList(),
+      streamId: json['stream_id'] as int?,
+      topic: json['topic'] as String?,
+    );
+
+Map<String, dynamic> _$UpdateMessageFlagsMessageDetailToJson(
+        UpdateMessageFlagsMessageDetail instance) =>
+    <String, dynamic>{
+      'type': _$MessageTypeEnumMap[instance.type]!,
+      'mentioned': instance.mentioned,
+      'user_ids': instance.userIds,
+      'stream_id': instance.streamId,
+      'topic': instance.topic,
+    };
+
 ReactionEvent _$ReactionEventFromJson(Map<String, dynamic> json) =>
     ReactionEvent(
       id: json['id'] as int,

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -420,6 +420,35 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     notifyListeners();
   }
 
+  void maybeUpdateMessageFlags(UpdateMessageFlagsEvent event) {
+    final isAdd = switch (event) {
+      UpdateMessageFlagsAddEvent()    => true,
+      UpdateMessageFlagsRemoveEvent() => false,
+    };
+
+    bool didUpdateAny = false;
+    if (isAdd && (event as UpdateMessageFlagsAddEvent).all) {
+      for (final message in messages) {
+        message.flags.add(event.flag);
+        didUpdateAny = true;
+      }
+    } else {
+      for (final messageId in event.messages) {
+        final index = _findMessageWithId(messageId);
+        if (index != -1) {
+          final message = messages[index];
+          isAdd ? message.flags.add(event.flag) : message.flags.remove(event.flag);
+          didUpdateAny = true;
+        }
+      }
+    }
+    if (!didUpdateAny) {
+      return;
+    }
+
+    notifyListeners();
+  }
+
   void maybeUpdateMessageReactions(ReactionEvent event) {
     final index = _findMessageWithId(event.messageId);
     if (index == -1) {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -309,6 +309,9 @@ class PerAccountStore extends ChangeNotifier {
     } else if (event is DeleteMessageEvent) {
       assert(debugLog("server event: delete_message ${event.messageIds}"));
       // TODO handle
+    } else if (event is UpdateMessageFlagsEvent) {
+      assert(debugLog("server event: update_message_flags/${event.op} ${event.flag.toJson()}"));
+      // TODO handle
     } else if (event is ReactionEvent) {
       assert(debugLog("server event: reaction/${event.op}"));
       for (final view in _messageListViews) {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -311,7 +311,9 @@ class PerAccountStore extends ChangeNotifier {
       // TODO handle
     } else if (event is UpdateMessageFlagsEvent) {
       assert(debugLog("server event: update_message_flags/${event.op} ${event.flag.toJson()}"));
-      // TODO handle
+      for (final view in _messageListViews) {
+        view.maybeUpdateMessageFlags(event);
+      }
     } else if (event is ReactionEvent) {
       assert(debugLog("server event: reaction/${event.op}"));
       for (final view in _messageListViews) {

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -10,19 +10,6 @@ import 'events_checks.dart';
 import 'model_checks.dart';
 
 void main() {
-  test('message: move flags into message object', () {
-    final message = eg.streamMessage();
-    MessageEvent mkEvent(List<MessageFlag> flags) => Event.fromJson({
-      'type': 'message',
-      'id': 1,
-      'message': (deepToJson(message) as Map<String, dynamic>)..remove('flags'),
-      'flags': flags.map((f) => f.toJson()).toList(),
-    }) as MessageEvent;
-    check(mkEvent(message.flags)).message.jsonEquals(message);
-    check(mkEvent([])).message.flags.deepEquals([]);
-    check(mkEvent([MessageFlag.read])).message.flags.deepEquals([MessageFlag.read]);
-  });
-
   test('user_settings: all known settings have event handling', () {
     final dataClassFieldNames = UserSettings.debugKnownNames;
     final enumNames = UserSettingName.values.map((n) => n.name);
@@ -41,5 +28,18 @@ void main() {
         '      matching on that enum, by adding new `switch` cases\n'
         '      on the pattern of the existing cases.'
     ).isEmpty();
+  });
+
+  test('message: move flags into message object', () {
+    final message = eg.streamMessage();
+    MessageEvent mkEvent(List<MessageFlag> flags) => Event.fromJson({
+      'type': 'message',
+      'id': 1,
+      'message': (deepToJson(message) as Map<String, dynamic>)..remove('flags'),
+      'flags': flags.map((f) => f.toJson()).toList(),
+    }) as MessageEvent;
+    check(mkEvent(message.flags)).message.jsonEquals(message);
+    check(mkEvent([])).message.flags.deepEquals([]);
+    check(mkEvent([MessageFlag.read])).message.flags.deepEquals([MessageFlag.read]);
   });
 }

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -42,4 +42,22 @@ void main() {
     check(mkEvent([])).message.flags.deepEquals([]);
     check(mkEvent([MessageFlag.read])).message.flags.deepEquals([MessageFlag.read]);
   });
+
+  test('update_message_flags/remove: require messageDetails in mark-as-unread', () {
+    final baseJson = {
+      'id': 1,
+      'type': 'update_message_flags',
+      'op': 'remove',
+      'flag': 'starred',
+      'messages': [123],
+      'all': false,
+    };
+    check(() => UpdateMessageFlagsRemoveEvent.fromJson(baseJson)).returnsNormally();
+    check(() => UpdateMessageFlagsRemoveEvent.fromJson({
+      ...baseJson, 'flag': 'read',
+    })).throws();
+    check(() => UpdateMessageFlagsRemoveEvent.fromJson({
+      ...baseJson, 'message_details': {'123': {'type': 'private', 'mentioned': false, 'user_ids': [2]}},
+    })).returnsNormally();
+  });
 }

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -155,7 +155,7 @@ StreamMessage streamMessage({
   int? lastEditTimestamp,
   List<Reaction>? reactions,
   int? timestamp,
-  List<String>? flags,
+  List<MessageFlag>? flags,
 }) {
   final effectiveStream = stream ?? _stream();
   // The use of JSON here is convenient in order to delegate parts of the data
@@ -191,7 +191,7 @@ DmMessage dmMessage({
   String? contentMarkdown,
   int? lastEditTimestamp,
   int? timestamp,
-  List<String>? flags,
+  List<MessageFlag>? flags,
 }) {
   assert(!to.any((user) => user.userId == from.userId));
   return DmMessage.fromJson({

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -9,6 +9,10 @@ import 'dart:convert';
 import 'package:checks/checks.dart';
 import 'package:http/http.dart' as http;
 
+extension ListChecks<T> on Subject<List<T>> {
+  Subject<T> operator [](int index) => has((l) => l[index], '[$index]');
+}
+
 extension NullableMapChecks<K, V> on Subject<Map<K, V>?> {
   void deepEquals(Map<Object?, Object?>? expected) {
     if (expected == null) {


### PR DESCRIPTION
We'll need to handle these events in the upcoming unread-messages model, for #253.

This PR also includes a draft commit:

```
wip msglist: Handle update_message_flags events in model
```

That would be helpful toward #79, but I'm really unsure about the efficiency of using `_findMessageWithId` (binary search) in this hot codepath. (The most common call will be for messages getting marked as read on scroll.) If that turns out to be OK, I can give that commit the tests it needs, and unmark as draft.