### PR TITLE
deps: Upgrade `intl` constraint, from ^0.18.0 to ^0.19.0

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -764,7 +764,7 @@ class _SendButtonState extends State<_SendButton> {
         tooltip: zulipLocalizations.composeBoxSendTooltip,
         style: const ButtonStyle(
           // Match the height of the content input.
-          minimumSize: MaterialStatePropertyAll(Size.square(_sendButtonSize)),
+          minimumSize: WidgetStatePropertyAll(Size.square(_sendButtonSize)),
           // With the default of [MaterialTapTargetSize.padded], not just the
           // tap target but the visual button would get padded to 48px square.
           // It would be nice if the tap target extended invisibly out from the

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -616,10 +616,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -1197,10 +1197,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      sha256: a75f83f14ad81d5fe4b3319710b90dec37da0e22612326b696c9e1b8f34bbf48
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "14.2.0"
   watcher:
     dependency: transitive
     description:
@@ -1282,5 +1282,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0-140.0.dev <4.0.0"
-  flutter: ">=3.20.0-7.0.pre.63"
+  dart: ">=3.4.0-256.0.dev <4.0.0"
+  flutter: ">=3.21.0-12.0.pre.26"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.4.0-140.0.dev <4.0.0'
-  flutter: '>=3.20.0-7.0.pre.63'
+  sdk: '>=3.4.0-256.0.dev <4.0.0'
+  flutter: '>=3.21.0-12.0.pre.26'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -54,7 +54,7 @@ dependencies:
   html: ^0.15.1
   http: ^1.0.0
   image_picker: ^1.0.0
-  intl: ^0.18.0
+  intl: ^0.19.0
   json_annotation: ^4.8.1
   package_info_plus: ^5.0.1
   path: ^1.8.3


### PR DESCRIPTION
No potentially breaking changes identified in the changelog:
  https://github.com/dart-lang/i18n/blob/main/pkgs/intl/CHANGELOG.md#0190

This addresses the following error:

  Note: intl is pinned to version 0.19.0 by flutter_localizations
    from the flutter SDK.
  See https://dart.dev/go/sdk-version-pinning for details.

  Because zulip depends on flutter_localizations from sdk which
    depends on intl 0.19.0, intl 0.19.0 is required.
  So, because zulip depends on intl ^0.18.0, version solving failed.

  You can try the following suggestion to make the pubspec resolve:
  * Try upgrading your constraint on intl: flutter pub add intl:^0.19.0

Fixes: #575 