### PR TITLE
Add helper text for "server URL" with link to documentation

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -308,6 +308,10 @@
   "@loginServerUrlInputLabel": {
     "description": "Input label in login page for Zulip server URL entry."
   },
+  "serverUrlDocLinkLabel": "What's this?",
+  "@serverUrlDocLinkLabel": {
+    "description": "Link to doc to help users understand what a server URL is and how to find theirs."
+  },
   "errorUnableToOpenLinkTitle": "Unable to open link",
   "@errorUnableToOpenLinkTitle": {
     "description": "Error title when a link fails to open."

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -308,6 +308,17 @@
   "@loginServerUrlInputLabel": {
     "description": "Input label in login page for Zulip server URL entry."
   },
+  "errorUnableToOpenLinkTitle": "Unable to open link",
+  "@errorUnableToOpenLinkTitle": {
+    "description": "Error title when a link fails to open."
+  },
+  "errorUnableToOpenLinkMessage": "Link could not be opened: {url}",
+  "@errorUnableToOpenLinkMessage": {
+    "description": "Error message when a link fails to open.",
+    "placeholders": {
+      "url": {"type": "String", "example": "http://example.com/"}
+    }
+  },
   "loginHidePassword": "Hide password",
   "@loginHidePassword": {
     "description": "Icon label for button to hide password in input form."

--- a/lib/widgets/launch_url.dart
+++ b/lib/widgets/launch_url.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
 import '../model/binding.dart';
 import '../model/internal_link.dart';
@@ -10,11 +11,12 @@ import 'store.dart';
 
 /// Handles showing an error dialog with a customizable message.
 Future<void> _showError(BuildContext context, String? message, String urlString) {
+  final zulipLocalizations = ZulipLocalizations.of(context);
   return showErrorDialog(
     context: context,
-    title: 'Unable to open link',
+    title: zulipLocalizations.errorUnableToOpenLinkTitle,
     message: [
-      'Link could not be opened: $urlString',
+      zulipLocalizations.errorUnableToOpenLinkMessage(urlString),
       if (message != null) message,
     ].join("\n\n"));
 }

--- a/lib/widgets/launch_url.dart
+++ b/lib/widgets/launch_url.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../model/binding.dart';
+import '../model/internal_link.dart';
+import 'dialog.dart';
+import 'message_list.dart';
+import 'store.dart';
+
+/// Handles showing an error dialog with a customizable message.
+Future<void> _showError(BuildContext context, String? message, String urlString) {
+  return showErrorDialog(
+    context: context,
+    title: 'Unable to open link',
+    message: [
+      'Link could not be opened: $urlString',
+      if (message != null) message,
+    ].join("\n\n"));
+}
+
+/// Launches a URL without considering a realm base URL.
+void launchUrlWithoutRealm(BuildContext context, Uri url) async {
+  bool launched = false;
+  String? errorMessage;
+  try {
+    launched = await ZulipBinding.instance.launchUrl(url,
+      mode: switch (defaultTargetPlatform) {
+        // On iOS we prefer LaunchMode.externalApplication because (for
+        // HTTP URLs) LaunchMode.platformDefault uses SFSafariViewController,
+        // which gives an awkward UX as described here:
+        //  https://chat.zulip.org/#narrow/stream/48-mobile/topic/in-app.20browser/near/1169118
+        TargetPlatform.iOS => UrlLaunchMode.externalApplication,
+        _ => UrlLaunchMode.platformDefault,
+      });
+  } on PlatformException catch (e) {
+    errorMessage = e.message;
+  }
+  if (!launched) {
+    if (!context.mounted) return;
+    await _showError(context, errorMessage, url.toString());
+  }
+}
+
+/// Launches a URL considering a realm base URL.
+void launchUrlWithRealm(BuildContext context, String urlString) async {
+  final store = PerAccountStoreWidget.of(context);
+  final url = store.tryResolveUrl(urlString);
+  if (url == null) { // TODO(log)
+    await _showError(context, null, urlString);
+    return;
+  }
+
+  final internalNarrow = parseInternalLink(url, store);
+  if (internalNarrow != null) {
+    Navigator.push(context,
+      MessageListPage.buildRoute(context: context, narrow: internalNarrow));
+    return;
+  }
+
+  launchUrlWithoutRealm(context, url);
+}

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -15,6 +15,7 @@ import '../model/store.dart';
 import 'app.dart';
 import 'dialog.dart';
 import 'input.dart';
+import 'launch_url.dart';
 import 'page.dart';
 import 'store.dart';
 import 'text.dart';
@@ -107,6 +108,9 @@ class ServerUrlTextEditingController extends TextEditingController {
 
 class AddAccountPage extends StatefulWidget {
   const AddAccountPage({super.key});
+
+  static final Uri serverUrlHelpUrl =
+    Uri.parse('https://zulip.com/help/logging-in#find-the-zulip-log-in-url');
 
   static Route<void> buildRoute() {
     return _LoginSequenceRoute(page: const AddAccountPage());
@@ -213,7 +217,6 @@ class _AddAccountPageState extends State<AddAccountPage> {
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400),
             child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-              // TODO(#109) Link to doc about what a "server URL" is and how to find it
               // TODO(#111) Perhaps give tappable realm URL suggestions based on text typed so far
               TextField(
                 controller: _controller,
@@ -229,7 +232,17 @@ class _AddAccountPageState extends State<AddAccountPage> {
                 decoration: InputDecoration(
                   labelText: zulipLocalizations.loginServerUrlInputLabel,
                   errorText: errorText,
-                  helperText: kLayoutPinningHelperText,
+                  helper: GestureDetector(
+                    onTap: () {
+                      launchUrlWithoutRealm(context, AddAccountPage.serverUrlHelpUrl);
+                    },
+                    child: Text(
+                      // Restate Material default
+                      // (`_InputDecoratorDefaultsM3.helperText` upstream)…
+                      style: Theme.of(context).textTheme.bodySmall!
+                        // …but use blue because this is a link.
+                        .apply(color: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor()),
+                      zulipLocalizations.serverUrlDocLinkLabel)),
                   hintText: 'your-org.zulipchat.com')),
               const SizedBox(height: 8),
               ElevatedButton(


### PR DESCRIPTION
Add helper text below the "server URL" field that, when tapped, opens relevant Zulip documentation explaining what a server URL is and how to find theirs. It will help users understand the "server URL" field during login.

Fixes: [#109](https://github.com/zulip/zulip-flutter/issues/109)

https://github.com/zulip/zulip-flutter/assets/38466275/2258cbfa-43d6-4339-b50c-c7967ff1472e

![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-29 at 10 55 02](https://github.com/zulip/zulip-flutter/assets/38466275/34c6ea62-3519-4aa7-bbea-8f7024ae5813)

https://github.com/zulip/zulip-flutter/assets/38466275/bb9f5144-7b5c-4ea0-bbb1-6a8f59da1cfc

![Screenshot_1711685963](https://github.com/zulip/zulip-flutter/assets/38466275/31133f4c-a54a-4592-a3e1-c5028b3615d7)