### PR TITLE
lightbox: Remove accidental bottom border on AppBar

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -147,6 +147,7 @@ class _LightboxPageState extends State<_LightboxPage> {
         centerTitle: false,
         foregroundColor: appBarForegroundColor,
         backgroundColor: appBarBackgroundColor,
+        shape: const Border(), // Remove bottom border from [AppBarTheme]
         elevation: appBarElevation,
 
         // TODO(#41): Show message author's avatar


### PR DESCRIPTION
Fixes: #550

| Before | After |
| --- | --- |
| <img width="561" alt="image" src="https://github.com/zulip/zulip-flutter/assets/22248748/0bacfae5-137e-406a-a7d5-38a31b8dc14e"> | <img width="561" alt="image" src="https://github.com/zulip/zulip-flutter/assets/22248748/70decba9-7011-4deb-8fac-457821dc01f1"> | 