### PR TITLE
Send hard-coded User-Agent in requests

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -80,6 +80,7 @@ class ApiConnection {
     assert(debugLog("${request.method} ${request.url}"));
 
     addAuth(request);
+    request.headers.addAll(userAgentHeader());
 
     final http.StreamedResponse response;
     try {
@@ -195,6 +196,13 @@ String _authHeaderValue({required String email, required String apiKey}) {
 Map<String, String> authHeader({required String email, required String apiKey}) {
   return {
     'Authorization': _authHeaderValue(email: email, apiKey: apiKey),
+  };
+}
+
+// TODO(#453): Create real User-Agent string
+Map<String, String> userAgentHeader() {
+  return {
+    'User-Agent': 'ZulipMobile/?.?.? (Android 14)',
   };
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 /// A mergeable [TextStyle] with 'Source Code Pro' and platform-aware fallbacks.

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -768,10 +768,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -1282,5 +1282,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0-162.0.dev <4.0.0"
-  flutter: ">=3.17.0-16.0.pre.23"
+  dart: ">=3.3.0-212.0.dev <4.0.0"
+  flutter: ">=3.18.0-7.0.pre.55"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.3.0-162.0.dev <4.0.0'
-  flutter: '>=3.17.0-16.0.pre.23'
+  sdk: '>=3.3.0-212.0.dev <4.0.0'
+  flutter: '>=3.18.0-7.0.pre.55'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -23,7 +23,10 @@ void main() {
         check(connection.lastRequest!).isA<http.Request>()
           ..method.equals('GET')
           ..url.asString.equals('${eg.realmUrl.origin}$expectedRelativeUrl')
-          ..headers.deepEquals(authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey))
+          ..headers.deepEquals({
+            ...authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey),
+            ...userAgentHeader(),
+          })
           ..body.equals('');
       });
     }
@@ -53,6 +56,7 @@ void main() {
           ..url.asString.equals('${eg.realmUrl.origin}/api/v1/example/route')
           ..headers.deepEquals({
             ...authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey),
+            ...userAgentHeader(),
             if (expectContentType)
               'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
           })
@@ -83,7 +87,10 @@ void main() {
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
           ..url.asString.equals('${eg.realmUrl.origin}/api/v1/example/route')
-          ..headers.deepEquals(authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey))
+          ..headers.deepEquals({
+            ...authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey),
+            ...userAgentHeader(),
+          })
           ..fields.deepEquals({})
           ..files.single.which(it()
             ..field.equals('file')
@@ -115,6 +122,7 @@ void main() {
           ..url.asString.equals('${eg.realmUrl.origin}/api/v1/example/route')
           ..headers.deepEquals({
             ...authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey),
+            ...userAgentHeader(),
             if (expectContentType)
               'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
           })

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -1,8 +1,6 @@
 /// `package:checks`-related extensions for the Flutter framework.
 library;
 
-import 'dart:ui';
-
 import 'package:checks/checks.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Zulip server will automatically mark messages as read if the request appears to come from a recognized client. We simply need to identify using the `User-Agent` header as an approved client.
See `sent_by_human` in https://github.com/zulip/zulip/blob/main/zerver/models.py

This PR has two commits, the first is a simple hard-coded user agent that will result in the desired behavior. The second calculates the user agent from the device, but this might not be how we want it calculated (espeically since `ZulipBinding` also contains an interface into device info).

A further improvement would be to get upstream to accept `ZulipFlutter` as a legitimate user agent so we aren't reusing the `ZulipMobile` name.

Fixes: #440