### PR TITLE
Multiple Images

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -309,6 +309,17 @@ class MathBlockNode extends BlockContentNode {
   }
 }
 
+class ImageNodeList extends BlockContentNode {
+  const ImageNodeList(this.images, {super.debugHtmlNode});
+
+  final List<ImageNode> images;
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return images.map((node) => node.toDiagnosticsNode()).toList();
+  }
+}
+
 class ImageNode extends BlockContentNode {
   const ImageNode({super.debugHtmlNode, required this.srcUrl});
 
@@ -1031,13 +1042,26 @@ class _ZulipContentParser {
 
   List<BlockContentNode> parseBlockContentList(dom.NodeList nodes) {
     assert(_debugParserContext == _ParserContext.block);
-    final acceptedNodes = nodes.where((node) {
+    final List<BlockContentNode> result = [];
+    List<ImageNode> imageNodes = [];
+    for (final node in nodes) {
       // We get a bunch of newline Text nodes between paragraphs.
       // A browser seems to ignore these; let's do the same.
-      if (node is dom.Text && (node.text == '\n')) return false;
-      return true;
-    });
-    return acceptedNodes.map(parseBlockContent).toList(growable: false);
+      if (node is dom.Text && (node.text == '\n')) continue;
+
+      final block = parseBlockContent(node);
+      if (block is ImageNode) {
+        imageNodes.add(block);
+        continue;
+      }
+      if (imageNodes.isNotEmpty) {
+        result.add(ImageNodeList(imageNodes));
+        imageNodes = [];
+      }
+      result.add(block);
+    }
+    if (imageNodes.isNotEmpty) result.add(ImageNodeList(imageNodes));
+    return result;
   }
 
   ZulipContent parse(String html) {

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -256,20 +256,20 @@ class MessageImage extends StatelessWidget {
         child: Padding(
           // TODO clean up this padding by imitating web less precisely;
           //   in particular, avoid adding loose whitespace at end of message.
-          // The corresponding element on web has a 5px two-sided margin…
-          // and then a 1px transparent border all around.
-          padding: const EdgeInsets.fromLTRB(1, 1, 6, 6),
+          padding: const EdgeInsets.only(right: 5, bottom: 5),
           child: ColoredBox(
             color: const Color.fromRGBO(0, 0, 0, 0.03),
-            child: SizedBox(
-              height: 100,
-              width: 150,
-              child: LightboxHero(
-                message: message,
-                src: resolvedSrc,
-                child: RealmContentNetworkImage(
-                  resolvedSrc,
-                  filterQuality: FilterQuality.medium)))))));
+            child: Padding(
+              padding: const EdgeInsets.all(1),
+              child: SizedBox(
+                height: 100,
+                width: 150,
+                child: LightboxHero(
+                  message: message,
+                  src: resolvedSrc,
+                  child: RealmContentNetworkImage(
+                    resolvedSrc,
+                    filterQuality: FilterQuality.medium))))))));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -259,16 +259,17 @@ class MessageImage extends StatelessWidget {
           // The corresponding element on web has a 5px two-sided margin…
           // and then a 1px transparent border all around.
           padding: const EdgeInsets.fromLTRB(1, 1, 6, 6),
-          child: Container(
-            height: 100,
-            width: 150,
+          child: ColoredBox(
             color: const Color.fromRGBO(0, 0, 0, 0.03),
-            child: LightboxHero(
-              message: message,
-              src: resolvedSrc,
-              child: RealmContentNetworkImage(
-                resolvedSrc,
-                filterQuality: FilterQuality.medium))))));
+            child: SizedBox(
+              height: 100,
+              width: 150,
+              child: LightboxHero(
+                message: message,
+                src: resolvedSrc,
+                child: RealmContentNetworkImage(
+                  resolvedSrc,
+                  filterQuality: FilterQuality.medium)))))));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -84,6 +84,8 @@ class BlockContentList extends StatelessWidget {
           return CodeBlock(node: node);
         } else if (node is MathBlockNode) {
           return MathBlock(node: node);
+        } else if (node is ImageNodeList) {
+          return MessageImageList(node: node);
         } else if (node is ImageNode) {
           return MessageImage(node: node);
         } else if (node is UnimplementedBlockContentNode) {
@@ -230,6 +232,18 @@ class ListItemWidget extends StatelessWidget {
   }
 }
 
