### PR TITLE
unreads: Track total and per-stream unread counts, in addition to IDs

### DIFF
--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -287,14 +287,23 @@ class Unreads extends ChangeNotifier {
                     .add(messageId);
               }
             }
-            newlyUnreadInStreams.forEach((incomingStreamId, incomingTopics) {
-              incomingTopics.forEach((incomingTopic, incomingMessageIds) {
+            for (
+              final MapEntry(key: incomingStreamId, value: incomingTopics)
+              in newlyUnreadInStreams.entries
+            ) {
+              for (
+                final MapEntry(key: incomingTopic, value: incomingMessageIds)
+                in incomingTopics.entries
+              ) {
                 _addAllInStreamTopic(incomingMessageIds..sort(), incomingStreamId, incomingTopic);
-              });
-            });
-            newlyUnreadInDms.forEach((incomingDmNarrow, incomingMessageIds) {
+              }
+            }
+            for (
+              final MapEntry(key: incomingDmNarrow, value: incomingMessageIds)
+              in newlyUnreadInDms.entries
+            ) {
               _addAllInDm(incomingMessageIds..sort(), incomingDmNarrow);
-            });
+            }
         }
     }
     notifyListeners();
@@ -328,21 +337,21 @@ class Unreads extends ChangeNotifier {
   // TODO use efficient model lookups
   void _slowRemoveAllInStreams(Set<int> idsToRemove) {
     final newlyEmptyStreams = [];
-    streams.forEach((streamId, topics) {
+    for (final MapEntry(key: streamId, value: topics) in streams.entries) {
       final newlyEmptyTopics = [];
-      topics.forEach((topic, messageIds) {
+      for (final MapEntry(key: topic, value: messageIds) in topics.entries) {
         messageIds.removeWhere((id) => idsToRemove.contains(id));
         if (messageIds.isEmpty) {
           newlyEmptyTopics.add(topic);
         }
-      });
+      }
       for (final topic in newlyEmptyTopics) {
         topics.remove(topic);
       }
       if (topics.isEmpty) {
         newlyEmptyStreams.add(streamId);
       }
-    });
+    }
     for (final streamId in newlyEmptyStreams) {
       streams.remove(streamId);
     }
@@ -387,12 +396,12 @@ class Unreads extends ChangeNotifier {
   // TODO use efficient model lookups
   void _slowRemoveAllInDms(Set<int> idsToRemove) {
     final newlyEmptyDms = [];
-    dms.forEach((dmNarrow, messageIds) {
+    for (final MapEntry(key: dmNarrow, value: messageIds) in dms.entries) {
       messageIds.removeWhere((id) => idsToRemove.contains(id));
       if (messageIds.isEmpty) {
         newlyEmptyDms.add(dmNarrow);
       }
-    });
+    }
     for (final dmNarrow in newlyEmptyDms) {
       dms.remove(dmNarrow);
     }

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -22,7 +22,8 @@ import 'narrow.dart';
 /// or unknown to the component. In all components,
 /// a message's status will be unknown if, at /register time,
 /// it was very old by the server's reckoning. See [oldUnreadsMissing].
-/// It may also be unknown for other reasons that differ by component; see each.
+/// In [mentions], there's another more complex reason
+/// the state might be unknown; see there.
 ///
 /// Messages in unsubscribed streams, and messages sent by muted users,
 /// are generally deemed read by the server and shouldn't be expected to appear.

--- a/test/model/unreads_checks.dart
+++ b/test/model/unreads_checks.dart
@@ -4,6 +4,7 @@ import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/unreads.dart';
 
 extension UnreadsChecks on Subject<Unreads> {
+  Subject<int> get count => has((u) => u.totalCount, 'count');
   Subject<Map<int, Map<String, QueueList<int>>>> get streams => has((u) => u.streams, 'streams');
   Subject<Map<DmNarrow, QueueList<int>>> get dms => has((u) => u.dms, 'dms');
   Subject<Set<int>> get mentions => has((u) => u.mentions, 'mentions');

--- a/test/model/unreads_checks.dart
+++ b/test/model/unreads_checks.dart
@@ -5,7 +5,7 @@ import 'package:zulip/model/unreads.dart';
 
 extension UnreadsChecks on Subject<Unreads> {
   Subject<int> get count => has((u) => u.totalCount, 'count');
-  Subject<Map<int, Map<String, QueueList<int>>>> get streams => has((u) => u.streams, 'streams');
+  Subject<Map<int, StreamUnreads>> get streams => has((u) => u.streams, 'streams');
   Subject<Map<DmNarrow, QueueList<int>>> get dms => has((u) => u.dms, 'dms');
   Subject<Set<int>> get mentions => has((u) => u.mentions, 'mentions');
   Subject<bool> get oldUnreadsMissing => has((u) => u.oldUnreadsMissing, 'oldUnreadsMissing');

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -87,6 +87,7 @@ void main() {
     }
 
     check(model)
+      ..count.equals(messages.where((m) => !m.flags.contains(MessageFlag.read)).length)
       ..streams.deepEquals(expectedStreams)
       ..dms.deepEquals(expectedDms)
       ..mentions.unorderedEquals(expectedMentions);

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -66,6 +66,7 @@ void main() {
           final streamUnreads = expectedStreams[message.streamId] ??= StreamUnreads.empty();
           final messageIds = streamUnreads.topics[message.subject] ??= QueueList();
           messageIds.add(message.id);
+          streamUnreads.count++;
         case DmMessage():
           final narrow = DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId);
           final messageIds = expectedDms[narrow] ??= QueueList();

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -63,6 +63,8 @@ Object? deepToJson(Object? object) {
       result = object.map((x) => deepToJson(x)).toList();
     case Map() when object.keys.every((k) => k is String):
       result = object.map((k, v) => MapEntry<String, dynamic>(k, deepToJson(v)));
+    case Map() when object.keys.every((k) => k is int):
+      result = object.map((k, v) => MapEntry<String, dynamic>(k.toString(), deepToJson(v)));
     default:
       return (null, false);
   }


### PR DESCRIPTION
Would it be helpful for the unreads model to track total and per-stream unread counts, so it can offer those numbers to callers without having to traverse the model and do sums for each call? Here's a PR that does that. I had this idea after reading @sirpengi's comment here and his referenced commit: https://github.com/zulip/zulip-flutter/pull/334#discussion_r1373339713.

With this PR, it's now efficient to learn the number of:

- total unreads
- unreads in a stream

in addition to these cases that were already efficient:
- unreads in a topic
- unreads in a DM