### PR TITLE
content: Handle KaTeX math, with a rough preview

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -80,6 +80,8 @@ class BlockContentList extends StatelessWidget {
           return ListNodeWidget(node: node);
         } else if (node is CodeBlockNode) {
           return CodeBlock(node: node);
+        } else if (node is MathBlockNode) {
+          return MathBlock(node: node);
         } else if (node is ImageNode) {
           return MessageImage(node: node);
         } else if (node is UnimplementedBlockContentNode) {
@@ -265,20 +267,13 @@ class CodeBlock extends StatelessWidget {
 
   final CodeBlockNode node;
 
+  static final _borderColor = const HSLColor.fromAHSL(0.15, 0, 0, 0).toColor();
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        border: Border.all(
-          width: 1,
-          color: const HSLColor.fromAHSL(0.15, 0, 0, 0).toColor()),
-        borderRadius: BorderRadius.circular(4)),
-      child: SingleChildScrollViewWithScrollbar(
-        scrollDirection: Axis.horizontal,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(7, 5, 7, 3),
-          child: Text.rich(_buildNodes(node.spans)))));
+    return _CodeBlockContainer(
+      borderColor: _borderColor,
+      child: Text.rich(_buildNodes(node.spans)));
   }
 
   InlineSpan _buildNodes(List<CodeBlockSpanNode> nodes) {
@@ -289,6 +284,29 @@ class CodeBlock extends StatelessWidget {
 
   InlineSpan _buildNode(CodeBlockSpanNode node) {
     return TextSpan(text: node.text, style: codeBlockTextStyle(node.type));
+  }
+}
+
+class _CodeBlockContainer extends StatelessWidget {
+  const _CodeBlockContainer({required this.borderColor, required this.child});
+
+  final Color borderColor;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(
+          width: 1,
+          color: borderColor),
+        borderRadius: BorderRadius.circular(4)),
+      child: SingleChildScrollViewWithScrollbar(
+        scrollDirection: Axis.horizontal,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(7, 5, 7, 3),
+          child: child)));
   }
 }
 
@@ -316,6 +334,23 @@ class _SingleChildScrollViewWithScrollbarState
         controller: controller,
         scrollDirection: widget.scrollDirection,
         child: widget.child));
+  }
+}
+
+class MathBlock extends StatelessWidget {
+  const MathBlock({super.key, required this.node});
+
+  final MathBlockNode node;
+
+  static final _borderColor = const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor();
+
+  @override
+  Widget build(BuildContext context) {
+    return _CodeBlockContainer(
+      borderColor: _borderColor,
+      child: Text.rich(TextSpan(
+        style: _kCodeBlockStyle,
+        children: [TextSpan(text: node.texSource)])));
   }
 }
 
@@ -475,6 +510,9 @@ class _InlineContentBuilder {
     } else if (node is ImageEmojiNode) {
       return WidgetSpan(alignment: PlaceholderAlignment.middle,
         child: MessageImageEmoji(node: node));
+    } else if (node is MathInlineNode) {
+      return TextSpan(style: _kInlineMathStyle,
+        children: [TextSpan(text: node.texSource)]);
     } else if (node is UnimplementedInlineContentNode) {
       return _errorUnimplemented(node);
     } else {
@@ -543,6 +581,9 @@ class _InlineContentBuilder {
     // ]);
   }
 }
+
+final _kInlineMathStyle = _kInlineCodeStyle.merge(TextStyle(
+  backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.93).toColor()));
 
 final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(const TextStyle(

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -168,6 +168,14 @@ void main() {
     const ImageEmojiNode(
       src: '/static/generated/emoji/images/emoji/unicode/zulip.png', alt: ':zulip:'));
 
+  testParseInline('parse inline math',
+    // "$$ \\lambda $$"
+    '<p><span class="katex">'
+      '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
+        '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
+      '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></p>',
+    const MathInlineNode(texSource: r'\lambda'));
+
   //
   // Block content.
   //
@@ -389,6 +397,29 @@ void main() {
         '<span></span><code><span class="unknown">class</span>'
         '\n</code></pre></div>'),
     ]);
+
+  testParse('parse math block',
+    // "```math\n\\lambda\n```"
+    '<p><span class="katex-display"><span class="katex">'
+      '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>λ</mi></mrow>'
+        '<annotation encoding="application/x-tex">\\lambda</annotation></semantics></math></span>'
+      '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></span></p>',
+    [const MathBlockNode(texSource: r'\lambda')]);
+
+  testParse('parse math block in quote',
+    // There's sometimes a quirky extra `<br>\n` at the end of the `<p>` that
+    // encloses the math block.  In particular this happens when the math block
+    // is the last thing in the quote; though not in a doubly-nested quote;
+    // and there might be further wrinkles yet to be found.  Some experiments:
+    //   https://chat.zulip.org/#narrow/stream/7-test-here/topic/content/near/1715732
+    // "````quote\n```math\n\\lambda\n```\n````"
+    '<blockquote>\n<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>λ</mi></mrow>'
+          '<annotation encoding="application/x-tex">\\lambda</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></span>'
+      '<br>\n</p>\n</blockquote>',
+    [const QuotationNode([MathBlockNode(texSource: r'\lambda')])]);
 
   testParse('parse image',
     // "https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3"

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -62,6 +62,17 @@ void main() {
     });
   });
 
+  testWidgets('MathBlock', (tester) async {
+    // "```math\n\\lambda\n```"
+    await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes: parseContent(
+      '<p><span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>λ</mi></mrow>'
+          '<annotation encoding="application/x-tex">\\lambda</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></span></p>',
+    ).nodes)));
+    tester.widget(find.text(r'\lambda'));
+  });
+
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {
     final height = tester.getSize(textFinder).height;
     final target = tester.getTopLeft(textFinder)
@@ -238,6 +249,17 @@ void main() {
         '<p>\u{1fabf}</p>');
       tester.widget(find.text('\u{1fabf}')); // "🪿"
     });
+  });
+
+  testWidgets('MathInlineNode', (tester) async {
+    // "$$ \\lambda $$"
+    await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes: parseContent(
+      '<p><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
+          '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></p>',
+    ).nodes)));
+    tester.widget(find.text(r'\lambda'));
   });
 
   group('RealmContentNetworkImage', () {


### PR DESCRIPTION
Fixes: #359

See discussion on visual design: https://chat.zulip.org/#narrow/stream/48-mobile/topic/TeX.20in.20Flutter.20app/near/1710839

Screenshots (of [these messages](https://chat.zulip.org/#narrow/stream/7-test-here/topic/math/near/1712027)):

| This PR | Zulip web |
| --- | --- |
| ![image](https://github.com/zulip/zulip-flutter/assets/28173/413b6652-1e7c-4d6c-bf50-4e23fdb4dea8) | ![image](https://github.com/zulip/zulip-flutter/assets/28173/08a7f7c8-20bf-499f-a30e-3915a774d983) |

