### PR TITLE
notif: Handle when app in background, too (on Android)

### DIFF
--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -100,6 +100,9 @@ abstract class ZulipBinding {
   /// Wraps [firebase_messaging.FirebaseMessaging.onMessage].
   Stream<firebase_messaging.RemoteMessage> get firebaseMessagingOnMessage;
 
+  /// Wraps [firebase_messaging.FirebaseMessaging.onBackgroundMessage].
+  void firebaseMessagingOnBackgroundMessage(firebase_messaging.BackgroundMessageHandler handler);
+
   /// Wraps the [FlutterLocalNotificationsPlugin] singleton constructor.
   FlutterLocalNotificationsPlugin get notifications;
 }
@@ -197,6 +200,11 @@ class LiveZulipBinding extends ZulipBinding {
   @override
   Stream<firebase_messaging.RemoteMessage> get firebaseMessagingOnMessage {
     return firebase_messaging.FirebaseMessaging.onMessage;
+  }
+
+  @override
+  void firebaseMessagingOnBackgroundMessage(firebase_messaging.BackgroundMessageHandler handler) {
+    firebase_messaging.FirebaseMessaging.onBackgroundMessage(handler);
   }
 
   @override

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -18,7 +18,7 @@ class NotificationService {
   @visibleForTesting
   static void debugReset() {
     instance.token.dispose();
-    instance.token = ValueNotifier(null);
+    _instance = null;
   }
 
   /// The FCM registration token for this install of the app.

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -192,6 +192,11 @@ class TestZulipBinding extends ZulipBinding {
   @override
   Stream<RemoteMessage> get firebaseMessagingOnMessage => firebaseMessaging.onMessage.stream;
 
+  @override
+  void firebaseMessagingOnBackgroundMessage(BackgroundMessageHandler handler) {
+    firebaseMessaging.onBackgroundMessage.stream.listen(handler);
+  }
+
   void _resetNotifications() {
     _notificationsPlugin = null;
   }
@@ -241,6 +246,12 @@ class FakeFirebaseMessaging extends Fake implements FirebaseMessaging {
   Stream<String> get onTokenRefresh => _tokenController.stream;
 
   StreamController<RemoteMessage> onMessage = StreamController.broadcast();
+
+  /// Controls [TestZulipBinding.firebaseMessagingOnBackgroundMessage].
+  ///
+  /// Calling [StreamController.add] on this will cause a call
+  /// to any handler registered through that method.
+  StreamController<RemoteMessage> onBackgroundMessage = StreamController.broadcast();
 }
 
 class FakeFlutterLocalNotificationsPlugin extends Fake implements FlutterLocalNotificationsPlugin {


### PR DESCRIPTION
This completes the core functionality of showing notifications on
Android, #320.

Sadly this does not work very well if the app isn't running at all:
e.g., if you terminate the app by swiping it away in the app switcher.
In that case the notification can be quite a bit delayed.

But fixing that seems likely to require some deeper debugging, and
getting our hands into Java or Kotlin code for I think the first time
in zulip-flutter.  So we'll deal with that as a followup issue, #342.
Details there.

Fixes: #320
