### PR TITLE
store: Retry registerQueue on failure; start testing UpdateMachine.load

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -704,6 +704,26 @@ class UpdateMachine {
     }
   }
 
+  /// In debug mode, controls whether [registerNotificationToken] should
+  /// have its normal effect.
+  ///
+  /// Outside of debug mode, this is always true and the setter has no effect.
+  static bool get debugEnableRegisterNotificationToken {
+    bool result = true;
+    assert(() {
+      result = _debugEnableRegisterNotificationToken;
+      return true;
+    }());
+    return result;
+  }
+  static bool _debugEnableRegisterNotificationToken = true;
+  static set debugEnableRegisterNotificationToken(bool value) {
+    assert(() {
+      _debugEnableRegisterNotificationToken = value;
+      return true;
+    }());
+  }
+
   /// Send this client's notification token to the server, now and if it changes.
   ///
   /// TODO The returned future isn't especially meaningful (it may or may not
@@ -712,6 +732,9 @@ class UpdateMachine {
   // TODO(#322) save acked token, to dedupe updating it on the server
   // TODO(#323) track the registerFcmToken/etc request, warn if not succeeding
   Future<void> registerNotificationToken() async {
+    if (!debugEnableRegisterNotificationToken) {
+      return;
+    }
     NotificationService.instance.token.addListener(_registerNotificationToken);
     await _registerNotificationToken();
   }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -602,7 +602,6 @@ class UpdateMachine {
   /// In the future this might load an old snapshot from local storage first.
   static Future<UpdateMachine> load(GlobalStore globalStore, int accountId) async {
     final account = globalStore.getAccount(accountId)!;
-    // TODO test UpdateMachine.load, now that it uses [GlobalStore.apiConnection]
     final connection = globalStore.apiConnectionFromAccount(account);
 
     final stopwatch = Stopwatch()..start();

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -608,8 +608,7 @@ class UpdateMachine {
     final stopwatch = Stopwatch()..start();
     final initialSnapshot = await registerQueue(connection); // TODO retry
     final t = (stopwatch..stop()).elapsed;
-    // TODO log the time better
-    if (kDebugMode) print("initial fetch time: ${t.inMilliseconds}ms");
+    assert(debugLog("initial fetch time: ${t.inMilliseconds}ms"));
 
     final store = PerAccountStore.fromInitialSnapshot(
       globalStore: globalStore,

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -3,6 +3,28 @@ import 'dart:ui';
 import 'package:checks/checks.dart';
 import 'package:zulip/api/model/model.dart';
 
+extension UserChecks on Subject<User> {
+  Subject<int> get userId => has((x) => x.userId, 'userId');
+  Subject<String?> get deliveryEmailStaleDoNotUse => has((x) => x.deliveryEmailStaleDoNotUse, 'deliveryEmailStaleDoNotUse');
+  Subject<String> get email => has((x) => x.email, 'email');
+  Subject<String> get fullName => has((x) => x.fullName, 'fullName');
+  Subject<String> get dateJoined => has((x) => x.dateJoined, 'dateJoined');
+  Subject<bool> get isActive => has((x) => x.isActive, 'isActive');
+  Subject<bool> get isOwner => has((x) => x.isOwner, 'isOwner');
+  Subject<bool> get isAdmin => has((x) => x.isAdmin, 'isAdmin');
+  Subject<bool> get isGuest => has((x) => x.isGuest, 'isGuest');
+  Subject<bool?> get isBillingAdmin => has((x) => x.isBillingAdmin, 'isBillingAdmin');
+  Subject<bool> get isBot => has((x) => x.isBot, 'isBot');
+  Subject<int?> get botType => has((x) => x.botType, 'botType');
+  Subject<int?> get botOwnerId => has((x) => x.botOwnerId, 'botOwnerId');
+  Subject<UserRole> get role => has((x) => x.role, 'role');
+  Subject<String> get timezone => has((x) => x.timezone, 'timezone');
+  Subject<String?> get avatarUrl => has((x) => x.avatarUrl, 'avatarUrl');
+  Subject<int> get avatarVersion => has((x) => x.avatarVersion, 'avatarVersion');
+  Subject<Map<int, ProfileFieldUserData>?> get profileData => has((x) => x.profileData, 'profileData');
+  Subject<bool> get isSystemBot => has((x) => x.isSystemBot, 'isSystemBot');
+}
+
 extension ZulipStreamChecks on Subject<ZulipStream> {
   Subject<int?> get canRemoveSubscribersGroup => has((e) => e.canRemoveSubscribersGroup, 'canRemoveSubscribersGroup');
 }


### PR DESCRIPTION
Fixes #556.

In addition to the test this adds, I wanted to manually test it
end-to-end, to help be sure this covered the scenario where this
retry is known to be needed in the wild:
 * The app is offline for a while, perhaps because the device
   is asleep.
 * The app comes online, tries polling, and finds the event queue
   has expired, so it attempts a re-register.
 * Before that completes (which after all takes several seconds
   if the realm is a large one), the app goes offline again.
 * That request's response therefore never reaches the app,
   and so when it eventually comes back online it needs to retry.

Step 1 is annoying to carry out literally, because it means
waiting 10 minutes for the event queue to expire.  To work around
that, I sabotaged the getEvents binding function to use a wrong
`queue_id` value:

    'queue_id': RawParameter('wrong' + queueId),

so that the server would always respond with a BAD_EVENT_QUEUE_ID
error, just the same as if the queue had expired.

Then to take the app offline and online again, I just turned
airplane mode on and off on my device.  Because I used a
physical device connected to my computer over USB, that caused
no interference to my watching the logs on the console.

In my manual testing, the retries worked perfectly: no matter
how many times I turned airplane mode on and off, or with what
timing, the app always returned to getting a fresh queue and
polling it for events.
