### PR TITLE
Add bottom bar for navigation, tabs for inbox

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -255,6 +255,52 @@ class HomePage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text("Home")),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: 0,
+        destinations: [
+          const NavigationDestination(
+            selectedIcon: Icon(Icons.inbox),
+            icon: Icon(Icons.inbox_outlined),
+            label: 'Inbox'),
+          const NavigationDestination(
+            selectedIcon: Icon(Icons.tag),
+            icon: Icon(Icons.tag_outlined),
+            label: 'Streams'),
+          const NavigationDestination(
+            selectedIcon: Icon(Icons.group_outlined),
+            icon: Icon(Icons.group),
+            label: 'Direct Messages'),
+          // TODO enable this when it's available
+          // NavigationDestination(
+          //   selectedIcon: Icon(Icons.account_circle),
+          //   icon: Icon(Icons.account_circle_outlined),
+          //   label: 'Profile'),
+          if (testStreamId != null) ...[
+            const NavigationDestination(
+              selectedIcon: Icon(Icons.bug_report),
+              icon: Icon(Icons.bug_report_outlined),
+              label: 'Test Stream'),
+          ],
+        ],
+        onDestinationSelected: (int index) {
+          switch (index) {
+            case 0:
+              Navigator.push(context, InboxPage.buildRoute(context: context));
+              break;
+            case 1:
+              Navigator.push(context, SubscriptionListPage.buildRoute(context: context));
+              break;
+            case 2:
+              Navigator.push(context, RecentDmConversationsPage.buildRoute(context: context));
+              break;
+            case 3:
+              Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: StreamNarrow(testStreamId!)));
+              break;
+          }
+        },
+      ),
       body: Center(
         child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
           DefaultTextStyle.merge(

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -178,7 +178,7 @@ class ChooseAccountPage extends StatelessWidget {
         title: title,
         subtitle: subtitle,
         onTap: () => Navigator.push(context,
-          HomePage.buildRoute(accountId: accountId))));
+          InboxPage.buildRoute(accountId: accountId))));
   }
 
   @override

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -11,6 +11,7 @@ import 'about_zulip.dart';
 import 'inbox.dart';
 import 'login.dart';
 import 'message_list.dart';
+import 'navigation_bar.dart';
 import 'page.dart';
 import 'recent_dm_conversations.dart';
 import 'store.dart';
