### PR TITLE
Remove unnecessary imports of dart:ui

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 /// A mergeable [TextStyle] with 'Source Code Pro' and platform-aware fallbacks.

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -768,10 +768,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -1282,5 +1282,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0-162.0.dev <4.0.0"
-  flutter: ">=3.17.0-16.0.pre.23"
+  dart: ">=3.3.0-212.0.dev <4.0.0"
+  flutter: ">=3.18.0-7.0.pre.55"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.3.0-162.0.dev <4.0.0'
-  flutter: '>=3.17.0-16.0.pre.23'
+  sdk: '>=3.3.0-212.0.dev <4.0.0'
+  flutter: '>=3.18.0-7.0.pre.55'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -1,8 +1,6 @@
 /// `package:checks`-related extensions for the Flutter framework.
 library;
 
-import 'dart:ui';
-
 import 'package:checks/checks.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Upstream Flutter (in flutter/flutter@c6741614041 ) changed `flutter/material.dart` to additionally export many types from `dart:ui`. This caused a lot of our imports to trigger an analysis warning of `unnecessary_import`.

Please make sure you update your Flutter SDK after pulling in these changes!

