### PR TITLE
fixes: Fix Notification delay when app is not running in background

### DIFF
--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -158,6 +158,7 @@ class NotificationService {
     _onRemoteMessage(message);
   }
 
+  @pragma('vm:entry-point')
   static Future<void> _onBackgroundMessage(FirebaseRemoteMessage message) async {
     // This callback will run in a separate isolate from the rest of the app.
     // See docs:


### PR DESCRIPTION
Fix: #342 
This PR is created after #482 . It was closed by mistake, so I created this. I tried DMing myself and also checked it in the "Test Here" section of chat.zulip.org. Now, I'm getting notifications on time even after the app is not running in the background. The test results are in the thread of #482 .