@@ -255,52 +256,7 @@ class HomePage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text("Home")),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: 0,
-        destinations: [
-          const NavigationDestination(
-            selectedIcon: Icon(Icons.inbox),
-            icon: Icon(Icons.inbox_outlined),
-            label: 'Inbox'),
-          const NavigationDestination(
-            selectedIcon: Icon(Icons.tag),
-            icon: Icon(Icons.tag_outlined),
-            label: 'Streams'),
-          const NavigationDestination(
-            selectedIcon: Icon(Icons.group_outlined),
-            icon: Icon(Icons.group),
-            label: 'Direct Messages'),
-          // TODO enable this when it's available
-          // NavigationDestination(
-          //   selectedIcon: Icon(Icons.account_circle),
-          //   icon: Icon(Icons.account_circle_outlined),
-          //   label: 'Profile'),
-          if (testStreamId != null) ...[
-            const NavigationDestination(
-              selectedIcon: Icon(Icons.bug_report),
-              icon: Icon(Icons.bug_report_outlined),
-              label: 'Test Stream'),
-          ],
-        ],
-        onDestinationSelected: (int index) {
-          switch (index) {
-            case 0:
-              Navigator.push(context, InboxPage.buildRoute(context: context));
-              break;
-            case 1:
-              Navigator.push(context, SubscriptionListPage.buildRoute(context: context));
-              break;
-            case 2:
-              Navigator.push(context, RecentDmConversationsPage.buildRoute(context: context));
-              break;
-            case 3:
-              Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: StreamNarrow(testStreamId!)));
-              break;
-          }
-        },
-      ),
+      bottomNavigationBar: ZulipNavigationBar(selectedPage: HomePage,),
       body: Center(
         child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
           DefaultTextStyle.merge(

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -6,6 +6,7 @@ import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
 import 'icons.dart';
 import 'message_list.dart';
+import 'navigation_bar.dart';
 import 'page.dart';
 import 'sticky_header.dart';
 import 'store.dart';
@@ -160,6 +161,7 @@ class _InboxPageState extends State<InboxPage> with PerAccountStoreAwareStateMix
 
     return Scaffold(
       appBar: AppBar(title: const Text('Inbox')),
+      bottomNavigationBar: ZulipNavigationBar(selectedPage: InboxPage),
       body: SafeArea(
         // Don't pad the bottom here; we want the list content to do that.
         bottom: false,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -17,6 +17,7 @@ import 'content.dart';
 import 'dialog.dart';
 import 'emoji_reaction.dart';
 import 'icons.dart';
+import 'navigation_bar.dart';
 import 'page.dart';
 import 'profile.dart';
 import 'sticky_header.dart';
@@ -86,6 +87,7 @@ class _MessageListPageState extends State<MessageListPage> {
           ? const Border()
           : null, // i.e., inherit
       ),
+      bottomNavigationBar: ZulipNavigationBar(selectedPage: MessageList),
       // TODO question for Vlad: for a stream view, should we set
       //   [backgroundColor] based on stream color, as in this frame:
       //     https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=132%3A9684&mode=dev

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -87,7 +87,6 @@ class _MessageListPageState extends State<MessageListPage> {
           ? const Border()
           : null, // i.e., inherit
       ),
-      bottomNavigationBar: ZulipNavigationBar(selectedPage: MessageList),
       // TODO question for Vlad: for a stream view, should we set
       //   [backgroundColor] based on stream color, as in this frame:
       //     https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=132%3A9684&mode=dev

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -17,7 +17,6 @@ import 'content.dart';
 import 'dialog.dart';
 import 'emoji_reaction.dart';
 import 'icons.dart';
-import 'navigation_bar.dart';
 import 'page.dart';
 import 'profile.dart';
 import 'sticky_header.dart';

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -13,6 +13,7 @@ class ZulipNavigationBar extends StatelessWidget {
     InboxPage: 0,
     SubscriptionListPage: 1,
     RecentDmConversationsPage: 2,
+    HomePage: 3,
   };
 
   ZulipNavigationBar({super.key, required this.selectedPage});

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
-import '../model/narrow.dart';
+import 'app.dart';
 import 'inbox.dart';
-import 'message_list.dart';
 import 'recent_dm_conversations.dart';
+import 'store.dart';
 import 'subscription_list.dart';
 
 class ZulipNavigationBar extends StatelessWidget {
@@ -19,18 +19,19 @@ class ZulipNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final accountId = PerAccountStoreWidget.accountIdOf(context);
     return NavigationBar(
         selectedIndex: pageToIndex[selectedPage] ?? 0,
-        destinations: [
-          const NavigationDestination(
+        destinations: const [
+          NavigationDestination(
             selectedIcon: Icon(Icons.inbox),
             icon: Icon(Icons.inbox_outlined),
             label: 'Inbox'),
-          const NavigationDestination(
+          NavigationDestination(
             selectedIcon: Icon(Icons.tag),
             icon: Icon(Icons.tag_outlined),
             label: 'Streams'),
-          const NavigationDestination(
+          NavigationDestination(
             selectedIcon: Icon(Icons.group),
             icon: Icon(Icons.group_outlined),
             label: 'Direct Messages'),
@@ -39,12 +40,10 @@ class ZulipNavigationBar extends StatelessWidget {
           //   selectedIcon: Icon(Icons.account_circle),
           //   icon: Icon(Icons.account_circle_outlined),
           //   label: 'Profile'),
-          if (testStreamId != null) ...[
-            const NavigationDestination(
-              selectedIcon: Icon(Icons.bug_report_outlined),
-              icon: Icon(Icons.bug_report_outlined),
-              label: 'Test Stream'),
-          ],
+          NavigationDestination(
+            selectedIcon: Icon(Icons.bug_report_outlined),
+            icon: Icon(Icons.bug_report_outlined),
+            label: 'Test Page'),
         ],
         onDestinationSelected: (int index) {
           switch (index) {
@@ -59,8 +58,7 @@ class ZulipNavigationBar extends StatelessWidget {
               break;
             case 3:
               Navigator.pushReplacement(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: StreamNarrow(testStreamId!)));
+                HomePage.buildRoute(accountId: accountId));
               break;
           }
         },

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../model/narrow.dart';
+import 'inbox.dart';
+import 'message_list.dart';
+import 'recent_dm_conversations.dart';
+import 'subscription_list.dart';
+
+class ZulipNavigationBar extends StatelessWidget {
+  final int testStreamId = 7;
+  final Type selectedPage;
+  final Map<Type, int> pageToIndex = {
+    InboxPage: 0,
+    SubscriptionListPage: 1,
+    RecentDmConversationsPage: 2,
+  };
+
+  ZulipNavigationBar({super.key, required this.selectedPage});
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+        selectedIndex: pageToIndex[selectedPage] ?? 0,
+        destinations: [
+          const NavigationDestination(
+            selectedIcon: Icon(Icons.inbox),
+            icon: Icon(Icons.inbox_outlined),
+            label: 'Inbox'),
+          const NavigationDestination(
+            selectedIcon: Icon(Icons.tag),
+            icon: Icon(Icons.tag_outlined),
+            label: 'Streams'),
+          const NavigationDestination(
+            selectedIcon: Icon(Icons.group_outlined),
+            icon: Icon(Icons.group),
+            label: 'Direct Messages'),
+          // TODO enable this when it's available
+          // NavigationDestination(
+          //   selectedIcon: Icon(Icons.account_circle),
+          //   icon: Icon(Icons.account_circle_outlined),
+          //   label: 'Profile'),
+          if (testStreamId != null) ...[
+            const NavigationDestination(
+              selectedIcon: Icon(Icons.bug_report),
+              icon: Icon(Icons.bug_report_outlined),
+              label: 'Test Stream'),
+          ],
+        ],
+        onDestinationSelected: (int index) {
+          switch (index) {
+            case 0:
+              Navigator.pushReplacement(context, InboxPage.buildRoute(context: context));
+              break;
+            case 1:
+              Navigator.pushReplacement(context, SubscriptionListPage.buildRoute(context: context));
+              break;
+            case 2:
+              Navigator.pushReplacement(context, RecentDmConversationsPage.buildRoute(context: context));
+              break;
+            case 3:
+              Navigator.pushReplacement(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: StreamNarrow(testStreamId!)));
+              break;
+          }
+        },
+      );
+  }
+}

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -41,7 +41,7 @@ class ZulipNavigationBar extends StatelessWidget {
           //   label: 'Profile'),
           if (testStreamId != null) ...[
             const NavigationDestination(
-              selectedIcon: Icon(Icons.bug_report),
+              selectedIcon: Icon(Icons.bug_report_outlined),
               icon: Icon(Icons.bug_report_outlined),
               label: 'Test Stream'),
           ],

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -21,8 +21,9 @@ class ZulipNavigationBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accountId = PerAccountStoreWidget.accountIdOf(context);
+    final selectedIndex = pageToIndex[selectedPage] ?? 0;
     return NavigationBar(
-        selectedIndex: pageToIndex[selectedPage] ?? 0,
+        selectedIndex: selectedIndex,
         destinations: const [
           NavigationDestination(
             selectedIcon: Icon(Icons.inbox),
@@ -47,6 +48,9 @@ class ZulipNavigationBar extends StatelessWidget {
             label: 'Test Page'),
         ],
         onDestinationSelected: (int index) {
+          if (selectedIndex == index) {
+            return;
+          }
           switch (index) {
             case 0:
               Navigator.pushReplacement(context, InboxPage.buildRoute(context: context));

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -35,7 +35,7 @@ class ZulipNavigationBar extends StatelessWidget {
             selectedIcon: Icon(Icons.group),
             icon: Icon(Icons.group_outlined),
             label: 'Direct Messages'),
-          // TODO enable this when it's available
+          // TODO enable this when the profile page is available
           // NavigationDestination(
           //   selectedIcon: Icon(Icons.account_circle),
           //   icon: Icon(Icons.account_circle_outlined),

--- a/lib/widgets/navigation_bar.dart
+++ b/lib/widgets/navigation_bar.dart
@@ -31,8 +31,8 @@ class ZulipNavigationBar extends StatelessWidget {
             icon: Icon(Icons.tag_outlined),
             label: 'Streams'),
           const NavigationDestination(
-            selectedIcon: Icon(Icons.group_outlined),
-            icon: Icon(Icons.group),
+            selectedIcon: Icon(Icons.group),
+            icon: Icon(Icons.group_outlined),
             label: 'Direct Messages'),
           // TODO enable this when it's available
           // NavigationDestination(

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -7,6 +7,7 @@ import '../model/unreads.dart';
 import 'content.dart';
 import 'icons.dart';
 import 'message_list.dart';
+import 'navigation_bar.dart';
 import 'page.dart';
 import 'store.dart';
 import 'unread_count_badge.dart';
@@ -58,6 +59,7 @@ class _RecentDmConversationsPageState extends State<RecentDmConversationsPage> w
     final sorted = model!.sorted;
     return Scaffold(
       appBar: AppBar(title: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+      bottomNavigationBar: ZulipNavigationBar(selectedPage: RecentDmConversationsPage),
       body: SafeArea(
         // Don't pad the bottom here; we want the list content to do that.
         bottom: false,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -6,6 +6,7 @@ import '../model/narrow.dart';
 import '../model/unreads.dart';
 import 'icons.dart';
 import 'message_list.dart';
+import 'navigation_bar.dart';
 import 'page.dart';
 import 'store.dart';
 import 'text.dart';
@@ -82,6 +83,7 @@ class _SubscriptionListPageState extends State<SubscriptionListPage> with PerAcc
 
     return Scaffold(
       appBar: AppBar(title: const Text("Streams")),
+      bottomNavigationBar: ZulipNavigationBar(selectedPage: SubscriptionListPage),
       body: SafeArea(
         // Don't pad the bottom here; we want the list content to do that.
         bottom: false,

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -45,7 +45,7 @@ void main() {
           navigatorObservers: [if (navigatorObserver != null) navigatorObserver],
           home: PerAccountStoreWidget(
             accountId: eg.selfAccount.id,
-            child: const InboxPage()))));
+            child: const Inbox()))));
 
     // global store and per-account store get loaded
     await tester.pumpAndSettle();

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -154,7 +154,9 @@ void main() {
       subscription,
     ], unreadMsgs: unreadMsgs);
     check(getItemCount()).equals(1);
-    check(tester.widget<Icon>(find.byType(Icon)).color)
+    final scaffoldBody = tester.widget<Scaffold>(find.byType(Scaffold)).body;
+    check(tester.widget<Icon>(find.descendant(of:
+      find.byWidget(scaffoldBody!), matching: find.byType(Icon))).color)
       .equals(swatch.iconOnPlainBackground);
     check(tester.widget<UnreadCountBadge>(find.byType(UnreadCountBadge)).backgroundColor)
       .equals(swatch);


### PR DESCRIPTION
I'm currently just fiddling around and looking and what maybe needs to be refactored around to get a similar navigation as the current Zulip app.

At this stage, the PR is a set of minimal changes to make it look/feel closer to a slightly more polished navigation. 

So far some findings:
- A more sophisticated router like go-router might be useful so that we can create deep links that follow the exact routing that the Zulip web client uses. Except with 1 main difference, specifying the server needs to be in the url.
  - Not sure what this would look like, perhaps: `https://open.zulip.app/<serverIdentifier>/<path on zulip server>`

![Screenshot_20240326_215308](https://github.com/zulip/zulip-flutter/assets/132584/2b83e895-987f-4ac0-852c-f24c60c1eeff)

[Screen_recording_20240326_215102.webm](https://github.com/zulip/zulip-flutter/assets/132584/6988aca5-2bf9-4216-8a14-0828e368c8e0)

Note that the animations between the different navigation routes for the bottom navigation bar is slightly incorrect, since it uses a *push* animation that applies to the entire page including the navigation bar, rather than only animating/transitioning the main body area that's being changed.

Partially addresses #311