### PR TITLE
api: Mark messages as read (updateMessageFlags and updateMessageFlagsForNarrow)

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -430,7 +430,7 @@ sealed class Message {
   Map<String, dynamic> toJson();
 }
 
-/// As in [Message.flags].
+/// https://zulip.com/api/update-message-flags#available-flags
 @JsonEnum(fieldRename: FieldRename.snake, alwaysCreate: true)
 enum MessageFlag {
   read,

--- a/lib/api/model/narrow.dart
+++ b/lib/api/model/narrow.dart
@@ -1,5 +1,19 @@
 typedef ApiNarrow = List<ApiNarrowElement>;
 
+/// Resolve any [ApiNarrowDm] elements appropriately.
+///
+/// This encapsulates a server-feature check.
+ApiNarrow resolveDmElements(ApiNarrow narrow, int zulipFeatureLevel) {
+  if (!narrow.any((element) => element is ApiNarrowDm)) {
+    return narrow;
+  }
+  final supportsOperatorDm = zulipFeatureLevel >= 177; // TODO(server-7)
+  return narrow.map((element) => switch (element) {
+    ApiNarrowDm() => element.resolve(legacy: !supportsOperatorDm),
+    _             => element,
+  }).toList();
+}
+
 /// An element in the list representing a narrow in the Zulip API.
 ///
 /// Docs: <https://zulip.com/api/construct-narrow>
@@ -51,6 +65,8 @@ class ApiNarrowTopic extends ApiNarrowElement {
 /// An instance directly of this class must not be serialized with [jsonEncode],
 /// and more generally its [operator] getter must not be called.
 /// Instead, call [resolve] and use the object it returns.
+///
+/// If part of [ApiNarrow] use [resolveDmElements].
 class ApiNarrowDm extends ApiNarrowElement {
   @override String get operator {
     assert(false,

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -288,3 +288,88 @@ Future<void> removeReaction(ApiConnection connection, {
     'reaction_type': RawParameter(reactionType.toJson()),
   });
 }
+
+/// https://zulip.com/api/update-message-flags
+Future<UpdateMessageFlagsResult> updateMessageFlags(ApiConnection connection, {
+  required List<int> messages,
+  required UpdateMessageFlagsOp op,
+  required MessageFlag flag,
+}) {
+  return connection.post('updateMessageFlags', UpdateMessageFlagsResult.fromJson, 'messages/flags', {
+    'messages': messages,
+    'op': RawParameter(op.toJson()),
+    'flag': RawParameter(flag.toJson()),
+  });
+}
+
+/// An `op` value for [updateMessageFlags] and [updateMessageFlagsForNarrow].
+@JsonEnum(fieldRename: FieldRename.snake, alwaysCreate: true)
+enum UpdateMessageFlagsOp {
+  add,
+  remove;
+
+  String toJson() => _$UpdateMessageFlagsOpEnumMap[this]!;
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UpdateMessageFlagsResult {
+  final List<int> messages;
+
+  UpdateMessageFlagsResult({
+    required this.messages,
+  });
+
+  factory UpdateMessageFlagsResult.fromJson(Map<String, dynamic> json) =>
+    _$UpdateMessageFlagsResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UpdateMessageFlagsResultToJson(this);
+}
+
+/// https://zulip.com/api/update-message-flags-for-narrow
+///
+/// This binding only supports feature levels 155+.
+// TODO(server-6) remove FL 155+ mention in doc, and the related `assert`
+Future<UpdateMessageFlagsForNarrowResult> updateMessageFlagsForNarrow(ApiConnection connection, {
+  required Anchor anchor,
+  bool? includeAnchor,
+  required int numBefore,
+  required int numAfter,
+  required ApiNarrow narrow,
+  required UpdateMessageFlagsOp op,
+  required MessageFlag flag,
+}) {
+  assert(connection.zulipFeatureLevel! >= 155);
+  return connection.post('updateMessageFlagsForNarrow', UpdateMessageFlagsForNarrowResult.fromJson, 'messages/flags/narrow', {
+    'anchor': RawParameter(anchor.toJson()),
+    if (includeAnchor != null) 'include_anchor': includeAnchor,
+    'num_before': numBefore,
+    'num_after': numAfter,
+    'narrow': resolveDmElements(narrow, connection.zulipFeatureLevel!),
+    'op': RawParameter(op.toJson()),
+    'flag': RawParameter(flag.toJson()),
+  });
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UpdateMessageFlagsForNarrowResult {
+  final int processedCount;
+  final int updatedCount;
+  final int? firstProcessedId;
+  final int? lastProcessedId;
+  final bool foundOldest;
+  final bool foundNewest;
+
+  UpdateMessageFlagsForNarrowResult({
+    required this.processedCount,
+    required this.updatedCount,
+    required this.firstProcessedId,
+    required this.lastProcessedId,
+    required this.foundOldest,
+    required this.foundNewest,
+  });
+
+  factory UpdateMessageFlagsForNarrowResult.fromJson(Map<String, dynamic> json) =>
+    _$UpdateMessageFlagsForNarrowResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UpdateMessageFlagsForNarrowResultToJson(this);
+}

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -92,12 +92,7 @@ Future<GetMessagesResult> getMessages(ApiConnection connection, {
 }) {
   return connection.get('getMessages', GetMessagesResult.fromJson, 'messages', {
     'narrow': resolveDmElements(narrow, connection.zulipFeatureLevel!),
-    'anchor': switch (anchor) {
-      NumericAnchor(:var messageId) => messageId,
-      AnchorCode.newest             => RawParameter('newest'),
-      AnchorCode.oldest             => RawParameter('oldest'),
-      AnchorCode.firstUnread        => RawParameter('first_unread'),
-    },
+    'anchor': RawParameter(anchor.toJson()),
     if (includeAnchor != null) 'include_anchor': includeAnchor,
     'num_before': numBefore,
     'num_after': numAfter,
@@ -112,17 +107,28 @@ Future<GetMessagesResult> getMessages(ApiConnection connection, {
 sealed class Anchor {
   /// This const constructor allows subclasses to have const constructors.
   const Anchor();
+
+  String toJson();
 }
 
 /// An anchor value for [getMessages] other than a specific message ID.
 ///
 /// https://zulip.com/api/get-messages#parameter-anchor
-enum AnchorCode implements Anchor { newest, oldest, firstUnread }
+@JsonEnum(fieldRename: FieldRename.snake, alwaysCreate: true)
+enum AnchorCode implements Anchor {
+  newest, oldest, firstUnread;
+
+  @override
+  String toJson() => _$AnchorCodeEnumMap[this]!;
+}
 
 /// A specific message ID, used as an anchor in [getMessages].
 class NumericAnchor extends Anchor {
   const NumericAnchor(this.messageId);
   final int messageId;
+
+  @override
+  String toJson() => messageId.toString();
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -90,15 +90,8 @@ Future<GetMessagesResult> getMessages(ApiConnection connection, {
   bool? applyMarkdown,
   // bool? useFirstUnreadAnchor // omitted because deprecated
 }) {
-  if (narrow.any((element) => element is ApiNarrowDm)) {
-    final supportsOperatorDm = connection.zulipFeatureLevel! >= 177; // TODO(server-7)
-    narrow = narrow.map((element) => switch (element) {
-      ApiNarrowDm() => element.resolve(legacy: !supportsOperatorDm),
-      _             => element,
-    }).toList();
-  }
   return connection.get('getMessages', GetMessagesResult.fromJson, 'messages', {
-    'narrow': narrow,
+    'narrow': resolveDmElements(narrow, connection.zulipFeatureLevel!),
     'anchor': switch (anchor) {
       NumericAnchor(:var messageId) => messageId,
       AnchorCode.newest             => RawParameter('newest'),

--- a/lib/api/route/messages.g.dart
+++ b/lib/api/route/messages.g.dart
@@ -60,8 +60,48 @@ Map<String, dynamic> _$UploadFileResultToJson(UploadFileResult instance) =>
       'uri': instance.uri,
     };
 
+UpdateMessageFlagsResult _$UpdateMessageFlagsResultFromJson(
+        Map<String, dynamic> json) =>
+    UpdateMessageFlagsResult(
+      messages:
+          (json['messages'] as List<dynamic>).map((e) => e as int).toList(),
+    );
+
+Map<String, dynamic> _$UpdateMessageFlagsResultToJson(
+        UpdateMessageFlagsResult instance) =>
+    <String, dynamic>{
+      'messages': instance.messages,
+    };
+
+UpdateMessageFlagsForNarrowResult _$UpdateMessageFlagsForNarrowResultFromJson(
+        Map<String, dynamic> json) =>
+    UpdateMessageFlagsForNarrowResult(
+      processedCount: json['processed_count'] as int,
+      updatedCount: json['updated_count'] as int,
+      firstProcessedId: json['first_processed_id'] as int?,
+      lastProcessedId: json['last_processed_id'] as int?,
+      foundOldest: json['found_oldest'] as bool,
+      foundNewest: json['found_newest'] as bool,
+    );
+
+Map<String, dynamic> _$UpdateMessageFlagsForNarrowResultToJson(
+        UpdateMessageFlagsForNarrowResult instance) =>
+    <String, dynamic>{
+      'processed_count': instance.processedCount,
+      'updated_count': instance.updatedCount,
+      'first_processed_id': instance.firstProcessedId,
+      'last_processed_id': instance.lastProcessedId,
+      'found_oldest': instance.foundOldest,
+      'found_newest': instance.foundNewest,
+    };
+
 const _$AnchorCodeEnumMap = {
   AnchorCode.newest: 'newest',
   AnchorCode.oldest: 'oldest',
   AnchorCode.firstUnread: 'first_unread',
+};
+
+const _$UpdateMessageFlagsOpEnumMap = {
+  UpdateMessageFlagsOp.add: 'add',
+  UpdateMessageFlagsOp.remove: 'remove',
 };

--- a/lib/api/route/messages.g.dart
+++ b/lib/api/route/messages.g.dart
@@ -59,3 +59,9 @@ Map<String, dynamic> _$UploadFileResultToJson(UploadFileResult instance) =>
     <String, dynamic>{
       'uri': instance.uri,
     };
+
+const _$AnchorCodeEnumMap = {
+  AnchorCode.newest: 'newest',
+  AnchorCode.oldest: 'oldest',
+  AnchorCode.firstUnread: 'first_unread',
+};

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -200,6 +200,19 @@ void main() {
     });
   });
 
+  test('Anchor.toJson', () {
+    void checkAnchor(Anchor anchor, String expected) {
+      check(anchor.toJson()).equals(expected);
+    }
+
+    checkAnchor(AnchorCode.newest,      'newest');
+    checkAnchor(AnchorCode.oldest,      'oldest');
+    checkAnchor(AnchorCode.firstUnread, 'first_unread');
+    checkAnchor(const NumericAnchor(1), '1');
+    checkAnchor(const NumericAnchor(999999999), '999999999');
+    checkAnchor(const NumericAnchor(10000000000000000), '10000000000000000');
+  });
+
   group('getMessages', () {
     Future<GetMessagesResult> checkGetMessages(
       FakeApiConnection connection, {
@@ -260,27 +273,19 @@ void main() {
       });
     });
 
-    test('anchor', () {
+    test('numeric anchor', () {
       return FakeApiConnection.with_((connection) async {
-        Future<void> checkAnchor(Anchor anchor, String expected) async {
-          connection.prepare(json: fakeResult.toJson());
-          await checkGetMessages(connection,
-            narrow: const AllMessagesNarrow().apiEncode(),
-            anchor: anchor, numBefore: 10, numAfter: 20,
-            expected: {
-              'narrow': jsonEncode([]),
-              'anchor': expected,
-              'num_before': '10',
-              'num_after': '20',
-            });
-        }
-
-        await checkAnchor(AnchorCode.newest,      'newest');
-        await checkAnchor(AnchorCode.oldest,      'oldest');
-        await checkAnchor(AnchorCode.firstUnread, 'first_unread');
-        await checkAnchor(const NumericAnchor(1), '1');
-        await checkAnchor(const NumericAnchor(999999999), '999999999');
-        await checkAnchor(const NumericAnchor(10000000000000000), '10000000000000000');
+        connection.prepare(json: fakeResult.toJson());
+        await checkGetMessages(connection,
+          narrow: const AllMessagesNarrow().apiEncode(),
+          anchor: const NumericAnchor(42),
+          numBefore: 10, numAfter: 20,
+          expected: {
+            'narrow': jsonEncode([]),
+            'anchor': '42',
+            'num_before': '10',
+            'num_after': '20',
+          });
       });
     });
   });


### PR DESCRIPTION
This PR adds all the api routes related to marking messages as read.

The complexities around the response of https://zulip.com/api/mark-all-as-read are ignored as it is deprecated (it is also ignored in zulip-mobile). On an examination of `lib/api/core.dart` it doesn't look like we check the value of the `result` field (where the status code is 200) so if the server returns `partially_completed` for the affected FLs it doesn't raise any errors (although we would treat the operation as completed).

Fixes part of #130 