### PR TITLE
Exclude deactivated users from @-mention autocomplete popup

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -289,6 +289,8 @@ class MentionAutocompleteQuery {
     // TODO(#236) test email too, not just name
     // TODO(#237) test with diacritics stripped, where appropriate
 
+    if (!user.isActive) return false;
+
     final List<String> nameWords = cache.nameWordsForUser(user);
 
     int nameWordsIndex = 0;

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -60,6 +60,7 @@ User user({
   String? email,
   String? fullName,
   String? avatarUrl,
+  bool? isActive,
   Map<int, ProfileFieldUserData>? profileData,
 }) {
   return User(
@@ -68,7 +69,7 @@ User user({
     email: email ?? 'name@example.com', // TODO generate example emails
     fullName: fullName ?? 'A user', // TODO generate example names
     dateJoined: '2023-04-28',
-    isActive: true,
+    isActive: isActive ?? true,
     isOwner: false,
     isAdmin: false,
     isGuest: false,

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -340,5 +340,12 @@ void main() {
     doCheck('Name Four Full Words', eg.user(fullName: 'Full Name Four Words'), false);
     doCheck('F Full', eg.user(fullName: 'Full Name Four Words'), false);
     doCheck('Four F', eg.user(fullName: 'Full Name Four Words'), false);
+
+    // User should always be excluded in case of inactive users
+    doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: false), false);
+    doCheck('Full', eg.user(fullName: 'Full Name', isActive: false), false);
+    // User that are already excluded will still be excluded in case of inactive users
+    doCheck('Fully Named', eg.user(fullName: 'Full Name', isActive: false), false);
+
   });
 }

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -97,7 +97,7 @@ world
     test('whitespace around info string', () {
       checkFenceWrap('''
 ````
-``` javascript 
+``` javascript
 // hello world
 ```
 ````
@@ -315,6 +315,13 @@ hello
       store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName)]);
       check(mention(user, silent: true, users: store.users)).equals('@_**Full Name|123**');
     });
+
+    test('`users` passed; has two users with same fullName but one of them is not active', () {
+      final store = eg.store();
+      store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName, isActive: false)]);
+      check(mention(user, silent: true, users: store.users)).equals('@_**Full Name|123**');
+    });
+
     test('`users` passed; user has unique fullName', () {
       final store = eg.store();
       store.addUsers([user, eg.user(userId: 234, fullName: 'Another Name')]);


### PR DESCRIPTION
Implementing #451 
# Logic Implemented
- Always exclude the users that have `isActive` set to false
- Show the id in the mention string if there are two users with the same full name even if one of them is deactivated
