### PR TITLE
sticky_header: Fix hit-testing of header

### DIFF
--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -592,11 +592,8 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
     assert(child != null);
     assert(geometry!.hitTestExtent > 0.0);
     if (header != null) {
-      final headerParentData = (header!.parentData as SliverPhysicalParentData);
-      final headerOffset = headerParentData.paintOffset
-        .inDirection(constraints.axisDirection);
       if (hitTestBoxChild(BoxHitTestResult.wrap(result), header!,
-            mainAxisPosition: mainAxisPosition - headerOffset,
+            mainAxisPosition: mainAxisPosition,
             crossAxisPosition: crossAxisPosition)) {
         return true;
       }
@@ -609,8 +606,17 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
   double childMainAxisPosition(RenderObject child) {
     if (child == this.child) return 0.0;
     assert(child == header);
+    // We use Sliver*Physical*ParentData, so the header's position is stored in
+    // physical coordinates.  To meet the spec of `childMainAxisPosition`, we
+    // need to convert to the sliver's coordinate system.
     final headerParentData = (header!.parentData as SliverPhysicalParentData);
-    return headerParentData.paintOffset.inDirection(constraints.axisDirection);
+    final paintOffset = headerParentData.paintOffset;
+    return switch (constraints.axisDirection) {
+      AxisDirection.right => paintOffset.dx,
+      AxisDirection.left  => geometry!.layoutExtent - header!.size.width  - paintOffset.dx,
+      AxisDirection.down  => paintOffset.dy,
+      AxisDirection.up    => geometry!.layoutExtent - header!.size.height - paintOffset.dy,
+    };
   }
 
   @override

--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  // Enable these checks.  See this property's doc, which is basically
+  // an apology for the fact that (for historical reasons) it isn't
+  // the default.
+  WidgetController.hitTestWarningShouldBeFatal = true;
+
+  await testMain();
+}


### PR DESCRIPTION
Fixes: #327

Also enable a bit of test config that I ended up not relying on, but that should be enabled in any case.
