### PR TITLE
text: Apply "Source Sans 3" and (on Android) "Noto Color Emoji" widely across the app

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -15,6 +15,7 @@ import 'page.dart';
 import 'recent_dm_conversations.dart';
 import 'store.dart';
 import 'subscription_list.dart';
+import 'text.dart';
 
 class ZulipApp extends StatelessWidget {
   const ZulipApp({super.key, this.navigatorObservers});
@@ -81,6 +82,7 @@ class ZulipApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = ThemeData(
+      typography: zulipTypography(context),
       appBarTheme: const AppBarTheme(
         // This prevents an elevation change in [AppBar]s so they stop turning
         // darker if there is something scrolled underneath it. See docs:

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -101,7 +101,7 @@ class Paragraph extends StatelessWidget {
   final ParagraphNode node;
 
   static TextStyle getTextStyle(BuildContext context) => const TextStyle(
-    fontFamily: 'Source Sans 3',
+    fontFamily: kDefaultFontFamily,
     fontSize: 14,
     height: (17 / 14),
   ).merge(weightVariableTextStyle(context));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -100,8 +100,9 @@ class Paragraph extends StatelessWidget {
 
   final ParagraphNode node;
 
-  static TextStyle getTextStyle(BuildContext context) => const TextStyle(
+  static TextStyle getTextStyle(BuildContext context) => TextStyle(
     fontFamily: kDefaultFontFamily,
+    fontFamilyFallback: defaultFontFamilyFallback,
     fontSize: 14,
     height: (17 / 14),
   ).merge(weightVariableTextStyle(context));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -103,8 +103,8 @@ class Paragraph extends StatelessWidget {
   static TextStyle getTextStyle(BuildContext context) => TextStyle(
     fontFamily: kDefaultFontFamily,
     fontFamilyFallback: defaultFontFamilyFallback,
-    fontSize: 14,
-    height: (17 / 14),
+    fontSize: kBaseFontSize,
+    height: (17 / kBaseFontSize),
   ).merge(weightVariableTextStyle(context));
 
   @override

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -100,7 +100,7 @@ class Paragraph extends StatelessWidget {
 
   final ParagraphNode node;
 
-  static TextStyle getTextStyle(BuildContext context) => const TextStyle(
+  static const textStyle = TextStyle(
     fontSize: kBaseFontSize,
     height: (17 / kBaseFontSize),
   );
@@ -113,7 +113,7 @@ class Paragraph extends StatelessWidget {
 
     final text = _buildBlockInlineContainer(
       node: node,
-      style: getTextStyle(context),
+      style: textStyle,
     );
 
     // If the paragraph didn't actually have a `p` element in the HTML,
@@ -646,7 +646,7 @@ class UserMention extends StatelessWidget {
         // One hopes an @-mention can't contain an embedded link.
         // (The parser on creating a UserMentionNode has a TODO to check that.)
         linkRecognizers: null,
-        style: Paragraph.getTextStyle(context),
+        style: Paragraph.textStyle,
         nodes: node.nodes));
   }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -100,12 +100,10 @@ class Paragraph extends StatelessWidget {
 
   final ParagraphNode node;
 
-  static TextStyle getTextStyle(BuildContext context) => TextStyle(
-    fontFamily: kDefaultFontFamily,
-    fontFamilyFallback: defaultFontFamilyFallback,
+  static TextStyle getTextStyle(BuildContext context) => const TextStyle(
     fontSize: kBaseFontSize,
     height: (17 / kBaseFontSize),
-  ).merge(weightVariableTextStyle(context));
+  );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -178,9 +178,8 @@ class ReactionChip extends StatelessWidget {
                             fontSize: (14 * 0.90),
                             height: 13 / (14 * 0.90),
                             color: labelColor,
-                          ).merge(selfVoted
-                            ? weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)
-                            : weightVariableTextStyle(context)),
+                          ).merge(weightVariableTextStyle(context,
+                              wght: selfVoted ? 600 : null)),
                           label),
                       )),
                   ]);
@@ -358,9 +357,8 @@ class _TextEmoji extends StatelessWidget {
         fontSize: 14 * 0.8,
         height: 1, // to be denser when we have to wrap
         color: selected ? _textColorSelected : _textColorUnselected,
-      ).merge(selected
-        ? weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)
-        : weightVariableTextStyle(context)),
+      ).merge(weightVariableTextStyle(context,
+          wght: selected ? 600 : null)),
       // Encourage line breaks before "_" (common in these), but try not
       // to leave a colon alone on a line. See:
       //   <https://github.com/flutter/flutter/issues/61081#issuecomment-1103330522>

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -174,6 +174,7 @@ class ReactionChip extends StatelessWidget {
                           textScaler: _labelTextScalerClamped(context),
                           style: TextStyle(
                             fontFamily: kDefaultFontFamily,
+                            fontFamilyFallback: defaultFontFamilyFallback,
                             fontSize: (14 * 0.90),
                             height: 13 / (14 * 0.90),
                             color: labelColor,
@@ -353,6 +354,7 @@ class _TextEmoji extends StatelessWidget {
       textWidthBasis: TextWidthBasis.longestLine,
       style: TextStyle(
         fontFamily: kDefaultFontFamily,
+        fontFamilyFallback: defaultFontFamilyFallback,
         fontSize: 14 * 0.8,
         height: 1, // to be denser when we have to wrap
         color: selected ? _textColorSelected : _textColorUnselected,

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -173,8 +173,6 @@ class ReactionChip extends StatelessWidget {
                           textWidthBasis: TextWidthBasis.longestLine,
                           textScaler: _labelTextScalerClamped(context),
                           style: TextStyle(
-                            fontFamily: kDefaultFontFamily,
-                            fontFamilyFallback: defaultFontFamilyFallback,
                             fontSize: (14 * 0.90),
                             height: 13 / (14 * 0.90),
                             color: labelColor,
@@ -352,8 +350,6 @@ class _TextEmoji extends StatelessWidget {
       textScaler: _textEmojiScalerClamped(context),
       textWidthBasis: TextWidthBasis.longestLine,
       style: TextStyle(
-        fontFamily: kDefaultFontFamily,
-        fontFamilyFallback: defaultFontFamilyFallback,
         fontSize: 14 * 0.8,
         height: 1, // to be denser when we have to wrap
         color: selected ? _textColorSelected : _textColorUnselected,

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -173,7 +173,7 @@ class ReactionChip extends StatelessWidget {
                           textWidthBasis: TextWidthBasis.longestLine,
                           textScaler: _labelTextScalerClamped(context),
                           style: TextStyle(
-                            fontFamily: 'Source Sans 3',
+                            fontFamily: kDefaultFontFamily,
                             fontSize: (14 * 0.90),
                             height: 13 / (14 * 0.90),
                             color: labelColor,
@@ -352,7 +352,7 @@ class _TextEmoji extends StatelessWidget {
       textScaler: _textEmojiScalerClamped(context),
       textWidthBasis: TextWidthBasis.longestLine,
       style: TextStyle(
-        fontFamily: 'Source Sans 3',
+        fontFamily: kDefaultFontFamily,
         fontSize: 14 * 0.8,
         height: 1, // to be denser when we have to wrap
         color: selected ? _textColorSelected : _textColorUnselected,

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -243,7 +243,7 @@ abstract class _HeaderItem extends StatelessWidget {
                 fontSize: 17,
                 height: (20 / 17),
                 color: const Color(0xFF222222),
-              ).merge(weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)),
+              ).merge(weightVariableTextStyle(context, wght: 600)),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               title))),

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -237,11 +237,12 @@ abstract class _HeaderItem extends StatelessWidget {
           Expanded(child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Text(
-              style: const TextStyle(
+              style: TextStyle(
                 fontFamily: kDefaultFontFamily,
+                fontFamilyFallback: defaultFontFamilyFallback,
                 fontSize: 17,
                 height: (20 / 17),
-                color: Color(0xFF222222),
+                color: const Color(0xFF222222),
               ).merge(weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -358,11 +359,12 @@ class _DmItem extends StatelessWidget {
               Expanded(child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Text(
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontFamily: kDefaultFontFamily,
+                    fontFamilyFallback: defaultFontFamilyFallback,
                     fontSize: 17,
                     height: (20 / 17),
-                    color: Color(0xFF222222),
+                    color: const Color(0xFF222222),
                   ).merge(weightVariableTextStyle(context)),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
@@ -484,11 +486,12 @@ class _TopicItem extends StatelessWidget {
               Expanded(child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Text(
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontFamily: kDefaultFontFamily,
+                    fontFamilyFallback: defaultFontFamilyFallback,
                     fontSize: 17,
                     height: (20 / 17),
-                    color: Color(0xFF222222),
+                    color: const Color(0xFF222222),
                   ).merge(weightVariableTextStyle(context)),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -238,7 +238,7 @@ abstract class _HeaderItem extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Text(
               style: const TextStyle(
-                fontFamily: 'Source Sans 3',
+                fontFamily: kDefaultFontFamily,
                 fontSize: 17,
                 height: (20 / 17),
                 color: Color(0xFF222222),
@@ -359,7 +359,7 @@ class _DmItem extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Text(
                   style: const TextStyle(
-                    fontFamily: 'Source Sans 3',
+                    fontFamily: kDefaultFontFamily,
                     fontSize: 17,
                     height: (20 / 17),
                     color: Color(0xFF222222),
@@ -485,7 +485,7 @@ class _TopicItem extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Text(
                   style: const TextStyle(
-                    fontFamily: 'Source Sans 3',
+                    fontFamily: kDefaultFontFamily,
                     fontSize: 17,
                     height: (20 / 17),
                     color: Color(0xFF222222),

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -237,12 +237,10 @@ abstract class _HeaderItem extends StatelessWidget {
           Expanded(child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Text(
-              style: TextStyle(
-                fontFamily: kDefaultFontFamily,
-                fontFamilyFallback: defaultFontFamilyFallback,
+              style: const TextStyle(
                 fontSize: 17,
                 height: (20 / 17),
-                color: const Color(0xFF222222),
+                color: Color(0xFF222222),
               ).merge(weightVariableTextStyle(context, wght: 600)),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -359,13 +357,11 @@ class _DmItem extends StatelessWidget {
               Expanded(child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Text(
-                  style: TextStyle(
-                    fontFamily: kDefaultFontFamily,
-                    fontFamilyFallback: defaultFontFamilyFallback,
+                  style: const TextStyle(
                     fontSize: 17,
                     height: (20 / 17),
-                    color: const Color(0xFF222222),
-                  ).merge(weightVariableTextStyle(context)),
+                    color: Color(0xFF222222),
+                  ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   title))),
@@ -486,13 +482,11 @@ class _TopicItem extends StatelessWidget {
               Expanded(child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Text(
-                  style: TextStyle(
-                    fontFamily: kDefaultFontFamily,
-                    fontFamilyFallback: defaultFontFamilyFallback,
+                  style: const TextStyle(
                     fontSize: 17,
                     height: (20 / 17),
-                    color: const Color(0xFF222222),
-                  ).merge(weightVariableTextStyle(context)),
+                    color: Color(0xFF222222),
+                  ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   topic))),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -637,7 +637,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
       fontSize: 16,
       letterSpacing: 0.02 * 16,
       height: (18 / 16),
-    ).merge(weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900));
+    ).merge(weightVariableTextStyle(context, wght: 600));
 
     final Widget streamWidget;
     if (!showStream) {
@@ -749,7 +749,7 @@ class DmRecipientHeader extends StatelessWidget {
                     fontSize: 16,
                     letterSpacing: 0.02 * 16,
                     height: (18 / 16),
-                  ).merge(weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)),
+                  ).merge(weightVariableTextStyle(context, wght: 600)),
                   overflow: TextOverflow.ellipsis)),
               RecipientHeaderDate(message: message,
                 color: _kDmRecipientHeaderDateColor),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -450,7 +450,7 @@ class MarkAsReadWidget extends StatelessWidget {
               backgroundColor: _UnreadMarker.color,
               minimumSize: const Size.fromHeight(38),
               textStyle: const TextStyle(
-                fontFamily: 'Source Sans 3',
+                fontFamily: kDefaultFontFamily,
                 fontSize: 18,
                 height: (23 / 18),
               ).merge(weightVariableTextStyle(context)),
@@ -631,7 +631,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     }
     final textStyle = TextStyle(
       color: contrastingColor,
-      fontFamily: 'Source Sans 3',
+      fontFamily: kDefaultFontFamily,
       fontSize: 16,
       letterSpacing: 0.02 * 16,
       height: (18 / 16),
@@ -742,7 +742,7 @@ class DmRecipientHeader extends StatelessWidget {
               Expanded(
                 child: Text(title,
                   style: const TextStyle(
-                    fontFamily: 'Source Sans 3',
+                    fontFamily: kDefaultFontFamily,
                     fontSize: 16,
                     letterSpacing: 0.02 * 16,
                     height: (18 / 16),
@@ -801,7 +801,7 @@ class DateText extends StatelessWidget {
     return Text(
       style: TextStyle(
         color: color,
-        fontFamily: 'Source Sans 3',
+        fontFamily: kDefaultFontFamily,
         fontSize: fontSize,
         height: height,
         // This is equivalent to css `all-small-caps`, see:

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -449,8 +449,9 @@ class MarkAsReadWidget extends StatelessWidget {
             style: FilledButton.styleFrom(
               backgroundColor: _UnreadMarker.color,
               minimumSize: const Size.fromHeight(38),
-              textStyle: const TextStyle(
+              textStyle: TextStyle(
                 fontFamily: kDefaultFontFamily,
+                fontFamilyFallback: defaultFontFamilyFallback,
                 fontSize: 18,
                 height: (23 / 18),
               ).merge(weightVariableTextStyle(context)),
@@ -632,6 +633,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     final textStyle = TextStyle(
       color: contrastingColor,
       fontFamily: kDefaultFontFamily,
+      fontFamilyFallback: defaultFontFamilyFallback,
       fontSize: 16,
       letterSpacing: 0.02 * 16,
       height: (18 / 16),
@@ -741,8 +743,9 @@ class DmRecipientHeader extends StatelessWidget {
                 child: Icon(size: 16, ZulipIcons.user)),
               Expanded(
                 child: Text(title,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontFamily: kDefaultFontFamily,
+                    fontFamilyFallback: defaultFontFamilyFallback,
                     fontSize: 16,
                     letterSpacing: 0.02 * 16,
                     height: (18 / 16),
@@ -802,6 +805,7 @@ class DateText extends StatelessWidget {
       style: TextStyle(
         color: color,
         fontFamily: kDefaultFontFamily,
+        fontFamilyFallback: defaultFontFamilyFallback,
         fontSize: fontSize,
         height: height,
         // This is equivalent to css `all-small-caps`, see:

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -449,12 +449,15 @@ class MarkAsReadWidget extends StatelessWidget {
             style: FilledButton.styleFrom(
               backgroundColor: _UnreadMarker.color,
               minimumSize: const Size.fromHeight(38),
-              textStyle: TextStyle(
-                fontFamily: kDefaultFontFamily,
-                fontFamilyFallback: defaultFontFamilyFallback,
-                fontSize: 18,
-                height: (23 / 18),
-              ).merge(weightVariableTextStyle(context)),
+              textStyle:
+                // Restate [FilledButton]'s default, which inherits from
+                // [zulipTypography]…
+                Theme.of(context).textTheme.labelLarge!
+                // …then clobber some attributes to follow Figma:
+                .merge(const TextStyle(
+                  fontSize: 18,
+                  height: (23 / 18))
+                .merge(weightVariableTextStyle(context, wght: 400))),
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(7)),
             ),
             onPressed: () => _handlePress(context),
@@ -632,8 +635,6 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     }
     final textStyle = TextStyle(
       color: contrastingColor,
-      fontFamily: kDefaultFontFamily,
-      fontFamilyFallback: defaultFontFamilyFallback,
       fontSize: 16,
       letterSpacing: 0.02 * 16,
       height: (18 / 16),
@@ -743,9 +744,7 @@ class DmRecipientHeader extends StatelessWidget {
                 child: Icon(size: 16, ZulipIcons.user)),
               Expanded(
                 child: Text(title,
-                  style: TextStyle(
-                    fontFamily: kDefaultFontFamily,
-                    fontFamilyFallback: defaultFontFamilyFallback,
+                  style: const TextStyle(
                     fontSize: 16,
                     letterSpacing: 0.02 * 16,
                     height: (18 / 16),
@@ -804,14 +803,12 @@ class DateText extends StatelessWidget {
     return Text(
       style: TextStyle(
         color: color,
-        fontFamily: kDefaultFontFamily,
-        fontFamilyFallback: defaultFontFamilyFallback,
         fontSize: fontSize,
         height: height,
         // This is equivalent to css `all-small-caps`, see:
         //   https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#all-small-caps
         fontFeatures: const [FontFeature.enable('c2sc'), FontFeature.enable('smcp')],
-      ).merge(weightVariableTextStyle(context)),
+      ),
       formatHeaderDate(
         zulipLocalizations,
         DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -127,7 +127,7 @@ class RecentDmConversationsItem extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 4),
               child: Text(
                 style: const TextStyle(
-                  fontFamily: 'Source Sans 3',
+                  fontFamily: kDefaultFontFamily,
                   fontSize: 17,
                   height: (20 / 17),
                   color: Color(0xFF222222),

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -8,7 +8,6 @@ import 'icons.dart';
 import 'message_list.dart';
 import 'page.dart';
 import 'store.dart';
-import 'text.dart';
 import 'unread_count_badge.dart';
 
 class RecentDmConversationsPage extends StatefulWidget {
@@ -126,13 +125,11 @@ class RecentDmConversationsItem extends StatelessWidget {
             Expanded(child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
               child: Text(
-                style: TextStyle(
-                  fontFamily: kDefaultFontFamily,
-                  fontFamilyFallback: defaultFontFamilyFallback,
+                style: const TextStyle(
                   fontSize: 17,
                   height: (20 / 17),
-                  color: const Color(0xFF222222),
-                ).merge(weightVariableTextStyle(context)),
+                  color: Color(0xFF222222),
+                ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 title))),

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -126,11 +126,12 @@ class RecentDmConversationsItem extends StatelessWidget {
             Expanded(child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
               child: Text(
-                style: const TextStyle(
+                style: TextStyle(
                   fontFamily: kDefaultFontFamily,
+                  fontFamilyFallback: defaultFontFamilyFallback,
                   fontSize: 17,
                   height: (20 / 17),
-                  color: Color(0xFF222222),
+                  color: const Color(0xFF222222),
                 ).merge(weightVariableTextStyle(context)),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -120,6 +120,7 @@ class _NoSubscriptionsItem extends StatelessWidget {
           style: TextStyle(
             color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
             fontFamily: kDefaultFontFamily,
+            fontFamilyFallback: defaultFontFamilyFallback,
             fontSize: 18,
             height: (20 / 18),
           ).merge(weightVariableTextStyle(context)))));
@@ -149,6 +150,7 @@ class _SubscriptionListHeader extends StatelessWidget {
                 style: TextStyle(
                   color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
                   fontFamily: kDefaultFontFamily,
+                  fontFamilyFallback: defaultFontFamilyFallback,
                   fontSize: 14,
                   letterSpacing: 0.04 * 14,
                   height: (16 / 14),
@@ -220,11 +222,12 @@ class SubscriptionItem extends StatelessWidget {
               //   or only those with unreads:
               //   https://github.com/zulip/zulip-flutter/pull/397#pullrequestreview-1742524205
               child: Text(
-                style: const TextStyle(
+                style: TextStyle(
                   fontFamily: kDefaultFontFamily,
+                  fontFamilyFallback: defaultFontFamilyFallback,
                   fontSize: 18,
                   height: (20 / 18),
-                  color: Color(0xFF262626),
+                  color: const Color(0xFF262626),
                 ).merge(hasUnreads
                   ? weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)
                   : weightVariableTextStyle(context)),

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -119,11 +119,9 @@ class _NoSubscriptionsItem extends StatelessWidget {
           textAlign: TextAlign.center,
           style: TextStyle(
             color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
-            fontFamily: kDefaultFontFamily,
-            fontFamilyFallback: defaultFontFamilyFallback,
             fontSize: 18,
             height: (20 / 18),
-          ).merge(weightVariableTextStyle(context)))));
+          ))));
   }
 }
 
@@ -149,12 +147,10 @@ class _SubscriptionListHeader extends StatelessWidget {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
-                  fontFamily: kDefaultFontFamily,
-                  fontFamilyFallback: defaultFontFamilyFallback,
                   fontSize: 14,
                   letterSpacing: 0.04 * 14,
                   height: (16 / 14),
-                ).merge(weightVariableTextStyle(context)))),
+                ))),
             const SizedBox(width: 8),
             Expanded(child: Divider(
               color: const HSLColor.fromAHSL(0.2, 240, 0.1, 0.5).toColor())),
@@ -222,12 +218,10 @@ class SubscriptionItem extends StatelessWidget {
               //   or only those with unreads:
               //   https://github.com/zulip/zulip-flutter/pull/397#pullrequestreview-1742524205
               child: Text(
-                style: TextStyle(
-                  fontFamily: kDefaultFontFamily,
-                  fontFamilyFallback: defaultFontFamilyFallback,
+                style: const TextStyle(
                   fontSize: 18,
                   height: (20 / 18),
-                  color: const Color(0xFF262626),
+                  color: Color(0xFF262626),
                 ).merge(weightVariableTextStyle(context,
                     wght: hasUnreads ? 600 : null)),
                 maxLines: 1,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -228,9 +228,8 @@ class SubscriptionItem extends StatelessWidget {
                   fontSize: 18,
                   height: (20 / 18),
                   color: const Color(0xFF262626),
-                ).merge(hasUnreads
-                  ? weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)
-                  : weightVariableTextStyle(context)),
+                ).merge(weightVariableTextStyle(context,
+                    wght: hasUnreads ? 600 : null)),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 subscription.name))),

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -119,7 +119,7 @@ class _NoSubscriptionsItem extends StatelessWidget {
           textAlign: TextAlign.center,
           style: TextStyle(
             color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
-            fontFamily: 'Source Sans 3',
+            fontFamily: kDefaultFontFamily,
             fontSize: 18,
             height: (20 / 18),
           ).merge(weightVariableTextStyle(context)))));
@@ -148,7 +148,7 @@ class _SubscriptionListHeader extends StatelessWidget {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
-                  fontFamily: 'Source Sans 3',
+                  fontFamily: kDefaultFontFamily,
                   fontSize: 14,
                   letterSpacing: 0.04 * 14,
                   height: (16 / 14),
@@ -221,7 +221,7 @@ class SubscriptionItem extends StatelessWidget {
               //   https://github.com/zulip/zulip-flutter/pull/397#pullrequestreview-1742524205
               child: Text(
                 style: const TextStyle(
-                  fontFamily: 'Source Sans 3',
+                  fontFamily: kDefaultFontFamily,
                   fontSize: 18,
                   height: (20 / 18),
                   color: Color(0xFF262626),

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -1,6 +1,12 @@
 import 'dart:io';
 import 'package:flutter/widgets.dart';
 
+/// The [TextStyle.fontFamily] to use in most of the app.
+///
+/// This is a variable-weight font, so any [TextStyle] that uses this should be
+/// merged with the result of calling [weightVariableTextStyle].
+const kDefaultFontFamily = 'Source Sans 3';
+
 /// A mergeable [TextStyle] with 'Source Code Pro' and platform-aware fallbacks.
 ///
 /// Callers should also call [weightVariableTextStyle] and merge that in too,

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -79,7 +79,7 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
     // and indeed it doesn't seem updated to be aware of variable fonts at all.
     value = wghtIfPlatformRequestsBold ?? FontWeight.bold.value.toDouble();
   }
-  assert(value >= 1 && value <= 1000); // https://fonts.google.com/variablefonts#axis-definitions
+  assert(value >= kWghtMin && value <= kWghtMax);
 
   return TextStyle(
     fontVariations: [FontVariation('wght', value)],
@@ -91,6 +91,16 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
 
     inherit: true);
 }
+
+/// The minimum that a [FontVariation] "wght" value can be.
+///
+/// See <https://fonts.google.com/variablefonts#axis-definitions>.
+const kWghtMin = 1.0;
+
+/// The maximum that a [FontVariation] "wght" value can be.
+///
+/// See <https://fonts.google.com/variablefonts#axis-definitions>.
+const kWghtMax = 1000.0;
 
 /// Find the nearest [FontWeight] constant for a variable-font "wght"-axis value.
 ///

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -80,7 +80,7 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
   }
   assert(value >= kWghtMin && value <= kWghtMax);
 
-  return TextStyle(
+  TextStyle result = TextStyle(
     fontVariations: [FontVariation('wght', value)],
 
     // This use of `fontWeight` shouldn't affect glyphs in the preferred,
@@ -89,6 +89,18 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
     fontWeight: clampVariableFontWeight(value),
 
     inherit: true);
+
+  assert(() {
+    final attributes = [
+      if (wght != null) 'wght: $wght',
+      if (wghtIfPlatformRequestsBold != null) 'wghtIfPlatformRequestsBold: $wghtIfPlatformRequestsBold',
+    ];
+    result = result.copyWith(
+      debugLabel: 'weightVariableTextStyle(${attributes.join(', ')})');
+    return true;
+  }());
+
+  return result;
 }
 
 /// The minimum that a [FontVariation] "wght" value can be.

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -72,7 +72,7 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
 }) {
   assert((wght != null) == (wghtIfPlatformRequestsBold != null));
   double value = wght ?? FontWeight.normal.value.toDouble();
-  if (context != null && MediaQuery.of(context).boldText) {
+  if (context != null && MediaQuery.boldTextOf(context)) {
     // The framework has a condition on [MediaQueryData.boldText]
     // in the [Text] widget, but that only affects `fontWeight`.
     // [Text] doesn't know where to land on the chosen font's "wght" axis if any,

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -10,6 +10,12 @@ import 'package:flutter/material.dart';
 /// Material library's widgets, such as the default styling of
 /// an [AppBar]'s title, of an [ElevatedButton]'s label, and so on.
 ///
+/// As of writing, it turns out that these styles also flow naturally into
+/// most of our own widgets' text styles.
+/// We often see this in the child of a [Material], for example,
+/// since by default [Material] applies an [AnimatedDefaultTextStyle]
+/// with the [TextTheme.bodyMedium] that gets its value from here.
+///
 /// Applies [kDefaultFontFamily] and [kDefaultFontFamilyFallback],
 /// being faithful to the Material-default font weights
 /// by running them through [weightVariableTextStyle].
@@ -22,6 +28,9 @@ import 'package:flutter/material.dart';
 /// to set font weights on variable-weight fonts. If this causes visible bugs,
 /// we should investigate and fix, but such bugs should become less likely as
 /// we transition from Material's widgets to our own bespoke ones.)
+// TODO decide if we like this data flow for our own widgets' text styles.
+//   Does our design fit well with the fields of a [TextTheme]?
+//   (That's [TextTheme.titleLarge], [TextTheme.bodyMedium], etc.)
 Typography zulipTypography(BuildContext context) {
   final typography = Theme.of(context).typography;
 

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -1,11 +1,23 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 /// The [TextStyle.fontFamily] to use in most of the app.
 ///
+/// The same [TextStyle] should also specify [defaultFontFamilyFallback]
+/// for [TextStyle.fontFamilyFallback].
+///
 /// This is a variable-weight font, so any [TextStyle] that uses this should be
 /// merged with the result of calling [weightVariableTextStyle].
 const kDefaultFontFamily = 'Source Sans 3';
+
+/// The [TextStyle.fontFamilyFallback] for use with [kDefaultFontFamily].
+List<String> get defaultFontFamilyFallback => [
+  // iOS doesn't support any of the formats this font is available in.
+  // If we use it on iOS, we'll get blank spaces where we could have had Apple-
+  // style emojis.
+  if (defaultTargetPlatform == TargetPlatform.android) 'Noto Color Emoji',
+];
 
 /// A mergeable [TextStyle] with 'Source Code Pro' and platform-aware fallbacks.
 ///

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -70,14 +70,13 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
   double? wght,
   double? wghtIfPlatformRequestsBold,
 }) {
-  assert((wght != null) == (wghtIfPlatformRequestsBold != null));
   double value = wght ?? FontWeight.normal.value.toDouble();
   if (context != null && MediaQuery.boldTextOf(context)) {
     // The framework has a condition on [MediaQueryData.boldText]
     // in the [Text] widget, but that only affects `fontWeight`.
     // [Text] doesn't know where to land on the chosen font's "wght" axis if any,
     // and indeed it doesn't seem updated to be aware of variable fonts at all.
-    value = wghtIfPlatformRequestsBold ?? FontWeight.bold.value.toDouble();
+    value = wghtIfPlatformRequestsBold ?? bolderWght(value);
   }
   assert(value >= kWghtMin && value <= kWghtMax);
 
@@ -101,6 +100,12 @@ const kWghtMin = 1.0;
 ///
 /// See <https://fonts.google.com/variablefonts#axis-definitions>.
 const kWghtMax = 1000.0;
+
+/// A [FontVariation] "wght" value that's 300 above a given, clamped to [kWghtMax].
+double bolderWght(double baseWght) {
+  assert(kWghtMin <= baseWght && baseWght <= kWghtMax);
+  return clampDouble(baseWght + 300, kWghtMin, kWghtMax);
+}
 
 /// Find the nearest [FontWeight] constant for a variable-font "wght"-axis value.
 ///

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -50,9 +50,8 @@ class UnreadCountBadge extends StatelessWidget {
             height: (18 / 16),
             fontFeatures: const [FontFeature.enable('smcp')], // small caps
             color: const Color(0xFF222222),
-          ).merge(bold
-            ? weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)
-            : weightVariableTextStyle(context)),
+          ).merge(weightVariableTextStyle(context,
+              wght: bold ? 600 : null)),
           count.toString())));
   }
 }

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -43,13 +43,11 @@ class UnreadCountBadge extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.fromLTRB(4, 0, 4, 1),
         child: Text(
-          style: TextStyle(
-            fontFamily: kDefaultFontFamily,
-            fontFamilyFallback: defaultFontFamilyFallback,
+          style: const TextStyle(
             fontSize: 16,
             height: (18 / 16),
-            fontFeatures: const [FontFeature.enable('smcp')], // small caps
-            color: const Color(0xFF222222),
+            fontFeatures: [FontFeature.enable('smcp')], // small caps
+            color: Color(0xFF222222),
           ).merge(weightVariableTextStyle(context,
               wght: bold ? 600 : null)),
           count.toString())));

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -43,12 +43,13 @@ class UnreadCountBadge extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.fromLTRB(4, 0, 4, 1),
         child: Text(
-          style: const TextStyle(
+          style: TextStyle(
             fontFamily: kDefaultFontFamily,
+            fontFamilyFallback: defaultFontFamilyFallback,
             fontSize: 16,
             height: (18 / 16),
-            fontFeatures: [FontFeature.enable('smcp')], // small caps
-            color: Color(0xFF222222),
+            fontFeatures: const [FontFeature.enable('smcp')], // small caps
+            color: const Color(0xFF222222),
           ).merge(bold
             ? weightVariableTextStyle(context, wght: 600, wghtIfPlatformRequestsBold: 900)
             : weightVariableTextStyle(context)),

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -44,7 +44,7 @@ class UnreadCountBadge extends StatelessWidget {
         padding: const EdgeInsets.fromLTRB(4, 0, 4, 1),
         child: Text(
           style: const TextStyle(
-            fontFamily: 'Source Sans 3',
+            fontFamily: kDefaultFontFamily,
             fontSize: 16,
             height: (18 / 16),
             fontFeatures: [FontFeature.enable('smcp')], // small caps

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -54,8 +54,37 @@ extension TextFieldChecks on Subject<TextField> {
 
 extension TextStyleChecks on Subject<TextStyle> {
   Subject<bool> get inherit => has((t) => t.inherit, 'inherit');
-  Subject<List<FontVariation>?> get fontVariations => has((t) => t.fontVariations, 'fontVariations');
   Subject<FontWeight?> get fontWeight => has((t) => t.fontWeight, 'fontWeight');
+  Subject<List<FontVariation>?> get fontVariations => has((t) => t.fontVariations, 'fontVariations');
+  Subject<String?> get fontFamily => has((t) => t.fontFamily, 'fontFamily');
+  Subject<List<String>?> get fontFamilyFallback => has((t) => t.fontFamilyFallback, 'fontFamilyFallback');
 
   // TODO others
+}
+
+
+extension TextThemeChecks on Subject<TextTheme> {
+  Subject<TextStyle?> get displayLarge => has((t) => t.displayLarge, 'displayLarge');
+  Subject<TextStyle?> get displayMedium => has((t) => t.displayMedium, 'displayMedium');
+  Subject<TextStyle?> get displaySmall => has((t) => t.displaySmall, 'displaySmall');
+  Subject<TextStyle?> get headlineLarge => has((t) => t.headlineLarge, 'headlineLarge');
+  Subject<TextStyle?> get headlineMedium => has((t) => t.headlineMedium, 'headlineMedium');
+  Subject<TextStyle?> get headlineSmall => has((t) => t.headlineSmall, 'headlineSmall');
+  Subject<TextStyle?> get titleLarge => has((t) => t.titleLarge, 'titleLarge');
+  Subject<TextStyle?> get titleMedium => has((t) => t.titleMedium, 'titleMedium');
+  Subject<TextStyle?> get titleSmall => has((t) => t.titleSmall, 'titleSmall');
+  Subject<TextStyle?> get bodyLarge => has((t) => t.bodyLarge, 'bodyLarge');
+  Subject<TextStyle?> get bodyMedium => has((t) => t.bodyMedium, 'bodyMedium');
+  Subject<TextStyle?> get bodySmall => has((t) => t.bodySmall, 'bodySmall');
+  Subject<TextStyle?> get labelLarge => has((t) => t.labelLarge, 'labelLarge');
+  Subject<TextStyle?> get labelMedium => has((t) => t.labelMedium, 'labelMedium');
+  Subject<TextStyle?> get labelSmall => has((t) => t.labelSmall, 'labelSmall');
+}
+
+extension TypographyChecks on Subject<Typography> {
+  Subject<TextTheme> get black => has((t) => t.black, 'black');
+  Subject<TextTheme> get white => has((t) => t.white, 'white');
+  Subject<TextTheme> get englishLike => has((t) => t.englishLike, 'englishLike');
+  Subject<TextTheme> get dense => has((t) => t.dense, 'dense');
+  Subject<TextTheme> get tall => has((t) => t.tall, 'tall');
 }

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -50,6 +50,7 @@ void main() {
       platformRequestsBold: true,
       expectedFontVariations: const [FontVariation('wght', 700)],
       expectedFontWeight: FontWeight.bold);
+
     testWeights('specific values; platform does not request bold',
       styleBuilder: (context) => weightVariableTextStyle(context, wght: 475, wghtIfPlatformRequestsBold: 675),
       platformRequestsBold: false,
@@ -60,6 +61,35 @@ void main() {
       platformRequestsBold: true,
       expectedFontVariations: const [FontVariation('wght', 675)],
       expectedFontWeight: FontWeight.w700);
+
+    testWeights('specific `wght`, default `wghtIfPlatformRequestsBold`; platform does not request bold',
+      styleBuilder: (context) => weightVariableTextStyle(context, wght: 475),
+      platformRequestsBold: false,
+      expectedFontVariations: const [FontVariation('wght', 475)],
+      expectedFontWeight: FontWeight.w500);
+    testWeights('specific `wght`, default `wghtIfPlatformRequestsBold`; platform requests bold',
+      styleBuilder: (context) => weightVariableTextStyle(context, wght: 475),
+      platformRequestsBold: true,
+      expectedFontVariations: const [FontVariation('wght', 775)],
+      expectedFontWeight: FontWeight.w800);
+
+    testWeights('default `wght`, specific `wghtIfPlatformRequestsBold`; platform does not request bold',
+      styleBuilder: (context) => weightVariableTextStyle(context, wghtIfPlatformRequestsBold: 775),
+      platformRequestsBold: false,
+      expectedFontVariations: const [FontVariation('wght', 400)],
+      expectedFontWeight: FontWeight.normal);
+    testWeights('default `wght`, specific `wghtIfPlatformRequestsBold`; platform requests bold',
+      styleBuilder: (context) => weightVariableTextStyle(context, wghtIfPlatformRequestsBold: 775),
+      platformRequestsBold: true,
+      expectedFontVariations: const [FontVariation('wght', 775)],
+      expectedFontWeight: FontWeight.w800);
+  });
+
+  test('bolderWght', () {
+    check(bolderWght(1)).equals(301);
+    check(bolderWght(400)).equals(700);
+    check(bolderWght(600)).equals(900);
+    check(bolderWght(900)).equals(1000);
   });
 
   test('clampVariableFontWeight: FontWeight has the assumed list of values', () {

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -7,6 +7,63 @@ import 'package:zulip/widgets/text.dart';
 import '../flutter_checks.dart';
 
 void main() {
+  group('zulipTypography', () {
+    Future<Typography> getZulipTypography(WidgetTester tester, {
+      required bool platformRequestsBold,
+    }) async {
+      late final Typography result;
+      await tester.pumpWidget(
+        MediaQuery(data: MediaQueryData(boldText: platformRequestsBold),
+          child: Builder(builder: (context) {
+            result = zulipTypography(context);
+            return const SizedBox.shrink();
+          })));
+      return result;
+    }
+
+    matchesFontFamilies(Subject<TextStyle> it) => it
+      ..fontFamily.equals(kDefaultFontFamily)
+      ..fontFamilyFallback.isNotNull().deepEquals(defaultFontFamilyFallback);
+
+    matchesWeight(FontWeight weight) => (Subject<TextStyle> it) => it
+      ..fontWeight.equals(weight)
+      ..fontVariations.isNotNull().contains(
+          FontVariation('wght', wghtFromFontWeight(weight)));
+
+    for (final platformRequestsBold in [false, true]) {
+      final description = platformRequestsBold
+        ? 'platform requests bold'
+        : 'platform does not request bold';
+      testWidgets(description, (tester) async {
+        check(await getZulipTypography(tester, platformRequestsBold: platformRequestsBold))
+          ..black.bodyMedium.isNotNull().which(matchesFontFamilies)
+          ..white.bodyMedium.isNotNull().which(matchesFontFamilies)
+          ..englishLike.bodyMedium.isNotNull().which(
+              matchesWeight(platformRequestsBold ? FontWeight.w700 : FontWeight.w400))
+          ..dense.bodyMedium.isNotNull().which(
+              matchesWeight(platformRequestsBold ? FontWeight.w700 : FontWeight.w400))
+          ..tall.bodyMedium.isNotNull().which(
+              matchesWeight(platformRequestsBold ? FontWeight.w700 : FontWeight.w400));
+      });
+    }
+
+    test('Typography has the assumed fields', () {
+      check(Typography().toDiagnosticsNode().getProperties().map((n) => n.name).toList())
+        .unorderedEquals(['black', 'white', 'englishLike', 'dense', 'tall']);
+    });
+  });
+
+  test('_convertTextTheme: TextTheme has the assumed fields', () {
+    check(const TextTheme().toDiagnosticsNode().getProperties().map((n) => n.name).toList())
+      .unorderedEquals([
+        'displayLarge',  'displayMedium',  'displaySmall',
+        'headlineLarge', 'headlineMedium', 'headlineSmall',
+        'titleLarge',    'titleMedium',    'titleSmall',
+        'bodyLarge',     'bodyMedium',     'bodySmall',
+        'labelLarge',    'labelMedium',    'labelSmall',
+      ]);
+  });
+
   group('weightVariableTextStyle', () {
     Future<void> testWeights(
       String description, {

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -56,8 +56,8 @@ void main() {
       expectedFontVariations: const [FontVariation('wght', 475)],
       expectedFontWeight: FontWeight.w500);
     testWeights('specific values; platform requests bold',
-      platformRequestsBold: true,
       styleBuilder: (context) => weightVariableTextStyle(context, wght: 475, wghtIfPlatformRequestsBold: 675),
+      platformRequestsBold: true,
       expectedFontVariations: const [FontVariation('wght', 675)],
       expectedFontWeight: FontWeight.w700);
   });


### PR DESCRIPTION
(As usual please pardon the battery-life indicator in some of these screenshots. Ugh.)

In the second set of screenshots, note that the 🤯 emoji is made to look the same in the message list and the reaction chip. (This is taken on the office Android device.)

| Before | After |
| --- | --- |
| ![image](https://github.com/zulip/zulip-flutter/assets/22248748/aab7290e-c7c0-4ce4-8ad5-28ae1c7f2af7) | ![image](https://github.com/zulip/zulip-flutter/assets/22248748/a66318aa-e1fb-42ac-80d4-cbe171c730df) |
| ![image](https://github.com/zulip/zulip-flutter/assets/22248748/63221a9b-1e66-4319-8f9e-e823b5072a75) | ![image](https://github.com/zulip/zulip-flutter/assets/22248748/e0e76e4a-a275-4578-8eec-39326d982be3) |

Fixes: #294
Fixes: #438