### PR TITLE
narrow [nfc]: Small tweaks to DmNarrow constructors

### DIFF
--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -155,10 +155,10 @@ class DmNarrow extends Narrow implements SendableNarrow {
 
   /// A [DmNarrow] for a 1:1 DM conversation, either with self or otherwise.
   factory DmNarrow.withUser(int userId, {required int selfUserId}) {
-    return DmNarrow(
-      allRecipientIds: {userId, selfUserId}.toList()..sort(),
-      selfUserId: selfUserId,
-    );
+    return DmNarrow(selfUserId: selfUserId,
+      allRecipientIds: (userId == selfUserId)  ? [selfUserId]
+                       : (userId < selfUserId) ? [userId, selfUserId]
+                       :                         [selfUserId, userId]);
   }
 
   /// A [DmNarrow] from a list of users which may or may not include self


### PR DESCRIPTION
The list of these constructors has been growing. This tweaks a couple of aspects that I happened to notice when rereading these as part of merging #304 just now.

---

narrow [nfc]: Factor out DmNarrow.withOtherUsers; doc constructors more

---

narrow [nfc]: Strength-reduce implementation of DmNarrow.withUser

No need to allocate a `Set` for this, as it's always either
just one or two elements.  This version should be a bit more
efficient if we find ourselves constructing many of these.

