### PR TITLE
Make login flow testable, and start testing it

### DIFF
--- a/lib/api/route/account.dart
+++ b/lib/api/route/account.dart
@@ -5,22 +5,14 @@ import '../core.dart';
 part 'account.g.dart';
 
 /// https://zulip.com/api/fetch-api-key
-Future<FetchApiKeyResult> fetchApiKey({
-  required Uri realmUrl,
-  required int? zulipFeatureLevel,
+Future<FetchApiKeyResult> fetchApiKey(ApiConnection connection, {
   required String username,
   required String password,
-}) async {
-  // TODO make this function testable by taking ApiConnection from caller
-  final connection = ApiConnection.live(realmUrl: realmUrl, zulipFeatureLevel: zulipFeatureLevel);
-  try {
-    return await connection.post('fetchApiKey', FetchApiKeyResult.fromJson, 'fetch_api_key', {
-      'username': RawParameter(username),
-      'password': RawParameter(password),
-    });
-  } finally {
-    connection.close();
-  }
+}) {
+  return connection.post('fetchApiKey', FetchApiKeyResult.fromJson, 'fetch_api_key', {
+    'username': RawParameter(username),
+    'password': RawParameter(password),
+  });
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -15,17 +15,8 @@ part 'realm.g.dart';
 // TODO(#107): Perhaps detect realmless root domain, for more specific onboarding feedback.
 //   See thread, and the zulip-mobile code and chat thread it links to:
 //     https://github.com/zulip/zulip-flutter/pull/55#discussion_r1160267577
-Future<GetServerSettingsResult> getServerSettings({
-  required Uri realmUrl,
-  required int? zulipFeatureLevel,
-}) async {
-  // TODO make this function testable by taking ApiConnection from caller
-  final connection = ApiConnection.live(realmUrl: realmUrl, zulipFeatureLevel: zulipFeatureLevel);
-  try {
-    return await connection.get('getServerSettings', GetServerSettingsResult.fromJson, 'server_settings', null);
-  } finally {
-    connection.close();
-  }
+Future<GetServerSettingsResult> getServerSettings(ApiConnection connection) {
+  return connection.get('getServerSettings', GetServerSettingsResult.fromJson, 'server_settings', null);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -183,12 +183,19 @@ abstract class GlobalStore extends ChangeNotifier {
 /// to keep the data up to date.  For that behavior, see
 /// [UpdateMachine].
 class PerAccountStore extends ChangeNotifier with StreamStore {
+  /// Construct a store for the user's data, starting from the given snapshot.
+  ///
+  /// If the [connection] parameter is omitted, it defaults
+  /// to `globalStore.apiConnectionFromAccount(account)`.
+  /// When present, it should be a connection that came from that method call,
+  /// but it may have already been used for other requests.
   factory PerAccountStore.fromInitialSnapshot({
     required GlobalStore globalStore,
     required Account account,
-    required ApiConnection connection,
+    ApiConnection? connection,
     required InitialSnapshot initialSnapshot,
   }) {
+    connection ??= globalStore.apiConnectionFromAccount(account);
     final streams = StreamStoreImpl(initialSnapshot: initialSnapshot);
     return PerAccountStore._(
       globalStore: globalStore,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -65,6 +65,12 @@ abstract class GlobalStore extends ChangeNotifier {
     String? apiKey,
   });
 
+  ApiConnection apiConnectionFromAccount(Account account) {
+    return apiConnection(
+      realmUrl: account.realmUrl, zulipFeatureLevel: account.zulipFeatureLevel,
+      email: account.email, apiKey: account.apiKey);
+  }
+
   final Map<int, PerAccountStore> _perAccountStores = {};
   final Map<int, Future<PerAccountStore>> _perAccountStoresLoading = {};
 
@@ -543,9 +549,7 @@ class UpdateMachine {
   /// In the future this might load an old snapshot from local storage first.
   static Future<UpdateMachine> load(GlobalStore globalStore, Account account) async {
     // TODO test UpdateMachine.load, now that it uses [GlobalStore.apiConnection]
-    final connection = globalStore.apiConnection(
-      realmUrl: account.realmUrl, zulipFeatureLevel: account.zulipFeatureLevel,
-      email: account.email, apiKey: account.apiKey);
+    final connection = globalStore.apiConnectionFromAccount(account);
 
     final stopwatch = Stopwatch()..start();
     final initialSnapshot = await registerQueue(connection); // TODO retry

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -53,6 +53,18 @@ abstract class GlobalStore extends ChangeNotifier {
   // TODO settings (those that are per-device rather than per-account)
   // TODO push token, and other data corresponding to GlobalSessionState
 
+  /// Construct a new [ApiConnection], real or fake as appropriate.
+  ///
+  /// Where a per-account store is available, use [PerAccountStore.connection].
+  /// This method is for use before a per-account store exists, such as in
+  /// the login flow.
+  ApiConnection apiConnection({
+    required Uri realmUrl,
+    required int? zulipFeatureLevel, // required even though nullable; see [ApiConnection.zulipFeatureLevel]
+    String? email,
+    String? apiKey,
+  });
+
   final Map<int, PerAccountStore> _perAccountStores = {};
   final Map<int, Future<PerAccountStore>> _perAccountStoresLoading = {};
 
@@ -452,6 +464,15 @@ class LiveGlobalStore extends GlobalStore {
     required AppDatabase db,
     required super.accounts,
   }) : _db = db;
+
+  @override
+  ApiConnection apiConnection({
+      required Uri realmUrl, required int? zulipFeatureLevel,
+      String? email, String? apiKey}) {
+    return ApiConnection.live(
+      realmUrl: realmUrl, zulipFeatureLevel: zulipFeatureLevel,
+      email: email, apiKey: apiKey);
+  }
 
   // We keep the API simple and synchronous for the bulk of the app's code
   // by doing this loading up front before constructing a [GlobalStore].

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -527,8 +527,6 @@ class LiveGlobalStore extends GlobalStore {
 }
 
 /// A [PerAccountStore] plus an event-polling loop to stay up to date.
-// TODO decouple "live"ness from polling and registerNotificationToken;
-//   the latter are made up of testable internal logic, not external integration
 class UpdateMachine {
   UpdateMachine.fromInitialSnapshot({
     required this.store,
@@ -544,7 +542,8 @@ class UpdateMachine {
   ///
   /// In the future this might load an old snapshot from local storage first.
   static Future<UpdateMachine> load(GlobalStore globalStore, Account account) async {
-    final connection = ApiConnection.live(
+    // TODO test UpdateMachine.load, now that it uses [GlobalStore.apiConnection]
+    final connection = globalStore.apiConnection(
       realmUrl: account.realmUrl, zulipFeatureLevel: account.zulipFeatureLevel,
       email: account.email, apiKey: account.apiKey);
 

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -285,7 +285,11 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
       realmUrl: widget.serverSettings.realmUrl,
       zulipFeatureLevel: widget.serverSettings.zulipFeatureLevel,
       email: email, apiKey: apiKey);
-    return (await getOwnUser(connection)).userId;
+    try {
+      return (await getOwnUser(connection)).userId;
+    } finally {
+      connection.close();
+    }
   }
 
   @override

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
-import '../api/core.dart';
 import '../api/exception.dart';
 import '../api/route/account.dart';
 import '../api/route/realm.dart';
@@ -153,8 +152,8 @@ class _AddAccountPageState extends State<AddAccountPage> {
     try {
       final GetServerSettingsResult serverSettings;
       try {
-        // TODO make this function testable by controlling ApiConnection
-        final connection = ApiConnection.live(realmUrl: url!, zulipFeatureLevel: null);
+        final globalStore = GlobalStoreWidget.of(context);
+        final connection = globalStore.apiConnection(realmUrl: url!, zulipFeatureLevel: null);
         try {
           serverSettings = await getServerSettings(connection);
         } finally {
@@ -281,7 +280,8 @@ class _PasswordLoginPageState extends State<PasswordLoginPage> {
   }
 
   Future<int> _getUserId(String email, apiKey) async {
-    final connection = ApiConnection.live( // TODO make this widget testable
+    final globalStore = GlobalStoreWidget.of(context);
+    final connection = globalStore.apiConnection(
       realmUrl: widget.serverSettings.realmUrl,
       zulipFeatureLevel: widget.serverSettings.zulipFeatureLevel,
       email: email, apiKey: apiKey);
@@ -353,8 +353,8 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
     try {
       final FetchApiKeyResult result;
       try {
-        // TODO make this function testable by controlling ApiConnection
-        final connection = ApiConnection.live(realmUrl: realmUrl,
+        final globalStore = GlobalStoreWidget.of(context);
+        final connection = globalStore.apiConnection(realmUrl: realmUrl,
           zulipFeatureLevel: serverSettings.zulipFeatureLevel);
         try {
           result = await fetchApiKey(connection,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -153,7 +153,13 @@ class _AddAccountPageState extends State<AddAccountPage> {
     try {
       final GetServerSettingsResult serverSettings;
       try {
-        serverSettings = await getServerSettings(realmUrl: url!, zulipFeatureLevel: null);
+        // TODO make this function testable by controlling ApiConnection
+        final connection = ApiConnection.live(realmUrl: url!, zulipFeatureLevel: null);
+        try {
+          serverSettings = await getServerSettings(connection);
+        } finally {
+          connection.close();
+        }
       } catch (e) {
         if (!context.mounted) {
           return;
@@ -343,10 +349,15 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
     try {
       final FetchApiKeyResult result;
       try {
-        result = await fetchApiKey(
-          realmUrl: realmUrl,
-          zulipFeatureLevel: serverSettings.zulipFeatureLevel,
-          username: username, password: password);
+        // TODO make this function testable by controlling ApiConnection
+        final connection = ApiConnection.live(realmUrl: realmUrl,
+          zulipFeatureLevel: serverSettings.zulipFeatureLevel);
+        try {
+          result = await fetchApiKey(connection,
+            username: username, password: password);
+        } finally {
+          connection.close();
+        }
       } on ApiRequestException catch (e) {
         if (!context.mounted) return;
         // TODO(#105) give more helpful feedback. The RN app is

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -96,20 +96,25 @@ class FakeApiConnection extends ApiConnection {
   /// which causes route bindings to behave as they would for the
   /// latest Zulip server versions.
   /// To set `zulipFeatureLevel` to null, pass null explicitly.
-  FakeApiConnection({Uri? realmUrl, int? zulipFeatureLevel = eg.futureZulipFeatureLevel})
-    : this._(
-        realmUrl: realmUrl ?? eg.realmUrl,
-        zulipFeatureLevel: zulipFeatureLevel,
-        client: FakeHttpClient(),
-      );
+  FakeApiConnection({
+    Uri? realmUrl,
+    int? zulipFeatureLevel = eg.futureZulipFeatureLevel,
+    String? email,
+    String? apiKey,
+  }) : this._(
+         realmUrl: realmUrl ?? eg.realmUrl,
+         zulipFeatureLevel: zulipFeatureLevel,
+         email: email,
+         apiKey: apiKey,
+         client: FakeHttpClient(),
+       );
 
   FakeApiConnection.fromAccount(Account account)
-    : this._(
+    : this(
         realmUrl: account.realmUrl,
         zulipFeatureLevel: account.zulipFeatureLevel,
         email: account.email,
-        apiKey: account.apiKey,
-        client: FakeHttpClient());
+        apiKey: account.apiKey);
 
   FakeApiConnection._({
     required super.realmUrl,

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -151,6 +151,19 @@ class FakeApiConnection extends ApiConnection {
     }
   }
 
+  /// True just if [close] has never been called on this connection.
+  // In principle this could live on [ApiConnection]... but [http.Client]
+  // offers no way to tell if [http.Client.close] has been called,
+  // so we follow that library's lead on this point of API design.
+  bool get isOpen => _isOpen;
+  bool _isOpen = true;
+
+  @override
+  void close() {
+    _isOpen = false;
+    super.close();
+  }
+
   http.BaseRequest? get lastRequest => client.lastRequest;
 
   http.BaseRequest? takeLastRequest() => client.takeLastRequest();

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -6,7 +6,6 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
 
-import 'api/fake_api.dart';
 import 'model/test_store.dart';
 import 'stdlib_checks.dart';
 
@@ -476,7 +475,6 @@ PerAccountStore store({Account? account, InitialSnapshot? initialSnapshot}) {
   return PerAccountStore.fromInitialSnapshot(
     globalStore: globalStore(accounts: [effectiveAccount]),
     account: effectiveAccount,
-    connection: FakeApiConnection.fromAccount(effectiveAccount),
     initialSnapshot: initialSnapshot ?? _initialSnapshot(),
   );
 }

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
 
@@ -19,6 +20,25 @@ Uri get _realmUrl => realmUrl;
 const String recentZulipVersion = '8.0';
 const int recentZulipFeatureLevel = 185;
 const int futureZulipFeatureLevel = 9999;
+
+GetServerSettingsResult serverSettings() {
+  return GetServerSettingsResult(
+    authenticationMethods: {},
+    externalAuthenticationMethods: [],
+    zulipFeatureLevel: recentZulipFeatureLevel,
+    zulipVersion: recentZulipVersion,
+    zulipMergeBase: recentZulipVersion,
+    pushNotificationsEnabled: true,
+    isIncompatible: false,
+    emailAuthEnabled: true,
+    requireEmailFormatUsernames: true,
+    realmUrl: realmUrl,
+    realmName: 'Example Zulip organization',
+    realmIcon: '$realmUrl/icon.png',
+    realmDescription: 'An example Zulip organization',
+    realmWebPublicAccessEnabled: false,
+  );
+}
 
 ////////////////////////////////////////////////////////////////
 // Users and accounts.

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -1,6 +1,18 @@
 import 'package:checks/checks.dart';
 import 'package:zulip/model/store.dart';
 
+extension AccountChecks on Subject<Account> {
+  Subject<int> get id => has((x) => x.id, 'id');
+  Subject<Uri> get realmUrl => has((x) => x.realmUrl, 'realmUrl');
+  Subject<int> get userId => has((x) => x.userId, 'userId');
+  Subject<String> get email => has((x) => x.email, 'email');
+  Subject<String> get apiKey => has((x) => x.apiKey, 'apiKey');
+  Subject<String> get zulipVersion => has((x) => x.zulipVersion, 'zulipVersion');
+  Subject<String?> get zulipMergeBase => has((x) => x.zulipMergeBase, 'zulipMergeBase');
+  Subject<int> get zulipFeatureLevel => has((x) => x.zulipFeatureLevel, 'zulipFeatureLevel');
+  Subject<String?> get ackedPushToken => has((x) => x.ackedPushToken, 'ackedPushToken');
+}
+
 extension GlobalStoreChecks on Subject<GlobalStore> {
   Subject<Iterable<Account>> get accounts => has((x) => x.accounts, 'accounts');
   Subject<Iterable<int>> get accountIds => has((x) => x.accountIds, 'accountIds');

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -34,7 +34,6 @@ void main() {
     final store1 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
       account: account1,
-      connection: FakeApiConnection.fromAccount(account1),
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(1).single.complete(store1);
@@ -46,7 +45,6 @@ void main() {
     final store2 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
       account: account2,
-      connection: FakeApiConnection.fromAccount(account2),
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(2).single.complete(store2);
@@ -74,13 +72,11 @@ void main() {
     final store1 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
       account: account1,
-      connection: FakeApiConnection.fromAccount(account1),
       initialSnapshot: eg.initialSnapshot(),
     );
     final store2 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
       account: account2,
-      connection: FakeApiConnection.fromAccount(account2),
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(1).single.complete(store1);
@@ -106,7 +102,6 @@ void main() {
     final store1 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
       account: account1,
-      connection: FakeApiConnection.fromAccount(account1),
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(1).single.complete(store1);

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -95,7 +95,6 @@ class TestGlobalStore extends GlobalStore {
     final store = PerAccountStore.fromInitialSnapshot(
       globalStore: this,
       account: account,
-      connection: FakeApiConnection.fromAccount(account),
       initialSnapshot: initialSnapshot,
     );
     updateMachines[account.id] = UpdateMachine.fromInitialSnapshot(

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -1,10 +1,21 @@
 import 'package:checks/checks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:zulip/api/route/account.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/widgets/login.dart';
+import 'package:zulip/widgets/store.dart';
 
+import '../api/fake_api.dart';
+import '../example_data.dart' as eg;
+import '../model/binding.dart';
 import '../stdlib_checks.dart';
 
 void main() {
+  TestZulipBinding.ensureInitialized();
+
   group('ServerUrlTextEditingController.tryParse', () {
     final controller = ServerUrlTextEditingController();
 
@@ -40,5 +51,72 @@ void main() {
     expectErrorFromText('ftp://foo',         ServerUrlValidationError.unsupportedSchemeOther);
     expectErrorFromText('!@#*asd;l4fkj',     ServerUrlValidationError.invalidUrl);
     expectErrorFromText('email@example.com', ServerUrlValidationError.noUseEmail);
+  });
+
+  // TODO test AddAccountPage
+
+  group('PasswordLoginPage', () {
+    late FakeApiConnection connection;
+
+    Future<void> prepare(WidgetTester tester,
+        GetServerSettingsResult serverSettings) async {
+      addTearDown(testBinding.reset);
+
+      connection = testBinding.globalStore.apiConnection(
+        realmUrl: serverSettings.realmUrl,
+        zulipFeatureLevel: serverSettings.zulipFeatureLevel);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: ZulipLocalizations.localizationsDelegates,
+          supportedLocales: ZulipLocalizations.supportedLocales,
+          home: GlobalStoreWidget(
+            child: PasswordLoginPage(serverSettings: serverSettings))));
+      await tester.pump(); // load global store
+    }
+
+    final findUsernameInput = find.byWidgetPredicate((widget) =>
+      widget is TextField
+      && (widget.autofillHints ?? []).contains(AutofillHints.email));
+    final findPasswordInput = find.byWidgetPredicate((widget) =>
+      widget is TextField
+      && (widget.autofillHints ?? []).contains(AutofillHints.password));
+    final findSubmitButton = find.widgetWithText(ElevatedButton, 'Log in');
+
+    void checkFetchApiKey({required String username, required String password}) {
+      check(connection.lastRequest).isA<http.Request>()
+        ..method.equals('POST')
+        ..url.path.equals('/api/v1/fetch_api_key')
+        ..bodyFields.deepEquals({
+          'username': username,
+          'password': password,
+        });
+    }
+
+    testWidgets('basic happy case', (tester) async {
+      final serverSettings = eg.serverSettings();
+      await prepare(tester, serverSettings);
+      check(testBinding.globalStore.accounts).isEmpty();
+
+      await tester.enterText(findUsernameInput, eg.selfAccount.email);
+      await tester.enterText(findPasswordInput, 'p455w0rd');
+      connection.prepare(json: FetchApiKeyResult(
+        apiKey: eg.selfAccount.apiKey,
+        email: eg.selfAccount.email,
+        userId: eg.selfAccount.userId,
+      ).toJson());
+      await tester.tap(findSubmitButton);
+      checkFetchApiKey(username: eg.selfAccount.email, password: 'p455w0rd');
+      await tester.idle();
+      check(testBinding.globalStore.accounts).single
+        .equals(eg.selfAccount.copyWith(
+          id: testBinding.globalStore.accounts.single.id));
+    });
+
+    // TODO test validators on the TextFormField widgets
+    // TODO test navigation, i.e. the call to pushAndRemoveUntil
+    // TODO test _getUserId case
+    // TODO test handling failure in fetchApiKey request
+    // TODO test _inProgress logic
   });
 }


### PR DESCRIPTION
Unlike almost everywhere else in our code, this was invoking the `ApiConnection.live` constructor directly and therefore wasn't possible to write tests for. Prompted by https://github.com/zulip/zulip-flutter/pull/519#pullrequestreview-1881464375 , fix that, and write a first test.

It'd be good to use this new capability in order to write more tests for the login UI, and I've left some TODO comments pointing at those; but this is as much as I had time to get to today, and it's enough to unblock writing tests for new functionality in this area such as #519.
