### PR TITLE
Add Noto Color Emoji back again; use it in message-list reaction chips on Android

### DIFF
--- a/assets/Noto_Color_Emoji/LICENSE
+++ b/assets/Noto_Color_Emoji/LICENSE
@@ -1,0 +1,92 @@
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -198,10 +198,6 @@ const _squareEmojiSize = 17.0;
 ///
 /// Determined experimentally:
 ///   <https://github.com/zulip/zulip-flutter/pull/410#discussion_r1402808701>
-// TODO Actually use Noto Color Emoji. Some Android
-//   phones use Noto Color Emoji automatically, and some don't; e.g., Samsung
-//   has its own emoji font:
-//     <https://github.com/zulip/zulip-flutter/pull/410#discussion_r1408403111>
 const _notoColorEmojiTextSize = 14.5;
 
 /// A [TextScaler] that limits Unicode and image emojis' max scale factor,
@@ -249,7 +245,10 @@ class _UnicodeEmoji extends StatelessWidget {
       case TargetPlatform.windows:
         return Text(
           textScaler: _squareEmojiScalerClamped(context),
-          style: const TextStyle(fontSize: _notoColorEmojiTextSize),
+          style: const TextStyle(
+            fontFamily: 'Noto Color Emoji',
+            fontSize: _notoColorEmojiTextSize,
+          ),
           strutStyle: const StrutStyle(fontSize: _notoColorEmojiTextSize, forceStrutHeight: true),
           parsed);
       case TargetPlatform.iOS:

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -198,7 +198,7 @@ const _squareEmojiSize = 17.0;
 ///
 /// Determined experimentally:
 ///   <https://github.com/zulip/zulip-flutter/pull/410#discussion_r1402808701>
-// TODO(#404) Actually bundle Noto Color Emoji with the app. Some Android
+// TODO Actually use Noto Color Emoji. Some Android
 //   phones use Noto Color Emoji automatically, and some don't; e.g., Samsung
 //   has its own emoji font:
 //     <https://github.com/zulip/zulip-flutter/pull/410#discussion_r1408403111>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,11 +111,6 @@ flutter:
     - assets/Source_Sans_3/LICENSE.md
 
   fonts:
-    # Zulip's custom icons.  To use or edit, see class ZulipIcons.
-    - family: Zulip Icons
-      fonts:
-        - asset: assets/icons/ZulipIcons.ttf
-
     - family: Source Code Pro
       fonts:
         - asset: assets/Source_Code_Pro/SourceCodeVF-Upright.otf
@@ -127,5 +122,10 @@ flutter:
         - asset: assets/Source_Sans_3/SourceSans3VF-Upright.otf
         - asset: assets/Source_Sans_3/SourceSans3VF-Italic.otf
           style: italic
+
+    # Zulip's custom icons.  To use or edit, see class ZulipIcons.
+    - family: Zulip Icons
+      fonts:
+        - asset: assets/icons/ZulipIcons.ttf
 
     # If adding a font, remember to account for its license in lib/licenses.dart.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,10 +107,27 @@ flutter:
   uses-material-design: true
 
   assets:
+    - assets/Noto_Color_Emoji/LICENSE
     - assets/Source_Code_Pro/LICENSE.md
     - assets/Source_Sans_3/LICENSE.md
 
   fonts:
+    # Google's emoji font. (Web uses these emoji for the "Google" emojiset.)
+    #
+    # This should not be used on iOS.
+    # iOS doesn't support any of the formats this font is available in,
+    # and if we use it on iOS (whether as a primary font or a fallback)
+    # we'll get blank spaces where we could have had Apple-style emojis.
+    #
+    # Also, in text that might contain non-emoji glyphs, this should
+    # always come after a non-emoji font in the chain of font-family
+    # fallbacks. Letting this font handle e.g. space characters will
+    # make text look weird.
+    # TODO don't bundle this on iOS; it wastes several MB because it's unused.
+    - family: Noto Color Emoji
+      fonts:
+        - asset: assets/Noto_Color_Emoji/Noto-COLRv1.ttf
+
     - family: Source Code Pro
       fonts:
         - asset: assets/Source_Code_Pro/SourceCodeVF-Upright.otf


### PR DESCRIPTION
- Bundle Noto Color Emoji, with a TODO to not bundle it on iOS (I'll file an issue for that TODO)
  - I'll say this fixes #404.
  - The "Licenses" page works again; this fixes #435
- Use Noto Color Emoji on Android (but not iOS) for reaction chips
  - I'll file an issue to use it for text elsewhere (on Android). But using it for reaction chips is easier and more urgent.

Screenshots from the office Android device (Samsung Galaxy S9 running Android 9):

(ignore/pardon the battery-life popup in the "After" screenshot)

| Before | After |
| --- | --- |
| ![image](https://github.com/zulip/zulip-flutter/assets/22248748/737861fe-56d5-4b9d-b2a9-c88fef2182b2) | ![image](https://github.com/zulip/zulip-flutter/assets/22248748/b396eedb-f589-40f3-b6de-a0c1f1cdab91) |

Fixes: #404
Fixes: #435