### PR TITLE
    msglist: Let recipient header overlap date, just like a message

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -191,16 +191,19 @@ mixin _MessageSequence {
     if (index == 0 || !haveSameRecipient(messages[index - 1], message)) {
       items.add(MessageListRecipientHeaderItem(message));
       canShareSender = false;
-    } else if (!messagesSameDay(messages[index - 1], message)) {
-      items.add(MessageListDateSeparatorItem(message));
-      canShareSender = false;
     } else {
       assert(items.last is MessageListMessageItem);
       final prevMessageItem = items.last as MessageListMessageItem;
       assert(identical(prevMessageItem.message, messages[index - 1]));
       assert(prevMessageItem.isLastInBlock);
       prevMessageItem.isLastInBlock = false;
-      canShareSender = (prevMessageItem.message.senderId == message.senderId);
+
+      if (!messagesSameDay(prevMessageItem.message, message)) {
+        items.add(MessageListDateSeparatorItem(message));
+        canShareSender = false;
+      } else {
+        canShareSender = (prevMessageItem.message.senderId == message.senderId);
+      }
     }
     items.add(MessageListMessageItem(message, content,
       showSender: !canShareSender, isLastInBlock: true));

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -967,7 +967,13 @@ void checkInvariants(MessageListView model) {
       ..showSender.equals(
         forcedShowSender || model.messages[j].senderId != model.messages[j-1].senderId)
       ..isLastInBlock.equals(
-        i == model.items.length || model.items[i] is! MessageListMessageItem);
+        i == model.items.length || switch (model.items[i]) {
+          MessageListMessageItem()
+          || MessageListDateSeparatorItem() => false,
+          MessageListRecipientHeaderItem()
+          || MessageListHistoryStartItem()
+          || MessageListLoadingItem()       => true,
+        });
   }
   check(model.items).length.equals(i);
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -689,16 +689,17 @@ void main() async {
   });
 
   test('recipient headers are maintained consistently', () async {
+    // TODO test date separators are maintained consistently too
     // This tests the code that maintains the invariant that recipient headers
-    // are present just where [canShareRecipientHeader] requires them.
+    // are present just where they're required.
     // In [checkInvariants] we check the current state against that invariant,
     // so here we just need to exercise that code through all the relevant cases.
     // Each [checkNotifiedOnce] call ensures there's been a [checkInvariants] call
     // (in the listener that increments [notifiedCount]).
     //
-    // A separate unit test covers [canShareRecipientHeader] itself.
-    // So this test just needs messages that can share, and messages that can't,
-    // and doesn't need to exercise the different reasons that messages can't.
+    // A separate unit test covers [haveSameRecipient] itself.  So this test
+    // just needs messages that have the same recipient, and that don't, and
+    // doesn't need to exercise the different reasons that messages don't.
 
     const timestamp = 1693602618;
     final stream = eg.stream();


### PR DESCRIPTION
Fixes: #479

Also update some tests that probably should have been updated in #469.

---
## Screenshots

Before:
![image](https://github.com/zulip/zulip-flutter/assets/28173/59470000-3d7b-49b9-8713-e7ec261d994b)

After:
![image](https://github.com/zulip/zulip-flutter/assets/28173/bebe146f-d92a-4e0a-8b82-847a41fe6725)
