### PR TITLE
Prepare for updating accounts in database

### DIFF
--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -142,7 +142,7 @@ String quoteAndReplyPlaceholder(PerAccountStore store, {
   final sender = store.users[message.senderId];
   assert(sender != null);
   final url = narrowLink(store,
-    SendableNarrow.ofMessage(message, selfUserId: store.account.userId),
+    SendableNarrow.ofMessage(message, selfUserId: store.selfUserId),
     nearMessageId: message.id);
   // See note in [quoteAndReply] about asking `mention` to omit the |<id> part.
   return '${mention(sender!, silent: true)} ${inlineLink('said', url)}: ' // TODO(i18n) ?
@@ -164,7 +164,7 @@ String quoteAndReply(PerAccountStore store, {
   final sender = store.users[message.senderId];
   assert(sender != null);
   final url = narrowLink(store,
-    SendableNarrow.ofMessage(message, selfUserId: store.account.userId),
+    SendableNarrow.ofMessage(message, selfUserId: store.selfUserId),
     nearMessageId: message.id);
     // Could ask `mention` to omit the |<id> part unless the mention is ambiguous…
     // but that would mean a linear scan through all users, and the extra noise

--- a/lib/model/database.dart
+++ b/lib/model/database.dart
@@ -7,10 +7,25 @@ import 'package:path_provider/path_provider.dart';
 
 part 'database.g.dart';
 
+/// The table of [Account] records in the app's database.
 class Accounts extends Table {
+  /// The ID of this account in the app's local database.
+  ///
+  /// This uniquely identifies the account within this install of the app,
+  /// and never changes for a given account.  It has no meaning to the server,
+  /// though, or anywhere else outside this install of the app.
   Column<int>    get id => integer().autoIncrement()();
 
+  /// The URL of the Zulip realm this account is on.
+  ///
+  /// This corresponds to [GetServerSettingsResult.realmUrl].
+  /// It never changes for a given account.
   Column<String> get realmUrl => text().map(const UriConverter())();
+
+  /// The Zulip user ID of this account.
+  ///
+  /// This is the identifier the server uses for the account.
+  /// It never changes for a given account.
   Column<int>    get userId => integer()();
 
   Column<String> get email => text()();

--- a/lib/model/database.g.dart
+++ b/lib/model/database.g.dart
@@ -182,8 +182,23 @@ class $AccountsTable extends Accounts with TableInfo<$AccountsTable, Account> {
 }
 
 class Account extends DataClass implements Insertable<Account> {
+  /// The ID of this account in the app's local database.
+  ///
+  /// This uniquely identifies the account within this install of the app,
+  /// and never changes for a given account.  It has no meaning to the server,
+  /// though, or anywhere else outside this install of the app.
   final int id;
+
+  /// The URL of the Zulip realm this account is on.
+  ///
+  /// This corresponds to [GetServerSettingsResult.realmUrl].
+  /// It never changes for a given account.
   final Uri realmUrl;
+
+  /// The Zulip user ID of this account.
+  ///
+  /// This is the identifier the server uses for the account.
+  /// It never changes for a given account.
   final int userId;
   final String email;
   final String apiKey;

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -95,7 +95,7 @@ Uri narrowLink(PerAccountStore store, Narrow narrow, {int? nearMessageId}) {
     fragment.write('/near/$nearMessageId');
   }
 
-  return store.account.realmUrl.replace(fragment: fragment.toString());
+  return store.realmUrl.replace(fragment: fragment.toString());
 }
 
 /// Create a new `Uri` object in relation to a given realmUrl.
@@ -124,7 +124,7 @@ Uri? tryResolveOnRealmUrl(String urlString, Uri realmUrl) {
 ///   #narrow/stream/1-announce/stream/1-announce (duplicated operator)
 // TODO(#252): handle all valid narrow links, returning a search narrow
 Narrow? parseInternalLink(Uri url, PerAccountStore store) {
-  if (!_isInternalLink(url, store.account.realmUrl)) return null;
+  if (!_isInternalLink(url, store.realmUrl)) return null;
 
   final (category, segments) = _getCategoryAndSegmentsFromFragment(url.fragment);
   switch (category) {

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -98,20 +98,10 @@ Uri narrowLink(PerAccountStore store, Narrow narrow, {int? nearMessageId}) {
   return store.realmUrl.replace(fragment: fragment.toString());
 }
 
-/// Create a new `Uri` object in relation to a given realmUrl.
-///
-/// Returns `null` if `urlString` could not be parsed as a `Uri`.
-Uri? tryResolveOnRealmUrl(String urlString, Uri realmUrl) {
-  try {
-    return realmUrl.resolve(urlString);
-  } on FormatException {
-    return null;
-  }
-}
-
 /// A [Narrow] from a given URL, on `store`'s realm.
 ///
-/// `url` must already be passed through [tryResolveOnRealmUrl].
+/// `url` must already be a result from [PerAccountStore.tryResolveUrl]
+/// on `store`.
 ///
 /// Returns `null` if any of the operator/operand pairs are invalid.
 ///

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -197,7 +197,7 @@ Narrow? _interpretNarrowSegments(List<String> segments, PerAccountStore store) {
 
   if (dmElement != null) {
     if (streamElement != null || topicElement != null) return null;
-    return DmNarrow.withUsers(dmElement.operand, selfUserId: store.account.userId);
+    return DmNarrow.withUsers(dmElement.operand, selfUserId: store.selfUserId);
   } else if (streamElement != null) {
     final streamId = streamElement.operand;
     if (topicElement != null) {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -205,6 +205,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
       realmEmoji: initialSnapshot.realmEmoji,
       customProfileFields: _sortCustomProfileFields(initialSnapshot.customProfileFields),
       accountId: accountId,
+      selfUserId: account.userId,
       userSettings: initialSnapshot.userSettings,
       users: Map.fromEntries(
         initialSnapshot.realmUsers
@@ -231,12 +232,14 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     required this.realmEmoji,
     required this.customProfileFields,
     required this.accountId,
+    required this.selfUserId,
     required this.userSettings,
     required this.users,
     required streams,
     required this.unreads,
     required this.recentDmConversationsView,
-  }) : _globalStore = globalStore,
+  }) : assert(selfUserId == globalStore.getAccount(accountId)!.userId),
+       _globalStore = globalStore,
        _streams = streams;
 
   ////////////////////////////////////////////////////////////////
@@ -262,6 +265,9 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
 
   final int accountId;
   Account get account => _globalStore.getAccount(accountId)!;
+
+  /// Always equal to `account.userId`.
+  final int selfUserId;
 
   final UserSettings? userSettings; // TODO(server-5)
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -119,12 +119,11 @@ abstract class GlobalStore extends ChangeNotifier {
     return store;
   }
 
-  Future<void> _reloadPerAccount(Account account) async {
-    assert(identical(_accounts[account.id], account));
-    assert(_perAccountStores.containsKey(account.id));
-    assert(!_perAccountStoresLoading.containsKey(account.id));
-    final store = await loadPerAccount(account.id);
-    _setPerAccount(account.id, store);
+  Future<void> _reloadPerAccount(int accountId) async {
+    assert(_perAccountStores.containsKey(accountId));
+    assert(!_perAccountStoresLoading.containsKey(accountId));
+    final store = await loadPerAccount(accountId);
+    _setPerAccount(accountId, store);
   }
 
   void _setPerAccount(int accountId, PerAccountStore store) {
@@ -672,7 +671,7 @@ class UpdateMachine {
         switch (e) {
           case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
             assert(debugLog('Lost event queue for $store.  Replacing…'));
-            await store._globalStore._reloadPerAccount(store.account);
+            await store._globalStore._reloadPerAccount(store.accountId);
             dispose();
             debugLog('… Event queue replaced.');
             return;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -261,6 +261,11 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
   /// Always equal to `account.realmUrl` and `connection.realmUrl`.
   final Uri realmUrl;
 
+  /// Resolve [reference] as a URL relative to [realmUrl].
+  ///
+  /// This returns null if [reference] fails to parse as a URL.
+  Uri? tryResolveUrl(String reference) => _tryResolveUrl(realmUrl, reference);
+
   final String zulipVersion; // TODO get from account; update there on initial snapshot
   final int maxFileUploadSizeMib; // No event for this.
   final Map<String, RealmDefaultExternalAccount> realmDefaultExternalAccounts;
@@ -496,6 +501,16 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
 }
 
 const _apiSendMessage = sendMessage; // Bit ugly; for alternatives, see: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20PerAccountStore.20methods/near/1545809
+const _tryResolveUrl = tryResolveUrl;
+
+/// Like [Uri.resolve], but on failure return null instead of throwing.
+Uri? tryResolveUrl(Uri baseUrl, String reference) {
+  try {
+    return baseUrl.resolve(reference);
+  } on FormatException {
+    return null;
+  }
+}
 
 /// A [GlobalStore] that uses a live server and live, persistent local database.
 ///

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -199,6 +199,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     return PerAccountStore._(
       globalStore: globalStore,
       connection: connection,
+      realmUrl: account.realmUrl,
       zulipVersion: initialSnapshot.zulipVersion,
       maxFileUploadSizeMib: initialSnapshot.maxFileUploadSizeMib,
       realmDefaultExternalAccounts: initialSnapshot.realmDefaultExternalAccounts,
@@ -226,6 +227,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
   PerAccountStore._({
     required GlobalStore globalStore,
     required this.connection,
+    required this.realmUrl,
     required this.zulipVersion,
     required this.maxFileUploadSizeMib,
     required this.realmDefaultExternalAccounts,
@@ -239,6 +241,8 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     required this.unreads,
     required this.recentDmConversationsView,
   }) : assert(selfUserId == globalStore.getAccount(accountId)!.userId),
+       assert(realmUrl == globalStore.getAccount(accountId)!.realmUrl),
+       assert(realmUrl == connection.realmUrl),
        _globalStore = globalStore,
        _streams = streams;
 
@@ -253,6 +257,9 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
 
   ////////////////////////////////
   // Data attached to the realm or the server.
+
+  /// Always equal to `account.realmUrl` and `connection.realmUrl`.
+  final Uri realmUrl;
 
   final String zulipVersion; // TODO get from account; update there on initial snapshot
   final int maxFileUploadSizeMib; // No event for this.

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -111,9 +111,7 @@ abstract class GlobalStore extends ChangeNotifier {
     }
 
     // It's up to us.  Start loading.
-    final account = getAccount(accountId);
-    assert(account != null, 'Account not found on global store');
-    future = loadPerAccount(account!);
+    future = loadPerAccount(accountId);
     _perAccountStoresLoading[accountId] = future;
     store = await future;
     _setPerAccount(accountId, store);
@@ -125,7 +123,7 @@ abstract class GlobalStore extends ChangeNotifier {
     assert(identical(_accounts[account.id], account));
     assert(_perAccountStores.containsKey(account.id));
     assert(!_perAccountStoresLoading.containsKey(account.id));
-    final store = await loadPerAccount(account);
+    final store = await loadPerAccount(account.id);
     _setPerAccount(account.id, store);
   }
 
@@ -141,7 +139,7 @@ abstract class GlobalStore extends ChangeNotifier {
   /// This method should be called only by the implementation of [perAccount].
   /// Other callers interested in per-account data should use [perAccount]
   /// and/or [perAccountSync].
-  Future<PerAccountStore> loadPerAccount(Account account);
+  Future<PerAccountStore> loadPerAccount(int accountId);
 
   // Just the Iterables, not the actual Map, to avoid clients mutating the map.
   // Mutations should go through the setters/mutators below.
@@ -517,8 +515,8 @@ class LiveGlobalStore extends GlobalStore {
   final AppDatabase _db;
 
   @override
-  Future<PerAccountStore> loadPerAccount(Account account) async {
-    final updateMachine = await UpdateMachine.load(this, account);
+  Future<PerAccountStore> loadPerAccount(int accountId) async {
+    final updateMachine = await UpdateMachine.load(this, accountId);
     return updateMachine.store;
   }
 
@@ -554,7 +552,8 @@ class UpdateMachine {
   /// Load the user's data from the server, and start an event queue going.
   ///
   /// In the future this might load an old snapshot from local storage first.
-  static Future<UpdateMachine> load(GlobalStore globalStore, Account account) async {
+  static Future<UpdateMachine> load(GlobalStore globalStore, int accountId) async {
+    final account = globalStore.getAccount(accountId)!;
     // TODO test UpdateMachine.load, now that it uses [GlobalStore.apiConnection]
     final connection = globalStore.apiConnectionFromAccount(account);
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -189,15 +189,16 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
   /// but it may have already been used for other requests.
   factory PerAccountStore.fromInitialSnapshot({
     required GlobalStore globalStore,
-    required Account account,
+    required int accountId,
     ApiConnection? connection,
     required InitialSnapshot initialSnapshot,
   }) {
+    final account = globalStore.getAccount(accountId)!;
     connection ??= globalStore.apiConnectionFromAccount(account);
     final streams = StreamStoreImpl(initialSnapshot: initialSnapshot);
     return PerAccountStore._(
       globalStore: globalStore,
-      account: account,
+      accountId: accountId,
       connection: connection,
       zulipVersion: initialSnapshot.zulipVersion,
       maxFileUploadSizeMib: initialSnapshot.maxFileUploadSizeMib,
@@ -223,7 +224,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
 
   PerAccountStore._({
     required GlobalStore globalStore,
-    required this.account,
+    required this.accountId,
     required this.connection,
     required this.zulipVersion,
     required this.maxFileUploadSizeMib,
@@ -240,7 +241,9 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
 
   final GlobalStore _globalStore;
 
-  final Account account;
+  final int accountId;
+  Account get account => _globalStore.getAccount(accountId)!;
+
   final ApiConnection connection; // TODO(#135): update zulipFeatureLevel with events
 
   // TODO(#135): Keep all this data updated by handling Zulip events from the server.
@@ -565,7 +568,7 @@ class UpdateMachine {
 
     final store = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
-      account: account,
+      accountId: accountId,
       connection: connection,
       initialSnapshot: initialSnapshot,
     );

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -26,12 +26,11 @@ void showMessageActionSheet({required BuildContext context, required Message mes
   // any message list, so that's fine.
   final isComposeBoxOffered = MessageListPage.composeBoxControllerOf(context) != null;
 
-  final selfUserId = store.account.userId;
   final hasThumbsUpReactionVote = message.reactions
     ?.aggregated.any((reactionWithVotes) =>
       reactionWithVotes.reactionType == ReactionType.unicodeEmoji
       && reactionWithVotes.emojiCode == '1f44d'
-      && reactionWithVotes.userIds.contains(selfUserId))
+      && reactionWithVotes.userIds.contains(store.selfUserId))
     ?? false;
 
   showDraggableScrollableModalBottomSheet(

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -265,7 +265,7 @@ class HomePage extends StatelessWidget {
               const SizedBox(height: 12),
               Text.rich(TextSpan(
                 text: 'Connected to: ',
-                children: [bold(store.account.realmUrl.toString())])),
+                children: [bold(store.realmUrl.toString())])),
               Text.rich(TextSpan(
                 text: 'Zulip server version: ',
                 children: [bold(store.zulipVersion)])),

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -786,7 +786,7 @@ void _launchUrl(BuildContext context, String urlString) async {
   }
 
   final store = PerAccountStoreWidget.of(context);
-  final url = tryResolveOnRealmUrl(urlString, store.account.realmUrl);
+  final url = tryResolveOnRealmUrl(urlString, store.realmUrl);
   if (url == null) { // TODO(log)
     await showError(context, null);
     return;

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -786,7 +786,7 @@ void _launchUrl(BuildContext context, String urlString) async {
   }
 
   final store = PerAccountStoreWidget.of(context);
-  final url = tryResolveOnRealmUrl(urlString, store.realmUrl);
+  final url = store.tryResolveUrl(urlString);
   if (url == null) { // TODO(log)
     await showError(context, null);
     return;

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -319,7 +319,7 @@ class _ImageEmoji extends StatelessWidget {
     if (parsedSrc == null) { // TODO(log)
       return _textFallback;
     }
-    final resolved = store.account.realmUrl.resolveUri(parsedSrc);
+    final resolved = store.realmUrl.resolveUri(parsedSrc);
 
     // Unicode and text emoji get scaled; it would look weird if image emoji didn't.
     final size = _squareEmojiScalerClamped(context).scale(_squareEmojiSize);

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -73,14 +73,13 @@ class ReactionChip extends StatelessWidget {
 
     final emojiset = store.userSettings?.emojiset ?? Emojiset.google;
 
-    final selfUserId = store.account.userId;
-    final selfVoted = userIds.contains(selfUserId);
+    final selfVoted = userIds.contains(store.selfUserId);
     final label = showName
       // TODO(i18n): List formatting, like you can do in JavaScript:
       //   new Intl.ListFormat('ja').format(['Chris', 'Greg', 'Alya', 'Shu'])
       //   // 'Chris、Greg、Alya、Shu'
       ? userIds.map((id) {
-          return id == selfUserId
+          return id == store.selfUserId
             ? 'You'
             : store.users[id]?.fullName ?? '(unknown user)'; // TODO(i18n)
         }).join(', ')

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -335,7 +335,7 @@ class _DmItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
-    final selfUser = store.users[store.account.userId]!;
+    final selfUser = store.users[store.selfUserId]!;
 
     final title = switch (narrow.otherRecipientIds) { // TODO dedupe with [RecentDmConversationsItem]
       [] => selfUser.fullName,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -745,7 +745,7 @@ class DmRecipientHeader extends StatelessWidget {
     final String title;
     if (message.allRecipientIds.length > 1) {
       title = zulipLocalizations.messageListGroupYouAndOthers(message.allRecipientIds
-        .where((id) => id != store.account.userId)
+        .where((id) => id != store.selfUserId)
         .map((id) => store.users[id]?.fullName ?? zulipLocalizations.unknownUserName)
         .sorted()
         .join(", "));
@@ -757,7 +757,7 @@ class DmRecipientHeader extends StatelessWidget {
     return GestureDetector(
       onTap: () => Navigator.push(context,
         MessageListPage.buildRoute(context: context,
-          narrow: DmNarrow.ofMessage(message, selfUserId: store.account.userId))),
+          narrow: DmNarrow.ofMessage(message, selfUserId: store.selfUserId))),
       child: ColoredBox(
         color: _kDmRecipientHeaderColor,
         child: Padding(

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -57,7 +57,7 @@ class ProfilePage extends StatelessWidget {
       FilledButton.icon(
         onPressed: () => Navigator.push(context,
           MessageListPage.buildRoute(context: context,
-            narrow: DmNarrow.withUser(userId, selfUserId: store.account.userId))),
+            narrow: DmNarrow.withUser(userId, selfUserId: store.selfUserId))),
         icon: const Icon(Icons.email),
         label: Text(zulipLocalizations.profileButtonSendDirectMessage)),
     ];

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -87,7 +87,7 @@ class RecentDmConversationsItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
-    final selfUser = store.users[store.account.userId]!;
+    final selfUser = store.users[store.selfUserId]!;
 
     final String title;
     final Widget avatar;

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -494,7 +494,7 @@ PerAccountStore store({Account? account, InitialSnapshot? initialSnapshot}) {
   final effectiveAccount = account ?? selfAccount;
   return PerAccountStore.fromInitialSnapshot(
     globalStore: globalStore(accounts: [effectiveAccount]),
-    account: effectiveAccount,
+    accountId: effectiveAccount.id,
     initialSnapshot: initialSnapshot ?? _initialSnapshot(),
   );
 }

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -225,9 +225,9 @@ hello
     test('AllMessagesNarrow', () {
       final store = eg.store();
       check(narrowLink(store, const AllMessagesNarrow()))
-        .equals(store.account.realmUrl.resolve('#narrow'));
+        .equals(store.realmUrl.resolve('#narrow'));
       check(narrowLink(store, const AllMessagesNarrow(), nearMessageId: 1))
-        .equals(store.account.realmUrl.resolve('#narrow/near/1'));
+        .equals(store.realmUrl.resolve('#narrow/near/1'));
     });
 
     test('StreamNarrow / TopicNarrow', () {
@@ -244,7 +244,7 @@ hello
           ? StreamNarrow(streamId)
           : TopicNarrow(streamId, topic);
         check(narrowLink(store, narrow, nearMessageId: nearMessageId))
-          .equals(store.account.realmUrl.resolve(expectedFragment));
+          .equals(store.realmUrl.resolve(expectedFragment));
       }
 
       checkNarrow(streamId: 1,   name: 'announce',       '#narrow/stream/1-announce');
@@ -275,10 +275,10 @@ hello
         final store = eg.store();
         final narrow = DmNarrow(allRecipientIds: allRecipientIds, selfUserId: selfUserId);
         check(narrowLink(store, narrow, nearMessageId: nearMessageId))
-          .equals(store.account.realmUrl.resolve(expectedFragment));
+          .equals(store.realmUrl.resolve(expectedFragment));
         store.connection.zulipFeatureLevel = 176;
         check(narrowLink(store, narrow, nearMessageId: nearMessageId))
-          .equals(store.account.realmUrl.resolve(legacyExpectedFragment));
+          .equals(store.realmUrl.resolve(legacyExpectedFragment));
       }
 
       checkNarrow(allRecipientIds: [1], selfUserId: 1,

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -111,6 +111,13 @@ class ContentExample {
     const ImageEmojiNode(
       src: '/user_avatars/2/emoji/images/204.png', alt: ':flutter:'));
 
+  static final emojiCustomInvalidUrl = ContentExample.inline(
+    'custom emoji with invalid URL',
+    null, // hypothetical, to test for a risk of crashing
+    '<p><img alt=":invalid:" class="emoji" src="::not a URL::" title="invalid"></p>',
+    const ImageEmojiNode(
+      src: '::not a URL::', alt: ':invalid:'));
+
   static final emojiZulipExtra = ContentExample.inline(
     'Zulip extra emoji',
     ":zulip:",
@@ -265,6 +272,17 @@ class ContentExample {
         '<img src="https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3"></a></div>', [
     ImageNodeList([
       ImageNode(srcUrl: 'https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3'),
+    ]),
+  ]);
+
+  static const imageInvalidUrl = ContentExample(
+    'single image with invalid URL',
+    null, // hypothetical, to test for a risk of crashing
+    '<div class="message_inline_image">'
+      '<a href="::not a URL::">'
+        '<img src="::not a URL::"></a></div>', [
+    ImageNodeList([
+      ImageNode(srcUrl: '::not a URL::'),
     ]),
   ]);
 
@@ -580,6 +598,7 @@ void main() {
   testParseExample(ContentExample.emojiUnicodeMultiCodepoint);
   testParseExample(ContentExample.emojiUnicodeLiteral);
   testParseExample(ContentExample.emojiCustom);
+  testParseExample(ContentExample.emojiCustomInvalidUrl);
   testParseExample(ContentExample.emojiZulipExtra);
 
   testParseExample(ContentExample.mathInline);
@@ -751,6 +770,7 @@ void main() {
   testParseExample(ContentExample.mathBlockInQuote);
 
   testParseExample(ContentExample.imageSingle);
+  testParseExample(ContentExample.imageInvalidUrl);
   testParseExample(ContentExample.imageCluster);
   testParseExample(ContentExample.imageClusterThenContent);
   testParseExample(ContentExample.imageMultipleClusters);

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -38,7 +38,7 @@ void main() {
     store ??= setupStore(realmUrl: realmUrl, streams: streams, users: users);
     for (final testCase in testCases) {
       final String urlString = testCase.$1;
-      final Uri url = tryResolveOnRealmUrl(urlString, realmUrl)!;
+      final Uri url = store.tryResolveUrl(urlString)!;
       final Narrow? expected = testCase.$2;
       test(urlString, () {
         check(parseInternalLink(url, store!)).equals(expected);
@@ -134,7 +134,7 @@ void main() {
       final Uri realmUrl = testCase.$4;
       test('${expected ? 'accepts': 'rejects'} $description: $urlString', () {
         final store = setupStore(realmUrl: realmUrl, streams: streams);
-        final url = tryResolveOnRealmUrl(urlString, realmUrl)!;
+        final url = store.tryResolveUrl(urlString)!;
         final result = parseInternalLink(url, store);
         check(result != null).equals(expected);
       });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -215,7 +215,7 @@ void main() {
       await prepareStore();
       updateMachine.debugPauseLoop();
       updateMachine.poll();
-      check(globalStore.perAccountSync(store.account.id)).identicalTo(store);
+      check(globalStore.perAccountSync(store.accountId)).identicalTo(store);
 
       // Let the server expire the event queue.
       connection.prepare(httpStatus: 400, json: {
@@ -228,7 +228,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       // The global store has a new store.
-      check(globalStore.perAccountSync(store.account.id)).not((it) => it.identicalTo(store));
+      check(globalStore.perAccountSync(store.accountId)).not((it) => it.identicalTo(store));
       updateFromGlobalStore();
 
       // The new UpdateMachine updates the new store.

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -28,7 +28,7 @@ void main() {
     final accounts = [account1, account2];
     final globalStore = LoadingTestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
-      globalStore.completers[accounts[accountId - 1]]!;
+      globalStore.completers[accountId]!;
 
     final future1 = globalStore.perAccount(1);
     final store1 = PerAccountStore.fromInitialSnapshot(
@@ -61,7 +61,7 @@ void main() {
     final accounts = [account1, account2];
     final globalStore = LoadingTestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
-      globalStore.completers[accounts[accountId - 1]]!;
+      globalStore.completers[accountId]!;
 
     final future1a = globalStore.perAccount(1);
     final future1b = globalStore.perAccount(1);
@@ -94,7 +94,7 @@ void main() {
     final accounts = [account1, account2];
     final globalStore = LoadingTestGlobalStore(accounts: accounts);
     List<Completer<PerAccountStore>> completers(int accountId) =>
-      globalStore.completers[accounts[accountId - 1]]!;
+      globalStore.completers[accountId]!;
 
     check(globalStore.perAccountSync(1)).isNull();
     final future1 = globalStore.perAccount(1);
@@ -388,12 +388,12 @@ void main() {
 class LoadingTestGlobalStore extends TestGlobalStore {
   LoadingTestGlobalStore({required super.accounts});
 
-  Map<Account, List<Completer<PerAccountStore>>> completers = {};
+  Map<int, List<Completer<PerAccountStore>>> completers = {};
 
   @override
-  Future<PerAccountStore> loadPerAccount(Account account) {
+  Future<PerAccountStore> loadPerAccount(int accountId) {
     final completer = Completer<PerAccountStore>();
-    (completers[account] ??= []).add(completer);
+    (completers[accountId] ??= []).add(completer);
     return completer.future;
   }
 }

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -33,7 +33,7 @@ void main() {
     final future1 = globalStore.perAccount(1);
     final store1 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
-      account: account1,
+      accountId: 1,
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(1).single.complete(store1);
@@ -44,7 +44,7 @@ void main() {
     final future2 = globalStore.perAccount(2);
     final store2 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
-      account: account2,
+      accountId: 2,
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(2).single.complete(store2);
@@ -71,12 +71,12 @@ void main() {
     final future2 = globalStore.perAccount(2);
     final store1 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
-      account: account1,
+      accountId: 1,
       initialSnapshot: eg.initialSnapshot(),
     );
     final store2 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
-      account: account2,
+      accountId: 2,
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(1).single.complete(store1);
@@ -101,7 +101,7 @@ void main() {
     check(globalStore.perAccountSync(1)).isNull();
     final store1 = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,
-      account: account1,
+      accountId: 1,
       initialSnapshot: eg.initialSnapshot(),
     );
     completers(1).single.complete(store1);

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -90,14 +90,15 @@ class TestGlobalStore extends GlobalStore {
   }
 
   @override
-  Future<PerAccountStore> loadPerAccount(Account account) {
-    final initialSnapshot = _initialSnapshots[account.id]!;
+  Future<PerAccountStore> loadPerAccount(int accountId) {
+    final account = getAccount(accountId)!;
+    final initialSnapshot = _initialSnapshots[accountId]!;
     final store = PerAccountStore.fromInitialSnapshot(
       globalStore: this,
       account: account,
       initialSnapshot: initialSnapshot,
     );
-    updateMachines[account.id] = UpdateMachine.fromInitialSnapshot(
+    updateMachines[accountId] = UpdateMachine.fromInitialSnapshot(
       store: store, initialSnapshot: initialSnapshot);
     return Future.value(store);
   }

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -91,11 +91,10 @@ class TestGlobalStore extends GlobalStore {
 
   @override
   Future<PerAccountStore> loadPerAccount(int accountId) {
-    final account = getAccount(accountId)!;
     final initialSnapshot = _initialSnapshots[accountId]!;
     final store = PerAccountStore.fromInitialSnapshot(
       globalStore: this,
-      account: account,
+      accountId: accountId,
       initialSnapshot: initialSnapshot,
     );
     updateMachines[accountId] = UpdateMachine.fromInitialSnapshot(

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -117,6 +117,18 @@ void main() {
         .deepEquals(expectedImages.map((n) => n.srcUrl));
     });
 
+    testWidgets('image with invalid src URL', (tester) async {
+      const example = ContentExample.imageInvalidUrl;
+      await prepareContent(tester, example.html);
+      // The image indeed has an invalid URL.
+      final expectedImages = (example.expectedNodes[0] as ImageNodeList).images;
+      check(() => Uri.parse(expectedImages.single.srcUrl)).throws();
+      check(tryResolveUrl(eg.realmUrl, expectedImages.single.srcUrl)).isNull();
+      // The MessageImage has shown up, but it doesn't attempt a RealmContentNetworkImage.
+      check(tester.widgetList(find.byType(MessageImage))).isNotEmpty();
+      check(tester.widgetList(find.byType(RealmContentNetworkImage))).isEmpty();
+    });
+
     testWidgets('multiple images', (tester) async {
       const example = ContentExample.imageCluster;
       await prepareContent(tester, example.html);
@@ -369,6 +381,13 @@ void main() {
       debugNetworkImageHttpClientProvider = null;
     });
 
+    testWidgets('smoke: custom emoji with invalid URL', (tester) async {
+      await prepareContent(tester, ContentExample.emojiCustomInvalidUrl.html);
+      final url = tester.widget<MessageImageEmoji>(find.byType(MessageImageEmoji)).node.src;
+      check(() => Uri.parse(url)).throws();
+      debugNetworkImageHttpClientProvider = null;
+    });
+
     testWidgets('smoke: Zulip extra emoji', (tester) async {
       await prepareContent(tester, ContentExample.emojiZulipExtra.html);
       tester.widget(find.byType(MessageImageEmoji));
@@ -449,6 +468,12 @@ void main() {
       const avatarUrl = '/avatar.png';
       check(await actualUrl(tester, avatarUrl))
         .equals(store.tryResolveUrl(avatarUrl)!);
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('smoke with invalid URL', (tester) async {
+      const avatarUrl = '::not a URL::';
+      check(await actualUrl(tester, avatarUrl)).isNull();
       debugNetworkImageHttpClientProvider = null;
     });
   });

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -73,6 +73,99 @@ void main() {
 
   testContentSmoke(ContentExample.quotation);
 
+  group('MessageImage, MessageImageList', () {
+    final message = eg.streamMessage();
+
+    Future<void> prepareContent(WidgetTester tester, String html) async {
+      addTearDown(testBinding.reset);
+
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      final httpClient = FakeImageHttpClient();
+
+      debugNetworkImageHttpClientProvider = () => httpClient;
+      httpClient.request.response
+        ..statusCode = HttpStatus.ok
+        ..content = kSolidBlueAvatar;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.ltr,
+            child: GlobalStoreWidget(
+              child: PerAccountStoreWidget(
+                accountId: eg.selfAccount.id,
+                child: MessageContent(
+                  message: message,
+                  content: parseContent(html)))))));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
+      debugNetworkImageHttpClientProvider = null;
+    }
+
+    testWidgets('single image', (tester) async {
+      const example = ContentExample.imageSingle;
+      await prepareContent(tester, example.html);
+      final expectedImages = (example.expectedNodes[0] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+
+    testWidgets('multiple images', (tester) async {
+      const example = ContentExample.imageCluster;
+      await prepareContent(tester, example.html);
+      final expectedImages = (example.expectedNodes[1] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+
+    testWidgets('content after image cluster', (tester) async {
+      const example = ContentExample.imageClusterThenContent;
+      await prepareContent(tester, example.html);
+      final expectedImages = (example.expectedNodes[1] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+
+    testWidgets('multiple clusters of images', (tester) async {
+      const example = ContentExample.imageMultipleClusters;
+      await prepareContent(tester, example.html);
+      final expectedImages = (example.expectedNodes[1] as ImageNodeList).images
+        + (example.expectedNodes[4] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+
+    testWidgets('image as immediate child in implicit paragraph', (tester) async {
+      const example = ContentExample.imageInImplicitParagraph;
+      await prepareContent(tester, example.html);
+      final expectedImages = ((example.expectedNodes[0] as ListNode)
+        .items[0][0] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+
+    testWidgets('image cluster in implicit paragraph', (tester) async {
+      const example = ContentExample.imageClusterInImplicitParagraph;
+      await prepareContent(tester, example.html);
+      final expectedImages = ((example.expectedNodes[0] as ListNode)
+        .items[0][1] as ImageNodeList).images;
+      final images = tester.widgetList<RealmContentNetworkImage>(
+        find.byType(RealmContentNetworkImage));
+      check(images.map((i) => i.src.toString()).toList())
+        .deepEquals(expectedImages.map((n) => n.srcUrl));
+    });
+  });
+
   group("CodeBlock", () {
     testContentSmoke(ContentExample.codeBlockPlain);
     testContentSmoke(ContentExample.codeBlockHighlightedShort);
@@ -250,99 +343,6 @@ void main() {
     // range of times. See comments in "show dates" test in
     // `test/widgets/message_list_test.dart`.
     tester.widget(find.textContaining(RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$')));
-  });
-
-  group('MessageImages', () {
-    final message = eg.streamMessage();
-
-    Future<void> prepareContent(WidgetTester tester, String html) async {
-      addTearDown(testBinding.reset);
-
-      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-      final httpClient = FakeImageHttpClient();
-
-      debugNetworkImageHttpClientProvider = () => httpClient;
-      httpClient.request.response
-        ..statusCode = HttpStatus.ok
-        ..content = kSolidBlueAvatar;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Directionality(
-            textDirection: TextDirection.ltr,
-            child: GlobalStoreWidget(
-              child: PerAccountStoreWidget(
-                accountId: eg.selfAccount.id,
-                child: MessageContent(
-                  message: message,
-                  content: parseContent(html)))))));
-      await tester.pump(); // global store
-      await tester.pump(); // per-account store
-      debugNetworkImageHttpClientProvider = null;
-    }
-
-    testWidgets('single image', (tester) async {
-      const example = ContentExample.imageSingle;
-      await prepareContent(tester, example.html);
-      final expectedImages = (example.expectedNodes[0] as ImageNodeList).images;
-      final images = tester.widgetList<RealmContentNetworkImage>(
-        find.byType(RealmContentNetworkImage));
-      check(images.map((i) => i.src.toString()).toList())
-        .deepEquals(expectedImages.map((n) => n.srcUrl));
-    });
-
-    testWidgets('multiple images', (tester) async {
-      const example = ContentExample.imageCluster;
-      await prepareContent(tester, example.html);
-      final expectedImages = (example.expectedNodes[1] as ImageNodeList).images;
-      final images = tester.widgetList<RealmContentNetworkImage>(
-        find.byType(RealmContentNetworkImage));
-      check(images.map((i) => i.src.toString()).toList())
-        .deepEquals(expectedImages.map((n) => n.srcUrl));
-    });
-
-    testWidgets('content after image cluster', (tester) async {
-      const example = ContentExample.imageClusterThenContent;
-      await prepareContent(tester, example.html);
-      final expectedImages = (example.expectedNodes[1] as ImageNodeList).images;
-      final images = tester.widgetList<RealmContentNetworkImage>(
-        find.byType(RealmContentNetworkImage));
-      check(images.map((i) => i.src.toString()).toList())
-        .deepEquals(expectedImages.map((n) => n.srcUrl));
-    });
-
-    testWidgets('multiple clusters of images', (tester) async {
-      const example = ContentExample.imageMultipleClusters;
-      await prepareContent(tester, example.html);
-      final expectedImages = (example.expectedNodes[1] as ImageNodeList).images
-        + (example.expectedNodes[4] as ImageNodeList).images;
-      final images = tester.widgetList<RealmContentNetworkImage>(
-        find.byType(RealmContentNetworkImage));
-      check(images.map((i) => i.src.toString()).toList())
-        .deepEquals(expectedImages.map((n) => n.srcUrl));
-    });
-
-    testWidgets('image as immediate child in implicit paragraph', (tester) async {
-      const example = ContentExample.imageInImplicitParagraph;
-      await prepareContent(tester, example.html);
-      final expectedImages = ((example.expectedNodes[0] as ListNode)
-        .items[0][0] as ImageNodeList).images;
-      final images = tester.widgetList<RealmContentNetworkImage>(
-        find.byType(RealmContentNetworkImage));
-      check(images.map((i) => i.src.toString()).toList())
-        .deepEquals(expectedImages.map((n) => n.srcUrl));
-    });
-
-    testWidgets('image cluster in implicit paragraph', (tester) async {
-      const example = ContentExample.imageClusterInImplicitParagraph;
-      await prepareContent(tester, example.html);
-      final expectedImages = ((example.expectedNodes[0] as ListNode)
-        .items[0][1] as ImageNodeList).images;
-      final images = tester.widgetList<RealmContentNetworkImage>(
-        find.byType(RealmContentNetworkImage));
-      check(images.map((i) => i.src.toString()).toList())
-        .deepEquals(expectedImages.map((n) => n.srcUrl));
-    });
   });
 
   group('RealmContentNetworkImage', () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -55,6 +55,21 @@ void main() {
     });
   }
 
+  /// Set [debugNetworkImageHttpClientProvider] to return a constant image.
+  ///
+  /// Returns the [FakeImageHttpClient] that handles the requests.
+  ///
+  /// The caller must set [debugNetworkImageHttpClientProvider] back to null
+  /// before the end of the test.
+  FakeImageHttpClient prepareBoringImageHttpClient() {
+    final httpClient = FakeImageHttpClient();
+    debugNetworkImageHttpClientProvider = () => httpClient;
+    httpClient.request.response
+      ..statusCode = HttpStatus.ok
+      ..content = kSolidBlueAvatar;
+    return httpClient;
+  }
+
   group('Heading', () {
     testWidgets('plain h6', (tester) async {
       await prepareContentBare(tester,
@@ -76,14 +91,8 @@ void main() {
   group('MessageImage, MessageImageList', () {
     Future<void> prepareContent(WidgetTester tester, String html) async {
       addTearDown(testBinding.reset);
-
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-      final httpClient = FakeImageHttpClient();
-
-      debugNetworkImageHttpClientProvider = () => httpClient;
-      httpClient.request.response
-        ..statusCode = HttpStatus.ok
-        ..content = kSolidBlueAvatar;
+      prepareBoringImageHttpClient();
 
       await tester.pumpWidget(GlobalStoreWidget(child: MaterialApp(
         home: PerAccountStoreWidget(accountId: eg.selfAccount.id,
@@ -342,14 +351,10 @@ void main() {
     final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);
 
     Future<Map<String, List<String>>> actualHeaders(WidgetTester tester, Uri src) async {
-      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
 
-      final httpClient = FakeImageHttpClient();
-      debugNetworkImageHttpClientProvider = () => httpClient;
-      httpClient.request.response
-        ..statusCode = HttpStatus.ok
-        ..content = kSolidBlueAvatar;
+      final httpClient = prepareBoringImageHttpClient();
 
       await tester.pumpWidget(GlobalStoreWidget(
         child: PerAccountStoreWidget(accountId: eg.selfAccount.id,

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -74,8 +74,6 @@ void main() {
   testContentSmoke(ContentExample.quotation);
 
   group('MessageImage, MessageImageList', () {
-    final message = eg.streamMessage();
-
     Future<void> prepareContent(WidgetTester tester, String html) async {
       addTearDown(testBinding.reset);
 
@@ -87,16 +85,11 @@ void main() {
         ..statusCode = HttpStatus.ok
         ..content = kSolidBlueAvatar;
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Directionality(
-            textDirection: TextDirection.ltr,
-            child: GlobalStoreWidget(
-              child: PerAccountStoreWidget(
-                accountId: eg.selfAccount.id,
-                child: MessageContent(
-                  message: message,
-                  content: parseContent(html)))))));
+      await tester.pumpWidget(GlobalStoreWidget(child: MaterialApp(
+        home: PerAccountStoreWidget(accountId: eg.selfAccount.id,
+          child: MessageContent(
+            message: eg.streamMessage(content: html),
+            content: parseContent(html))))));
       await tester.pump(); // global store
       await tester.pump(); // per-account store
       debugNetworkImageHttpClientProvider = null;

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -347,6 +347,32 @@ void main() {
     tester.widget(find.textContaining(RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$')));
   });
 
+  group('MessageImageEmoji', () {
+    Future<void> prepareContent(WidgetTester tester, String html) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      prepareBoringImageHttpClient();
+
+      await tester.pumpWidget(GlobalStoreWidget(child: MaterialApp(
+        home: PerAccountStoreWidget(accountId: eg.selfAccount.id,
+          child: BlockContentList(nodes: parseContent(html).nodes)))));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
+    }
+
+    testWidgets('smoke: custom emoji', (tester) async {
+      await prepareContent(tester, ContentExample.emojiCustom.html);
+      tester.widget(find.byType(MessageImageEmoji));
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('smoke: Zulip extra emoji', (tester) async {
+      await prepareContent(tester, ContentExample.emojiZulipExtra.html);
+      tester.widget(find.byType(MessageImageEmoji));
+      debugNetworkImageHttpClientProvider = null;
+    });
+  });
+
   group('RealmContentNetworkImage', () {
     final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -458,7 +458,7 @@ void main() {
           check(findAvatarImageWidget(tester)).isNull();
         } else {
           check(findAvatarImageWidget(tester)).isNotNull()
-            .src.equals(resolveUrl(avatarUrl, eg.selfAccount));
+            .src.equals(eg.selfAccount.realmUrl.resolve(avatarUrl));
         }
       }
 

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -35,7 +35,7 @@ class MyWidgetWithMixinState extends State<MyWidgetWithMixin> with PerAccountSto
   @override
   Widget build(BuildContext context) {
     final brightness = Theme.of(context).brightness;
-    final accountId = PerAccountStoreWidget.of(context).account.id;
+    final accountId = PerAccountStoreWidget.of(context).accountId;
     return Text('brightness: $brightness; accountId: $accountId');
   }
 }
@@ -87,7 +87,7 @@ void main() {
             child: Builder(
               builder: (context) {
                 final store = PerAccountStoreWidget.of(context);
-                return Text('found store, account: ${store.account.id}');
+                return Text('found store, account: ${store.accountId}');
               })))));
     await tester.pump();
     await tester.pump();
@@ -109,7 +109,7 @@ void main() {
             child: Builder(
               builder: (context) {
                 final store = PerAccountStoreWidget.of(context);
-                return Text('found store, account: ${store.account.id}');
+                return Text('found store, account: ${store.accountId}');
               })))));
 
     // First, the global store has to load.
@@ -137,7 +137,7 @@ void main() {
             child: Builder(
               builder: (context) {
                 final store = PerAccountStoreWidget.of(context);
-                return Text('found store, account: ${store.account.id}');
+                return Text('found store, account: ${store.accountId}');
               })))));
 
     // (... even one that really is separate, with its own fresh state node ...)


### PR DESCRIPTION
Currently we insert `Account` records into the database on login, and never update them. We'll need to update them in order to do:
* #458
* #322

and other things.

This branch doesn't yet make any new changes in the database, but it does some refactoring on PerAccountStore and friends which we'll need in order to do so. It also takes care of various things that became noticeable along the way:
* adding some handy getters like `store.selfUserId` and `self.realmUrl`;
* fixing where we'd been crashing if the server somehow sent us an invalid URL (one `Uri.parse` rejects) in the HTML or as a user's avatar;
* adding more content-widget tests, to test that latter change, and using the facilities recently added in #511.

The main commit is this one near the beginning:

---

store [nfc]: Keep just one copy of Account object

We're going to want to update these, when things like
the server version or the acked push token change.
To avoid endless bugs, it'll then be important that there
be just one copy to be updated.

