### PR TITLE
android: Trust user-supplied CAs, except on known servers

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:networkSecurityConfig="@xml/network_security_config"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- For reference on this file's semantics:
+           https://developer.android.com/training/articles/security-config#FileFormat -->
+    <base-config>
+        <!-- If the user has configured additional CAs on the device, trust those
+             too.  This can be useful for an internal Zulip server in a corporate
+             or institutional environment, and was a recurring user request:
+               https://github.com/zulip/zulip-mobile/issues/3312
+               https://github.com/zulip/zulip-flutter/issues/461 -->
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+    <domain-config>
+        <!-- But revert to the default, stricter behavior — trusting only the
+             system CA list — where we know we can, which means for domains where
+             we know a legitimate cert will always come from a widely-trusted CA.
+             Specifically, we know this is the case for Zulip Cloud and other
+             domains operated by the core Zulip developers at Kandra Labs. -->
+        <domain includeSubdomains="true">zulipchat.com</domain>
+        <domain includeSubdomains="true">zulip.com</domain>
+        <domain includeSubdomains="true">zulip.org</domain>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
This is copied from the corresponding config in zulip-mobile, which was added in the following commit:
  https://github.com/zulip/zulip-mobile/commit/85c3a716a7bbf00c936beaf34bc84a0e6bf5c885

Unlike in zulip-mobile, though, we don't need any adjustments in debug (or profile) builds, because we don't use the `android:usesCleartextTraffic` attribute which this would clobber.

(React Native debug builds reach out to the development host over cleartext HTTP in order to support hot updates; but the Flutter development tools have the host contact the app instead, using the Dart VM protocol.  It's also not clear that any Dart libraries respect the `android:usesCleartextTraffic` flag anyway.)

Fixes: #461