### PR TITLE
notif: Support iOS!

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		157DB5307E82FD55510A52F6 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		3752899A2AF472D400475D9C /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3EAE3F3F518B95B7BFEB4FE7 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4541FE48FEFD549440B32652 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -68,7 +69,6 @@
 				4541FE48FEFD549440B32652 /* Pods-Runner.release.xcconfig */,
 				7A94C3F14B90E7FC7BC4B082 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -105,6 +105,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				3752899A2AF472D400475D9C /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -358,6 +359,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 66KHCWMEYB;
 				ENABLE_BITCODE = NO;
@@ -487,6 +489,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 66KHCWMEYB;
 				ENABLE_BITCODE = NO;
@@ -510,6 +513,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 66KHCWMEYB;
 				ENABLE_BITCODE = NO;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -26,6 +28,16 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>By allowing camera access, you can take photos and send them in Zulip messages.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Choose photos from your library and send them in Zulip messages.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -45,17 +57,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>By allowing camera access, you can take photos and send them in Zulip messages.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Choose photos from your library and send them in Zulip messages.</string>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -37,6 +37,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -15,10 +15,16 @@ import 'package:firebase_core/firebase_core.dart';
 const kFirebaseOptionsAndroid = FirebaseOptions(
   // This `appId` and `messagingSenderId` are the same as in zulip-mobile;
   // see zulip-mobile:android/app/src/main/res/values/firebase.xml .
-  appId: '1:835904834568:android:6ae61ae43a7c3410',
-  messagingSenderId: '835904834568',
+  appId: '1:${_ZulipFirebaseOptions.projectNumber}:android:6ae61ae43a7c3410',
+  messagingSenderId: _ZulipFirebaseOptions.projectNumber,
+  projectId: _ZulipFirebaseOptions.projectId,
+  apiKey: _ZulipFirebaseOptions.firebaseApiKey,
+);
 
-  projectId: 'zulip-android',
+abstract class _ZulipFirebaseOptions {
+  static const projectNumber = '835904834568';
+
+  static const projectId = 'zulip-android';
 
   // Despite the name, this Google Cloud "API key" is a very different kind
   // of thing from a Zulip "API key".  In particular, it's designed to be
@@ -29,8 +35,10 @@ const kFirebaseOptionsAndroid = FirebaseOptions(
   // This key was created fresh for this use in zulip-flutter.
   // It's easy to create additional keys associated with the same `appId`
   // and other details above, and to enable or disable individual keys.
+  // See the Google Cloud console:
+  //   https://console.cloud.google.com/apis/credentials
   //
   // TODO: Perhaps use a different key in published builds; still fundamentally
   //   public, but would avoid accidental reuse in dev or modified builds.
-  apiKey: 'AIzaSyC6kw5sqCYjxQl2Lbd_8MDmc1lu2EG0pY4',
-);
+  static const firebaseApiKey = 'AIzaSyC6kw5sqCYjxQl2Lbd_8MDmc1lu2EG0pY4';
+}

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -21,9 +21,31 @@ const kFirebaseOptionsAndroid = FirebaseOptions(
   apiKey: _ZulipFirebaseOptions.firebaseApiKey,
 );
 
