### PR TITLE
Subscription api events

### DIFF
--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -156,6 +156,116 @@ const _$UserRoleEnumMap = {
   UserRole.unknown: null,
 };
 
+SubscriptionAddEvent _$SubscriptionAddEventFromJson(
+        Map<String, dynamic> json) =>
+    SubscriptionAddEvent(
+      id: json['id'] as int,
+      subscriptions: (json['subscriptions'] as List<dynamic>)
+          .map((e) => Subscription.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SubscriptionAddEventToJson(
+        SubscriptionAddEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'op': instance.op,
+      'subscriptions': instance.subscriptions,
+    };
+
+SubscriptionRemoveEvent _$SubscriptionRemoveEventFromJson(
+        Map<String, dynamic> json) =>
+    SubscriptionRemoveEvent(
+      id: json['id'] as int,
+      streamIds: (SubscriptionRemoveEvent._readStreamIds(json, 'stream_ids')
+              as List<dynamic>)
+          .map((e) => e as int)
+          .toList(),
+    );
+
+Map<String, dynamic> _$SubscriptionRemoveEventToJson(
+        SubscriptionRemoveEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'op': instance.op,
+      'stream_ids': instance.streamIds,
+    };
+
+SubscriptionUpdateEvent _$SubscriptionUpdateEventFromJson(
+        Map<String, dynamic> json) =>
+    SubscriptionUpdateEvent(
+      id: json['id'] as int,
+      streamId: json['stream_id'] as int,
+      property: $enumDecode(_$SubscriptionPropertyEnumMap, json['property']),
+      value: SubscriptionUpdateEvent._readValue(json, 'value'),
+    );
+
+Map<String, dynamic> _$SubscriptionUpdateEventToJson(
+        SubscriptionUpdateEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'op': instance.op,
+      'stream_id': instance.streamId,
+      'property': _$SubscriptionPropertyEnumMap[instance.property]!,
+      'value': instance.value,
+    };
+
+const _$SubscriptionPropertyEnumMap = {
+  SubscriptionProperty.color: 'color',
+  SubscriptionProperty.isMuted: 'is_muted',
+  SubscriptionProperty.inHomeView: 'in_home_view',
+  SubscriptionProperty.pinToTop: 'pin_to_top',
+  SubscriptionProperty.desktopNotifications: 'desktop_notifications',
+  SubscriptionProperty.audibleNotifications: 'audible_notifications',
+  SubscriptionProperty.pushNotifications: 'push_notifications',
+  SubscriptionProperty.emailNotifications: 'email_notifications',
+  SubscriptionProperty.wildcardMentionsNotify: 'wildcard_mentions_notify',
+  SubscriptionProperty.unknown: 'unknown',
+};
+
+SubscriptionPeerAddEvent _$SubscriptionPeerAddEventFromJson(
+        Map<String, dynamic> json) =>
+    SubscriptionPeerAddEvent(
+      id: json['id'] as int,
+      streamIds:
+          (json['stream_ids'] as List<dynamic>).map((e) => e as int).toList(),
+      userIds:
+          (json['user_ids'] as List<dynamic>).map((e) => e as int).toList(),
+    );
+
+Map<String, dynamic> _$SubscriptionPeerAddEventToJson(
+        SubscriptionPeerAddEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'op': instance.op,
+      'stream_ids': instance.streamIds,
+      'user_ids': instance.userIds,
+    };
+
+SubscriptionPeerRemoveEvent _$SubscriptionPeerRemoveEventFromJson(
+        Map<String, dynamic> json) =>
+    SubscriptionPeerRemoveEvent(
+      id: json['id'] as int,
+      streamIds:
+          (json['stream_ids'] as List<dynamic>).map((e) => e as int).toList(),
+      userIds:
+          (json['user_ids'] as List<dynamic>).map((e) => e as int).toList(),
+    );
+
+Map<String, dynamic> _$SubscriptionPeerRemoveEventToJson(
+        SubscriptionPeerRemoveEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'op': instance.op,
+      'stream_ids': instance.streamIds,
+      'user_ids': instance.userIds,
+    };
+
 StreamCreateEvent _$StreamCreateEventFromJson(Map<String, dynamic> json) =>
     StreamCreateEvent(
       id: json['id'] as int,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -312,35 +312,8 @@ enum StreamPostPolicy {
 /// For docs, search for "subscriptions:"
 /// in <https://zulip.com/api/register-queue>.
 @JsonSerializable(fieldRename: FieldRename.snake)
-class Subscription {
-  // First, fields that are about the stream and not the user's relation to it.
-  // These are largely the same as in [ZulipStream].
-
-  final int streamId;
-  final String name;
-  final String description;
-  final String renderedDescription;
-
-  final int dateCreated;
-  final int? firstMessageId;
-  final int? streamWeeklyTraffic;
-
-  final bool inviteOnly;
-  final bool isWebPublic;
-  final bool historyPublicToSubscribers;
-  final int? messageRetentionDays;
+class Subscription extends ZulipStream {
   // final List<int> subscribers; // we register with includeSubscribers false
-
-  final StreamPostPolicy streamPostPolicy;
-  // final bool? isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
-
-  // TODO(server-6): `canRemoveSubscribersGroupId` added in FL 142
-  // TODO(server-8): in FL 197 renamed to `canRemoveSubscribersGroup`
-  @JsonKey(readValue: _readCanRemoveSubscribersGroup)
-  final int? canRemoveSubscribersGroup;
-
-  // Then, fields that are specific to the subscription,
-  // i.e. the user's relationship to the stream.
 
   final bool? desktopNotifications;
   final bool? emailNotifications;
@@ -349,23 +322,25 @@ class Subscription {
   final bool? audibleNotifications;
 
   final bool pinToTop;
-
   final bool isMuted;
   // final bool? inHomeView; // deprecated; ignore
 
   final String color;
 
-  static int? _readCanRemoveSubscribersGroup(Map json, String key) {
-    return json[key] ?? json['can_remove_subscribers_group_id'];
-  }
-
   Subscription({
-    required this.streamId,
-    required this.name,
-    required this.description,
-    required this.renderedDescription,
-    required this.dateCreated,
-    required this.inviteOnly,
+    required super.streamId,
+    required super.name,
+    required super.description,
+    required super.renderedDescription,
+    required super.dateCreated,
+    required super.firstMessageId,
+    required super.inviteOnly,
+    required super.isWebPublic,
+    required super.historyPublicToSubscribers,
+    required super.messageRetentionDays,
+    required super.streamPostPolicy,
+    required super.canRemoveSubscribersGroup,
+    required super.streamWeeklyTraffic,
     required this.desktopNotifications,
     required this.emailNotifications,
     required this.wildcardMentionsNotify,
@@ -373,19 +348,13 @@ class Subscription {
     required this.audibleNotifications,
     required this.pinToTop,
     required this.isMuted,
-    required this.isWebPublic,
     required this.color,
-    required this.streamPostPolicy,
-    required this.messageRetentionDays,
-    required this.historyPublicToSubscribers,
-    required this.firstMessageId,
-    required this.streamWeeklyTraffic,
-    required this.canRemoveSubscribersGroup,
   });
 
   factory Subscription.fromJson(Map<String, dynamic> json) =>
     _$SubscriptionFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$SubscriptionToJson(this);
 }
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -315,17 +315,17 @@ enum StreamPostPolicy {
 class Subscription extends ZulipStream {
   // final List<int> subscribers; // we register with includeSubscribers false
 
-  final bool? desktopNotifications;
-  final bool? emailNotifications;
-  final bool? wildcardMentionsNotify;
-  final bool? pushNotifications;
-  final bool? audibleNotifications;
+  bool? desktopNotifications;
+  bool? emailNotifications;
+  bool? wildcardMentionsNotify;
+  bool? pushNotifications;
+  bool? audibleNotifications;
 
-  final bool pinToTop;
-  final bool isMuted;
+  bool pinToTop;
+  bool isMuted;
   // final bool? inHomeView; // deprecated; ignore
 
-  final String color;
+  String color;
 
   Subscription({
     required super.streamId,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -249,8 +249,8 @@ class ZulipStream {
   final bool historyPublicToSubscribers;
   final int? messageRetentionDays;
 
-  final int streamPostPolicy; // TODO enum
-  // final bool isAnnouncementOnly; // deprecated; ignore
+  final StreamPostPolicy streamPostPolicy;
+  // final bool isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
 
   final int? canRemoveSubscribersGroupId; // TODO(server-6)
 
@@ -273,6 +273,27 @@ class ZulipStream {
     _$ZulipStreamFromJson(json);
 
   Map<String, dynamic> toJson() => _$ZulipStreamToJson(this);
+}
+
+/// Policy for which users can post to the stream.
+///
+/// For docs, search for "stream_post_policy"
+/// in <https://zulip.com/api/get-stream-by-id>
+@JsonEnum(valueField: 'apiValue')
+enum StreamPostPolicy {
+  any(apiValue: 1),
+  administrators(apiValue: 2),
+  fullMembers(apiValue: 3),
+  moderators(apiValue: 4),
+  unknown(apiValue: null);
+
+  const StreamPostPolicy({
+    required this.apiValue,
+  });
+
+  final int? apiValue;
+
+  int? toJson() => apiValue;
 }
 
 /// As in `subscriptions` in the initial snapshot.
@@ -299,8 +320,8 @@ class Subscription {
   final int? messageRetentionDays;
   // final List<int> subscribers; // we register with includeSubscribers false
 
-  final int streamPostPolicy; // TODO enum
-  // final bool? isAnnouncementOnly; // deprecated; ignore
+  final StreamPostPolicy streamPostPolicy;
+  // final bool? isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
 
   final int? canRemoveSubscribersGroupId; // TODO(server-6)
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -252,7 +252,17 @@ class ZulipStream {
   final StreamPostPolicy streamPostPolicy;
   // final bool isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
 
-  final int? canRemoveSubscribersGroupId; // TODO(server-6)
+  // TODO(server-6): `canRemoveSubscribersGroupId` added in FL 142
+  // TODO(server-8): in FL 197 renamed to `canRemoveSubscribersGroup`
+  @JsonKey(readValue: _readCanRemoveSubscribersGroup)
+  final int? canRemoveSubscribersGroup;
+
+  // TODO(server-8): added in FL 199, was previously only on [Subscription] objects
+  final int? streamWeeklyTraffic;
+
+  static int? _readCanRemoveSubscribersGroup(Map json, String key) {
+    return json[key] ?? json['can_remove_subscribers_group_id'];
+  }
 
   ZulipStream({
     required this.streamId,
@@ -266,7 +276,8 @@ class ZulipStream {
     required this.historyPublicToSubscribers,
     required this.messageRetentionDays,
     required this.streamPostPolicy,
-    required this.canRemoveSubscribersGroupId,
+    required this.canRemoveSubscribersGroup,
+    required this.streamWeeklyTraffic,
   });
 
   factory ZulipStream.fromJson(Map<String, dynamic> json) =>

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -326,7 +326,7 @@ class Subscription {
   final int? streamWeeklyTraffic;
 
   final bool inviteOnly;
-  final bool? isWebPublic; // TODO(server-??): doc doesn't say when added
+  final bool isWebPublic;
   final bool historyPublicToSubscribers;
   final int? messageRetentionDays;
   // final List<int> subscribers; // we register with includeSubscribers false
@@ -334,7 +334,10 @@ class Subscription {
   final StreamPostPolicy streamPostPolicy;
   // final bool? isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
 
-  final int? canRemoveSubscribersGroupId; // TODO(server-6)
+  // TODO(server-6): `canRemoveSubscribersGroupId` added in FL 142
+  // TODO(server-8): in FL 197 renamed to `canRemoveSubscribersGroup`
+  @JsonKey(readValue: _readCanRemoveSubscribersGroup)
+  final int? canRemoveSubscribersGroup;
 
   // Then, fields that are specific to the subscription,
   // i.e. the user's relationship to the stream.
@@ -351,6 +354,10 @@ class Subscription {
   // final bool? inHomeView; // deprecated; ignore
 
   final String color;
+
+  static int? _readCanRemoveSubscribersGroup(Map json, String key) {
+    return json[key] ?? json['can_remove_subscribers_group_id'];
+  }
 
   Subscription({
     required this.streamId,
@@ -373,7 +380,7 @@ class Subscription {
     required this.historyPublicToSubscribers,
     required this.firstMessageId,
     required this.streamWeeklyTraffic,
-    required this.canRemoveSubscribersGroupId,
+    required this.canRemoveSubscribersGroup,
   });
 
   factory Subscription.fromJson(Map<String, dynamic> json) =>

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -155,7 +155,8 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
       isWebPublic: json['is_web_public'] as bool,
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       messageRetentionDays: json['message_retention_days'] as int?,
-      streamPostPolicy: json['stream_post_policy'] as int,
+      streamPostPolicy:
+          $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
       canRemoveSubscribersGroupId:
           json['can_remove_subscribers_group_id'] as int?,
     );
@@ -176,6 +177,14 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'can_remove_subscribers_group_id': instance.canRemoveSubscribersGroupId,
     };
 
+const _$StreamPostPolicyEnumMap = {
+  StreamPostPolicy.any: 1,
+  StreamPostPolicy.administrators: 2,
+  StreamPostPolicy.fullMembers: 3,
+  StreamPostPolicy.moderators: 4,
+  StreamPostPolicy.unknown: null,
+};
+
 Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       streamId: json['stream_id'] as int,
       name: json['name'] as String,
@@ -192,7 +201,8 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       isMuted: json['is_muted'] as bool,
       isWebPublic: json['is_web_public'] as bool?,
       color: json['color'] as String,
-      streamPostPolicy: json['stream_post_policy'] as int,
+      streamPostPolicy:
+          $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
       messageRetentionDays: json['message_retention_days'] as int?,
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       firstMessageId: json['first_message_id'] as int?,

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -201,7 +201,7 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       audibleNotifications: json['audible_notifications'] as bool?,
       pinToTop: json['pin_to_top'] as bool,
       isMuted: json['is_muted'] as bool,
-      isWebPublic: json['is_web_public'] as bool?,
+      isWebPublic: json['is_web_public'] as bool,
       color: json['color'] as String,
       streamPostPolicy:
           $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
@@ -209,8 +209,8 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       firstMessageId: json['first_message_id'] as int?,
       streamWeeklyTraffic: json['stream_weekly_traffic'] as int?,
-      canRemoveSubscribersGroupId:
-          json['can_remove_subscribers_group_id'] as int?,
+      canRemoveSubscribersGroup: Subscription._readCanRemoveSubscribersGroup(
+          json, 'can_remove_subscribers_group') as int?,
     );
 
 Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
@@ -227,7 +227,7 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.streamPostPolicy,
-      'can_remove_subscribers_group_id': instance.canRemoveSubscribersGroupId,
+      'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
       'desktop_notifications': instance.desktopNotifications,
       'email_notifications': instance.emailNotifications,
       'wildcard_mentions_notify': instance.wildcardMentionsNotify,

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -157,8 +157,9 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
       messageRetentionDays: json['message_retention_days'] as int?,
       streamPostPolicy:
           $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
-      canRemoveSubscribersGroupId:
-          json['can_remove_subscribers_group_id'] as int?,
+      canRemoveSubscribersGroup: ZulipStream._readCanRemoveSubscribersGroup(
+          json, 'can_remove_subscribers_group') as int?,
+      streamWeeklyTraffic: json['stream_weekly_traffic'] as int?,
     );
 
 Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
@@ -174,7 +175,8 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.streamPostPolicy,
-      'can_remove_subscribers_group_id': instance.canRemoveSubscribersGroupId,
+      'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
+      'stream_weekly_traffic': instance.streamWeeklyTraffic,
     };
 
 const _$StreamPostPolicyEnumMap = {

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -193,7 +193,16 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       description: json['description'] as String,
       renderedDescription: json['rendered_description'] as String,
       dateCreated: json['date_created'] as int,
+      firstMessageId: json['first_message_id'] as int?,
       inviteOnly: json['invite_only'] as bool,
+      isWebPublic: json['is_web_public'] as bool,
+      historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
+      messageRetentionDays: json['message_retention_days'] as int?,
+      streamPostPolicy:
+          $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
+      canRemoveSubscribersGroup: ZulipStream._readCanRemoveSubscribersGroup(
+          json, 'can_remove_subscribers_group') as int?,
+      streamWeeklyTraffic: json['stream_weekly_traffic'] as int?,
       desktopNotifications: json['desktop_notifications'] as bool?,
       emailNotifications: json['email_notifications'] as bool?,
       wildcardMentionsNotify: json['wildcard_mentions_notify'] as bool?,
@@ -201,16 +210,7 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       audibleNotifications: json['audible_notifications'] as bool?,
       pinToTop: json['pin_to_top'] as bool,
       isMuted: json['is_muted'] as bool,
-      isWebPublic: json['is_web_public'] as bool,
       color: json['color'] as String,
-      streamPostPolicy:
-          $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
-      messageRetentionDays: json['message_retention_days'] as int?,
-      historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
-      firstMessageId: json['first_message_id'] as int?,
-      streamWeeklyTraffic: json['stream_weekly_traffic'] as int?,
-      canRemoveSubscribersGroup: Subscription._readCanRemoveSubscribersGroup(
-          json, 'can_remove_subscribers_group') as int?,
     );
 
 Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
@@ -221,13 +221,13 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'rendered_description': instance.renderedDescription,
       'date_created': instance.dateCreated,
       'first_message_id': instance.firstMessageId,
-      'stream_weekly_traffic': instance.streamWeeklyTraffic,
       'invite_only': instance.inviteOnly,
       'is_web_public': instance.isWebPublic,
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.streamPostPolicy,
       'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
+      'stream_weekly_traffic': instance.streamWeeklyTraffic,
       'desktop_notifications': instance.desktopNotifications,
       'email_notifications': instance.emailNotifications,
       'wildcard_mentions_notify': instance.wildcardMentionsNotify,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -305,6 +305,52 @@ class PerAccountStore extends ChangeNotifier {
         subscriptions.remove(stream.streamId);
       }
       notifyListeners();
+    } else if (event is SubscriptionAddEvent) {
+      assert(debugLog("server event: subscription/add"));
+      for (final subscription in event.subscriptions) {
+        subscriptions[subscription.streamId] = subscription;
+      }
+      notifyListeners();
+    } else if (event is SubscriptionRemoveEvent) {
+      assert(debugLog("server event: subscription/remove"));
+      for (final streamId in event.streamIds) {
+        subscriptions.remove(streamId);
+      }
+      notifyListeners();
+    } else if (event is SubscriptionUpdateEvent) {
+      assert(debugLog("server event: subscription/update"));
+      final subscription = subscriptions[event.streamId];
+      if (subscription == null) return; // TODO(log)
+      switch (event.property) {
+        case SubscriptionProperty.color:
+          subscription.color                  = event.value as String;
+        case SubscriptionProperty.isMuted:
+          subscription.isMuted                = event.value as bool;
+        case SubscriptionProperty.inHomeView:
+          subscription.isMuted                = !(event.value as bool);
+        case SubscriptionProperty.pinToTop:
+          subscription.pinToTop               = event.value as bool;
+        case SubscriptionProperty.desktopNotifications:
+          subscription.desktopNotifications   = event.value as bool;
+        case SubscriptionProperty.audibleNotifications:
+          subscription.audibleNotifications   = event.value as bool;
+        case SubscriptionProperty.pushNotifications:
+          subscription.pushNotifications      = event.value as bool;
+        case SubscriptionProperty.emailNotifications:
+          subscription.emailNotifications     = event.value as bool;
+        case SubscriptionProperty.wildcardMentionsNotify:
+          subscription.wildcardMentionsNotify = event.value as bool;
+        case SubscriptionProperty.unknown:
+          // unrecognized property; do nothing
+          return;
+      }
+      notifyListeners();
+    } else if (event is SubscriptionPeerAddEvent) {
+      assert(debugLog("server event: subscription/peer_add"));
+      // TODO(#374): handle event
+    } else if (event is SubscriptionPeerRemoveEvent) {
+      assert(debugLog("server event: subscription/peer_remove"));
+      // TODO(#374): handle event
     } else if (event is MessageEvent) {
       assert(debugLog("server event: message ${jsonEncode(event.message.toJson())}"));
       recentDmConversationsView.handleMessageEvent(event);

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -15,6 +15,10 @@ extension AlertWordsEventChecks on Subject<AlertWordsEvent> {
   Subject<List<String>> get alertWords => has((e) => e.alertWords, 'alertWords');
 }
 
+extension SubscriptionRemoveEventChecks on Subject<SubscriptionRemoveEvent> {
+  Subject<List<int>> get streamIds => has((e) => e.streamIds, 'streamIds');
+}
+
 extension MessageEventChecks on Subject<MessageEvent> {
   Subject<Message> get message => has((e) => e.message, 'message');
 }

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -30,6 +30,18 @@ void main() {
     ).isEmpty();
   });
 
+  test('subscription/remove: deserialize stream_ids correctly', () {
+    check(Event.fromJson({
+      'id': 1,
+      'type': 'subscription',
+      'op': 'remove',
+      'subscriptions': [
+        {'stream_id': 123, 'name': 'name 1'},
+        {'stream_id': 456, 'name': 'name 2'},
+      ],
+    }) as SubscriptionRemoveEvent).streamIds.jsonEquals([123, 456]);
+  });
+
   test('message: move flags into message object', () {
     final message = eg.streamMessage();
     MessageEvent mkEvent(List<MessageFlag> flags) => Event.fromJson({

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -1,6 +1,10 @@
 import 'package:checks/checks.dart';
 import 'package:zulip/api/model/model.dart';
 
+extension ZulipStreamChecks on Subject<ZulipStream> {
+  Subject<int?> get canRemoveSubscribersGroup => has((e) => e.canRemoveSubscribersGroup, 'canRemoveSubscribersGroup');
+}
+
 extension MessageChecks on Subject<Message> {
   Subject<String> get content => has((e) => e.content, 'content');
   Subject<bool> get isMeMessage => has((e) => e.isMeMessage, 'isMeMessage');

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -65,6 +65,43 @@ void main() {
     });
   });
 
+  group('ZulipStream.canRemoveSubscribersGroup', () {
+    final Map<String, dynamic> baseJson = Map.unmodifiable({
+      'stream_id': 123,
+      'name': 'A stream',
+      'description': 'A description',
+      'rendered_description': '<p>A description</p>',
+      'date_created': 1686774898,
+      'first_message_id': null,
+      'invite_only': false,
+      'is_web_public': false,
+      'history_public_to_subscribers': true,
+      'message_retention_days': null,
+      'stream_post_policy': StreamPostPolicy.any.apiValue,
+      // 'can_remove_subscribers_group': null,
+      'stream_weekly_traffic': null,
+    });
+
+    test('smoke', () {
+      check(ZulipStream.fromJson({ ...baseJson,
+        'can_remove_subscribers_group': 123,
+      })).canRemoveSubscribersGroup.equals(123);
+    });
+
+    // TODO(server-8): field renamed in FL 197
+    test('support old can_remove_subscribers_group_id', () {
+      check(ZulipStream.fromJson({ ...baseJson,
+        'can_remove_subscribers_group_id': 456,
+      })).canRemoveSubscribersGroup.equals(456);
+    });
+
+    // TODO(server-6): field added in FL 142
+    test('support field missing', () {
+      check(ZulipStream.fromJson({ ...baseJson,
+      })).canRemoveSubscribersGroup.isNull();
+    });
+  });
+
   group('Message', () {
     test('no crash on unrecognized flag', () {
       final m1 = Message.fromJson(

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -125,6 +125,46 @@ ZulipStream stream({
 }
 const _stream = stream;
 
+/// Construct an example subscription from a stream.
+///
+/// We only allow overrides of values specific to the [Subscription], all
+/// other properties are copied from the [ZulipStream] provided.
+Subscription subscription(
+  ZulipStream stream, {
+  bool? desktopNotifications,
+  bool? emailNotifications,
+  bool? wildcardMentionsNotify,
+  bool? pushNotifications,
+  bool? audibleNotifications,
+  bool? pinToTop,
+  bool? isMuted,
+  String? color,
+}) {
+  return Subscription(
+    streamId: stream.streamId,
+    name: stream.name,
+    description: stream.description,
+    renderedDescription: stream.renderedDescription,
+    dateCreated: stream.dateCreated,
+    firstMessageId: stream.firstMessageId,
+    inviteOnly: stream.inviteOnly,
+    isWebPublic: stream.isWebPublic,
+    historyPublicToSubscribers: stream.historyPublicToSubscribers,
+    messageRetentionDays: stream.messageRetentionDays,
+    streamPostPolicy: stream.streamPostPolicy,
+    canRemoveSubscribersGroup: stream.canRemoveSubscribersGroup,
+    streamWeeklyTraffic: stream.streamWeeklyTraffic,
+    desktopNotifications: desktopNotifications ?? false,
+    emailNotifications: emailNotifications ?? false,
+    wildcardMentionsNotify: wildcardMentionsNotify ?? false,
+    pushNotifications: pushNotifications ?? false,
+    audibleNotifications: audibleNotifications ?? false,
+    pinToTop: pinToTop ?? false,
+    isMuted: isMuted ?? false,
+    color: color ?? "#FF0000",
+  );
+}
+
 ////////////////////////////////////////////////////////////////
 // Messages, and pieces of messages.
 //

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -104,7 +104,8 @@ ZulipStream stream({
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
   StreamPostPolicy? streamPostPolicy,
-  int? canRemoveSubscribersGroupId,
+  int? canRemoveSubscribersGroup,
+  int? streamWeeklyTraffic,
 }) {
   return ZulipStream(
     streamId: streamId ?? 123, // TODO generate example IDs
@@ -118,7 +119,8 @@ ZulipStream stream({
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
     streamPostPolicy: streamPostPolicy ?? StreamPostPolicy.any,
-    canRemoveSubscribersGroupId: canRemoveSubscribersGroupId ?? 123,
+    canRemoveSubscribersGroup: canRemoveSubscribersGroup ?? 123,
+    streamWeeklyTraffic: streamWeeklyTraffic,
   );
 }
 const _stream = stream;

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -103,7 +103,7 @@ ZulipStream stream({
   bool? isWebPublic,
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
-  int? streamPostPolicy,
+  StreamPostPolicy? streamPostPolicy,
   int? canRemoveSubscribersGroupId,
 }) {
   return ZulipStream(
@@ -117,7 +117,7 @@ ZulipStream stream({
     isWebPublic: isWebPublic ?? false,
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
-    streamPostPolicy: streamPostPolicy ?? 1,
+    streamPostPolicy: streamPostPolicy ?? StreamPostPolicy.any,
     canRemoveSubscribersGroupId: canRemoveSubscribersGroupId ?? 123,
   );
 }

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:checks/checks.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/events.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/notifications.dart';
 
@@ -176,6 +177,52 @@ void main() {
       connection.prepare(json: {});
       await null; // Run microtasks.  TODO use FakeAsync for these tests.
       checkLastRequest(token: '456def');
+    });
+  });
+
+  group('handleEvent for SubscriptionEvent', () {
+    final stream = eg.stream();
+
+    test('SubscriptionProperty.color updates with a string value', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [stream],
+        subscriptions: [eg.subscription(stream, color: "#FF0000")],
+      ));
+      check(store.subscriptions[stream.streamId]!.color).equals('#FF0000');
+
+      store.handleEvent(SubscriptionUpdateEvent(id: 1,
+        streamId: stream.streamId,
+        property: SubscriptionProperty.color,
+        value: "#FF00FF"));
+      check(store.subscriptions[stream.streamId]!.color).equals('#FF00FF');
+    });
+
+    test('SubscriptionProperty.isMuted updates with a boolean value', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [stream],
+        subscriptions: [eg.subscription(stream, isMuted: false)],
+      ));
+      check(store.subscriptions[stream.streamId]!.isMuted).isFalse();
+
+      store.handleEvent(SubscriptionUpdateEvent(id: 1,
+        streamId: stream.streamId,
+        property: SubscriptionProperty.isMuted,
+        value: true));
+      check(store.subscriptions[stream.streamId]!.isMuted).isTrue();
+    });
+
+    test('SubscriptionProperty.inHomeView updates isMuted instead', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [stream],
+        subscriptions: [eg.subscription(stream, isMuted: false)],
+      ));
+      check(store.subscriptions[stream.streamId]!.isMuted).isFalse();
+
+      store.handleEvent(SubscriptionUpdateEvent(id: 1,
+        streamId: stream.streamId,
+        property: SubscriptionProperty.inHomeView,
+        value: false));
+      check(store.subscriptions[stream.streamId]!.isMuted).isTrue();
     });
   });
 }


### PR DESCRIPTION
Clean up `Subscription` and `ZulipStream`: make `Subscription` extend `ZulipStream` and move fields around so only `Subscription` specific fields are in the class definition. Also handles the events `subscription/op:add`, `subscription/op:remove`, and `subscription/op:update`.

Fixes part of #187 