### PR TITLE
content: Open links externally on iOS

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -895,7 +896,15 @@ void _launchUrl(BuildContext context, String urlString) async {
   bool launched = false;
   String? errorMessage;
   try {
-    launched = await ZulipBinding.instance.launchUrl(url);
+    launched = await ZulipBinding.instance.launchUrl(url,
+      mode: switch (defaultTargetPlatform) {
+        // On iOS we prefer LaunchMode.externalApplication because (for
+        // HTTP URLs) LaunchMode.platformDefault uses SFSafariViewController,
+        // which gives an awkward UX as described here:
+        //  https://chat.zulip.org/#narrow/stream/48-mobile/topic/in-app.20browser/near/1169118
+        TargetPlatform.iOS => UrlLaunchMode.externalApplication,
+        _ => UrlLaunchMode.platformDefault,
+      });
   } on PlatformException catch (e) {
     errorMessage = e.message;
   }

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:checks/checks.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -318,8 +319,11 @@ void main() {
         '<p><a href="https://example/">hello</a></p>');
 
       await tapText(tester, find.text('hello'));
+
+      final expectedLaunchMode = defaultTargetPlatform == TargetPlatform.iOS ?
+        LaunchMode.externalApplication : LaunchMode.platformDefault;
       check(testBinding.takeLaunchUrlCalls())
-        .single.equals((url: Uri.parse('https://example/'), mode: LaunchMode.platformDefault));
+        .single.equals((url: Uri.parse('https://example/'), mode: expectedLaunchMode));
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
     testWidgets('multiple links in paragraph', (tester) async {


### PR DESCRIPTION
On iOS we prefer LaunchMode.externalApplication because LaunchMode.platformDefault uses SFSafariViewController which provides a weird UX for reasons mentioned in [this]( https://chat.zulip.org/#narrow/stream/48-mobile/topic/in-app.20browser/near/1169118) discussion.

| Before | After |
| - | - |
| ![before](https://github.com/zulip/zulip-flutter/assets/36819268/c3cef395-185c-42eb-8313-efc0c5b5899d) |  ![after](https://github.com/zulip/zulip-flutter/assets/36819268/6aaaf077-6136-40e0-87ae-2c4be93aac3b) |

Fixes: #280