+class MessageImageList extends StatelessWidget {
+  const MessageImageList({super.key, required this.node});
+
+  final ImageNodeList node;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      children: node.images.map((imageNode) => MessageImage(node: imageNode)).toList());
+  }
+}
+
 class MessageImage extends StatelessWidget {
   const MessageImage({super.key, required this.node});
 
@@ -239,7 +253,6 @@ class MessageImage extends StatelessWidget {
   Widget build(BuildContext context) {
     final message = InheritedMessage.of(context);
 
-    // TODO(#193) multiple images in a row
     // TODO image hover animation
     final src = node.srcUrl;
 
@@ -251,7 +264,7 @@ class MessageImage extends StatelessWidget {
         Navigator.of(context).push(getLightboxRoute(
           context: context, message: message, src: resolvedSrc));
       },
-      child: Align(
+      child: UnconstrainedBox(
         alignment: Alignment.centerLeft,
         child: Padding(
           // TODO clean up this padding by imitating web less precisely;

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -87,6 +87,10 @@ class BlockContentList extends StatelessWidget {
         } else if (node is ImageNodeList) {
           return MessageImageList(node: node);
         } else if (node is ImageNode) {
+          assert(false,
+            "[ImageNode] not allowed in [BlockContentList]. "
+            "It should be wrapped in [ImageNodeList]."
+          );
           return MessageImage(node: node);
         } else if (node is UnimplementedBlockContentNode) {
           return Text.rich(_errorUnimplemented(node));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -262,7 +262,6 @@ class MessageImage extends StatelessWidget {
           child: Container(
             height: 100,
             width: 150,
-            alignment: Alignment.center,
             color: const Color.fromRGBO(0, 0, 0, 0.03),
             child: LightboxHero(
               message: message,

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -365,6 +365,71 @@ class ContentExample {
       ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/51b70540cf6a5b3c8a0b919c893b8abddd447e88/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d33'),
     ]),
   ]);
+
+  static const imageInImplicitParagraph = ContentExample(
+    'image as immediate child in implicit paragraph',
+    "* https://chat.zulip.org/user_avatars/2/realm/icon.png",
+    '<ul>\n'
+      '<li>'
+        '<div class="message_inline_image">'
+          '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png">'
+            '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png"></a></div></li>\n</ul>', [
+    ListNode(ListStyle.unordered, [[
+      ImageNodeList([
+        ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png'),
+      ]),
+    ]]),
+  ]);
+
+  static const imageClusterInImplicitParagraph = ContentExample(
+    'image cluster in implicit paragraph',
+    "* [icon.png](https://chat.zulip.org/user_avatars/2/realm/icon.png) [icon.png](https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2)",
+    '<ul>\n'
+      '<li>'
+        '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png">icon.png</a> '
+        '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2">icon.png</a>'
+        '<div class="message_inline_image">'
+          '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png" title="icon.png">'
+            '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png"></a></div>'
+        '<div class="message_inline_image">'
+          '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2" title="icon.png">'
+            '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2"></a></div></li>\n</ul>', [
+    ListNode(ListStyle.unordered, [[
+      ParagraphNode(wasImplicit: true, links: null, nodes: [
+        LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png', nodes: [TextNode('icon.png')]),
+        TextNode(' '),
+        LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2', nodes: [TextNode('icon.png')]),
+      ]),
+      ImageNodeList([
+        ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png'),
+        ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2'),
+      ]),
+    ]]),
+  ]);
+
+  static final imageClusterInImplicitParagraphThenContent = ContentExample(
+    'impossible content after image cluster in implicit paragraph',
+    // Image previews are always inserted at the end of the paragraph
+    //  so it would be impossible to have content after.
+    null,
+    '<ul>\n'
+      '<li>'
+        '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png">icon.png</a> '
+        '<div class="message_inline_image">'
+          '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png" title="icon.png">'
+            '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png"></a></div>'
+        'more text</li>\n</ul>', [
+    ListNode(ListStyle.unordered, [[
+      const ParagraphNode(wasImplicit: true, links: null, nodes: [
+        LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png', nodes: [TextNode('icon.png')]),
+        TextNode(' '),
+      ]),
+      const ImageNodeList([
+        ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png'),
+      ]),
+      blockUnimplemented('more text'),
+    ]]),
+  ]);
 }
 
 UnimplementedBlockContentNode blockUnimplemented(String html) {
@@ -689,6 +754,9 @@ void main() {
   testParseExample(ContentExample.imageCluster);
   testParseExample(ContentExample.imageClusterThenContent);
   testParseExample(ContentExample.imageMultipleClusters);
+  testParseExample(ContentExample.imageInImplicitParagraph);
+  testParseExample(ContentExample.imageClusterInImplicitParagraph);
+  testParseExample(ContentExample.imageClusterInImplicitParagraphThenContent);
 
   testParse('parse nested lists, quotes, headings, code blocks',
     // "1. > ###### two\n   > * three\n\n      four"

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -256,6 +256,115 @@ class ContentExample {
         '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></span>'
       '<br>\n</p>\n</blockquote>',
     [QuotationNode([MathBlockNode(texSource: r'\lambda')])]);
+
+  static const imageSingle = ContentExample(
+    'single image',
+    "https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3",
+    '<div class="message_inline_image">'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3">'
+        '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3"></a></div>', [
+    ImageNodeList([
+      ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3'),
+    ]),
+  ]);
+
+  static const imageCluster = ContentExample(
+    'multiple images',
+    "https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3\nhttps://chat.zulip.org/user_avatars/2/realm/icon.png?version=4",
+    '<p>'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3">https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3</a><br>\n'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=4">https://chat.zulip.org/user_avatars/2/realm/icon.png?version=4</a></p>\n'
+    '<div class="message_inline_image">'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3">'
+        '<img src="https://uploads.zulipusercontent.net/f535ba07f95b99a83aa48e44fd62bbb6c6cf6615/68747470733a2f2f636861742e7a756c69702e6f72672f757365725f617661746172732f322f7265616c6d2f69636f6e2e706e673f76657273696f6e3d33"></a></div>'
+    '<div class="message_inline_image">'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=4">'
+        '<img src="https://uploads.zulipusercontent.net/8f63bc2632a0e41be3f457d86c077e61b4a03e7e/68747470733a2f2f636861742e7a756c69702e6f72672f757365725f617661746172732f322f7265616c6d2f69636f6e2e706e673f76657273696f6e3d34"></a></div>', [
+    ParagraphNode(links: null, nodes: [
+      LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3', nodes: [TextNode('https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3')]),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=4', nodes: [TextNode('https://chat.zulip.org/user_avatars/2/realm/icon.png?version=4')]),
+    ]),
+    ImageNodeList([
+      ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/f535ba07f95b99a83aa48e44fd62bbb6c6cf6615/68747470733a2f2f636861742e7a756c69702e6f72672f757365725f617661746172732f322f7265616c6d2f69636f6e2e706e673f76657273696f6e3d33'),
+      ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/8f63bc2632a0e41be3f457d86c077e61b4a03e7e/68747470733a2f2f636861742e7a756c69702e6f72672f757365725f617661746172732f322f7265616c6d2f69636f6e2e706e673f76657273696f6e3d34'),
+    ]),
+  ]);
+
+  static const imageClusterThenContent = ContentExample(
+    'content after image cluster',
+    "https://chat.zulip.org/user_avatars/2/realm/icon.png\nhttps://chat.zulip.org/user_avatars/2/realm/icon.png?version=2\n\nmore content",
+    '<p>content '
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png">icon.png</a> '
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2">icon.png</a></p>\n'
+    '<div class="message_inline_image">'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png" title="icon.png">'
+        '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png"></a></div>'
+    '<div class="message_inline_image">'
+      '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2" title="icon.png">'
+        '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2"></a></div>'
+    '<p>more content</p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('content '),
+      LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png', nodes: [TextNode('icon.png')]),
+      TextNode(' '),
+      LinkNode(url: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2', nodes: [TextNode('icon.png')]),
+    ]),
+    ImageNodeList([
+      ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png'),
+      ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=2'),
+    ]),
+    ParagraphNode(links: null, nodes: [
+      TextNode('more content'),
+    ]),
+  ]);
+
+  static const imageMultipleClusters = ContentExample(
+    'multiple clusters of images',
+    "https://en.wikipedia.org/static/images/icons/wikipedia.png\nhttps://en.wikipedia.org/static/images/icons/wikipedia.png?v=1\n\nTest\n\nhttps://en.wikipedia.org/static/images/icons/wikipedia.png?v=2\nhttps://en.wikipedia.org/static/images/icons/wikipedia.png?v=3",
+    '<p>'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png">https://en.wikipedia.org/static/images/icons/wikipedia.png</a><br>\n' '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png?v=1">https://en.wikipedia.org/static/images/icons/wikipedia.png?v=1</a></p>\n'
+    '<div class="message_inline_image">'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png">'
+        '<img src="https://uploads.zulipusercontent.net/34b2695ca83af76204b0b25a8f2019ee35ec38fa/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e67"></a></div>'
+    '<div class="message_inline_image">'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png?v=1">'
+        '<img src="https://uploads.zulipusercontent.net/d200fb112aaccbff9df767373a201fa59601f362/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d31"></a></div>'
+    '<p>Test</p>\n'
+    '<p>'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png?v=2">https://en.wikipedia.org/static/images/icons/wikipedia.png?v=2</a><br>\n'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png?v=3">https://en.wikipedia.org/static/images/icons/wikipedia.png?v=3</a></p>\n'
+    '<div class="message_inline_image">'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png?v=2">'
+        '<img src="https://uploads.zulipusercontent.net/c4db87e81348dac94eacaa966b46d968b34029cc/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d32"></a></div>'
+    '<div class="message_inline_image">'
+      '<a href="https://en.wikipedia.org/static/images/icons/wikipedia.png?v=3">'
+        '<img src="https://uploads.zulipusercontent.net/51b70540cf6a5b3c8a0b919c893b8abddd447e88/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d33"></a></div>', [
+    ParagraphNode(links: null, nodes: [
+      LinkNode(url: 'https://en.wikipedia.org/static/images/icons/wikipedia.png', nodes: [TextNode('https://en.wikipedia.org/static/images/icons/wikipedia.png')]),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      LinkNode(url: 'https://en.wikipedia.org/static/images/icons/wikipedia.png?v=1', nodes: [TextNode('https://en.wikipedia.org/static/images/icons/wikipedia.png?v=1')]),
+    ]),
+    ImageNodeList([
+      ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/34b2695ca83af76204b0b25a8f2019ee35ec38fa/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e67'),
+      ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/d200fb112aaccbff9df767373a201fa59601f362/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d31'),
+    ]),
+    ParagraphNode(links: null, nodes: [
+      TextNode('Test'),
+    ]),
+    ParagraphNode(links: null, nodes: [
+      LinkNode(url: 'https://en.wikipedia.org/static/images/icons/wikipedia.png?v=2', nodes: [TextNode('https://en.wikipedia.org/static/images/icons/wikipedia.png?v=2')]),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      LinkNode(url: 'https://en.wikipedia.org/static/images/icons/wikipedia.png?v=3', nodes: [TextNode('https://en.wikipedia.org/static/images/icons/wikipedia.png?v=3')]),
+    ]),
+    ImageNodeList([
+      ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/c4db87e81348dac94eacaa966b46d968b34029cc/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d32'),
+      ImageNode(srcUrl: 'https://uploads.zulipusercontent.net/51b70540cf6a5b3c8a0b919c893b8abddd447e88/68747470733a2f2f656e2e77696b6970656469612e6f72672f7374617469632f696d616765732f69636f6e732f77696b6970656469612e706e673f763d33'),
+    ]),
+  ]);
 }
 
 UnimplementedBlockContentNode blockUnimplemented(String html) {
@@ -576,14 +685,10 @@ void main() {
   testParseExample(ContentExample.mathBlock);
   testParseExample(ContentExample.mathBlockInQuote);
 
-  testParse('parse image',
-    // "https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3"
-    '<div class="message_inline_image">'
-        '<a href="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3">'
-        '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3">'
-        '</a></div>', const [
-      ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3'),
-    ]);
+  testParseExample(ContentExample.imageSingle);
+  testParseExample(ContentExample.imageCluster);
+  testParseExample(ContentExample.imageClusterThenContent);
+  testParseExample(ContentExample.imageMultipleClusters);
 
   testParse('parse nested lists, quotes, headings, code blocks',
     // "1. > ###### two\n   > * three\n\n      four"

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -321,6 +321,28 @@ void main() {
       check(images.map((i) => i.src.toString()).toList())
         .deepEquals(expectedImages.map((n) => n.srcUrl));
     });
+
+    testWidgets('image as immediate child in implicit paragraph', (tester) async {
+      const example = ContentExample.imageInImplicitParagraph;
+      await prepareContent(tester, example.html);
+      final expectedImages = ((example.expectedNodes[0] as ListNode)
+        .items[0][0] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+
+    testWidgets('image cluster in implicit paragraph', (tester) async {
+      const example = ContentExample.imageClusterInImplicitParagraph;
+      await prepareContent(tester, example.html);
+      final expectedImages = ((example.expectedNodes[0] as ListNode)
+        .items[0][1] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
   });
 
   group('RealmContentNetworkImage', () {


### PR DESCRIPTION
Rebased on top of #511 for new style of content tests.

Fixes: #193 

### Basic Multiple Images
```
[4-64ecbf0935ea5.png](/user_uploads/57965/lBu8Ccyg4Ex0wo07RZdYnpKg/4-64ecbf0935ea5.png)
[5-64ecbc38c4267.png](/user_uploads/57965/MBk-n_Ok52kDQ_vZzrKJm4oQ/5-64ecbc38c4267.png)
[6-64ecbf34264c2.png](/user_uploads/57965/PWZuqtSLFvyQDQkJBXEJmuDY/6-64ecbf34264c2.png)
[7-64ecb1c909b78.png](/user_uploads/57965/bLx4viPDcyoingbDSiNvg3V5/7-64ecb1c909b78.png)
```

| Flutter |  Web  |
| ------ | ------ |
| <img src="https://github.com/zulip/zulip-flutter/assets/98299/f33f2d7d-8bb8-4439-9038-d6fd65bab038" width=300 /> | <img src="https://github.com/zulip/zulip-flutter/assets/98299/7990d4a0-1f3b-4889-847b-41de1c3eddf8" width=300 /> |

### Multiple Clusters in same message
```
# Multiple image clusters in the same message

[4-64ecbf0935ea5.png](/user_uploads/57965/pHPfjDy_9FBEVSu5rnx4yBVJ/4-64ecbf0935ea5.png)
[5-64ecbc38c4267.png](/user_uploads/57965/B8i5AfRqwTJMx_y7Q4U4ejjz/5-64ecbc38c4267.png)

And some other things

[6-64ecbf34264c2.png](/user_uploads/57965/BFABVscknYHOZ8-Sos-vkIUH/6-64ecbf34264c2.png)
[7-64ecb1c909b78.png](/user_uploads/57965/ZE8KqaXEjMJWZu749CDE2gqG/7-64ecb1c909b78.png)
```

| Flutter |  Web  |
| ------ | ------ |
| <img src="https://github.com/zulip/zulip-flutter/assets/98299/51c09c8d-e347-44a4-8e56-b89fc580d8e8" width=300 /> | <img src="https://github.com/zulip/zulip-flutter/assets/98299/144147d4-40fa-466f-9a10-ea4649c7fa56" width=300 /> |

### Layout for profile image

All images so far show landscape images, so confirming here that the layout for a profile image is also what we expect:

```
[taylor-swift-self-titled-billboard-1240.webp](/user_uploads/57965/dqmQrKyxXK0UfQOUTS5I_y-0/taylor-swift-self-titled-billboard-1240.webp)
```

| Flutter |  Web  |
| ------ | ------ |
| <img src="https://github.com/zulip/zulip-flutter/assets/98299/c611f644-b6b7-4098-9479-7bac18393a5b" width=300 /> | <img src="https://github.com/zulip/zulip-flutter/assets/98299/85cf0ad1-eb7e-42a9-9c1b-39e898482799" width=300 /> |


### Layout for  tiny image

Images are laid out in a 150px by 100px space, and in general are scaled down to be contained inside the space. When the image is smaller  than the area, it is centered and un-scaled.

```
Here's a tiny 50px image:
[Zulip-icon-50px.png](/user_uploads/57965/dfy-dlSZGwEckvtLHAtMtQPZ/Zulip-icon-50px.png)
```

| Flutter |  Web  |
| ------ | ------ |
| <img src="https://github.com/zulip/zulip-flutter/assets/98299/4b1e1ba5-c513-4c89-a8db-7eff97105074" width=300 /> | <img src="https://github.com/zulip/zulip-flutter/assets/98299/983d2519-4d9c-4c81-9c2b-ce31106e41e4" width=300 /> |


### Images in a List

The layout works here but is problematic on web:

```
# Images in a list?
- [4-64ecbf0935ea5.png](/user_uploads/57965/m3W57BzdI0k_4CE0tqJ_B9ma/4-64ecbf0935ea5.png) [6-64ecbf34264c2.png](/user_uploads/57965/32I1XhzrXrM-IvHIGgvzT37N/6-64ecbf34264c2.png)
```

| Flutter |  Web  |
| ------ | ------ |
| <img src="https://github.com/zulip/zulip-flutter/assets/98299/fb2313ac-1885-40ed-8d5c-e0eeca272b5b" width=300 /> | <img src="https://github.com/zulip/zulip-flutter/assets/98299/8dedb7a4-ae29-4b84-bf73-c5896a9ab94b" width=300 /> |
