### PR TITLE
autocomplete: Add user avatars to user-mention autocompletes

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -342,21 +342,6 @@ class UserMentionAutocompleteResult extends MentionAutocompleteResult {
   final int userId;
 }
 
-enum WildcardMentionType {
-  all,
-  everyone,
-  stream,
-}
+// TODO(#233): // class UserGroupMentionAutocompleteResult extends MentionAutocompleteResult {
 
-class WildcardMentionAutocompleteResult extends MentionAutocompleteResult {
-  WildcardMentionAutocompleteResult({required this.type});
-
-  final WildcardMentionType type;
-}
-
-
-class UserGroupMentionAutocompleteResult extends MentionAutocompleteResult {
-  UserGroupMentionAutocompleteResult({required this.userGroupId});
-
-  final int userGroupId;
-}
+// TODO(#234): // class WildcardMentionAutocompleteResult extends MentionAutocompleteResult {

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'content.dart';
 import 'store.dart';
 import '../model/autocomplete.dart';
 import '../model/compose.dart';
@@ -119,10 +120,11 @@ class _ComposeAutocompleteState extends State<ComposeAutocomplete> with PerAccou
 
   Widget _buildItem(BuildContext _, int index) {
     final option = _resultsToDisplay[index];
+    Widget avatar;
     String label;
     switch (option) {
       case UserMentionAutocompleteResult(:var userId):
-        // TODO(#227) avatar
+        avatar = Avatar(userId: userId, size: 32, borderRadius: 3);
         label = PerAccountStoreWidget.of(context).users[userId]!.fullName;
     }
     return InkWell(
@@ -130,8 +132,13 @@ class _ComposeAutocompleteState extends State<ComposeAutocomplete> with PerAccou
         _onTapOption(option);
       },
       child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Text(label)));
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+        child: Row(
+          children: [
+            avatar,
+            const SizedBox(width: 8),
+            Text(label),
+          ])));
   }
 
   @override

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -107,10 +107,6 @@ class _ComposeAutocompleteState extends State<ComposeAutocomplete> with PerAccou
         // TODO(i18n) language-appropriate space character; check active keyboard?
         //   (maybe handle centrally in `widget.controller`)
         replacementString = '${mention(store.users[userId]!, silent: intent.query.silent, users: store.users)} ';
