### PR TITLE
content test: Aim taps on links more precisely at the text

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -664,26 +664,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: e45c31f458d01fd9ef4a214feb2e153b72d5b1907435f4332b1637a2f348c021
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.18"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "54808cfcfa87dbc0d74c61ac063d624adf1bd5c0407301f32b06c783c60dc4ca"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "7e71be3c161472f6c9158ac8875dd8de575060d60b5d159ebca3600ea32c9116"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -1290,5 +1290,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0-244.0.dev <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.10"
+  dart: ">=3.3.0-276.0.dev <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.98"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.3.0-244.0.dev <4.0.0'
-  flutter: '>=3.18.0-18.0.pre.10'
+  sdk: '>=3.3.0-276.0.dev <4.0.0'
+  flutter: '>=3.18.0-18.0.pre.98'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -62,6 +62,13 @@ void main() {
     });
   });
 
+  Future<void> tapText(WidgetTester tester, Finder textFinder) async {
+    final height = tester.getSize(textFinder).height;
+    final target = tester.getTopLeft(textFinder)
+      .translate(height/4, height/2); // aim for middle of first letter
+    await tester.tapAt(target);
+  }
+
   group('LinkNode interactions', () {
     // The Flutter test font uses square glyphs, so width equals height:
     //   https://github.com/flutter/flutter/wiki/Flutter-Test-Fonts
@@ -85,7 +92,7 @@ void main() {
       await prepareContent(tester,
         '<p><a href="https://example/">hello</a></p>');
 
-      await tester.tap(find.text('hello'));
+      await tapText(tester, find.text('hello'));
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: Uri.parse('https://example/'), mode: LaunchMode.platformDefault));
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
@@ -111,7 +118,7 @@ void main() {
     testWidgets('link nested in other spans', (tester) async {
       await prepareContent(tester,
         '<p><strong><em><a href="https://a/">word</a></em></strong></p>');
-      await tester.tap(find.text('word'));
+      await tapText(tester, find.text('word'));
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: Uri.parse('https://a/'), mode: LaunchMode.platformDefault));
     });
@@ -134,7 +141,7 @@ void main() {
     testWidgets('relative links are resolved', (tester) async {
       await prepareContent(tester,
         '<p><a href="/a/b?c#d">word</a></p>');
-      await tester.tap(find.text('word'));
+      await tapText(tester, find.text('word'));
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: Uri.parse('${eg.realmUrl}a/b?c#d'), mode: LaunchMode.platformDefault));
     });
@@ -142,7 +149,7 @@ void main() {
     testWidgets('link inside HeadingNode', (tester) async {
       await prepareContent(tester,
         '<h6><a href="https://a/">word</a></h6>');
-      await tester.tap(find.text('word'));
+      await tapText(tester, find.text('word'));
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: Uri.parse('https://a/'), mode: LaunchMode.platformDefault));
     });
@@ -151,7 +158,7 @@ void main() {
       await prepareContent(tester,
         '<p><a href="file:///etc/bad">word</a></p>');
       testBinding.launchUrlResult = false;
-      await tester.tap(find.text('word'));
+      await tapText(tester, find.text('word'));
       await tester.pump();
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: Uri.parse('file:///etc/bad'), mode: LaunchMode.platformDefault));
@@ -187,7 +194,7 @@ void main() {
       final pushedRoutes = await prepareContent(tester,
         html: '<p><a href="/#narrow/stream/1-check">stream</a></p>');
 
-      await tester.tap(find.text('stream'));
+      await tapText(tester, find.text('stream'));
       check(testBinding.takeLaunchUrlCalls()).isEmpty();
       check(pushedRoutes).single.isA<WidgetRoute>()
         .page.isA<MessageListPage>().narrow.equals(const StreamNarrow(1));
@@ -198,7 +205,7 @@ void main() {
       final pushedRoutes = await prepareContent(tester,
         html: '<p><a href="/#narrow/stream/1-check/topic">invalid</a></p>');
 
-      await tester.tap(find.text('invalid'));
+      await tapText(tester, find.text('invalid'));
       final expectedUrl = eg.realmUrl.resolve('/#narrow/stream/1-check/topic');
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: expectedUrl, mode: LaunchMode.platformDefault));


### PR DESCRIPTION
By saying `tester.tapAt(find.text('hello'))`, we had been aiming at the center of the Text widgets, and expecting that to hit the recognizer we've put on the span, even though the widget is much wider than the span and the latter doesn't reach the former's center. Effectively we were relying on the presence of issue #214.

But with an upstream change yesterday:
* https://github.com/flutter/flutter/pull/140621
* https://github.com/flutter/flutter/issues/43400

such a tap no longer hits the span.  That broke these tests.

To fix them, aim the taps near the start of the widget instead.

---

Also bump the Flutter version to require that upstream change, fixing #214.

Fixes: #475
Fixes: #214 
