### PR TITLE
msglist: Update layout in messages

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -857,60 +857,64 @@ class MessageWithPossibleSender extends StatelessWidget {
 
     Widget? senderRow;
     if (item.showSender) {
-      senderRow = GestureDetector(
-        onTap: () => Navigator.push(context,
-          ProfilePage.buildRoute(context: context,
-            userId: message.senderId)),
-        child: Text(message.senderFullName, // TODO get from user data
-          style: const TextStyle(
-            fontFamily: 'Source Sans 3',
-            fontSize: 18,
-            height: (22 / 18),
-          ).merge(weightVariableTextStyle(context, wght: 600,
-                    wghtIfPlatformRequestsBold: 900))));
+      senderRow = Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          Flexible(
+            child: GestureDetector(
+              onTap: () => Navigator.push(context,
+                ProfilePage.buildRoute(context: context,
+                  userId: message.senderId)),
+              child: Row(
+                children: [
+                  Avatar(size: 32, borderRadius: 3,
+                    userId: message.senderId),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(message.senderFullName, // TODO get from user data
+                      style: const TextStyle(
+                        fontFamily: 'Source Sans 3',
+                        fontSize: 18,
+                        height: (22 / 18),
+                      ).merge(weightVariableTextStyle(context, wght: 600,
+                                wghtIfPlatformRequestsBold: 900)),
+                      overflow: TextOverflow.ellipsis)),
+                ]))),
+          const SizedBox(width: 4),
+          Text(time,
+            style: TextStyle(
+              color: _kMessageTimestampColor,
+              fontFamily: 'Source Sans 3',
+              fontSize: 16,
+              height: (18 / 16),
+              fontFeatures: const [FontFeature.enable('c2sc'), FontFeature.enable('smcp')],
+            ).merge(weightVariableTextStyle(context))),
+        ]);
     }
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onLongPress: () => showMessageActionSheet(context: context, message: message),
       child: Padding(
-        padding: const EdgeInsets.only(top: 2, bottom: 3, left: 8, right: 8),
+        padding: const EdgeInsets.symmetric(vertical: 4),
         child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          item.showSender
-            ? Padding(
-                padding: const EdgeInsets.fromLTRB(3, 6, 11, 0),
-                child: GestureDetector(
-                  onTap: () => Navigator.push(context,
-                    ProfilePage.buildRoute(context: context,
-                      userId: message.senderId)),
-                  child: Avatar(size: 35, borderRadius: 4,
-                    userId: message.senderId)))
-            : const SizedBox(width: 3 + 35 + 11),
+          const SizedBox(width: 16),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                if (item.showSender) ...[
-                  const SizedBox(height: 3),
-                  senderRow!,
+                if (senderRow != null) ...[
+                  const SizedBox(height: 2),
+                  senderRow,
                   const SizedBox(height: 4),
                 ],
                 MessageContent(message: message, content: item.content),
                 if ((message.reactions?.total ?? 0) > 0)
                   ReactionChipsList(messageId: message.id, reactions: message.reactions!)
               ])),
