### PR TITLE
Add date separators

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -181,7 +181,9 @@ mixin _MessageSequence {
     final message = messages[index];
     final content = contents[index];
     bool canShareSender;
-    if (index > 0 && canShareRecipientHeader(messages[index - 1], message)) {
+    if (index > 0
+        && haveSameRecipient(messages[index - 1], message)
+        && messagesSameDay(messages[index - 1], message)) {
       assert(items.last is MessageListMessageItem);
       final prevMessageItem = items.last as MessageListMessageItem;
       assert(identical(prevMessageItem.message, messages[index - 1]));
@@ -228,7 +230,7 @@ mixin _MessageSequence {
 }
 
 @visibleForTesting
-bool canShareRecipientHeader(Message prevMessage, Message message) {
+bool haveSameRecipient(Message prevMessage, Message message) {
   if (prevMessage is StreamMessage && message is StreamMessage) {
     if (prevMessage.streamId != message.streamId) return false;
     if (prevMessage.subject != message.subject) return false;
@@ -239,6 +241,7 @@ bool canShareRecipientHeader(Message prevMessage, Message message) {
   } else {
     return false;
   }
+  return true;
 
   // switch ((prevMessage, message)) {
   //   case (StreamMessage(), StreamMessage()):
@@ -248,12 +251,14 @@ bool canShareRecipientHeader(Message prevMessage, Message message) {
   //   default:
   //     return false;
   // }
+}
 
+@visibleForTesting
+bool messagesSameDay(Message prevMessage, Message message) {
   // TODO memoize [DateTime]s... also use memoized for showing date/time in msglist
   final prevTime = DateTime.fromMillisecondsSinceEpoch(prevMessage.timestamp * 1000);
   final time = DateTime.fromMillisecondsSinceEpoch(message.timestamp * 1000);
   if (!_sameDay(prevTime, time)) return false;
-
   return true;
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -708,26 +708,50 @@ class RecipientHeaderDate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final zulipLocalizations = ZulipLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(10, 0, 16, 0),
-      child: Text(
-        style: TextStyle(
-          color: color,
-          fontFamily: 'Source Sans 3',
-          fontSize: 16,
-          // In Figma this has a line-height of 19, but using 18
-          // here to match the stream/topic text widgets helps
-          // to align all the text to the same baseline.
-          height: (18 / 16),
-          // This is equivalent to css `all-small-caps`, see:
-          //   https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#all-small-caps
-          fontFeatures: const [FontFeature.enable('c2sc'), FontFeature.enable('smcp')],
-        ).merge(weightVariableTextStyle(context)),
-        formatHeaderDate(
-          zulipLocalizations,
-          DateTime.fromMillisecondsSinceEpoch(message.timestamp * 1000),
-          now: DateTime.now())));
+      child: DateText(
+        color: color,
+        fontSize: 16,
+        // In Figma this has a line-height of 19, but using 18
+        // here to match the stream/topic text widgets helps
+        // to align all the text to the same baseline.
+        height: (18 / 16),
+        timestamp: message.timestamp));
+  }
+}
+
+class DateText extends StatelessWidget {
+  const DateText({
+    super.key,
+    required this.color,
+    required this.fontSize,
+    required this.height,
+    required this.timestamp,
+  });
+
+  final Color color;
+  final double fontSize;
+  final double height;
+  final int timestamp;
+
+  @override
+  Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    return Text(
+      style: TextStyle(
+        color: color,
+        fontFamily: 'Source Sans 3',
+        fontSize: fontSize,
+        height: height,
+        // This is equivalent to css `all-small-caps`, see:
+        //   https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#all-small-caps
+        fontFeatures: const [FontFeature.enable('c2sc'), FontFeature.enable('smcp')],
+      ).merge(weightVariableTextStyle(context)),
+      formatHeaderDate(
+        zulipLocalizations,
+        DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
+        now: DateTime.now()));
   }
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -344,6 +344,11 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
             final header = RecipientHeader(message: data.message, narrow: widget.narrow);
             return StickyHeaderItem(allowOverflow: true,
               header: header, child: header);
+          case MessageListDateSeparatorItem():
+            final header = RecipientHeader(message: data.message, narrow: widget.narrow);
+            return StickyHeaderItem(allowOverflow: true,
+              header: header,
+              child: DateSeparator(message: data.message));
           case MessageListMessageItem():
             final header = RecipientHeader(message: data.message, narrow: widget.narrow);
             return MessageItem(
@@ -460,6 +465,50 @@ class RecipientHeader extends StatelessWidget {
         showStream: narrow is AllMessagesNarrow),
       DmMessage() => DmRecipientHeader(message: message),
     };
+  }
+}
+
+class DateSeparator extends StatelessWidget {
+  const DateSeparator({super.key, required this.message});
+
+  final Message message;
+
+  // This color matches recipient headers.  TODO(design) is that what we want?
+  static final _textColor = Colors.black.withOpacity(0.4);
+
+  @override
+  Widget build(BuildContext context) {
+    // This makes the small-caps text vertically centered,
+    // to align with the vertically centered divider lines.
+    const textBottomPadding = 2.0;
+
+    return ColoredBox(color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 2),
+        child: Row(children: [
+          const Expanded(
+            child: SizedBox(height: 0,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      width: 0,
+                      color: Colors.black)))))),
+          Padding(padding: const EdgeInsets.fromLTRB(2, 0, 2, textBottomPadding),
+            child: DateText(
+              color: _textColor,
+              fontSize: 16,
+              height: (16 / 16),
+              timestamp: message.timestamp)),
+          const SizedBox(height: 0, width: 12,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(
+                    width: 0,
+                    color: Colors.black)))))
+        ])),
+    );
   }
 }
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -948,11 +948,13 @@ void checkInvariants(MessageListView model) {
   for (int j = 0; j < model.messages.length; j++) {
     bool isFirstInBlock = false;
     if (j == 0
-        || !haveSameRecipient(model.messages[j-1], model.messages[j])
-        || !messagesSameDay(model.messages[j-1], model.messages[j])) {
+        || !haveSameRecipient(model.messages[j-1], model.messages[j])) {
       check(model.items[i++]).isA<MessageListRecipientHeaderItem>()
         .message.identicalTo(model.messages[j]);
       isFirstInBlock = true;
+    } else if (!messagesSameDay(model.messages[j-1], model.messages[j])) {
+      check(model.items[i++]).isA<MessageListDateSeparatorItem>()
+        .message.identicalTo(model.messages[j]);
     }
     check(model.items[i++]).isA<MessageListMessageItem>()
       ..message.identicalTo(model.messages[j])
@@ -966,6 +968,10 @@ void checkInvariants(MessageListView model) {
 }
 
 extension MessageListRecipientHeaderItemChecks on Subject<MessageListRecipientHeaderItem> {
+  Subject<Message> get message => has((x) => x.message, 'message');
+}
+
+extension MessageListDateSeparatorItemChecks on Subject<MessageListDateSeparatorItem> {
   Subject<Message> get message => has((x) => x.message, 'message');
 }
 


### PR DESCRIPTION
Fixes: #173

This is a draft because it needs tests and also some cleanups in the code. But from a user perspective it already works great — so I'm sharing this in order to get feedback on the visual design. As mentioned at https://github.com/zulip/zulip-flutter/issues/173#issuecomment-1871744164 , I don't see an existing design for this in Figma, so for a first draft I've taken what's in web and adapted it.

## Design questions

* In web the dates have color `hsl(0deg 0% 15% / 75%)`, which is the same as the dates in the recipient headers. Here, our dates in recipient headers are lighter than that: they're black with 40% alpha. So I used that color for these, though it makes the dates lighter than in web. @terpimost do you think this is the color we want?
* In web the dates are slightly smaller in the date separators than they are in the recipient headers. But the CSS that results in this on the recipient headers side looks like a bug: there's both a `calc(12em / 14)` and a `calc(15em / 14)` applying multiplicatively. (This bug illustrates why in the CSS for zulip-mobile's webview, [we use `rem` and not `em`](https://github.com/zulip/zulip-mobile/blob/main/docs/background/webview.md#why-rem-and-not-em).) So I'm not sure that difference is intended, and in this draft I've made the size the same as in the recipient headers.
* ~~The vertical alignment here is just that everything's centered. But that seems to get the dividers a bit too high compared to the text. I'll have to fiddle with this (perhaps by adjusting the text's line-height).~~ I fixed this by adding some bottom padding to the text.

## Other adjustments from web

* In web the dates and timestamps are 10px from the right, but in the current design they're 16px in. So I put this at 16px to match.
* In web there's 2px horizontal padding before and after each divider line (though web's implementation of that is a bit complex). I copied that.
* I made the dividers one physical pixel tall (not one logical pixel, which would typically be several physical pixels).
* I made the dividers black, like in web.

## Screenshot

Here's a screenshot of the current revision:

![Screenshot_1703883619](https://github.com/zulip/zulip-flutter/assets/28173/ce9409be-1210-4a92-b070-61489868d954)
