### PR TITLE
Unread markers

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -106,7 +106,7 @@ mixin _MessageSequence {
       (message, messageId) => message.id.compareTo(messageId));
   }
 
-  int _findItemWithMessageId(int messageId) {
+  int findItemWithMessageId(int messageId) {
     return binarySearchByKey(items, messageId, _compareItemToMessageId);
   }
 
@@ -129,7 +129,7 @@ mixin _MessageSequence {
     final content = parseContent(message.content);
     contents[index] = content;
 
-    final itemIndex = _findItemWithMessageId(message.id);
+    final itemIndex = findItemWithMessageId(message.id);
     assert(itemIndex > -1
       && items[itemIndex] is MessageListMessageItem
       && identical((items[itemIndex] as MessageListMessageItem).message, message));

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -7,6 +7,11 @@ import 'package:checks/checks.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+extension AnimationChecks<T> on Subject<Animation<T>> {
+  Subject<AnimationStatus> get status => has((d) => d.status, 'status');
+  Subject<T> get value => has((d) => d.value, 'value');
+}
+
 extension ClipboardDataChecks on Subject<ClipboardData> {
   Subject<String?> get text => has((d) => d.text, 'text');
 }


### PR DESCRIPTION
This PR introduces unread markers with animations whenever the read state changes for a message. Bundled into this PR is also:

- Associated integration tests and docs on obtaining performance metrics from a physical device that I used to confirm the performance of the animation being used
- A fix for animation state being lost when the number of items in the message list changes. This involved adding a unique key to every message as well as providing a `findChildIndexCallback` to `StickyHeaderListView.builder`.

![screenshow_with_new_border](https://github.com/zulip/zulip-flutter/assets/98299/70f83b49-5ba7-4706-b574-7e6db8ec937a)


Discussion related to design of this on CZO: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20unread.20marker

Fixes: #79