### PR TITLE
Redesigned DM recipient headers

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -194,6 +194,21 @@
       "filename": {"type": "String", "example": "file.txt"}
     }
   },
+  "unknownUserName": "(unknown user)",
+  "@unknownUserName": {
+    "description": "Name placeholder to use for a user when we don't know their name."
+  },
+  "messageListGroupYouAndOthers": "You and {others}",
+  "@messageListGroupYouAndOthers": {
+    "description": "Message list recipient header for a DM group with others.",
+    "placeholders": {
+      "others": {"type": "String", "example": "Alice, Bob"}
+    }
+  },
+  "messageListGroupYouWithYourself": "You with yourself",
+  "@messageListGroupYouWithYourself": {
+    "description": "Message list recipient header for a DM group that only includes yourself."
+  },
   "contentValidationErrorTooLong": "Message length shouldn't be greater than 10000 characters.",
   "@contentValidationErrorTooLong": {
     "description": "Content validation error message when the message is too long."

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -680,12 +680,16 @@ class DmRecipientHeader extends StatelessWidget {
             child: Text(style: const TextStyle(color: Colors.white),
               title)),
           RecipientHeaderDate(message: message,
-            color: _kRecipientHeaderDateColor),
+            color: _kDmRecipientHeaderDateColor),
         ])));
   }
 }
 
-final _kDmRecipientHeaderColor = const HSLColor.fromAHSL(1, 0, 0, 0.27).toColor();
+// TODO(#95): web uses different color in dark mode
+// Header color from `color-background-private-message-header`
+//   in zulip:web/styles/zulip.css .
+final _kDmRecipientHeaderColor = const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor();
+final _kDmRecipientHeaderDateColor = Colors.black.withOpacity(0.4);
 
 class RecipientHeaderDate extends StatelessWidget {
   const RecipientHeaderDate({super.key, required this.message, required this.color});
@@ -714,8 +718,6 @@ class RecipientHeaderDate extends StatelessWidget {
           DateTime.fromMillisecondsSinceEpoch(message.timestamp * 1000))));
   }
 }
-
-final _kRecipientHeaderDateColor = const HSLColor.fromAHSL(0.75, 0, 0, 0.15).toColor();
 
 final _kRecipientHeaderDateFormat = DateFormat('y-MM-dd', 'en_US'); // TODO(#278)
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -652,17 +652,18 @@ class DmRecipientHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final store = PerAccountStoreWidget.of(context);
     final String title;
     if (message.allRecipientIds.length > 1) {
-      final otherNames = message.allRecipientIds
+      title = zulipLocalizations.messageListGroupYouAndOthers(message.allRecipientIds
         .where((id) => id != store.account.userId)
-        .map((id) => store.users[id]?.fullName ?? '(unknown user)')
+        .map((id) => store.users[id]?.fullName ?? zulipLocalizations.unknownUserName)
         .sorted()
-        .join(", ");
-      title = 'You and $otherNames';
+        .join(", "));
     } else {
-      title = 'You with yourself'; // TODO pick string; web has glitchy "You and $yourname"
+      // TODO pick string; web has glitchy "You and $yourname"
+      title = zulipLocalizations.messageListGroupYouWithYourself;
     }
 
     return GestureDetector(

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -666,7 +666,6 @@ class DmRecipientHeader extends StatelessWidget {
     }
 
     return GestureDetector(
-      behavior: HitTestBehavior.translucent,
       onTap: () => Navigator.push(context,
         MessageListPage.buildRoute(context: context,
           narrow: DmNarrow.ofMessage(message, selfUserId: store.account.userId))),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -670,18 +670,28 @@ class DmRecipientHeader extends StatelessWidget {
       onTap: () => Navigator.push(context,
         MessageListPage.buildRoute(context: context,
           narrow: DmNarrow.ofMessage(message, selfUserId: store.account.userId))),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          border: Border.all(color: _kDmRecipientHeaderColor)),
-        child: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-          RecipientHeaderChevronContainer(
-            color: _kDmRecipientHeaderColor,
-            child: Text(style: const TextStyle(color: Colors.white),
-              title)),
-          RecipientHeaderDate(message: message,
-            color: _kDmRecipientHeaderDateColor),
-        ])));
+      child: ColoredBox(
+        color: _kDmRecipientHeaderColor,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 11),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 6),
+                child: Icon(size: 16, ZulipIcons.user)),
+              Expanded(
+                child: Text(title,
+                  style: const TextStyle(
+                    fontFamily: 'Source Sans 3',
+                    fontSize: 16,
+                    letterSpacing: 0.02 * 16,
+                    height: (18 / 16),
+                  ).merge(weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)),
+                  overflow: TextOverflow.ellipsis)),
+              RecipientHeaderDate(message: message,
+                color: _kDmRecipientHeaderDateColor),
+            ]))));
   }
 }
 
