### PR TITLE
android: Bump minSdkVersion to 24, aka Android 7 Nougat

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
 
     defaultConfig {
         applicationId "com.zulip.flutter"
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         // These are synced to local.properties from pubspec.yaml by the flutter tool.
         versionCode localProperties.getProperty('flutter.versionCode').toInteger()


### PR DESCRIPTION
This is the same minimum we have on the zulip-mobile RN app.

We've had it at the Flutter default of 19, aka Android 4.4 KitKat. But we're now beginning to bump into the need for "multidex" support:
  https://docs.flutter.dev/deployment/android#enabling-multidex-support
at least in debug builds.  The simplest way to do that is to have minSdkVersion at 21 or higher; which is a good prompt for us to bump it to the version we were going to want to bump it to anyway.