+/// Configuration used for finding the notification token on iOS.
+///
+/// On iOS, we don't use Firebase to actually deliver notifications;
+/// rather the Zulip notification bouncer service communicates with
+/// the Apple Push Notification service (APNs) directly.
+///
+/// But we do use the Firebase library as a convenient binding to the
+/// platform API for the setup steps of requesting the user's permission
+/// to show notifications, and getting the token that the service uses
+/// to represent that permission.
+/// These values are similar to [kFirebaseOptionsAndroid] but are for iOS,
+/// and they let us initialize the Firebase library so that we can do that.
+///
+/// TODO: Cut out Firebase for APNs and use a thinner platform-API binding.
+const kFirebaseOptionsIos = FirebaseOptions(
+  appId: '1:${_ZulipFirebaseOptions.projectNumber}:ios:9cad34899ca57ba6',
+  messagingSenderId: _ZulipFirebaseOptions.projectNumber,
+  projectId: _ZulipFirebaseOptions.projectId,
+  apiKey: _ZulipFirebaseOptions.firebaseApiKey,
+);
+
 abstract class _ZulipFirebaseOptions {
   static const projectNumber = '835904834568';
 
+  // Despite its value, this name applies across Android and iOS.
   static const projectId = 'zulip-android';
 
   // Despite the name, this Google Cloud "API key" is a very different kind

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
-import '../firebase_options.dart';
 import '../widgets/store.dart';
 import 'store.dart';
 
@@ -92,7 +91,8 @@ abstract class ZulipBinding {
   /// Initialize Firebase, to use for notifications.
   ///
   /// This wraps [firebase_core.Firebase.initializeApp].
-  Future<void> firebaseInitializeApp();
+  Future<void> firebaseInitializeApp({
+      required firebase_core.FirebaseOptions options});
 
   /// Wraps [firebase_messaging.FirebaseMessaging.instance].
   firebase_messaging.FirebaseMessaging get firebaseMessaging;
@@ -174,22 +174,9 @@ class LiveZulipBinding extends ZulipBinding {
   }
 
   @override
-  Future<void> firebaseInitializeApp() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-        return firebase_core.Firebase.initializeApp(options: kFirebaseOptionsAndroid);
-
-      case TargetPlatform.iOS:
-        // TODO(#321): Set up Firebase on iOS.  (Or do something else instead.)
-        return Future.value();
-
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-      case TargetPlatform.fuchsia:
-        // Do nothing; we don't offer notifications on these platforms.
-        return Future.value();
-    }
+  Future<void> firebaseInitializeApp({
+      required firebase_core.FirebaseOptions options}) {
+    return firebase_core.Firebase.initializeApp(options: options);
   }
 
   @override

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -12,7 +12,6 @@ import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
 import '../api/route/events.dart';
 import '../api/route/messages.dart';
-import '../api/route/notifications.dart';
 import '../log.dart';
 import '../notifications.dart';
 import 'autocomplete.dart';
@@ -544,8 +543,6 @@ class LivePerAccountStore extends PerAccountStore {
   /// TODO The returned future isn't especially meaningful (it may or may not
   ///   mean we actually sent the token).  Make it just `void` once we fix the
   ///   one test that relies on the future.
-  ///
-  /// TODO(#321) handle iOS/APNs; currently only Android/FCM
   // TODO(#322) save acked token, to dedupe updating it on the server
   // TODO(#323) track the registerFcmToken/etc request, warn if not succeeding
   Future<void> registerNotificationToken() async {
@@ -557,6 +554,6 @@ class LivePerAccountStore extends PerAccountStore {
   Future<void> _registerNotificationToken() async {
     final token = NotificationService.instance.token.value;
     if (token == null) return;
-    await registerFcmToken(connection, token: token);
+    await NotificationService.registerToken(connection, token: token);
   }
 }

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -6,7 +6,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
+import 'api/core.dart';
 import 'api/notifications.dart';
+import 'api/route/notifications.dart';
 import 'firebase_options.dart';
 import 'log.dart';
 import 'model/binding.dart';
@@ -106,6 +108,20 @@ class NotificationService {
     // some reason the FCM system decides to replace the token.  So both paths
     // need to save the value.
     token.value = value;
+  }
+
+  static Future<void> registerToken(ApiConnection connection, {required String token}) async {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        await registerFcmToken(connection, token: token);
+
+      case TargetPlatform.iOS:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+      case TargetPlatform.fuchsia:
+        assert(false);
+    }
   }
 
   static void _onForegroundMessage(FirebaseRemoteMessage message) {

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import 'api/notifications.dart';
+import 'firebase_options.dart';
 import 'log.dart';
 import 'model/binding.dart';
 import 'model/narrow.dart';
@@ -58,7 +59,8 @@ class NotificationService {
   Future<void> start() async {
     if (defaultTargetPlatform != TargetPlatform.android) return; // TODO(#321)
 
-    await ZulipBinding.instance.firebaseInitializeApp();
+    await ZulipBinding.instance.firebaseInitializeApp(
+      options: kFirebaseOptionsAndroid);
 
     // TODO(#324) defer notif setup if user not logged into any accounts
     //   (in order to avoid calling for permissions)

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -174,7 +175,7 @@ class TestZulipBinding extends ZulipBinding {
   FakeFirebaseMessaging? _firebaseMessaging;
 
   @override
-  Future<void> firebaseInitializeApp() async {
+  Future<void> firebaseInitializeApp({required FirebaseOptions options}) async {
     _firebaseInitialized = true;
   }
 

--- a/test/notifications_test.dart
+++ b/test/notifications_test.dart
@@ -81,6 +81,14 @@ void main() {
     await NotificationService.instance.start();
   }
 
+  group('permissions', () {
+    testWidgets('on iOS request permission', (tester) async {
+      await init();
+      check(testBinding.firebaseMessaging.takeRequestPermissionCalls())
+        .length.equals(1);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+  });
+
   group('NotificationChannelManager', () {
     test('smoke', () async {
       await init();


### PR DESCRIPTION
Fixes #321.

---

There's one notable limitation in the functionality here, which I've filed as:
* #408 

Also the permissions prompt comes annoyingly early:
* #324 

We can fix those in the Beta 2 period.

---

I've manually tested this with my own Zulip dev server (running main), and it works. Testing notifications with a dev version of the client is kind of a pain, unfortunately (even after the simplifications I made to it this month):
https://github.com/zulip/zulip-mobile/blob/main/docs/howto/push-notifications.md#ios
so for review, given the impending Beta 1, I think it's best to skip that for now — for manual testing we can just rely on what I've done already, and on the next alpha release.

---

Screenshot of the notifications in Notification Center:

![Screenshot 2023-11-21 at 3 46 13 PM](https://github.com/zulip/zulip-flutter/assets/28173/a02e46a4-b23d-4b15-8f15-6d37c6fbbd33)

(There were also messages with content "4", "2", and "0". They didn't produce notifications because of #408 -- the app was open in the foreground at the time.)

(The icon needs to be replaced; that's #390.)