@@ -720,29 +730,6 @@ class RecipientHeaderDate extends StatelessWidget {
 }
 
 final _kRecipientHeaderDateFormat = DateFormat('y-MM-dd', 'en_US'); // TODO(#278)
-
-/// A widget with the distinctive chevron-tailed shape in Zulip recipient headers.
-class RecipientHeaderChevronContainer extends StatelessWidget {
-  const RecipientHeaderChevronContainer(
-    {super.key, required this.color, required this.child});
-
-  final Color color;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    const chevronLength = 5.0;
-    const recipientBorderShape = BeveledRectangleBorder(
-      borderRadius: BorderRadius.only(
-        topRight: Radius.elliptical(chevronLength, double.infinity),
-        bottomRight: Radius.elliptical(chevronLength, double.infinity)));
-    return Container(
-      decoration: ShapeDecoration(color: color, shape: recipientBorderShape),
-      padding: const EdgeInsets.only(right: chevronLength),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 4, 6, 3), child: child));
-  }
-}
 
 /// A Zulip message, showing the sender's name and avatar if specified.
 class MessageWithPossibleSender extends StatelessWidget {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -333,6 +333,7 @@ void main() {
     });
 
     testWidgets('show names on DMs', (tester) async {
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       await setupMessageListPage(tester, messages: [
         eg.dmMessage(from: eg.selfUser, to: []),
         eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
@@ -341,20 +342,25 @@ void main() {
       store.addUser(eg.otherUser);
       store.addUser(eg.thirdUser);
       await tester.pump();
-      tester.widget(find.text("You with yourself"));
-      tester.widget(find.text("You and ${eg.otherUser.fullName}"));
-      tester.widget(find.text("You and ${eg.otherUser.fullName}, ${eg.thirdUser.fullName}"));
+      tester.widget(find.text(zulipLocalizations.messageListGroupYouWithYourself));
+      tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
+        eg.otherUser.fullName)));
+      tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
+        "${eg.otherUser.fullName}, ${eg.thirdUser.fullName}")));
     });
 
     testWidgets('show names on DMs: smoothly handle unknown users', (tester) async {
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       await setupMessageListPage(tester, messages: [
         eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
         eg.dmMessage(from: eg.thirdUser, to: [eg.selfUser, eg.otherUser]),
       ]);
       store.addUser(eg.thirdUser);
       await tester.pump();
-      tester.widget(find.text("You and (unknown user)"));
-      tester.widget(find.text("You and (unknown user), ${eg.thirdUser.fullName}"));
+      tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
+        zulipLocalizations.unknownUserName)));
+      tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
+        "${zulipLocalizations.unknownUserName}, ${eg.thirdUser.fullName}")));
     });
 
     testWidgets('show dates', (tester) async {


### PR DESCRIPTION
This is built on top of #416.

This PR updates the DM recipient headers to the new style. Text style and spacing was taken from the same sources as #416:

- https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=538%3A20849&mode=dev
- https://github.com/zulip/zulip-mobile/issues/5511

But given there were no mockups that included a DM recipient header the style used here also looked to how web renders these headers (in particular the color to use for the background, and icon to use for display).

![dm_header](https://github.com/zulip/zulip-flutter/assets/98299/41cc6e5a-1cfa-4a22-bdb6-6839e83dec14)

Here showing behavior when the system requests a larger font:
![exploded_font](https://github.com/zulip/zulip-flutter/assets/98299/7ded9e31-7a1d-4843-ba2e-c487cdb46b88)