-      case WildcardMentionAutocompleteResult():
-        replacementString = '[unimplemented]'; // TODO(#234)
-      case UserGroupMentionAutocompleteResult():
-        replacementString = '[unimplemented]'; // TODO(#233)
     }
 
     widget.controller.value = intent.textEditingValue.replaced(
@@ -128,10 +124,6 @@ class _ComposeAutocompleteState extends State<ComposeAutocomplete> with PerAccou
       case UserMentionAutocompleteResult(:var userId):
         // TODO(#227) avatar
         label = PerAccountStoreWidget.of(context).users[userId]!.fullName;
-      case WildcardMentionAutocompleteResult():
-        label = '[unimplemented]'; // TODO(#234)
-      case UserGroupMentionAutocompleteResult():
-        label = '[unimplemented]'; // TODO(#233)
     }
     return InkWell(
       onTap: () {

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -6,6 +6,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/compose.dart';
 import 'package:zulip/model/narrow.dart';
+import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/store.dart';
 
@@ -13,11 +14,17 @@ import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../model/binding.dart';
 import '../model/test_store.dart';
+import 'content_test.dart';
 
 /// Simulates loading a [MessageListPage] and tapping to focus the compose input.
 ///
 /// Also adds [users] to the [PerAccountStore],
 /// so they can show up in autocomplete.
+///
+/// Also sets [debugNetworkImageHttpClientProvider] to return a constant image.
+///
+/// The caller must set [debugNetworkImageHttpClientProvider] back to null
+/// before the end of the test.
 Future<Finder> setupToComposeInput(WidgetTester tester, {
   required List<User> users,
 }) async {
@@ -38,6 +45,8 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
     historyLimited: false,
     messages: [message],
   ).toJson());
+
+  prepareBoringImageHttpClient();
 
   await tester.pumpWidget(
     MaterialApp(
@@ -65,10 +74,26 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   group('ComposeAutocomplete', () {
+
+    Finder findNetworkImage(String url) {
+      return find.byWidgetPredicate((widget) => switch(widget) {
+        Image(image: NetworkImage(url: var imageUrl)) when imageUrl == url
+          => true,
+        _ => false,
+      });
+    }
+
+    void checkUserShown(User user, PerAccountStore store, {required bool expected}) {
+      check(find.text(user.fullName).evaluate().length).equals(expected ? 1 : 0);
+      final avatarFinder =
+        findNetworkImage(store.tryResolveUrl(user.avatarUrl!).toString());
+      check(avatarFinder.evaluate().length).equals(expected ? 1 : 0);
+    }
+
     testWidgets('options appear, disappear, and change correctly', (WidgetTester tester) async {
-      final user1 = eg.user(userId: 1, fullName: 'User One');
-      final user2 = eg.user(userId: 2, fullName: 'User Two');
-      final user3 = eg.user(userId: 3, fullName: 'User Three');
+      final user1 = eg.user(userId: 1, fullName: 'User One', avatarUrl: 'user1.png');
+      final user2 = eg.user(userId: 2, fullName: 'User Two', avatarUrl: 'user2.png');
+      final user3 = eg.user(userId: 3, fullName: 'User Three', avatarUrl: 'user3.png');
       final composeInputFinder = await setupToComposeInput(tester, users: [user1, user2, user3]);
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
@@ -77,34 +102,37 @@ void main() {
       await tester.enterText(composeInputFinder, 'hello @user ');
       await tester.enterText(composeInputFinder, 'hello @user t');
       await tester.pumpAndSettle(); // async computation; options appear
+
       // "User Two" and "User Three" appear, but not "User One"
-      check(tester.widgetList(find.text('User One'))).isEmpty();
-      tester.widget(find.text('User Two'));
-      tester.widget(find.text('User Three'));
+      checkUserShown(user1, store, expected: false);
+      checkUserShown(user2, store, expected: true);
+      checkUserShown(user3, store, expected: true);
 
       // Finishing autocomplete updates compose box; causes options to disappear
       await tester.tap(find.text('User Three'));
       await tester.pump();
       check(tester.widget<TextField>(composeInputFinder).controller!.text)
         .contains(mention(user3, users: store.users));
-      check(tester.widgetList(find.text('User One'))).isEmpty();
-      check(tester.widgetList(find.text('User Two'))).isEmpty();
-      check(tester.widgetList(find.text('User Three'))).isEmpty();
+      checkUserShown(user1, store, expected: false);
+      checkUserShown(user2, store, expected: false);
+      checkUserShown(user3, store, expected: false);
 
       // Then a new autocomplete intent brings up options again
       // TODO(#226): Remove this extra edit when this bug is fixed.
       await tester.enterText(composeInputFinder, 'hello @user tw');
       await tester.enterText(composeInputFinder, 'hello @user two');
       await tester.pumpAndSettle(); // async computation; options appear
-      tester.widget(find.text('User Two'));
+      checkUserShown(user2, store, expected: true);
 
       // Removing autocomplete intent causes options to disappear
       // TODO(#226): Remove one of these edits when this bug is fixed.
       await tester.enterText(composeInputFinder, '');
       await tester.enterText(composeInputFinder, ' ');
-      check(tester.widgetList(find.text('User One'))).isEmpty();
-      check(tester.widgetList(find.text('User Two'))).isEmpty();
-      check(tester.widgetList(find.text('User Three'))).isEmpty();
+      checkUserShown(user1, store, expected: false);
+      checkUserShown(user2, store, expected: false);
+      checkUserShown(user3, store, expected: false);
+
+      debugNetworkImageHttpClientProvider = null;
     });
   });
 }

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -27,6 +27,21 @@ import 'dialog_checks.dart';
 import 'message_list_checks.dart';
 import 'page_checks.dart';
 
+/// Set [debugNetworkImageHttpClientProvider] to return a constant image.
+///
+/// Returns the [FakeImageHttpClient] that handles the requests.
+///
+/// The caller must set [debugNetworkImageHttpClientProvider] back to null
+/// before the end of the test.
+FakeImageHttpClient prepareBoringImageHttpClient() {
+  final httpClient = FakeImageHttpClient();
+  debugNetworkImageHttpClientProvider = () => httpClient;
+  httpClient.request.response
+    ..statusCode = HttpStatus.ok
+    ..content = kSolidBlueAvatar;
+  return httpClient;
+}
+
 void main() {
   // For testing a new content feature:
   //
@@ -62,21 +77,6 @@ void main() {
         'testContentExample requires expectedText');
       tester.widget(find.text(example.expectedText!));
     });
-  }
-
-  /// Set [debugNetworkImageHttpClientProvider] to return a constant image.
-  ///
-  /// Returns the [FakeImageHttpClient] that handles the requests.
-  ///
-  /// The caller must set [debugNetworkImageHttpClientProvider] back to null
-  /// before the end of the test.
-  FakeImageHttpClient prepareBoringImageHttpClient() {
-    final httpClient = FakeImageHttpClient();
-    debugNetworkImageHttpClientProvider = () => httpClient;
-    httpClient.request.response
-      ..statusCode = HttpStatus.ok
-      ..content = kSolidBlueAvatar;
-    return httpClient;
   }
 
   group('Heading', () {


### PR DESCRIPTION
When mentioning users, their avatars are shown beside their names in the autocomplete popup.

<img src="https://github.com/zulip/zulip-flutter/assets/59946442/021de9b5-7f3f-4ffa-a479-c609c9710e23" width="300"/>

Fixes: #227