### PR TITLE
anchors 1/n: Handle GrowthDirection.reverse in sticky_header

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -218,8 +218,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       _scrollToBottomVisibleValue.value = true;
     }
 
-    final extentRemainingAboveViewport = scrollMetrics.maxScrollExtent - scrollMetrics.pixels;
-    if (extentRemainingAboveViewport < kFetchMessagesBufferPixels) {
+    if (scrollMetrics.extentAfter < kFetchMessagesBufferPixels) {
       // TODO: This ends up firing a second time shortly after we fetch a batch.
       //   The result is that each time we decide to fetch a batch, we end up
       //   fetching two batches in quick succession.  This is basically harmless

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -329,35 +329,39 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         if (i == 1) return MarkAsReadWidget(narrow: widget.narrow);
 
         final data = model!.items[length - 1 - (i - 2)];
-        switch (data) {
-          case MessageListHistoryStartItem():
-            return const Center(
-              child: Padding(
-                padding: EdgeInsets.symmetric(vertical: 16.0),
-                child: Text("No earlier messages."))); // TODO use an icon
-          case MessageListLoadingItem():
-            return const Center(
-              child: Padding(
-                padding: EdgeInsets.symmetric(vertical: 16.0),
-                child: CircularProgressIndicator())); // TODO perhaps a different indicator
-          case MessageListRecipientHeaderItem():
-            final header = RecipientHeader(message: data.message, narrow: widget.narrow);
-            return StickyHeaderItem(allowOverflow: true,
-              header: header, child: header);
-          case MessageListDateSeparatorItem():
-            final header = RecipientHeader(message: data.message, narrow: widget.narrow);
-            return StickyHeaderItem(allowOverflow: true,
-              header: header,
-              child: DateSeparator(message: data.message));
-          case MessageListMessageItem():
-            final header = RecipientHeader(message: data.message, narrow: widget.narrow);
-            return MessageItem(
-              key: ValueKey(data.message.id),
-              header: header,
-              trailingWhitespace: i == 1 ? 8 : 11,
-              item: data);
-        }
+        return _buildItem(data, i);
       });
