### PR TITLE
text: Set 0 letter spacing throughout zulipTypography

### DIFF
--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -36,6 +36,10 @@ Typography zulipTypography(BuildContext context) {
 
   convertGeometry(TextTheme inputTextTheme) {
     TextTheme result = _weightVariableTextTheme(context, inputTextTheme);
+
+    result = _convertTextTheme(result, (maybeInputStyle, _) =>
+      maybeInputStyle?.merge(const TextStyle(letterSpacing: 0)));
+
     return result;
   }
 

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -34,6 +34,11 @@ import 'package:flutter/material.dart';
 Typography zulipTypography(BuildContext context) {
   final typography = Theme.of(context).typography;
 
+  convertGeometry(TextTheme inputTextTheme) {
+    TextTheme result = _weightVariableTextTheme(context, inputTextTheme);
+    return result;
+  }
+
   Typography result = typography.copyWith(
     black: typography.black.apply(
       fontFamily: kDefaultFontFamily,
@@ -42,9 +47,9 @@ Typography zulipTypography(BuildContext context) {
       fontFamily: kDefaultFontFamily,
       fontFamilyFallback: defaultFontFamilyFallback),
 
-    dense:       _weightVariableTextTheme(context, typography.dense),
-    englishLike: _weightVariableTextTheme(context, typography.englishLike),
-    tall:        _weightVariableTextTheme(context, typography.tall),
+    dense:       convertGeometry(typography.dense),
+    englishLike: convertGeometry(typography.englishLike),
+    tall:        convertGeometry(typography.tall),
   );
 
   assert(() {

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -59,6 +59,7 @@ extension TextFieldChecks on Subject<TextField> {
 extension TextStyleChecks on Subject<TextStyle> {
   Subject<bool> get inherit => has((t) => t.inherit, 'inherit');
   Subject<FontWeight?> get fontWeight => has((t) => t.fontWeight, 'fontWeight');
+  Subject<double?> get letterSpacing => has((t) => t.letterSpacing, 'letterSpacing');
   Subject<List<FontVariation>?> get fontVariations => has((t) => t.fontVariations, 'fontVariations');
   Subject<String?> get fontFamily => has((t) => t.fontFamily, 'fontFamily');
   Subject<List<String>?> get fontFamilyFallback => has((t) => t.fontFamilyFallback, 'fontFamilyFallback');

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -47,6 +47,13 @@ void main() {
       });
     }
 
+    testWidgets('zero letter spacing', (tester) async {
+      check(await getZulipTypography(tester, platformRequestsBold: false))
+        ..englishLike.bodyMedium.isNotNull().letterSpacing.equals(0)
+        ..dense.bodyMedium.isNotNull().letterSpacing.equals(0)
+        ..tall.bodyMedium.isNotNull().letterSpacing.equals(0);
+    });
+
     test('Typography has the assumed fields', () {
       check(Typography().toDiagnosticsNode().getProperties().map((n) => n.name).toList())
         .unorderedEquals(['black', 'white', 'englishLike', 'dense', 'tall']);


### PR DESCRIPTION
Screenshots coming soon.

After this, there's still more to do for #548:

- letter spacing of 1% (i.e., 0.01 times `fontSize`) in buttons
- perhaps audit for UI code that's meant to follow Figma already,
  but where we failed to set a non-zero letter spacing that was
  specified in Figma

Fixes: #545
Fixes-partly: #548