### PR TITLE
autocomplete: Exclude deactivated users from @-mention autocomplete popup

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -287,6 +287,11 @@ class MentionAutocompleteQuery {
 
   bool testUser(User user, AutocompleteDataCache cache) {
     // TODO(#236) test email too, not just name
+
+    return _testName(user, cache);
+  }
+
+  bool _testName(User user, AutocompleteDataCache cache) {
     // TODO(#237) test with diacritics stripped, where appropriate
 
     final List<String> nameWords = cache.nameWordsForUser(user);

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -288,6 +288,8 @@ class MentionAutocompleteQuery {
   bool testUser(User user, AutocompleteDataCache cache) {
     // TODO(#236) test email too, not just name
 
+    if (!user.isActive) return false;
+
     return _testName(user, cache);
   }
 

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -59,6 +59,7 @@ User user({
   int? userId,
   String? email,
   String? fullName,
+  bool? isActive,
   String? avatarUrl,
   Map<int, ProfileFieldUserData>? profileData,
 }) {
@@ -68,7 +69,7 @@ User user({
     email: email ?? 'name@example.com', // TODO generate example emails
     fullName: fullName ?? 'A user', // TODO generate example names
     dateJoined: '2023-04-28',
-    isActive: true,
+    isActive: isActive ?? true,
     isOwner: false,
     isAdmin: false,
     isGuest: false,

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -312,6 +312,12 @@ void main() {
       expected ? check(result).isTrue() : check(result).isFalse();
     }
 
+    test('user is always excluded when not active regardless of other criteria', () {
+      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: false), false);
+      // When active then other criteria will be checked
+      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: true), true);
+    });
+
     test('user is included if fullname words match the query', () {
       doCheck('', eg.user(fullName: 'Full Name'), true);
       doCheck('', eg.user(fullName: ''), true); // Unlikely case, but should not crash

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -305,40 +305,42 @@ void main() {
     }
   });
 
-  test('MentionAutocompleteQuery.testUser', () {
+  group('MentionAutocompleteQuery.testUser', () {
     doCheck(String rawQuery, User user, bool expected) {
       final result = MentionAutocompleteQuery(rawQuery)
         .testUser(user, AutocompleteDataCache());
       expected ? check(result).isTrue() : check(result).isFalse();
     }
 
-    doCheck('', eg.user(fullName: 'Full Name'), true);
-    doCheck('', eg.user(fullName: ''), true); // Unlikely case, but should not crash
-    doCheck('Full Name', eg.user(fullName: 'Full Name'), true);
-    doCheck('full name', eg.user(fullName: 'Full Name'), true);
-    doCheck('Full Name', eg.user(fullName: 'full name'), true);
-    doCheck('Full', eg.user(fullName: 'Full Name'), true);
-    doCheck('Name', eg.user(fullName: 'Full Name'), true);
-    doCheck('Full Name', eg.user(fullName: 'Fully Named'), true);
-    doCheck('Full Four', eg.user(fullName: 'Full Name Four Words'), true);
-    doCheck('Name Words', eg.user(fullName: 'Full Name Four Words'), true);
-    doCheck('Full F', eg.user(fullName: 'Full Name Four Words'), true);
-    doCheck('F Four', eg.user(fullName: 'Full Name Four Words'), true);
-    doCheck('full full', eg.user(fullName: 'Full Full Name'), true);
-    doCheck('full full', eg.user(fullName: 'Full Name Full'), true);
+    test('user is included if fullname words match the query', () {
+      doCheck('', eg.user(fullName: 'Full Name'), true);
+      doCheck('', eg.user(fullName: ''), true); // Unlikely case, but should not crash
+      doCheck('Full Name', eg.user(fullName: 'Full Name'), true);
+      doCheck('full name', eg.user(fullName: 'Full Name'), true);
+      doCheck('Full Name', eg.user(fullName: 'full name'), true);
+      doCheck('Full', eg.user(fullName: 'Full Name'), true);
+      doCheck('Name', eg.user(fullName: 'Full Name'), true);
+      doCheck('Full Name', eg.user(fullName: 'Fully Named'), true);
+      doCheck('Full Four', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('Name Words', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('Full F', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('F Four', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('full full', eg.user(fullName: 'Full Full Name'), true);
+      doCheck('full full', eg.user(fullName: 'Full Name Full'), true);
 
-    doCheck('F', eg.user(fullName: ''), false); // Unlikely case, but should not crash
-    doCheck('Fully Named', eg.user(fullName: 'Full Name'), false);
-    doCheck('Full Name', eg.user(fullName: 'Full'), false);
-    doCheck('Full Name', eg.user(fullName: 'Name'), false);
-    doCheck('ull ame', eg.user(fullName: 'Full Name'), false);
-    doCheck('ull Name', eg.user(fullName: 'Full Name'), false);
-    doCheck('Full ame', eg.user(fullName: 'Full Name'), false);
-    doCheck('Full Full', eg.user(fullName: 'Full Name'), false);
-    doCheck('Name Name', eg.user(fullName: 'Full Name'), false);
-    doCheck('Name Full', eg.user(fullName: 'Full Name'), false);
-    doCheck('Name Four Full Words', eg.user(fullName: 'Full Name Four Words'), false);
-    doCheck('F Full', eg.user(fullName: 'Full Name Four Words'), false);
-    doCheck('Four F', eg.user(fullName: 'Full Name Four Words'), false);
+      doCheck('F', eg.user(fullName: ''), false); // Unlikely case, but should not crash
+      doCheck('Fully Named', eg.user(fullName: 'Full Name'), false);
+      doCheck('Full Name', eg.user(fullName: 'Full'), false);
+      doCheck('Full Name', eg.user(fullName: 'Name'), false);
+      doCheck('ull ame', eg.user(fullName: 'Full Name'), false);
+      doCheck('ull Name', eg.user(fullName: 'Full Name'), false);
+      doCheck('Full ame', eg.user(fullName: 'Full Name'), false);
+      doCheck('Full Full', eg.user(fullName: 'Full Name'), false);
+      doCheck('Name Name', eg.user(fullName: 'Full Name'), false);
+      doCheck('Name Full', eg.user(fullName: 'Full Name'), false);
+      doCheck('Name Four Full Words', eg.user(fullName: 'Full Name Four Words'), false);
+      doCheck('F Full', eg.user(fullName: 'Full Name Four Words'), false);
+      doCheck('Four F', eg.user(fullName: 'Full Name Four Words'), false);
+    });
   });
 }

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -95,9 +95,10 @@ world
     });
 
     test('whitespace around info string', () {
+      const infoString = ' javascript ';
       checkFenceWrap('''
 ````
-``` javascript 
+```$infoString
 // hello world
 ```
 ````

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -316,6 +316,11 @@ hello
       store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName)]);
       check(mention(user, silent: true, users: store.users)).equals('@_**Full Name|123**');
     });
+    test('`users` passed; has two same-name users but one of them is deactivated', () {
+      final store = eg.store();
+      store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName, isActive: false)]);
+      check(mention(user, silent: true, users: store.users)).equals('@_**Full Name|123**');
+    });
     test('`users` passed; user has unique fullName', () {
       final store = eg.store();
       store.addUsers([user, eg.user(userId: 234, fullName: 'Another Name')]);


### PR DESCRIPTION
## Logic Implemented 

### autocomplete: Exclude deactivated users from @-mention autocomplete popup
Deactivated users can not be mentioned, so this ensures that deactivated users are excluded from the list that gets rendered in autocomplete popup.

### compose test: Check ID still included if same-name users deactivated
While autocomplete does not include deactivated users, there still is a possibility that same-name users with one or more of them deactivated gets mentioned, which will make the mentioned user ambiguous without the id, this is explained in #451.

Fixes #451