-          Container(
-            width: 80,
-            padding: const EdgeInsets.only(top: 4, right: 16 - 8),
-            alignment: Alignment.topRight,
-            child: Text(time,
-              style: TextStyle(
-                color: _kMessageTimestampColor,
-                fontFamily: 'Source Sans 3',
-                fontSize: 16,
-                height: (18 / 16),
-                fontFeatures: const [FontFeature.enable('c2sc'), FontFeature.enable('smcp')],
-              ).merge(weightVariableTextStyle(context)))),
+          const SizedBox(width: 16),
         ])));
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -899,22 +899,22 @@ class MessageWithPossibleSender extends StatelessWidget {
       onLongPress: () => showMessageActionSheet(context: context, message: message),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                if (senderRow != null) ...[
-                  const SizedBox(height: 2),
-                  senderRow,
-                  const SizedBox(height: 4),
-                ],
-                MessageContent(message: message, content: item.content),
-                if ((message.reactions?.total ?? 0) > 0)
-                  ReactionChipsList(messageId: message.id, reactions: message.reactions!)
-              ])),
-          const SizedBox(width: 16),
+        child: Column(children: [
+          if (senderRow != null)
+            Padding(padding: const EdgeInsets.fromLTRB(16, 2, 16, 4),
+              child: senderRow),
+          Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  MessageContent(message: message, content: item.content),
+                  if ((message.reactions?.total ?? 0) > 0)
+                    ReactionChipsList(messageId: message.id, reactions: message.reactions!)
+                ])),
+            const SizedBox(width: 16),
+          ]),
         ])));
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -855,6 +855,21 @@ class MessageWithPossibleSender extends StatelessWidget {
     final time = _kMessageTimestampFormat
       .format(DateTime.fromMillisecondsSinceEpoch(1000 * message.timestamp));
 
+    Widget? senderRow;
+    if (item.showSender) {
+      senderRow = GestureDetector(
+        onTap: () => Navigator.push(context,
+          ProfilePage.buildRoute(context: context,
+            userId: message.senderId)),
+        child: Text(message.senderFullName, // TODO get from user data
+          style: const TextStyle(
+            fontFamily: 'Source Sans 3',
+            fontSize: 18,
+            height: (22 / 18),
+          ).merge(weightVariableTextStyle(context, wght: 600,
+                    wghtIfPlatformRequestsBold: 900))));
+    }
+
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onLongPress: () => showMessageActionSheet(context: context, message: message),
@@ -877,17 +892,7 @@ class MessageWithPossibleSender extends StatelessWidget {
               children: [
                 if (item.showSender) ...[
                   const SizedBox(height: 3),
-                  GestureDetector(
-                    onTap: () => Navigator.push(context,
-                      ProfilePage.buildRoute(context: context,
-                        userId: message.senderId)),
-                    child: Text(message.senderFullName, // TODO get from user data
-                      style: const TextStyle(
-                        fontFamily: 'Source Sans 3',
-                        fontSize: 18,
-                        height: (22 / 18),
-                      ).merge(weightVariableTextStyle(context, wght: 600,
-                                wghtIfPlatformRequestsBold: 900)))),
+                  senderRow!,
                   const SizedBox(height: 4),
                 ],
                 MessageContent(message: message, content: item.content),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -852,11 +852,11 @@ class MessageWithPossibleSender extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final message = item.message;
-    final time = _kMessageTimestampFormat
-      .format(DateTime.fromMillisecondsSinceEpoch(1000 * message.timestamp));
 
     Widget? senderRow;
     if (item.showSender) {
+      final time = _kMessageTimestampFormat
+        .format(DateTime.fromMillisecondsSinceEpoch(1000 * message.timestamp));
       senderRow = Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.baseline,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -841,6 +841,9 @@ String formatHeaderDate(
 }
 
 /// A Zulip message, showing the sender's name and avatar if specified.
+// Design referenced from:
+//   - https://github.com/zulip/zulip-mobile/issues/5511
+//   - https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=538%3A20849&mode=dev
 class MessageWithPossibleSender extends StatelessWidget {
   const MessageWithPossibleSender({super.key, required this.item});
 
@@ -855,7 +858,6 @@ class MessageWithPossibleSender extends StatelessWidget {
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onLongPress: () => showMessageActionSheet(context: context, message: message),
-      // TODO clean up this layout, by less precisely imitating web
       child: Padding(
         padding: const EdgeInsets.only(top: 2, bottom: 3, left: 8, right: 8),
         child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
@@ -880,7 +882,12 @@ class MessageWithPossibleSender extends StatelessWidget {
                       ProfilePage.buildRoute(context: context,
                         userId: message.senderId)),
                     child: Text(message.senderFullName, // TODO get from user data
-                      style: const TextStyle(fontWeight: FontWeight.bold))),
+                      style: const TextStyle(
+                        fontFamily: 'Source Sans 3',
+                        fontSize: 18,
+                        height: (22 / 18),
+                      ).merge(weightVariableTextStyle(context, wght: 600,
+                                wghtIfPlatformRequestsBold: 900)))),
                   const SizedBox(height: 4),
                 ],
                 MessageContent(message: message, content: item.content),
@@ -891,7 +898,14 @@ class MessageWithPossibleSender extends StatelessWidget {
             width: 80,
             padding: const EdgeInsets.only(top: 4, right: 16 - 8),
             alignment: Alignment.topRight,
-            child: Text(time, style: _kMessageTimestampStyle)),
+            child: Text(time,
+              style: TextStyle(
+                color: _kMessageTimestampColor,
+                fontFamily: 'Source Sans 3',
+                fontSize: 16,
+                height: (18 / 16),
+                fontFeatures: const [FontFeature.enable('c2sc'), FontFeature.enable('smcp')],
+              ).merge(weightVariableTextStyle(context)))),
         ])));
   }
 }
@@ -899,11 +913,7 @@ class MessageWithPossibleSender extends StatelessWidget {
 // TODO web seems to ignore locale in formatting time, but we could do better
 final _kMessageTimestampFormat = DateFormat('h:mm aa', 'en_US');
 
-// TODO this seems to come out lighter than on web
-final _kMessageTimestampStyle = TextStyle(
-  fontSize: 12,
-  fontWeight: FontWeight.w400,
-  color: const HSLColor.fromAHSL(0.4, 0, 0, 0.2).toColor());
+final _kMessageTimestampColor = const HSLColor.fromAHSL(1, 0, 0, 0.5).toColor();
 
 Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
   final store = PerAccountStoreWidget.of(context);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -86,8 +86,8 @@ void main() {
 
     testWidgets('basic', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
-        messages: List.generate(200, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
-      check(itemCount(tester)).equals(203);
+        messages: List.generate(300, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
+      check(itemCount(tester)).equals(303);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -100,7 +100,7 @@ void main() {
       await tester.pump(Duration.zero); // Allow a frame for the response to arrive.
 
       // Now we have more messages.
-      check(itemCount(tester)).equals(303);
+      check(itemCount(tester)).equals(403);
     });
 
     testWidgets('observe double-fetch glitch', (tester) async {


### PR DESCRIPTION
~~Rebased on top of #447 as that impacted tests passing.~~

As a foundation for my work on #170, I needed to update the layout of messages so that the star icon could be positioned in the appropriate place. This also enables the placement of future decorations to messages (like markers for moved/edited) and moves us closer to #157 

Screenshot of the new message layout:
![Simulator Screenshot - iPhone 14 - 2023-12-07 at 15 20 51](https://github.com/zulip/zulip-flutter/assets/98299/3aac1e0b-4f50-4592-9b18-6725bb4121c4)

Because the new layout is more compact, this caused the `basic` test of the `fetch older messages on scroll` group to fail as a second request for new messages is triggered. This is due to the first batch of new messages not being tall enough to be beyond the threshold (see `kFetchMessagesBufferPixels` in `lib/widgets/message_list.dart`) for loading another batch. A proper fix to this would be to tweak the threshold behavior, but instead opted to fix the test by adjusting the response size and opened #445.