### PR TITLE
content: Fix **`bold code`** rendering with regular weight

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -454,7 +454,7 @@ class InlineContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text.rich(_builder.build());
+    return Text.rich(_builder.build(context));
   }
 }
 
@@ -463,14 +463,20 @@ class _InlineContentBuilder {
 
   final InlineContent widget;
 
-  InlineSpan build() {
+  InlineSpan build(BuildContext context) {
+    assert(_context == null);
+    _context = context;
     assert(_recognizer == widget.recognizer);
     assert(_recognizerStack == null || _recognizerStack!.isEmpty);
     final result = _buildNodes(widget.nodes, style: widget.style);
+    assert(identical(_context, context));
+    _context = null;
     assert(_recognizer == widget.recognizer);
     assert(_recognizerStack == null || _recognizerStack!.isEmpty);
     return result;
   }
+
+  BuildContext? _context;
 
   // Why do we have to track `recognizer` here, rather than apply it
   // once at the top of the affected span?  Because the events don't bubble
@@ -531,7 +537,7 @@ class _InlineContentBuilder {
   }
 
   InlineSpan _buildStrong(StrongNode node) => _buildNodes(node.nodes,
-    style: const TextStyle(fontWeight: FontWeight.w600));
+    style: weightVariableTextStyle(_context, wght: 600, wghtIfPlatformRequestsBold: 900));
 
   InlineSpan _buildEmphasis(EmphasisNode node) => _buildNodes(node.nodes,
     style: const TextStyle(fontStyle: FontStyle.italic));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -600,9 +600,18 @@ class _InlineContentBuilder {
 final _kInlineMathStyle = _kInlineCodeStyle.merge(TextStyle(
   backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.93).toColor()));
 
+// Even though [kMonospaceTextStyle] is a variable-weight font,
+// it's acceptable to skip [weightVariableTextStyle] here,
+// assuming the text gets the effect of [weightVariableTextStyle]
+// through inheritance, e.g., from a [DefaultTextStyle].
 final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(const TextStyle(
     backgroundColor: Color(0xffeeeeee),
+    fontSize: 0.825 * kBaseFontSize));
+
+final _kCodeBlockStyle = kMonospaceTextStyle
+  .merge(const TextStyle(
+    backgroundColor: Color.fromRGBO(255, 255, 255, 1),
     fontSize: 0.825 * kBaseFontSize))
   .merge(
     // TODO(a11y) pass a BuildContext, to handle platform request for bold text.
@@ -610,14 +619,6 @@ final _kInlineCodeStyle = kMonospaceTextStyle
     //   we get at the end) could live on one [InheritedWidget], at the
     //   MessageList or higher, so the computation doesn't get repeated
     //   frequently. Then consumers can just look it up on the InheritedWidget.
-    weightVariableTextStyle(null));
-
-final _kCodeBlockStyle = kMonospaceTextStyle
-  .merge(const TextStyle(
-    backgroundColor: Color.fromRGBO(255, 255, 255, 1),
-    fontSize: 0.825 * kBaseFontSize))
-  .merge(
-    // TODO(a11y) pass a BuildContext; see comment in _kInlineCodeStyle above.
     weightVariableTextStyle(null));
 
 // const _kInlineCodeLeftBracket = '⸤';

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -200,8 +200,9 @@ TextStyle weightVariableTextStyle(BuildContext? context, {
     fontVariations: [FontVariation('wght', value)],
 
     // This use of `fontWeight` shouldn't affect glyphs in the preferred,
-    // "wght"-axis font. If it does, see for debugging:
-    //   https://github.com/zulip/zulip-flutter/issues/65#issuecomment-1550666764
+    // "wght"-axis font. But it can; see upstream bug:
+    //   https://github.com/flutter/flutter/issues/136779
+    // TODO(#500) await/send upstream bugfix?
     fontWeight: clampVariableFontWeight(value),
 
     inherit: true);


### PR DESCRIPTION
Also format `**bold text**` using weightVariableTextStyle, fixing #499, and update a comment to point to #500.

| Before | After |
| --- | --- |
| ![image](https://github.com/zulip/zulip-flutter/assets/22248748/a0b927a5-eef5-4eb5-9544-a46315bd083f) | ![image](https://github.com/zulip/zulip-flutter/assets/22248748/52ec3e12-bbf5-44f9-9bb7-2086310c3e3a) |

Fixes: #498
Fixes: #499