### PR TITLE
notif android: Keep the notification icon from being resource-shrunk away

### DIFF
--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is necessary for notifications to work in release builds.
+
+     The issue is that the package:flutter_local_notifications API has us
+     identify which icon we want to use via a string name, in Dart code,
+     and that's invisible to the resource shrinker:
+       https://developer.android.com/build/shrink-code#keep-resources
+     If the icon isn't named in this file, it gets removed in release builds
+     (more precisely, replaced with a 0-byte file, which is invalid for its
+     image format).  The system then discards notifications that try to use
+     the invalid icon file:
+       https://github.com/zulip/zulip-flutter/issues/528
+     -->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/zulip_notification"
+    />

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -322,7 +322,8 @@ class NotificationDisplayManager {
         '(Zulip internal error)', // TODO never implicitly create channel: https://github.com/MaikuB/flutter_local_notifications/issues/2135
         tag: conversationKey,
         color: kZulipBrandColor,
-        icon: 'zulip_notification', // TODO vary for debug
+        // TODO vary notification icon for debug
+        icon: 'zulip_notification', // This name must appear in keep.xml too: https://github.com/zulip/zulip-flutter/issues/528
         // TODO(#128) inbox-style
 
         // TODO plugin sets PendingIntent.FLAG_UPDATE_CURRENT; is that OK?


### PR DESCRIPTION
Details in the new comment and in the issue thread.

Fixes: #528