+  }
+
+  Widget _buildItem(MessageListItem data, int i) {
+    switch (data) {
+      case MessageListHistoryStartItem():
+        return const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: Text("No earlier messages."))); // TODO use an icon
+      case MessageListLoadingItem():
+        return const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: CircularProgressIndicator())); // TODO perhaps a different indicator
+      case MessageListRecipientHeaderItem():
+        final header = RecipientHeader(message: data.message, narrow: widget.narrow);
+        return StickyHeaderItem(allowOverflow: true,
+          header: header, child: header);
+      case MessageListDateSeparatorItem():
+        final header = RecipientHeader(message: data.message, narrow: widget.narrow);
+        return StickyHeaderItem(allowOverflow: true,
+          header: header,
+          child: DateSeparator(message: data.message));
+      case MessageListMessageItem():
+        final header = RecipientHeader(message: data.message, narrow: widget.narrow);
+        return MessageItem(
+          key: ValueKey(data.message.id),
+          header: header,
+          trailingWhitespace: i == 1 ? 8 : 11,
+          item: data);
+    }
   }
 }
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -260,7 +260,7 @@ class StickyHeaderListView extends BoxScrollView {
 
   @override
   Widget buildChildLayout(BuildContext context) {
-    return _SliverStickyHeaderList(
+    return SliverStickyHeaderList(
       headerPlacement: (reverseHeader ^ reverse)
         ? HeaderPlacement.scrollingEnd : HeaderPlacement.scrollingStart,
       delegate: childrenDelegate);
@@ -274,23 +274,24 @@ class StickyHeaderListView extends BoxScrollView {
 /// the ambient [Directionality] is RTL or LTR.
 enum HeaderPlacement { scrollingStart, scrollingEnd }
 
-class _SliverStickyHeaderList extends RenderObjectWidget {
-  _SliverStickyHeaderList({
+class SliverStickyHeaderList extends RenderObjectWidget {
+  SliverStickyHeaderList({
+    super.key,
     required this.headerPlacement,
     required SliverChildDelegate delegate,
-  }) : child = _SliverStickyHeaderListInner(
+  }) : _child = _SliverStickyHeaderListInner(
     headerPlacement: headerPlacement,
     delegate: delegate,
   );
 
   final HeaderPlacement headerPlacement;
-  final _SliverStickyHeaderListInner child;
+  final _SliverStickyHeaderListInner _child;
 
   @override
-  _SliverStickyHeaderListElement createElement() => _SliverStickyHeaderListElement(this);
+  RenderObjectElement createElement() => _SliverStickyHeaderListElement(this);
 
   @override
-  _RenderSliverStickyHeaderList createRenderObject(BuildContext context) {
+  RenderSliver createRenderObject(BuildContext context) {
     final element = context as _SliverStickyHeaderListElement;
     return _RenderSliverStickyHeaderList(element: element);
   }
@@ -299,10 +300,10 @@ class _SliverStickyHeaderList extends RenderObjectWidget {
 enum _SliverStickyHeaderListSlot { header, list }
 
 class _SliverStickyHeaderListElement extends RenderObjectElement {
-  _SliverStickyHeaderListElement(_SliverStickyHeaderList super.widget);
+  _SliverStickyHeaderListElement(SliverStickyHeaderList super.widget);
 
   @override
-  _SliverStickyHeaderList get widget => super.widget as _SliverStickyHeaderList;
+  SliverStickyHeaderList get widget => super.widget as SliverStickyHeaderList;
 
   @override
   _RenderSliverStickyHeaderList get renderObject => super.renderObject as _RenderSliverStickyHeaderList;
@@ -334,14 +335,14 @@ class _SliverStickyHeaderListElement extends RenderObjectElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _child = updateChild(_child, widget.child, _SliverStickyHeaderListSlot.list);
+    _child = updateChild(_child, widget._child, _SliverStickyHeaderListSlot.list);
   }
 
   @override
-  void update(_SliverStickyHeaderList newWidget) {
+  void update(SliverStickyHeaderList newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _child = updateChild(_child, widget.child, _SliverStickyHeaderListSlot.list);
+    _child = updateChild(_child, widget._child, _SliverStickyHeaderListSlot.list);
     renderObject.child!.markHeaderNeedsRebuild();
   }
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -399,6 +399,8 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
 
   final _SliverStickyHeaderListElement _element;
 
+  SliverStickyHeaderList get _widget => _element.widget;
+
   Widget? _headerWidget;
 
   /// The limiting edge (if any) of the header's item,
@@ -425,7 +427,7 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
     double? endBound;
     if (item != null && !item.allowOverflow) {
       final childParentData = listChild!.parentData! as SliverMultiBoxAdaptorParentData;
-      endBound = switch (_element.widget.headerPlacement) {
+      endBound = switch (_widget.headerPlacement) {
         HeaderPlacement.scrollingStart =>
           childParentData.layoutOffset! + listChild.size.onAxis(constraints.axis),
         HeaderPlacement.scrollingEnd =>
@@ -523,7 +525,7 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
 
   bool _headerAtCoordinateEnd() {
     return axisDirectionIsReversed(constraints.axisDirection)
-      ^ (_element.widget.headerPlacement == HeaderPlacement.scrollingEnd);
+      ^ (_widget.headerPlacement == HeaderPlacement.scrollingEnd);
   }
 
   @override

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -17,7 +17,6 @@ import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/message_list.dart';
-import 'package:zulip/widgets/sticky_header.dart';
 import 'package:zulip/widgets/store.dart';
 
 import '../api/fake_api.dart';
@@ -76,13 +75,13 @@ void main() {
   }
 
   ScrollController? findMessageListScrollController(WidgetTester tester) {
-    final stickyHeaderListView = tester.widget<StickyHeaderListView>(find.byType(StickyHeaderListView));
-    return stickyHeaderListView.controller;
+    final scrollView = tester.widget<CustomScrollView>(find.byType(CustomScrollView));
+    return scrollView.controller;
   }
 
   group('fetch older messages on scroll', () {
     int? itemCount(WidgetTester tester) =>
-      tester.widget<StickyHeaderListView>(find.byType(StickyHeaderListView)).semanticChildCount;
+      tester.widget<CustomScrollView>(find.byType(CustomScrollView)).semanticChildCount;
 
     testWidgets('basic', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
@@ -527,7 +526,7 @@ void main() {
     testWidgets('animation state persistence', (WidgetTester tester) async {
       // Check that _UnreadMarker maintains its in-progress animation
       // as the number of items changes in MessageList. See
-      // `findChildIndexCallback` passed into [StickyHeaderListView.builder]
+      // `findChildIndexCallback` passed into [SliverStickyHeaderList]
       // at [_MessageListState._buildListView].
       final message = eg.streamMessage(flags: []);
       await setupMessageListPage(tester, messages: [message]);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -148,7 +148,7 @@ void main() {
       // Initial state should be not visible, as the message list renders with latest message in view
       check(isButtonVisible(tester)).equals(false);
 
-      scrollController.jumpTo(600);
+      scrollController.jumpTo(-600);
       await tester.pump();
       check(isButtonVisible(tester)).equals(true);
 
@@ -165,7 +165,7 @@ void main() {
       // Initial state should be not visible, as the message list renders with latest message in view
       check(isButtonVisible(tester)).equals(false);
 
-      scrollController.jumpTo(600);
+      scrollController.jumpTo(-600);
       await tester.pump();
       check(isButtonVisible(tester)).equals(true);
 
@@ -187,7 +187,7 @@ void main() {
       // Initial state should be not visible, as the message list renders with latest message in view
       check(isButtonVisible(tester)).equals(false);
 
-      scrollController.jumpTo(600);
+      scrollController.jumpTo(-600);
       await tester.pump();
       check(isButtonVisible(tester)).equals(true);
 

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -67,38 +67,38 @@ void main() {
 
   for (final reverse in [true, false]) {
     for (final reverseHeader in [true, false]) {
-      for (final allowOverflow in [true, false]) {
-        final name = 'sticky headers: '
-          'scroll ${reverse ? 'up' : 'down'}, '
-          'header at ${reverseHeader ? 'bottom' : 'top'}, '
-          'headers ${allowOverflow ? 'overflow' : 'bounded'}';
-        testWidgets(name, (tester) =>
-          _checkSequence(tester,
-            Axis.vertical,
-            reverse: reverse,
-            reverseHeader: reverseHeader,
-            allowOverflow: allowOverflow,
-          ));
-      }
-    }
-  }
-
-  for (final reverse in [true, false]) {
-    for (final reverseHeader in [true, false]) {
-      for (final allowOverflow in [true, false]) {
-        for (final textDirection in TextDirection.values) {
+      for (final growthDirection in GrowthDirection.values) {
+        for (final allowOverflow in [true, false]) {
           final name = 'sticky headers: '
-            '${textDirection.name.toUpperCase()} '
-            'scroll ${reverse ? 'backward' : 'forward'}, '
-            'header at ${reverseHeader ? 'end' : 'start'}, '
+            'scroll ${reverse ? 'up' : 'down'}, '
+            'header at ${reverseHeader ? 'bottom' : 'top'}, '
+            '$growthDirection, '
             'headers ${allowOverflow ? 'overflow' : 'bounded'}';
           testWidgets(name, (tester) =>
             _checkSequence(tester,
-              Axis.horizontal, textDirection: textDirection,
+              Axis.vertical,
               reverse: reverse,
               reverseHeader: reverseHeader,
+              growthDirection: growthDirection,
               allowOverflow: allowOverflow,
             ));
+
+          for (final textDirection in TextDirection.values) {
+            final name = 'sticky headers: '
+              '${textDirection.name.toUpperCase()} '
+              'scroll ${reverse ? 'backward' : 'forward'}, '
+              'header at ${reverseHeader ? 'end' : 'start'}, '
+              '$growthDirection, '
+              'headers ${allowOverflow ? 'overflow' : 'bounded'}';
+            testWidgets(name, (tester) =>
+              _checkSequence(tester,
+                Axis.horizontal, textDirection: textDirection,
+                reverse: reverse,
+                reverseHeader: reverseHeader,
+                growthDirection: growthDirection,
+                allowOverflow: allowOverflow,
+              ));
+          }
         }
       }
     }
@@ -111,6 +111,7 @@ Future<void> _checkSequence(
   TextDirection? textDirection,
   bool reverse = false,
   bool reverseHeader = false,
+  GrowthDirection growthDirection = GrowthDirection.forward,
   required bool allowOverflow,
 }) async {
   assert(textDirection != null || axis == Axis.vertical);
@@ -118,21 +119,35 @@ Future<void> _checkSequence(
     Axis.horizontal => reverseHeader ^ (textDirection == TextDirection.rtl),
     Axis.vertical   => reverseHeader,
   };
+  final reverseGrowth = (growthDirection == GrowthDirection.reverse);
 
   final controller = ScrollController();
+  const listKey = ValueKey("list");
+  const emptyKey = ValueKey("empty");
   await tester.pumpWidget(Directionality(
     textDirection: textDirection ?? TextDirection.rtl,
-    child: StickyHeaderListView(
+    child: CustomScrollView(
       controller: controller,
       scrollDirection: axis,
       reverse: reverse,
-      reverseHeader: reverseHeader,
-      children: List.generate(100, (i) => StickyHeaderItem(
-        allowOverflow: allowOverflow,
-        header: _Header(i, height: 20),
-        child: _Item(i, height: 100))))));
+      anchor: reverseGrowth ? 1.0 : 0.0,
+      center: reverseGrowth ? emptyKey : listKey,
+      slivers: [
+        SliverStickyHeaderList(
+          key: listKey,
+          headerPlacement: (reverseHeader ^ reverse)
+            ? HeaderPlacement.scrollingEnd : HeaderPlacement.scrollingStart,
+          delegate: SliverChildListDelegate(
+            List.generate(100, (i) => StickyHeaderItem(
+              allowOverflow: allowOverflow,
+              header: _Header(i, height: 20),
+              child: _Item(i, height: 100))))),
+        const SliverPadding(
+          key: emptyKey,
+          padding: EdgeInsets.zero),
+      ])));
 
-  final overallSize = tester.getSize(find.byType(StickyHeaderListView));
+  final overallSize = tester.getSize(find.byType(CustomScrollView));
   final extent = overallSize.onAxis(axis);
   assert(extent % 100 == 0);
 
@@ -143,7 +158,7 @@ Future<void> _checkSequence(
           (extent / 2 - inset) * (headerAtCoordinateEnd ? 1 : -1));
   }
 
-  final first = !(reverse ^ reverseHeader);
+  final first = !(reverse ^ reverseHeader ^ reverseGrowth);
 
   final itemFinder = first ? find.byType(_Item).first : find.byType(_Item).last;
 
@@ -155,10 +170,11 @@ Future<void> _checkSequence(
 
   Future<void> checkState() async {
     // Check the header comes from the expected item.
-    final scrollOffset = controller.position.pixels;
+    final scrollOffset = controller.position.pixels * (reverseGrowth ? -1 : 1);
     final expectedHeaderIndex = first
       ? (scrollOffset / 100).floor()
       : (extent ~/ 100 - 1) + (scrollOffset / 100).ceil();
+    // print("$scrollOffset, $extent, $expectedHeaderIndex");
     check(tester.widget<_Item>(itemFinder).index).equals(expectedHeaderIndex);
     check(_headerIndex(tester)).equals(expectedHeaderIndex);
 
@@ -180,7 +196,7 @@ Future<void> _checkSequence(
   }
 
   Future<void> jumpAndCheck(double position) async {
-    controller.jumpTo(position);
+    controller.jumpTo(position * (reverseGrowth ? -1 : 1));
     await tester.pump();
     await checkState();
   }


### PR DESCRIPTION
This is the first of several PRs leading us to #80 and #82, opening the message list at an anchor other than the latest message in history.

For this PR, the main work is to lift one of the simplifying assumptions I originally made for an MVP of the `sticky_header` library, allowing the SliverStickyHeaderList to be a sliver that counts backward in the enclosing ScrollView rather than forward.

We also rearrange some things in how MessageList builds the list, in order to exercise that new flexibility and to get closer to how we'll want things when implementing #80 and #82.

## Main commit messages

sticky_header: Handle GrowthDirection.reverse

This resolves the last of the "TODO dir" comments in this library.

We had originally written this library to rely on the assumption
that `constraints.growthDirection` was `GrowthDirection.forward`,
i.e. that the direction in which `constraints.scrollOffset` increases
was the same as `constraints.axisDirection`, in order to keep down
the number of distinct directions one needs to keep track of in
writing and reading (and debugging) the implementation.

But now that this logic is relatively solid within that case --
and now that we have a solid test suite for this library -- we can
go back and identify the handful of places that need to be flipped
around for `GrowthDirection.reverse`, and do so.

This support isn't yet especially *useful*: there are a couple of
unrelated bugs which are triggered when the area allotted to this
sliver isn't the entire viewport, and there isn't a lot of reason
to have a sliver with GrowthDirection.reverse when no other sliver
is potentially occupying part of the viewport.  We'll fix those
separately.

---

msglist [nfc]: Let ScrollView count forward, and sliver handle reverse

This means that the overall scroll view has AxisDirection.down
as the scroll direction, rather than AxisDirection.up, and the
SliverStickyHeader is passed GrowthDirection.reverse instead
of GrowthDirection.forward in order to get the same effect.

This makes the scrolling a little easier to think about when focused
on MessageList's code, because for example (as seen in this diff)
`scrollMetrics.extentBefore` now refers to the messages that are
older than the ones on screen, rather than those that are newer.

This also brings us closer to the setup we'll want for #80 and #82,
opening the message list at an anchor other than the end: the empty
placeholder sliver at the bottom will become the list of messages
after the starting anchor, while the sliver at the top will remain
the list of messages above the anchor.
