### PR TITLE
content: Show code, mentions, and times properly even in headings etc.

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -497,7 +497,7 @@ class MathBlock extends StatelessWidget {
 //
 
 Widget _buildBlockInlineContainer({
-  required TextStyle? style,
+  required TextStyle style,
   required BlockInlineContainerNode node,
 }) {
   if (node.links == null) {
@@ -513,7 +513,7 @@ class _BlockInlineContainer extends StatefulWidget {
     {required this.links, required this.style, required this.nodes});
 
   final List<LinkNode> links;
-  final TextStyle? style;
+  final TextStyle style;
   final List<InlineContentNode> nodes;
 
   @override
@@ -576,7 +576,7 @@ class InlineContent extends StatelessWidget {
 
   final GestureRecognizer? recognizer;
   final Map<LinkNode, GestureRecognizer>? linkRecognizers;
-  final TextStyle? style;
+  final TextStyle style;
   final List<InlineContentNode> nodes;
 
   late final _InlineContentBuilder _builder;

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -179,8 +179,9 @@ class Heading extends StatelessWidget {
       child: _buildBlockInlineContainer(
         style: TextStyle(
           fontSize: kBaseFontSize * emHeight,
-          fontWeight: FontWeight.w600,
-          height: 1.4),
+          height: 1.4,
+        )
+          .merge(weightVariableTextStyle(context, wght: 600)),
         node: node));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1198,8 +1198,9 @@ InlineSpan _errorUnimplemented(UnimplementedNode node) {
   }
 }
 
-const errorStyle = TextStyle(fontWeight: FontWeight.bold, color: Colors.red);
+const errorStyle = TextStyle(
+  fontSize: kBaseFontSize, fontWeight: FontWeight.bold, color: Colors.red);
 
 final errorCodeStyle = kMonospaceTextStyle
-  .merge(const TextStyle(color: Colors.red))
+  .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red))
   .merge(weightVariableTextStyle(null)); // TODO(a11y) pass a BuildContext

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -57,6 +57,7 @@ extension ValueNotifierChecks<T> on Subject<ValueNotifier<T>> {
 
 extension TextChecks on Subject<Text> {
   Subject<String?> get data => has((t) => t.data, 'data');
+  Subject<TextStyle?> get style => has((t) => t.style, 'style');
 }
 
 extension TextFieldChecks on Subject<TextField> {
@@ -100,4 +101,8 @@ extension TypographyChecks on Subject<Typography> {
   Subject<TextTheme> get englishLike => has((t) => t.englishLike, 'englishLike');
   Subject<TextTheme> get dense => has((t) => t.dense, 'dense');
   Subject<TextTheme> get tall => has((t) => t.tall, 'tall');
+}
+
+extension InlineSpanChecks on Subject<InlineSpan> {
+  Subject<TextStyle?> get style => has((x) => x.style, 'style');
 }

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -76,6 +76,13 @@ class ContentExample {
   /// to have it defined for each test case right next to [html] and [expectedNodes].
   final String? expectedText;
 
+  static final strong = ContentExample.inline(
+    'strong/bold',
+    '**bold**',
+    expectedText: 'bold',
+    '<p><strong>bold</strong></p>',
+    const StrongNode(nodes: [TextNode('bold')]));
+
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',
     ":thumbs_up:",
@@ -604,10 +611,7 @@ void main() {
       TextNode('\nb'),
     ])]);
 
