### PR TITLE
Mark as read

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -289,6 +289,10 @@
       "num": {"type": "int", "example": "4"}
     }
   },
+  "errorInvalidResponse": "The server sent an invalid response",
+  "@errorInvalidResponse": {
+    "description": "Error message when an API call returned an invalid response."
+  },
   "errorNetworkRequestFailed": "Network request failed",
   "@errorNetworkRequestFailed": {
     "description": "Error message when a network request fails."
@@ -322,6 +326,28 @@
   "serverUrlValidationErrorUnsupportedScheme": "The server URL must start with http:// or https://.",
   "@serverUrlValidationErrorUnsupportedScheme": {
     "description": "Error message when URL has an unsupported scheme."
+  },
+  "markAsReadLabel": "Mark {num, plural, =1{1 message} other{{num} messages}} as read",
+  "@markAsReadLabel": {
+    "description": "Button text to mark messages as read.",
+    "placeholders": {
+      "num": {"type": "int", "example": "4"}
+    }
+  },
+  "markAsReadComplete": "Marked {num, plural, =1{1 message} other{{num} messages}} as read.",
+  "@markAsReadComplete": {
+    "description": "Message when marking messages as read has completed.",
+    "placeholders": {
+      "num": {"type": "int", "example": "4"}
+    }
+  },
+  "markAsReadInProgress": "Marking messages as read...",
+  "@markAsReadInProgress": {
+    "description": "Progress message when marking messages as read."
+  },
+  "errorMarkAsReadFailedTitle": "Mark as read failed",
+  "@errorMarkAsReadFailedTitle": {
+    "description": "Error title when mark as read action failed."
   },
   "userRoleOwner": "Owner",
   "@userRoleOwner": {

--- a/lib/api/model/narrow.dart
+++ b/lib/api/model/narrow.dart
@@ -114,6 +114,14 @@ class ApiNarrowPmWith extends ApiNarrowDm {
   ApiNarrowPmWith._(super.operand, {super.negated});
 }
 
+// TODO: generalize into ApiNarrowIs
+class ApiNarrowIsUnread extends ApiNarrowElement {
+  @override String get operator => 'is';
+  @override String get operand => 'unread';
+
+  ApiNarrowIsUnread({super.negated});
+}
+
 class ApiNarrowMessageId extends ApiNarrowElement {
   @override String get operator => 'id';
 

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -84,6 +84,8 @@ Uri narrowLink(PerAccountStore store, Narrow narrow, {int? nearMessageId}) {
         fragment.write('${element.operand.join(',')}-$suffix');
       case ApiNarrowDm():
         assert(false, 'ApiNarrowDm should have been resolved');
+      case ApiNarrowIsUnread():
+        fragment.write(element.operand.toString());
       case ApiNarrowMessageId():
         fragment.write(element.operand.toString());
     }

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -56,17 +56,14 @@ String? decodeHashComponent(String str) {
 // When you want to point the server to a location in a message list, you
 // you do so by passing the `anchor` param.
 Uri narrowLink(PerAccountStore store, Narrow narrow, {int? nearMessageId}) {
-  final apiNarrow = narrow.apiEncode();
+  // TODO(server-7)
+  final apiNarrow = resolveDmElements(
+    narrow.apiEncode(), store.connection.zulipFeatureLevel!);
   final fragment = StringBuffer('narrow');
   for (ApiNarrowElement element in apiNarrow) {
     fragment.write('/');
     if (element.negated) {
       fragment.write('-');
-    }
-
-    if (element is ApiNarrowDm) {
-      final supportsOperatorDm = store.connection.zulipFeatureLevel! >= 177; // TODO(server-7)
-      element = element.resolve(legacy: !supportsOperatorDm);
     }
 
     fragment.write('${element.operator}/');

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -123,7 +123,53 @@ class Unreads extends ChangeNotifier {
 
   final int selfUserId;
 
+  // TODO(#346): account for muted topics and streams
+  // TODO(#370): maintain this count incrementally, rather than recomputing from scratch
+  int countInAllMessagesNarrow() {
+    int c = 0;
+    for (final messageIds in dms.values) {
+      c = c + messageIds.length;
+    }
+    for (final topics in streams.values) {
+      for (final messageIds in topics.values) {
+        c = c + messageIds.length;
+      }
+    }
+    return c;
+  }
+
+  // TODO(#346): account for muted topics and streams
+  // TODO(#370): maintain this count incrementally, rather than recomputing from scratch
+  int countInStreamNarrow(int streamId) {
+    final topics = streams[streamId];
+    if (topics == null) return 0;
+    int c = 0;
+    for (final messageIds in topics.values) {
+      c = c + messageIds.length;
+    }
+    return c;
+  }
+
+  // TODO(#346): account for muted topics and streams
+  int countInTopicNarrow(int streamId, String topic) {
+    final topics = streams[streamId];
+    return topics?[topic]?.length ?? 0;
+  }
+
   int countInDmNarrow(DmNarrow narrow) => dms[narrow]?.length ?? 0;
+
+  int countInNarrow(Narrow narrow) {
+    switch (narrow) {
+      case AllMessagesNarrow():
+        return countInAllMessagesNarrow();
+      case StreamNarrow():
+        return countInStreamNarrow(narrow.streamId);
+      case TopicNarrow():
+        return countInTopicNarrow(narrow.streamId, narrow.topic);
+      case DmNarrow():
+        return countInDmNarrow(narrow);
+    }
+  }
 
   void handleMessageEvent(MessageEvent event) {
     final message = event.message;

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -146,6 +146,53 @@ void main() {
     });
   });
 
+  group('count helpers', () {
+    test('countInAllMessagesNarrow', () {
+      final stream1 = eg.stream();
+      final stream2 = eg.stream();
+      prepare();
+      fillWithMessages([
+        eg.streamMessage(stream: stream1, topic: 'a', flags: []),
+        eg.streamMessage(stream: stream1, topic: 'b', flags: []),
+        eg.streamMessage(stream: stream1, topic: 'b', flags: []),
+        eg.streamMessage(stream: stream2, topic: 'c', flags: []),
+        eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], flags: []),
+        eg.dmMessage(from: eg.thirdUser, to: [eg.selfUser], flags: []),
+      ]);
+      check(model.countInAllMessagesNarrow()).equals(6);
+    });
+
+    test('countInStreamNarrow', () {
+      final stream = eg.stream();
+      prepare();
+      fillWithMessages([
+        eg.streamMessage(stream: stream, topic: 'a', flags: []),
+        eg.streamMessage(stream: stream, topic: 'a', flags: []),
+        eg.streamMessage(stream: stream, topic: 'b', flags: []),
+        eg.streamMessage(stream: stream, topic: 'b', flags: []),
+        eg.streamMessage(stream: stream, topic: 'b', flags: []),
+      ]);
+      check(model.countInStreamNarrow(stream.streamId)).equals(5);
+    });
+
+    test('countInTopicNarrow', () {
+      final stream = eg.stream();
+      prepare();
+      fillWithMessages(List.generate(7, (i) => eg.streamMessage(
+        stream: stream, topic: 'a', flags: [])));
+      check(model.countInTopicNarrow(stream.streamId, 'a')).equals(7);
+    });
+
+    test('countInDmNarrow', () {
+      prepare();
+      fillWithMessages(List.generate(5, (i) => eg.dmMessage(
+        from: eg.otherUser, to: [eg.selfUser], flags: [])));
+      final narrow = DmNarrow.withUser(
+        eg.otherUser.userId, selfUserId: eg.selfUser.userId);
+      check(model.countInDmNarrow(narrow)).equals(5);
+    });
+  });
+
   group('handleMessageEvent', () {
     for (final (isUnread, isStream, isDirectMentioned, isWildcardMentioned) in [
       (true,  true,  true,  true ),


### PR DESCRIPTION
This is proceeded by #361 and #363, which both provide api routes necessary for functionality here. This implements the manual "Mark as Read" button that allows the user to explicitly mark messages in their current narrow as read.

This series of PRs fixes: #130

---

Design made to match figma spec at https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?type=design&node-id=132-9684&mode=design&t=jJwHzloKJ0TMOG4M-0

![mark_as_read_figma](https://github.com/zulip/zulip-flutter/assets/98299/04a83dfe-2b24-442f-841f-c53398f0a174)

![mark_as_unread_updated](https://github.com/zulip/zulip-flutter/assets/98299/6df68acb-4d3d-4598-a5fe-eb5282e3bae3)
