### PR TITLE
notif: Add `vm:entry-point` pragma to _onBackgroundMessage

### DIFF
--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -174,6 +174,12 @@ class NotificationService {
     _onRemoteMessage(message);
   }
 
+  // This pragma `vm:entry-point` is needed in release mode, when this method
+  // is needed at all (i.e. on Android):
+  //   https://firebase.google.com/docs/cloud-messaging/flutter/receive#background_messages
+  //   https://github.com/firebase/flutterfire/issues/9446#issuecomment-1240554285
+  //   https://github.com/zulip/zulip-flutter/issues/528#issuecomment-1960646800
+  @pragma('vm:entry-point')
   static Future<void> _onBackgroundMessage(FirebaseRemoteMessage message) async {
     // This callback will run in a separate isolate from the rest of the app.
     // See docs:


### PR DESCRIPTION
This fixes part of #528, following the suggestion @n-92 made here:
  https://github.com/zulip/zulip-flutter/issues/342#issuecomment-1874716442

Even with this change, notifications still don't yet work on Android in release builds.  But after this change, when the app wasn't in the foreground, they get farther than before.  Specifically they get just as far as they get, with or without this change, when the app was in the foreground.  Details here:
  https://github.com/zulip/zulip-flutter/issues/528#issuecomment-1960646800