-  testParseInline('parse strong/bold',
-    // "**bold**"
-    '<p><strong>bold</strong></p>',
-    const StrongNode(nodes: [TextNode('bold')]));
+  testParseExample(ContentExample.strong);
 
   testParseInline('parse deleted/strike-through',
     // "~~strike through~~"

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -83,6 +83,13 @@ class ContentExample {
     '<p><strong>bold</strong></p>',
     const StrongNode(nodes: [TextNode('bold')]));
 
+  static final emphasis = ContentExample.inline(
+    'emphasis/italic',
+    '*italic*',
+    expectedText: 'italic',
+    '<p><em>italic</em></p>',
+    const EmphasisNode(nodes: [TextNode('italic')]));
+
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',
     ":thumbs_up:",
@@ -618,10 +625,7 @@ void main() {
     '<p><del>strike through</del></p>',
     const DeletedNode(nodes: [TextNode('strike through')]));
 
-  testParseInline('parse emphasis/italic',
-    // "*italic*"
-    '<p><em>italic</em></p>',
-    const EmphasisNode(nodes: [TextNode('italic')]));
+  testParseExample(ContentExample.emphasis);
 
   testParseInline('parse inline code',
     // "`inline code`"

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -90,6 +90,13 @@ class ContentExample {
     '<p><em>italic</em></p>',
     const EmphasisNode(nodes: [TextNode('italic')]));
 
+  static final inlineCode = ContentExample.inline(
+    'inline code',
+    '`inline code`',
+    expectedText: 'inline code',
+    '<p><code>inline code</code></p>',
+    const InlineCodeNode(nodes: [TextNode('inline code')]));
+
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',
     ":thumbs_up:",
@@ -627,10 +634,7 @@ void main() {
 
   testParseExample(ContentExample.emphasis);
 
-  testParseInline('parse inline code',
-    // "`inline code`"
-    '<p><code>inline code</code></p>',
-    const InlineCodeNode(nodes: [TextNode('inline code')]));
+  testParseExample(ContentExample.inlineCode);
 
   testParseInline('parse nested del, strong, em, code',
     // "~~***`word`***~~"

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -125,6 +125,13 @@ class ContentExample {
     const ImageEmojiNode(
       src: '/static/generated/emoji/images/emoji/unicode/zulip.png', alt: ':zulip:'));
 
+  static final globalTime = ContentExample.inline(
+    'global time',
+    "<time:2024-03-07T15:00:00-08:00>",
+    '<p><time datetime="2024-03-07T23:00:00Z">2024-03-07T15:00:00-08:00</time></p>',
+    GlobalTimeNode(
+      datetime: DateTime.parse("2024-03-07T23:00:00Z")));
+
   static const spoilerDefaultHeader = ContentExample(
     'spoiler with default header',
     '```spoiler\nhello world\n```',
@@ -707,11 +714,7 @@ void main() {
   testParseExample(ContentExample.mathInline);
 
   group('global times', () {
-    testParseInline('smoke',
-      // "<time:2024-01-30T17:33:00Z>"
-      '<p><time datetime="2024-01-30T17:33:00Z">2024-01-30T17:33:00Z</time></p>',
-      GlobalTimeNode(datetime: DateTime.parse('2024-01-30T17:33Z')),
-    );
+    testParseExample(ContentExample.globalTime);
 
     testParseInline('handles missing attribute',
       // No markdown, this is unexpected response

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -97,6 +97,48 @@ class ContentExample {
     '<p><code>inline code</code></p>',
     const InlineCodeNode(nodes: [TextNode('inline code')]));
 
+  static final userMentionPlain = ContentExample.inline(
+    'plain user @-mention',
+    "@**Greg Price**",
+    expectedText: '@Greg Price',
+    '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>',
+    const UserMentionNode(nodes: [TextNode('@Greg Price')]));
+
+  static final userMentionSilent = ContentExample.inline(
+    'silent user @-mention',
+    "@_**Greg Price**",
+    expectedText: 'Greg Price',
+    '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>',
+    const UserMentionNode(nodes: [TextNode('Greg Price')]));
+
+  static final userMentionSilentClassOrderReversed = ContentExample.inline(
+    'silent user @-mention, class order reversed',
+    "@_**Greg Price**", // (hypothetical server variation)
+    expectedText: 'Greg Price',
+    '<p><span class="silent user-mention" data-user-id="2187">Greg Price</span></p>',
+    const UserMentionNode(nodes: [TextNode('Greg Price')]));
+
+  static final groupMentionPlain = ContentExample.inline(
+    'plain group @-mention',
+    "@*test-empty*",
+    expectedText: '@test-empty',
+    '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
+    const UserMentionNode(nodes: [TextNode('@test-empty')]));
+
+  static final groupMentionSilent = ContentExample.inline(
+    'silent group @-mention',
+    "@_*test-empty*",
+    expectedText: 'test-empty',
+    '<p><span class="user-group-mention silent" data-user-group-id="186">test-empty</span></p>',
+    const UserMentionNode(nodes: [TextNode('test-empty')]));
+
+  static final groupMentionSilentClassOrderReversed = ContentExample.inline(
+    'silent group @-mention, class order reversed',
+    "@_*test-empty*", // (hypothetical server variation)
+    expectedText: 'test-empty',
+    '<p><span class="silent user-group-mention" data-user-group-id="186">test-empty</span></p>',
+    const UserMentionNode(nodes: [TextNode('test-empty')]));
+
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',
     ":thumbs_up:",
@@ -682,35 +724,13 @@ void main() {
         nodes: [TextNode('t')])])])]));
 
   group('parse @-mentions', () {
-    testParseInline('plain user @-mention',
-      // "@**Greg Price**"
-      '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>',
-      const UserMentionNode(nodes: [TextNode('@Greg Price')]));
+    testParseExample(ContentExample.userMentionPlain);
+    testParseExample(ContentExample.userMentionSilent);
+    testParseExample(ContentExample.userMentionSilentClassOrderReversed);
 
-    testParseInline('silent user @-mention',
-      // "@_**Greg Price**"
-      '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>',
-      const UserMentionNode(nodes: [TextNode('Greg Price')]));
-
-    testParseInline('silent user @-mention, class order reversed',
-      // "@_**Greg Price**" (hypothetical server variation)
-      '<p><span class="silent user-mention" data-user-id="2187">Greg Price</span></p>',
-      const UserMentionNode(nodes: [TextNode('Greg Price')]));
-
-    testParseInline('plain group @-mention',
-      // "@*test-empty*"
-      '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
-      const UserMentionNode(nodes: [TextNode('@test-empty')]));
-
-    testParseInline('silent group @-mention',
-      // "@_*test-empty*"
-      '<p><span class="user-group-mention silent" data-user-group-id="186">test-empty</span></p>',
-      const UserMentionNode(nodes: [TextNode('test-empty')]));
-
-    testParseInline('silent group @-mention, class order reversed',
-      // "@_*test-empty*" (hypothetical server variation)
-      '<p><span class="silent user-group-mention" data-user-group-id="186">test-empty</span></p>',
-      const UserMentionNode(nodes: [TextNode('test-empty')]));
+    testParseExample(ContentExample.groupMentionPlain);
+    testParseExample(ContentExample.groupMentionSilent);
+    testParseExample(ContentExample.groupMentionSilentClassOrderReversed);
 
     // TODO test wildcard mentions
   });

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -282,6 +282,8 @@ void main() {
 
   testContentSmoke(ContentExample.emphasis);
 
+  testContentSmoke(ContentExample.inlineCode);
+
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {
     final height = tester.getSize(textFinder).height;
     final target = tester.getTopLeft(textFinder)

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -288,12 +288,16 @@ void main() {
 
   testContentSmoke(ContentExample.emphasis);
 
-  testContentSmoke(ContentExample.inlineCode);
+  group('inline code', () {
+    testContentSmoke(ContentExample.inlineCode);
+  });
 
-  testContentSmoke(ContentExample.userMentionPlain);
-  testContentSmoke(ContentExample.userMentionSilent);
-  testContentSmoke(ContentExample.groupMentionPlain);
-  testContentSmoke(ContentExample.groupMentionSilent);
+  group('UserMention', () {
+    testContentSmoke(ContentExample.userMentionPlain);
+    testContentSmoke(ContentExample.userMentionSilent);
+    testContentSmoke(ContentExample.groupMentionPlain);
+    testContentSmoke(ContentExample.groupMentionSilent);
+  });
 
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {
     final height = tester.getSize(textFinder).height;
@@ -459,18 +463,22 @@ void main() {
     testContentSmoke(ContentExample.emojiUnicodeLiteral);
   });
 
-  testContentSmoke(ContentExample.mathInline);
+  group('inline math', () {
+    testContentSmoke(ContentExample.mathInline);
+  });
 
-  testWidgets('GlobalTime smoke', (tester) async {
-    // "<time:2024-01-30T17:33:00Z>"
-    await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes: parseContent(
-      '<p><time datetime="2024-01-30T17:33:00Z">2024-01-30T17:33:00Z</time></p>'
-    ).nodes)));
-    // The time is shown in the user's timezone and the result will depend on
-    // the timezone of the environment running this test. Accept here a wide
-    // range of times. See comments in "show dates" test in
-    // `test/widgets/message_list_test.dart`.
-    tester.widget(find.textContaining(RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$')));
+  group('GlobalTime', () {
+    testWidgets('smoke', (tester) async {
+      // "<time:2024-01-30T17:33:00Z>"
+      await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes: parseContent(
+        '<p><time datetime="2024-01-30T17:33:00Z">2024-01-30T17:33:00Z</time></p>'
+      ).nodes)));
+      // The time is shown in the user's timezone and the result will depend on
+      // the timezone of the environment running this test. Accept here a wide
+      // range of times. See comments in "show dates" test in
+      // `test/widgets/message_list_test.dart`.
+      tester.widget(find.textContaining(RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$')));
+    });
   });
 
   group('MessageImageEmoji', () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -284,6 +284,11 @@ void main() {
 
   testContentSmoke(ContentExample.inlineCode);
 
+  testContentSmoke(ContentExample.userMentionPlain);
+  testContentSmoke(ContentExample.userMentionSilent);
+  testContentSmoke(ContentExample.groupMentionPlain);
+  testContentSmoke(ContentExample.groupMentionSilent);
+
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {
     final height = tester.getSize(textFinder).height;
     final target = tester.getTopLeft(textFinder)

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -12,6 +12,7 @@ import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/store.dart';
+import 'package:zulip/widgets/text.dart';
 
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
@@ -40,10 +41,15 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   Future<void> prepareContentBare(WidgetTester tester, String html) async {
-    await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: ZulipLocalizations.localizationsDelegates,
-      supportedLocales: ZulipLocalizations.supportedLocales,
-      home: BlockContentList(nodes: parseContent(html).nodes),
+    await tester.pumpWidget(Builder(
+      builder: (context) {
+        return MaterialApp(
+          theme: ThemeData(typography: zulipTypography(context)),
+          localizationsDelegates: ZulipLocalizations.localizationsDelegates,
+          supportedLocales: ZulipLocalizations.supportedLocales,
+          home: Scaffold(body: BlockContentList(nodes: parseContent(html).nodes)),
+        );
+      }
     ));
   }
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -278,6 +278,8 @@ void main() {
 
   testContentSmoke(ContentExample.mathBlock);
 
+  testContentSmoke(ContentExample.strong);
+
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {
     final height = tester.getSize(textFinder).height;
     final target = tester.getTopLeft(textFinder)

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -468,16 +468,18 @@ void main() {
   });
 
   group('GlobalTime', () {
+    // "<time:2024-01-30T17:33:00Z>"
+    const timeSpanHtml = '<time datetime="2024-01-30T17:33:00Z">2024-01-30T17:33:00Z</time>';
+    // The time is shown in the user's timezone and the result will depend on
+    // the timezone of the environment running these tests. Accept here a wide
+    // range of times. See comments in "show dates" test in
+    // `test/widgets/message_list_test.dart`.
+    final renderedTextRegexp = RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$');
+
     testWidgets('smoke', (tester) async {
-      // "<time:2024-01-30T17:33:00Z>"
-      await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes: parseContent(
-        '<p><time datetime="2024-01-30T17:33:00Z">2024-01-30T17:33:00Z</time></p>'
-      ).nodes)));
-      // The time is shown in the user's timezone and the result will depend on
-      // the timezone of the environment running this test. Accept here a wide
-      // range of times. See comments in "show dates" test in
-      // `test/widgets/message_list_test.dart`.
-      tester.widget(find.textContaining(RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$')));
+      await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes:
+        parseContent('<p>$timeSpanHtml</p>').nodes)));
+      tester.widget(find.textContaining(renderedTextRegexp));
     });
   });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -280,6 +280,8 @@ void main() {
 
   testContentSmoke(ContentExample.strong);
 
+  testContentSmoke(ContentExample.emphasis);
+
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {
     final height = tester.getSize(textFinder).height;
     final target = tester.getTopLeft(textFinder)


### PR DESCRIPTION
Also, use `weightVariableTextStyle` in one place we forgot to.

Fixes: #538