### PR TITLE
notif: Internationalize group DM notification message and

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -440,5 +440,13 @@
   "allMessagesPageTitle": "All messages",
   "@allMessagesPageTitle": {
     "description": "Title for the page of all messages"
+  },
+  "notifGroupDmConversationLabel": "{senderFullName} to you and {numOthers, plural, =1{1 other} other{{numOthers} others}}",
+  "@notifGroupDmConversationLabel": {
+    "description": "Label for a group DM conversation notification.",
+    "placeholders": {
+      "senderFullName": {"type": "String", "example": "Alice"},
+      "numOthers": {"type": "int", "example": "4"}
+    }
   }
 }

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -10,6 +10,7 @@ import '../api/notifications.dart';
 import '../host/android_notifications.dart';
 import '../log.dart';
 import '../model/binding.dart';
+import '../model/localizations.dart';
 import '../model/narrow.dart';
 import '../widgets/app.dart';
 import '../widgets/message_list.dart';
@@ -89,13 +90,15 @@ class NotificationDisplayManager {
 
   static void _onMessageFcmMessage(MessageFcmMessage data, Map<String, dynamic> dataJson) {
     assert(debugLog('notif message content: ${data.content}'));
+    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
     final title = switch (data.recipient) {
       FcmMessageStreamRecipient(:var streamName?, :var topic) =>
         '$streamName > $topic',
       FcmMessageStreamRecipient(:var topic) =>
         '(unknown stream) > $topic', // TODO get stream name from data
       FcmMessageDmRecipient(:var allRecipientIds) when allRecipientIds.length > 2 =>
-        '${data.senderFullName} to you and ${allRecipientIds.length - 2} others', // TODO(i18n), also plural; TODO use others' names, from data
+        zulipLocalizations.notifGroupDmConversationLabel(
+          data.senderFullName, allRecipientIds.length - 2), // TODO use others' names, from data
       FcmMessageDmRecipient() =>
         data.senderFullName,
     };

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -169,11 +169,20 @@ void main() {
         expectedTagComponent: 'stream:${message.streamId}:${message.subject}');
     }));
 
-    test('group DM', () => awaitFakeAsync((async) async {
+    test('group DM: 3 users', () => awaitFakeAsync((async) async {
       await init();
       final message = eg.dmMessage(from: eg.thirdUser, to: [eg.otherUser, eg.selfUser]);
       await checkNotifications(async, messageFcmMessage(message),
-        expectedTitle: "${eg.thirdUser.fullName} to you and 1 others",
+        expectedTitle: "${eg.thirdUser.fullName} to you and 1 other",
+        expectedTagComponent: 'dm:${message.allRecipientIds.join(",")}');
+    }));
+
+    test('group DM: more than 3 users', () => awaitFakeAsync((async) async {
+      await init();
+      final message = eg.dmMessage(from: eg.thirdUser,
+        to: [eg.otherUser, eg.selfUser, eg.fourthUser]);
+      await checkNotifications(async, messageFcmMessage(message),
+        expectedTitle: "${eg.thirdUser.fullName} to you and 2 others",
         expectedTagComponent: 'dm:${message.allRecipientIds.join(",")}');
     }));
 


### PR DESCRIPTION
handle number properly

This commit addresses the issue of handling plural and singular forms of the string when a group DM notification message is received. The previous implementation used a hard-coded string. Now it uses an internationalized string.

I have also added a test so that both the singular and plural forms of the string are tested.

Fixes: #573