### PR TITLE
New `read_for_sender` flag when sending a new message

### DIFF
--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -177,6 +177,7 @@ Future<SendMessageResult> sendMessage(
   required String content,
   String? queueId,
   String? localId,
+  bool? readBySender,
 }) {
   final supportsTypeDirect = connection.zulipFeatureLevel! >= 174; // TODO(server-7)
   return connection.post('sendMessage', SendMessageResult.fromJson, 'messages', {
@@ -193,6 +194,7 @@ Future<SendMessageResult> sendMessage(
     'content': RawParameter(content),
     if (queueId != null) 'queue_id': queueId, // TODO should this use RawParameter?
     if (localId != null) 'local_id': localId, // TODO should this use RawParameter?
+    if (readBySender != null) 'read_by_sender': readBySender,
   });
 }
 

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -191,8 +191,8 @@ Future<SendMessageResult> sendMessage(
       throw Exception('impossible destination') // TODO(dart-3) show this statically
     ),
     'content': RawParameter(content),
-    if (queueId != null) 'queue_id': queueId,
-    if (localId != null) 'local_id': localId,
+    if (queueId != null) 'queue_id': queueId, // TODO should this use RawParameter?
+    if (localId != null) 'local_id': localId, // TODO should this use RawParameter?
   });
 }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -377,13 +377,13 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     }
   }
 
-  Future<void> sendMessage({required MessageDestination destination, required String content, bool? readBySender}) {
+  Future<void> sendMessage({required MessageDestination destination, required String content}) {
     // TODO implement outbox; see design at
     //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M3881.20Sending.20outbox.20messages.20is.20fraught.20with.20issues/near/1405739
     return _apiSendMessage(connection,
       destination: destination,
       content: content,
-      readBySender: readBySender,
+      readBySender: true,
     );
   }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -377,10 +377,14 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     }
   }
 
-  Future<void> sendMessage({required MessageDestination destination, required String content}) {
+  Future<void> sendMessage({required MessageDestination destination, required String content, bool? readBySender}) {
     // TODO implement outbox; see design at
     //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M3881.20Sending.20outbox.20messages.20is.20fraught.20with.20issues/near/1405739
-    return _apiSendMessage(connection, destination: destination, content: content);
+    return _apiSendMessage(connection,
+      destination: destination,
+      content: content,
+      readBySender: readBySender,
+    );
   }
 
   static List<CustomProfileField> _sortCustomProfileFields(List<CustomProfileField> initialCustomProfileFields) {

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -733,7 +733,7 @@ class _SendButtonState extends State<_SendButton> {
 
     final store = PerAccountStoreWidget.of(context);
     final content = widget.contentController.textNormalized;
-    store.sendMessage(destination: widget.getDestination(), content: content, readBySender: true);
+    store.sendMessage(destination: widget.getDestination(), content: content);
 
     widget.contentController.clear();
   }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -733,7 +733,7 @@ class _SendButtonState extends State<_SendButton> {
 
     final store = PerAccountStoreWidget.of(context);
     final content = widget.contentController.textNormalized;
-    store.sendMessage(destination: widget.getDestination(), content: content);
+    store.sendMessage(destination: widget.getDestination(), content: content, readBySender: true);
 
     widget.contentController.clear();
   }

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -300,17 +300,37 @@ void main() {
       FakeApiConnection connection, {
       required MessageDestination destination,
       required String content,
+      String? queueId,
+      String? localId,
       required Map<String, String> expectedBodyFields,
     }) async {
       connection.prepare(json: SendMessageResult(id: 42).toJson());
       final result = await sendMessage(connection,
-        destination: destination, content: content);
+        destination: destination, content: content,
+        queueId: queueId, localId: localId);
       check(result).id.equals(42);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
         ..url.path.equals('/api/v1/messages')
         ..bodyFields.deepEquals(expectedBodyFields);
     }
+
+    test('smoke', () {
+      return FakeApiConnection.with_((connection) async {
+        await checkSendMessage(connection,
+          destination: StreamDestination(streamId, topic), content: content,
+          queueId: 'abc:123',
+          localId: '456',
+          expectedBodyFields: {
+            'type': 'stream',
+            'to': streamId.toString(),
+            'topic': topic,
+            'content': content,
+            'queue_id': '"abc:123"',
+            'local_id': '"456"',
+          });
+      });
+    });
 
     test('to stream', () {
       return FakeApiConnection.with_((connection) async {

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -302,12 +302,13 @@ void main() {
       required String content,
       String? queueId,
       String? localId,
+      bool? readBySender,
       required Map<String, String> expectedBodyFields,
     }) async {
       connection.prepare(json: SendMessageResult(id: 42).toJson());
       final result = await sendMessage(connection,
         destination: destination, content: content,
-        queueId: queueId, localId: localId);
+        queueId: queueId, localId: localId, readBySender: readBySender);
       check(result).id.equals(42);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -321,6 +322,7 @@ void main() {
           destination: StreamDestination(streamId, topic), content: content,
           queueId: 'abc:123',
           localId: '456',
+          readBySender: true,
           expectedBodyFields: {
             'type': 'stream',
             'to': streamId.toString(),
@@ -328,6 +330,7 @@ void main() {
             'content': content,
             'queue_id': '"abc:123"',
             'local_id': '"456"',
+            'read_by_sender': 'true',
           });
       });
     });


### PR DESCRIPTION
PR is built on top of #447 in order for tests to pass.

Adds a new flag introduced in https://github.com/zulip/zulip/pull/28204 .

Fixes: #440 