### PR TITLE
Upgrade Gradle, AGP, other Android build deps and metadata

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,6 +20,8 @@ try {
 }
 
 android {
+    namespace "com.zulip.flutter"
+
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -6,21 +12,12 @@ if (localPropertiesFile.exists()) {
     }
 }
 
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
 def keystoreProperties = new Properties()
 try {
     keystoreProperties.load(new FileInputStream(rootProject.file('release-keystore.properties')))
 } catch (FileNotFoundException ignored) {
     keystoreProperties = null
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion flutter.compileSdkVersion
@@ -80,5 +77,5 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,3 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.zulip.flutter">
-</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.zulip.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <uses-permission android:name="android.permission.INTERNET"/>
    <application
         android:label="Zulip beta"

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,8 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.zulip.flutter">
-    <!-- The INTERNET permission is required for development. Specifically,
-         the Flutter tool needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
-    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,3 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.zulip.flutter">
-</manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,5 +5,12 @@ android.enableJetifier=true
 # Versions for our Android build dependencies.
 # Defining them here makes them available both in
 # settings.gradle and in the build.gradle files.
+
 agpVersion=7.2.0
-kotlinVersion=1.7.10
+
+# Generally update this to the version found in recent releases
+# of Android Studio, as listed in this table:
+#   https://kotlinlang.org/docs/releases.html#release-details
+# A helpful discussion is at:
+#   https://stackoverflow.com/a/74425347
+kotlinVersion=1.9.10

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
 
 # Versions for our Android build dependencies.
 # Defining them here makes them available both in

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,9 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+
+# Versions for our Android build dependencies.
+# Defining them here makes them available both in
+# settings.gradle and in the build.gradle files.
+agpVersion=7.2.0
+kotlinVersion=1.7.10

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,8 +2,6 @@ org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 
 # Versions for our Android build dependencies.
 # Defining them here makes them available both in

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,12 +1,15 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
 
 # Versions for our Android build dependencies.
 # Defining them here makes them available both in
 # settings.gradle and in the build.gradle files.
 
-agpVersion=7.4.2
+agpVersion=8.1.4
 
 # Generally update this to the version found in recent releases
 # of Android Studio, as listed in this table:

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@ android.enableJetifier=true
 # Defining them here makes them available both in
 # settings.gradle and in the build.gradle files.
 
-agpVersion=7.2.0
+agpVersion=7.4.2
 
 # Generally update this to the version found in recent releases
 # of Android Studio, as listed in this table:

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -6,6 +6,8 @@
 #  the wrapper is the one from the new Gradle too.)
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,9 @@
+# How to upgrade Gradle:
+#   $ tools/gradle wrapper --distribution-type=all --gradle-version=NEW_VERSION
+#   $ tools/gradle wrapper --distribution-type=all --gradle-version=NEW_VERSION
+# (Yep, run the same command twice.  The first updates this file so we use
+#  the new Gradle; the second updates the wrapper's jar and scripts, so that
+#  the wrapper is the one from the new Gradle too.)
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,26 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }
+    settings.ext.flutterSdkPath = flutterSdkPath()
+
+    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "$agpVersion" apply false
+    id "org.jetbrains.kotlin.android" version "$kotlinVersion" apply false
+}
+
 include ':app'
-
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
-
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"

--- a/tools/gradle
+++ b/tools/gradle
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+this_dir=${BASH_SOURCE[0]%/*}
+# shellcheck source=tools/lib/ensure-coreutils.sh
+. "${this_dir}"/lib/ensure-coreutils.sh
+root_dir=$(readlink -f "${this_dir}"/..)
+
+exec "${root_dir}"/android/gradlew -p "${root_dir}"/android "$@"


### PR DESCRIPTION
There are currently some warnings that `flutter run` prints for Android targets. After the Android notifications work I did a couple of weeks ago, I sat down to resolve those:
* migrating how we invoke Flutter's Gradle code
* upgrading the Kotlin version we use

and then went on to upgrade our versions of Gradle and the Android Gradle Plugin too. Most of this PR comes from that time; then I came back and finished up the last AGP upgrade, which involved a couple of extra wrinkles.

Other than clearing warnings, some of these changes are supposed to reduce the build time, which is nice. I haven't measured the effect, though — it's possible our project isn't large enough to really see the difference.

I validated things by building and running the app and checking that
* it seems to work on a cursory check;
* it successfully receives notifications, both in a debug and a release build, and in all three conditions of running in the foreground, running in the background, and not already running at all.

  (This last is the one area where I have any particular concerns about some part of the app failing to work due to Android build changes, without the whole app failing to build in the first place. Few other places in our code interact with the Android layer at all, and basically none of the most important functionality.)

---

This doesn't go quite to the very latest AGP (8.2.2), because that upgrade causes a couple of build errors. They look like they might not be that deep; but I've spent enough time on this for now, so shipping the upgrades I have rather than investigating. I don't know of anything we'd currently gain by taking the upgrade from 8.1.x to 8.2.x anyway.
