### PR TITLE
msglist: Have content pad bottom inset when the compose box isn't shown

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -61,8 +61,12 @@ class _MessageListPageState extends State<MessageListPage> {
               // MediaQuery.removePadding with `removeTop: true`.
               context: context,
 
-              // The compose box pads the bottom inset.
-              removeBottom: true,
+              // The compose box, when present, pads the bottom inset.
+              // TODO this copies the details of when the compose box is shown;
+              //   if those details get complicated, refactor to avoid copying.
+              // TODO(#311) If we have a bottom nav, it will pad the bottom
+              //   inset, and this should always be true.
+              removeBottom: widget.narrow is! AllMessagesNarrow,
 
               child: Expanded(
                 child: MessageList(narrow: widget.narrow))),
@@ -228,6 +232,13 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         color: Colors.white,
         // Pad the left and right insets, for small devices in landscape.
         child: SafeArea(
+          // Don't let this be the place we pad the bottom inset. When there's
+          // no compose box, we want to let the message-list content pad it.
+          // TODO(#311) Remove as unnecessary if we do a bottom nav.
+          //   The nav will pad the bottom inset, and an ancestor of this widget
+          //   will have a `MediaQuery.removePadding` with `removeBottom: true`.
+          bottom: false,
+
           child: Center(
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 760),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -250,9 +250,12 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
                     Positioned(
                       bottom: 0,
                       right: 0,
-                      child: ScrollToBottomButton(
-                        scrollController: scrollController,
-                        visibleValue: _scrollToBottomVisibleValue)),
+                      // TODO(#311) SafeArea shouldn't be needed if we have a
+                      //   bottom nav. That will pad the bottom inset.
+                      child: SafeArea(
+                        child: ScrollToBottomButton(
+                          scrollController: scrollController,
+                          visibleValue: _scrollToBottomVisibleValue))),
                   ])))))));
   }
 


### PR DESCRIPTION
This takes advantage of some of StickyHeaderListView's default behavior (inherited from ListView). From the doc on ListView:

https://api.flutter.dev/flutter/widgets/ListView-class.html
> By default, ListView will automatically pad the list's scrollable
> extremities to avoid partial obstructions indicated by
> MediaQuery's padding. To avoid this behavior, override with a zero
> padding property.

The code changes here are just to arrange for that default behavior to help us out: we let the real height of the bottom inset propagate down to the StickyHeaderListView, with the MediaQuery mechanism.

Fixes: #263 