### PR TITLE
login: display message when account already logged in

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -63,6 +63,18 @@
   "@actionSheetOptionUnstarMessage":  {
     "description": "Label for unstar button on action sheet."
   },
+  "errorAccountLoggedInTitle": "Account already logged in",
+  "@errorAccountLoggedInTitle": {
+    "description": "Error title on attempting to log into an account that's already logged in."
+  },
+  "errorAccountLoggedIn": "The account {email} at {server} is already in your list of accounts.",
+  "@errorAccountLoggedIn": {
+    "description": "Error message on attempting to log into an account that's already logged in.",
+    "placeholders": {
+      "email": {"type": "String", "example": "user@example.com"},
+      "server": {"type": "String", "example": "https://example.com"}
+    }
+  },
   "errorCouldNotFetchMessageSource": "Could not fetch message source",
   "@errorCouldNotFetchMessageSource": {
     "description": "Error message when the source of a message could not be fetched."

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -25,7 +25,7 @@ import 'stream.dart';
 import 'unreads.dart';
 
 export 'package:drift/drift.dart' show Value;
-export 'database.dart' show Account, AccountsCompanion;
+export 'database.dart' show Account, AccountsCompanion, AccountAlreadyExistsException;
 
 /// Store for all the user's data.
 ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -994,7 +994,7 @@ packages:
     source: hosted
     version: "7.0.0"
   sqlite3:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqlite3
       sha256: "072128763f1547e3e9b4735ce846bfd226d68019ccda54db4cd427b12dfdedc9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.13
   url_launcher: ^6.1.11
   url_launcher_android: ">=6.1.0"
+  sqlite3: ^2.4.0
 
 dev_dependencies:
   flutter_driver:

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -2,11 +2,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:checks/checks.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/core.dart';
 import 'package:zulip/api/exception.dart';
+import 'package:zulip/model/localizations.dart';
 
 import '../stdlib_checks.dart';
 import 'exception_checks.dart';
@@ -161,7 +161,7 @@ void main() {
           ..which(condition));
     }
 
-    final zulipLocalizations = lookupZulipLocalizations(ZulipLocalizations.supportedLocales.first);
+    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
     checkRequest(http.ClientException('Oops'), (it) => it.message.equals('Oops'));
     checkRequest(const TlsException('Oops'), (it) => it.message.equals('Oops'));
     checkRequest((foo: 'bar'), (it) => it

--- a/test/model/database_test.dart
+++ b/test/model/database_test.dart
@@ -41,6 +41,54 @@ void main() {
         'acked_push_token': null,
       });
     });
+
+    test('create account with same realm and userId ', () async {
+      final accountData = AccountsCompanion.insert(
+        realmUrl: Uri.parse('https://chat.example/'),
+        userId: 1,
+        email: 'asdf@example.org',
+        apiKey: '1234',
+        zulipVersion: '6.0',
+        zulipMergeBase: const Value('6.0'),
+        zulipFeatureLevel: 42,
+      );
+      final accountDataWithSameUserId = AccountsCompanion.insert(
+        realmUrl: Uri.parse('https://chat.example/'),
+        userId: 1,
+        email: 'otheremail@example.org',
+        apiKey: '12345',
+        zulipVersion: '6.0',
+        zulipMergeBase: const Value('6.0'),
+        zulipFeatureLevel: 42,
+      );
+      await database.createAccount(accountData);
+      await check(database.createAccount(accountDataWithSameUserId))
+        .throws<AccountAlreadyExistsException>();
+    });
+
+    test('create account with same realm and email', () async {
+      final accountData = AccountsCompanion.insert(
+        realmUrl: Uri.parse('https://chat.example/'),
+        userId: 1,
+        email: 'asdf@example.org',
+        apiKey: '1234',
+        zulipVersion: '6.0',
+        zulipMergeBase: const Value('6.0'),
+        zulipFeatureLevel: 42,
+      );
+      final accountDataWithSameEmail = AccountsCompanion.insert(
+        realmUrl: Uri.parse('https://chat.example/'),
+        userId: 2,
+        email: 'asdf@example.org',
+        apiKey: '12345',
+        zulipVersion: '6.0',
+        zulipMergeBase: const Value('6.0'),
+        zulipFeatureLevel: 42,
+      );
+      await database.createAccount(accountData);
+      await check(database.createAccount(accountDataWithSameEmail))
+        .throws<AccountAlreadyExistsException>();
+    });
   });
 
   group('migrations', () {

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -76,6 +76,16 @@ class TestGlobalStore extends GlobalStore {
 
   @override
   Future<Account> doInsertAccount(AccountsCompanion data) async {
+    // Check for duplication is typically handled by the database but since
+    // we're not using a real database, this needs to be handled here.
+    // See [AppDatabase.createAccount].
+    if (accounts.any((account) =>
+          data.realmUrl.value == account.realmUrl
+          && (data.userId.value == account.userId
+              || data.email.value == account.email))) {
+      throw AccountAlreadyExistsException();
+    }
+
     final accountId = data.id.present ? data.id.value : _nextAccountId++;
     return Account(
       id: accountId,


### PR DESCRIPTION
Handles #108 , though doesn't address other kinds of SQL errors, I set up some scaffold code to start handling errors that come from the store.

(This is my first PR (in Dart/Flutter/Zulip), so bear with me.)

My initial instinct was to use the Snackbar to signal this issue. (Screenshot in below comment)
However, I saw after that there's a showErrorDialog, so I'm updating it to use it in a separate commit.

The Snackbar is likely a better UX for this scenario since there's little the user can do in a dialog, and there's no input needed from the user. We can also add a action in the snackbar to navigate to the logged in account.

Happy to squash changes once I hear back on some feedback.

Screenshot (using macOS build to debug, blurred out credentials):
![Frame 3 (1)](https://github.com/zulip/zulip-flutter/assets/132584/347bff44-4d6b-4d8c-ac19-58974a196bc7)

Fixes: #108 