### PR TITLE
notif android: Request permission at startup

### DIFF
--- a/test/notifications_test.dart
+++ b/test/notifications_test.dart
@@ -82,11 +82,11 @@ void main() {
   }
 
   group('permissions', () {
-    testWidgets('on iOS request permission', (tester) async {
+    testWidgets('request permission', (tester) async {
       await init();
       check(testBinding.firebaseMessaging.takeRequestPermissionCalls())
         .length.equals(1);
-    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+    }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
   });
 
   group('NotificationChannelManager', () {


### PR DESCRIPTION
This is necessary (on Android 13+) in order to be able to actually show a notification in the UI.

Fixes: #520
