### PR TITLE
inbox: Fix collapsing a section from its sticky header

### DIFF
--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -119,6 +119,8 @@ final Account otherAccount = account(
 
 final User thirdUser = user(fullName: 'Third User', email: 'third@example');
 
+final User fourthUser  = user(fullName: 'Fourth User', email: 'fourth@example');
+
 ////////////////////////////////////////////////////////////////
 // Streams and subscriptions.
 //


### PR DESCRIPTION
Collapsing a stream/all-DMs section through a sticky header behaves as expected without shifting other sections off the screen.

Fixes: zulip#391.

<img src="https://github.com/zulip/zulip-flutter/assets/59946442/fc6f692a-48c6-4de7-a06d-90ae27c68b29" width="300" />