### PR TITLE
content: Stop accidentally dropping paragraph text style in user mentions

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -98,6 +98,12 @@ class Paragraph extends StatelessWidget {
 
   final ParagraphNode node;
 
+  static TextStyle getTextStyle(BuildContext context) => const TextStyle(
+    fontFamily: 'Source Sans 3',
+    fontSize: 14,
+    height: (17 / 14),
+  ).merge(weightVariableTextStyle(context));
+
   @override
   Widget build(BuildContext context) {
     // Empty paragraph winds up with zero height.
@@ -106,11 +112,7 @@ class Paragraph extends StatelessWidget {
 
     final text = _buildBlockInlineContainer(
       node: node,
-      style: const TextStyle(
-        fontFamily: 'Source Sans 3',
-        fontSize: 14,
-        height: (17 / 14),
-      ).merge(weightVariableTextStyle(context)),
+      style: getTextStyle(context),
     );
 
     // If the paragraph didn't actually have a `p` element in the HTML,
@@ -594,7 +596,7 @@ class UserMention extends StatelessWidget {
         // One hopes an @-mention can't contain an embedded link.
         // (The parser on creating a UserMentionNode has a TODO to check that.)
         linkRecognizers: null,
-        style: null,
+        style: Paragraph.getTextStyle(context),
         nodes: node.nodes));
   }
 


### PR DESCRIPTION
Fixes #430.

| Before | After |
| --- | --- |
| ![9BCFC81E-C98D-4759-BF6D-50E08DA70075](https://github.com/zulip/zulip-flutter/assets/22248748/a721dfb1-cba5-4404-9472-e231ab7cbef9) | ![F7119704-62FC-4A27-B25F-36563BFD0448](https://github.com/zulip/zulip-flutter/assets/22248748/a12c85dc-3b59-4864-ac00-419bc772b3d9) |