### PR TITLE
lint: Enable no_literal_bool_comparisons

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,7 +23,7 @@ linter:
   # producing the lint.
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    no_literal_bool_comparisons: true
     prefer_relative_imports: true
 
 # Additional information about this file can be found at


### PR DESCRIPTION
Docs:
  https://dart.dev/tools/linter-rules/no_literal_bool_comparisons

---

I noticed this from https://github.com/zulip/zulip-flutter/pull/305#discussion_r1336338055 .

It's possible we should make a pass of enabling a swath of the same rules that are applied in the Flutter repo. But it looks like so far this is only the second one that's come up that we want to enable (that wasn't already through the `include` we got from the `flutter create` template); so as long as those are few and far between, that's probably not worth it.
