### PR TITLE
snackbar: Handle connectivity changes and show appropriate SnackBar#465

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -1,3 +1,4 @@
+// @formatter:off
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -16,7 +17,7 @@ import 'recent_dm_conversations.dart';
 import 'store.dart';
 import 'subscription_list.dart';
 import 'text.dart';
-import'snackbar.dart';
+import 'snackbar.dart';
 
 class ZulipApp extends StatefulWidget {
   const ZulipApp({super.key, this.navigatorObservers});
@@ -88,7 +89,7 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
   @override
   Future<bool> didPushRouteInformation(routeInformation) async {
     if (routeInformation case RouteInformation(
-      uri: Uri(scheme: 'zulip', host: 'login') && var url)
+    uri: Uri(scheme: 'zulip', host: 'login') && var url)
     ) {
       await LoginPage.handleWebAuthUrl(url);
       return true;
@@ -142,45 +143,45 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
     );
 
     return GlobalStoreWidget(
-      child: Builder(builder: (context) {
-        final globalStore = GlobalStoreWidget.of(context);
-        // TODO(#524) choose initial account as last one used
-        final initialAccountId = globalStore.accounts.firstOrNull?.id;
-        return MaterialApp(
-          title: 'Zulip',
-          localizationsDelegates: ZulipLocalizations.localizationsDelegates,
-          supportedLocales: ZulipLocalizations.supportedLocales,
-          theme: theme,
+        child: Builder(builder: (context) {
+          final globalStore = GlobalStoreWidget.of(context);
+          // TODO(#524) choose initial account as last one used
+          final initialAccountId = globalStore.accounts.firstOrNull?.id;
+          return MaterialApp(
+              title: 'Zulip',
+              localizationsDelegates: ZulipLocalizations.localizationsDelegates,
+              supportedLocales: ZulipLocalizations.supportedLocales,
+              theme: theme,
 
-          navigatorKey: ZulipApp.navigatorKey,
-          navigatorObservers: widget.navigatorObservers ?? const [],
-          builder: (BuildContext context, Widget? child) {
-            if (!ZulipApp.ready.value) {
-              SchedulerBinding.instance.addPostFrameCallback(
-                (_) => widget._declareReady());
-            }
-            GlobalLocalizations.zulipLocalizations = ZulipLocalizations.of(context);
-            return child!;
-          },
+              navigatorKey: ZulipApp.navigatorKey,
+              navigatorObservers: widget.navigatorObservers ?? const [],
+              builder: (BuildContext context, Widget? child) {
+                if (!ZulipApp.ready.value) {
+                  SchedulerBinding.instance.addPostFrameCallback(
+                          (_) => widget._declareReady());
+                }
+                GlobalLocalizations.zulipLocalizations = ZulipLocalizations.of(context);
+                return child!;
+              },
 
-          // We use onGenerateInitialRoutes for the real work of specifying the
-          // initial nav state.  To do that we need [MaterialApp] to decide to
-          // build a [Navigator]... which means specifying either `home`, `routes`,
-          // `onGenerateRoute`, or `onUnknownRoute`.  Make it `onGenerateRoute`.
-          // It never actually gets called, though: `onGenerateInitialRoutes`
-          // handles startup, and then we always push whole routes with methods
-          // like [Navigator.push], never mere names as with [Navigator.pushNamed].
-          onGenerateRoute: (_) => null,
+              // We use onGenerateInitialRoutes for the real work of specifying the
+              // initial nav state.  To do that we need [MaterialApp] to decide to
+              // build a [Navigator]... which means specifying either `home`, `routes`,
+              // `onGenerateRoute`, or `onUnknownRoute`.  Make it `onGenerateRoute`.
+              // It never actually gets called, though: `onGenerateInitialRoutes`
+              // handles startup, and then we always push whole routes with methods
+              // like [Navigator.push], never mere names as with [Navigator.pushNamed].
+              onGenerateRoute: (_) => null,
 
-          onGenerateInitialRoutes: (_) {
-            return [
-              MaterialWidgetRoute(page: const ChooseAccountPage()),
-              if (initialAccountId != null) ...[
-                HomePage.buildRoute(accountId: initialAccountId),
-                InboxPage.buildRoute(accountId: initialAccountId),
-              ],
-            ];
-          });
+              onGenerateInitialRoutes: (_) {
+                return [
+                  MaterialWidgetRoute(page: const ChooseAccountPage()),
+                  if (initialAccountId != null) ...[
+                    HomePage.buildRoute(accountId: initialAccountId),
+                    InboxPage.buildRoute(accountId: initialAccountId),
+                  ],
+                ];
+              });
         }));
   }
 }
@@ -195,18 +196,18 @@ class ChooseAccountPage extends StatelessWidget {
   const ChooseAccountPage({super.key});
 
   Widget _buildAccountItem(
-    BuildContext context, {
-    required int accountId,
-    required Widget title,
-    Widget? subtitle,
-  }) {
+      BuildContext context, {
+        required int accountId,
+        required Widget title,
+        Widget? subtitle,
+      }) {
     return Card(
-      clipBehavior: Clip.hardEdge,
-      child: ListTile(
-        title: title,
-        subtitle: subtitle,
-        onTap: () => Navigator.push(context,
-          HomePage.buildRoute(accountId: accountId))));
+        clipBehavior: Clip.hardEdge,
+        child: ListTile(
+            title: title,
+            subtitle: subtitle,
+            onTap: () => Navigator.push(context,
+                HomePage.buildRoute(accountId: accountId))));
   }
 
   @override
@@ -215,31 +216,31 @@ class ChooseAccountPage extends StatelessWidget {
     assert(!PerAccountStoreWidget.debugExistsOf(context));
     final globalStore = GlobalStoreWidget.of(context);
     return Scaffold(
-      appBar: AppBar(
-        title: Text(zulipLocalizations.chooseAccountPageTitle),
-        actions: const [ChooseAccountPageOverflowButton()]),
-      body: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400),
-            child: Column(mainAxisSize: MainAxisSize.min, children: [
-              Flexible(child: SingleChildScrollView(
-                padding: const EdgeInsets.only(top: 8),
-                child: Column(mainAxisSize: MainAxisSize.min, children: [
-                  for (final (:accountId, :account) in globalStore.accountEntries)
-                    _buildAccountItem(context,
-                      accountId: accountId,
-                      title: Text(account.realmUrl.toString()),
-                      subtitle: Text(account.email)),
-                ]))),
-              const SizedBox(height: 12),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  AddAccountPage.buildRoute()),
-                child: Text(zulipLocalizations.chooseAccountButtonAddAnAccount)),
-            ]))),
-      ));
+        appBar: AppBar(
+            title: Text(zulipLocalizations.chooseAccountPageTitle),
+            actions: const [ChooseAccountPageOverflowButton()]),
+        body: SafeArea(
+          minimum: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+          child: Center(
+              child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  child: Column(mainAxisSize: MainAxisSize.min, children: [
+                    Flexible(child: SingleChildScrollView(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: Column(mainAxisSize: MainAxisSize.min, children: [
+                          for (final (:accountId, :account) in globalStore.accountEntries)
+                            _buildAccountItem(context,
+                                accountId: accountId,
+                                title: Text(account.realmUrl.toString()),
+                                subtitle: Text(account.email)),
+                        ]))),
+                    const SizedBox(height: 12),
+                    ElevatedButton(
+                        onPressed: () => Navigator.push(context,
+                            AddAccountPage.buildRoute()),
+                        child: Text(zulipLocalizations.chooseAccountButtonAddAnAccount)),
+                  ]))),
+        ));
   }
 }
 
@@ -251,17 +252,17 @@ class ChooseAccountPageOverflowButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopupMenuButton<ChooseAccountPageOverflowMenuItem>(
-      itemBuilder: (BuildContext context) => const [
-        PopupMenuItem(
-          value: ChooseAccountPageOverflowMenuItem.aboutZulip,
-          child: Text('About Zulip')),
-      ],
-      onSelected: (item) {
-        switch (item) {
-          case ChooseAccountPageOverflowMenuItem.aboutZulip:
-            Navigator.push(context, AboutZulipPage.buildRoute(context));
-        }
-      });
+        itemBuilder: (BuildContext context) => const [
+          PopupMenuItem(
+              value: ChooseAccountPageOverflowMenuItem.aboutZulip,
+              child: Text('About Zulip')),
+        ],
+        onSelected: (item) {
+          switch (item) {
+            case ChooseAccountPageOverflowMenuItem.aboutZulip:
+              Navigator.push(context, AboutZulipPage.buildRoute(context));
+          }
+        });
   }
 }
 
@@ -270,7 +271,7 @@ class HomePage extends StatelessWidget {
 
   static Route<void> buildRoute({required int accountId}) {
     return MaterialAccountWidgetRoute(accountId: accountId,
-      page: const HomePage());
+        page: const HomePage());
   }
 
   @override
@@ -279,7 +280,7 @@ class HomePage extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
 
     InlineSpan bold(String text) => TextSpan(
-      text: text, style: const TextStyle(fontWeight: FontWeight.bold));
+        text: text, style: const TextStyle(fontWeight: FontWeight.bold));
 
     int? testStreamId;
     if (store.connection.realmUrl.origin == 'https://chat.zulip.org') {
@@ -287,57 +288,56 @@ class HomePage extends StatelessWidget {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text("Home")),
-      body: Center(
-        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-          DefaultTextStyle.merge(
-            textAlign: TextAlign.center,
-            style: const TextStyle(fontSize: 18),
-            child: Column(children: [
-              const Text('🚧 Under construction 🚧'),
-              const SizedBox(height: 12),
-              Text.rich(TextSpan(
-                text: 'Connected to: ',
-                children: [bold(store.realmUrl.toString())])),
-              Text.rich(TextSpan(
-                text: 'Zulip server version: ',
-                children: [bold(store.zulipVersion)])),
-              Text(zulipLocalizations.subscribedToNStreams(store.subscriptions.length)),
-            ])),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const AllMessagesNarrow())),
-            child: Text(zulipLocalizations.allMessagesPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              InboxPage.buildRoute(context: context)),
-            child: const Text("Inbox")), // TODO(i18n)
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              SubscriptionListPage.buildRoute(context: context)),
-            child: const Text("Subscribed streams")),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              RecentDmConversationsPage.buildRoute(context: context)),
-            child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-          if (testStreamId != null) ...[
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: StreamNarrow(testStreamId!))),
-              child: const Text("#test here")), // scaffolding hack, see above
-          ],
-          const SizedBox(
-              height: 40,
-              child:SnackBarPage()
-          )
-
-        ])));
+        appBar: AppBar(title: const Text("Home")),
+        body: Center(
+            child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              DefaultTextStyle.merge(
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 18),
+                  child: Column(children: [
+                    const Text('🚧 Under construction 🚧'),
+                    const SizedBox(height: 12),
+                    Text.rich(TextSpan(
+                        text: 'Connected to: ',
+                        children: [bold(store.realmUrl.toString())])),
+                    Text.rich(TextSpan(
+                        text: 'Zulip server version: ',
+                        children: [bold(store.zulipVersion)])),
+                    Text(zulipLocalizations.subscribedToNStreams(store.subscriptions.length)),
+                  ])),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                      MessageListPage.buildRoute(context: context,
+                          narrow: const AllMessagesNarrow())),
+                  child: Text(zulipLocalizations.allMessagesPageTitle)),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                      InboxPage.buildRoute(context: context)),
+                  child: const Text("Inbox")), // TODO(i18n)
+              const SizedBox(height: 16),
+              ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                      SubscriptionListPage.buildRoute(context: context)),
+                  child: const Text("Subscribed streams")),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                      RecentDmConversationsPage.buildRoute(context: context)),
+                  child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+              if (testStreamId != null) ...[
+                const SizedBox(height: 16),
+                ElevatedButton(
+                    onPressed: () => Navigator.push(context,
+                        MessageListPage.buildRoute(context: context,
+                            narrow: StreamNarrow(testStreamId!))),
+                    child: const Text("#test here")),
+                SizedBox(
+                  height:40,
+                  child:SnackBarPage(isStale:store.isstale),
+                )// scaffolding hack, see above
+              ]])));
   }
 }
+// @formatter:off

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -16,6 +16,7 @@ import 'recent_dm_conversations.dart';
 import 'store.dart';
 import 'subscription_list.dart';
 import 'text.dart';
+import'snackbar.dart';
 
 class ZulipApp extends StatelessWidget {
   const ZulipApp({super.key, this.navigatorObservers});
@@ -300,6 +301,11 @@ class HomePage extends StatelessWidget {
                   narrow: StreamNarrow(testStreamId!))),
               child: const Text("#test here")), // scaffolding hack, see above
           ],
+          const SizedBox(
+              height: 40,
+              child:SnackBarPage()
+          )
+
         ])));
   }
 }

--- a/lib/widgets/snackbar.dart
+++ b/lib/widgets/snackbar.dart
@@ -1,0 +1,224 @@
+//
+// import 'dart:async';
+// import 'package:flutter/material.dart';
+// import 'package:connectivity_plus/connectivity_plus.dart';
+//
+// class SnackBarPage extends StatefulWidget {
+//   const SnackBarPage({super.key});
+//
+//   @override
+//   SnackBarPageState createState() => SnackBarPageState();
+// }
+//
+// class SnackBarPageState extends State<SnackBarPage> {
+//   late ConnectivityResult _connectivityResult; // ignore: unused_field
+//   late StreamSubscription<ConnectivityResult> _connectivitySubscription;
+//
+//   @override
+//   void initState() {
+//     super.initState();
+//     // Initialize connectivity status
+//     _initConnectivity();
+//   }
+//
+//   @override
+//   void didChangeDependencies() {
+//     super.didChangeDependencies();
+//     // Subscribe to connectivity changes
+//     _connectivitySubscription = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+//       setState(() {
+//         _connectivityResult = result;
+//       });
+//       // Show or dismiss snackbar based on connectivity changes
+//       showSnackBar(result);
+//     });
+//   }
+//
+//   @override
+//   void dispose() {
+//     _connectivitySubscription.cancel(); // Cancel subscription to avoid memory leaks
+//     super.dispose();
+//   }
+//
+//   Future<void> _initConnectivity() async {
+//     final ConnectivityResult connectivityResult = await Connectivity().checkConnectivity();
+//     setState(() {
+//       _connectivityResult = connectivityResult;
+//     });
+//     //  initial snackbar based on connectivity status
+//     showSnackBar(connectivityResult);
+//   }
+//
+//   void showSnackBar(ConnectivityResult connectivityResult) {
+//     final bool isConnected = connectivityResult != ConnectivityResult.none;
+//     ScaffoldMessenger.of(context).hideCurrentSnackBar();
+//
+//     if (isConnected) {
+//       ScaffoldMessenger.of(context).showSnackBar(
+//         const SnackBar(
+//           content: Row(
+//             children: [
+//               Icon(
+//                 Icons.sync,
+//                 color: Colors.white,
+//               ),
+//               SizedBox(width: 8),
+//               Text(
+//                 'Connecting',
+//                 style: TextStyle(color: Colors.white),
+//               ),
+//             ],
+//           ),
+//           duration:  Duration(seconds: 3),
+//         ),
+//       );
+//     } else {
+//       ScaffoldMessenger.of(context).showSnackBar(
+//         const SnackBar(
+//           content:  Row(
+//             children: [
+//               Icon(
+//                 Icons.error_outline,
+//                 color: Colors.white,
+//               ),
+//               SizedBox(width: 2),
+//               Text(
+//                 'No Internet Connection',
+//                 style:  TextStyle(color: Colors.white),
+//               ),
+//             ],
+//           ),
+//           duration:  Duration(seconds: 365),
+//         ),
+//       );
+//     }
+//   }
+//
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return const Scaffold(
+//       body:  Center(
+//         child:   Text(''),
+//       ),
+//     );
+//   }
+// }
+//
+
+
+
+
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class SnackBarPage extends StatefulWidget {
+  const SnackBarPage({super.key});
+
+  @override
+  SnackBarPageState createState() => SnackBarPageState();
+}
+
+
+class SnackBarPageState extends State<SnackBarPage> {
+  late ConnectivityResult _connectivityResult; // ignore: unused_field
+  late StreamSubscription<ConnectivityResult> _connectivitySubscription;
+  late ScaffoldMessengerState _scaffoldMessengerState;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize connectivity status
+    _initConnectivity();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Subscribe to connectivity changes
+    _connectivitySubscription = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+      setState(() {
+        _connectivityResult = result;
+      });
+      // Show or dismiss snackbar based on connectivity changes
+      showSnackBar(result);
+    });
+    // Get the ScaffoldMessengerState
+    _scaffoldMessengerState = ScaffoldMessenger.of(context);
+  }
+
+  @override
+  void dispose() {
+    _connectivitySubscription.cancel(); // Cancel subscription to avoid memory leaks
+    super.dispose();
+  }
+
+  Future<void> _initConnectivity() async {
+    final ConnectivityResult connectivityResult = await Connectivity().checkConnectivity();
+    setState(() {
+      _connectivityResult = connectivityResult;
+    });
+    // Show initial snackbar based on connectivity status
+    showSnackBar(connectivityResult);
+  }
+
+  void showSnackBar(ConnectivityResult connectivityResult) {
+    final bool isConnected = connectivityResult != ConnectivityResult.none;
+    _scaffoldMessengerState.hideCurrentSnackBar(); // Hide current snackbar
+
+    if (isConnected) {
+      _scaffoldMessengerState.showSnackBar(
+        const SnackBar(
+          content: Row(
+            children: [
+              Icon(
+                Icons.sync,
+                color: Colors.white,
+              ),
+              SizedBox(width: 8),
+              Text(
+                'Connecting',
+                style: TextStyle(color: Colors.white),
+              ),
+            ],
+          ),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    } else {
+      _scaffoldMessengerState.showSnackBar(
+        const SnackBar(
+          content: Row(
+            children: [
+              Icon(
+                Icons.error_outline,
+                color: Colors.white,
+              ),
+              SizedBox(width: 2),
+              Text(
+                'No Internet Connection',
+                style: TextStyle(color: Colors.white),
+              ),
+            ],
+          ),
+          duration: Duration(seconds: 365),
+        ),
+      );
+    }
+  }
+
+  void hideSnackBar() {
+    _scaffoldMessengerState.hideCurrentSnackBar();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text(''),
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/snackbar.dart
+++ b/lib/widgets/snackbar.dart
@@ -1,156 +1,39 @@
-//
-// import 'dart:async';
-// import 'package:flutter/material.dart';
-// import 'package:connectivity_plus/connectivity_plus.dart';
-//
-// class SnackBarPage extends StatefulWidget {
-//   const SnackBarPage({super.key});
-//
-//   @override
-//   SnackBarPageState createState() => SnackBarPageState();
-// }
-//
-// class SnackBarPageState extends State<SnackBarPage> {
-//   late ConnectivityResult _connectivityResult; // ignore: unused_field
-//   late StreamSubscription<ConnectivityResult> _connectivitySubscription;
-//
-//   @override
-//   void initState() {
-//     super.initState();
-//     // Initialize connectivity status
-//     _initConnectivity();
-//   }
-//
-//   @override
-//   void didChangeDependencies() {
-//     super.didChangeDependencies();
-//     // Subscribe to connectivity changes
-//     _connectivitySubscription = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
-//       setState(() {
-//         _connectivityResult = result;
-//       });
-//       // Show or dismiss snackbar based on connectivity changes
-//       showSnackBar(result);
-//     });
-//   }
-//
-//   @override
-//   void dispose() {
-//     _connectivitySubscription.cancel(); // Cancel subscription to avoid memory leaks
-//     super.dispose();
-//   }
-//
-//   Future<void> _initConnectivity() async {
-//     final ConnectivityResult connectivityResult = await Connectivity().checkConnectivity();
-//     setState(() {
-//       _connectivityResult = connectivityResult;
-//     });
-//     //  initial snackbar based on connectivity status
-//     showSnackBar(connectivityResult);
-//   }
-//
-//   void showSnackBar(ConnectivityResult connectivityResult) {
-//     final bool isConnected = connectivityResult != ConnectivityResult.none;
-//     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-//
-//     if (isConnected) {
-//       ScaffoldMessenger.of(context).showSnackBar(
-//         const SnackBar(
-//           content: Row(
-//             children: [
-//               Icon(
-//                 Icons.sync,
-//                 color: Colors.white,
-//               ),
-//               SizedBox(width: 8),
-//               Text(
-//                 'Connecting',
-//                 style: TextStyle(color: Colors.white),
-//               ),
-//             ],
-//           ),
-//           duration:  Duration(seconds: 3),
-//         ),
-//       );
-//     } else {
-//       ScaffoldMessenger.of(context).showSnackBar(
-//         const SnackBar(
-//           content:  Row(
-//             children: [
-//               Icon(
-//                 Icons.error_outline,
-//                 color: Colors.white,
-//               ),
-//               SizedBox(width: 2),
-//               Text(
-//                 'No Internet Connection',
-//                 style:  TextStyle(color: Colors.white),
-//               ),
-//             ],
-//           ),
-//           duration:  Duration(seconds: 365),
-//         ),
-//       );
-//     }
-//   }
-//
-//
-//   @override
-//   Widget build(BuildContext context) {
-//     return const Scaffold(
-//       body:  Center(
-//         child:   Text(''),
-//       ),
-//     );
-//   }
-// }
-//
-
-
-
-
+// @formatter:off
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 
 class SnackBarPage extends StatefulWidget {
-  const SnackBarPage({super.key});
-
+  final bool isStale;
+  const SnackBarPage({super.key, required this.isStale});
   @override
   SnackBarPageState createState() => SnackBarPageState();
 }
 
-
 class SnackBarPageState extends State<SnackBarPage> {
   late ConnectivityResult _connectivityResult; // ignore: unused_field
   late StreamSubscription<ConnectivityResult> _connectivitySubscription;
-  late ScaffoldMessengerState _scaffoldMessengerState;
 
   @override
   void initState() {
     super.initState();
-    // Initialize connectivity status
     _initConnectivity();
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // Subscribe to connectivity changes
-    _connectivitySubscription = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+    _connectivitySubscription = Connectivity().onConnectivityChanged.listen((result) {
       setState(() {
         _connectivityResult = result;
       });
-      // Show or dismiss snackbar based on connectivity changes
       showSnackBar(result);
     });
-    // Get the ScaffoldMessengerState
-    _scaffoldMessengerState = ScaffoldMessenger.of(context);
   }
 
   @override
   void dispose() {
-    _connectivitySubscription.cancel(); // Cancel subscription to avoid memory leaks
+    _connectivitySubscription.cancel();
     super.dispose();
   }
 
@@ -159,66 +42,53 @@ class SnackBarPageState extends State<SnackBarPage> {
     setState(() {
       _connectivityResult = connectivityResult;
     });
-    // Show initial snackbar based on connectivity status
     showSnackBar(connectivityResult);
   }
 
   void showSnackBar(ConnectivityResult connectivityResult) {
     final bool isConnected = connectivityResult != ConnectivityResult.none;
-    _scaffoldMessengerState.hideCurrentSnackBar(); // Hide current snackbar
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
 
-    if (isConnected) {
-      _scaffoldMessengerState.showSnackBar(
-        const SnackBar(
-          content: Row(
-            children: [
-              Icon(
-                Icons.sync,
-                color: Colors.white,
-              ),
-              SizedBox(width: 8),
-              Text(
-                'Connecting',
-                style: TextStyle(color: Colors.white),
-              ),
-            ],
-          ),
-          duration: Duration(seconds: 3),
-        ),
-      );
-    } else {
-      _scaffoldMessengerState.showSnackBar(
-        const SnackBar(
-          content: Row(
-            children: [
-              Icon(
-                Icons.error_outline,
-                color: Colors.white,
-              ),
-              SizedBox(width: 2),
-              Text(
-                'No Internet Connection',
-                style: TextStyle(color: Colors.white),
-              ),
-            ],
-          ),
-          duration: Duration(seconds: 365),
-        ),
-      );
+    if (!isConnected) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Row(
+              children: [
+                Icon(
+                  Icons.error_outline,
+                  color: Colors.white,
+                ),
+                SizedBox(width: 8),
+                Text(
+                    'No Internet Connection',
+                    style: TextStyle(color: Colors.white)),],),
+            duration: Duration(days: 365),
+          ));
     }
-  }
-
-  void hideSnackBar() {
-    _scaffoldMessengerState.hideCurrentSnackBar();
+    else if (widget.isStale) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Row(
+                children: [
+                  Icon(
+                    Icons.sync,
+                    color: Colors.white,
+                  ),
+                  SizedBox(width: 8),
+                  Text(
+                    'Connecting',
+                    style: TextStyle(color: Colors.white),
+                  )]),
+            duration: Duration(seconds: 20),
+          ));
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      body: Center(
-        child: Text(''),
-      ),
-    );
+        body: Center(
+          child: Text(''),
+        ));
   }
-}
-
+} // @formatter:off

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import device_info_plus
 import file_selector_macos
 import firebase_core
@@ -17,6 +18,7 @@ import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -201,6 +201,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "224a77051d52a11fbad53dd57827594d3bd24f945af28bd70bab376d68d437f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
   convert:
     dependency: "direct main"
     description:
@@ -724,6 +740,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  connectivity_plus: ^5.0.0
 
   app_settings: ^5.0.0
   collection: ^1.17.2

--- a/test/widgets/snackbar_test.dart
+++ b/test/widgets/snackbar_test.dart
@@ -1,105 +1,30 @@
+//@formatter:off
 import 'package:flutter/material.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/snackbar.dart';
 
-
-
-
-// void main() {
-//   testWidgets('showSnackBar displays correct SnackBar based on connectivity', (WidgetTester tester) async {
-//     // Create a test widget
-//     await tester.pumpWidget(
-//       MaterialApp(
-//         home: Builder(
-//           builder: (BuildContext context) {
-//             return const SnackBarPage();
-//           },
-//         ),
-//       ),
-//     );
-//
-//
-//     final snackBarPageState = tester.state<SnackBarPageState>(find.byType(SnackBarPage));
-//
-//     // Show SnackBar for connectivity result
-//     snackBarPageState.showSnackBar(ConnectivityResult.wifi);
-//     await tester.pump();
-//
-//
-//     expect(find.text('Connecting'), findsOneWidget);
-//     //expect(find.text('No Internet Connection'), findsOneWidget); // Assuming  no internet connection for wifi
-//
-//     //  Hide the SnackBar
-//     ScaffoldMessenger.of(tester.element(find.byType(SnackBarPage))).hideCurrentSnackBar();
-//
-//     //  SnackBar for no internet connection
-//     snackBarPageState.showSnackBar(ConnectivityResult.none); // Call showSnackBar with no internet connection
-//     await tester.pump(); // Rebuild widget tree
-//
-//
-// //    expect(find.text('Connecting'), findsNothing); // SnackBar for connecting should be hidden
-//     expect(find.text('No Internet Connection'), findsOneWidget);
-//
-//     // Hide the SnackBar
-//     ScaffoldMessenger.of(tester.element(find.byType(SnackBarPage))).hideCurrentSnackBar();
-//   });
-// }
-//
-//
-//
-
-
 void main() {
-  testWidgets('showSnackBar displays correct SnackBar based on connectivity', (WidgetTester tester) async {
-    // Create a test widget
+  testWidgets('SnackBarPage displays correct SnackBar based on connectivity', (WidgetTester tester) async {
+    //  connection restored with isStale = true
     await tester.pumpWidget(
       MaterialApp(
-        home: Builder(
-          builder: (BuildContext context) {
-            return const SnackBarPage();
-          },
-        ),
-      ),
+          home: Builder(
+              builder: (BuildContext context) {
+                return const SnackBarPage(isStale: true);
+              })),
     );
 
-    // Wait for initialization of SnackBarPageState
-    await tester.pump(Duration.zero);
-
+    //  state of SnackBarPage
     final snackBarPageState = tester.state<SnackBarPageState>(find.byType(SnackBarPage));
-
-    // Show SnackBar for connectivity result
     snackBarPageState.showSnackBar(ConnectivityResult.wifi);
     await tester.pump();
-
-    // Check visibility of the SnackBar
-    expect(find.byType(SnackBar), findsOneWidget);
     expect(find.text('Connecting'), findsOneWidget);
-
-    // Hide the SnackBar
-    snackBarPageState.hideSnackBar();
+    //  showSnackBar with ConnectivityResult.none
+    snackBarPageState.showSnackBar(ConnectivityResult.none);
+    // Wait for the widget to rebuild with the new SnackBar
     await tester.pump();
-
-    // Check visibility of the SnackBar after hiding
-    expect(find.byType(SnackBar), findsNothing);
-
-    // SnackBar for no internet connection
-    snackBarPageState.showSnackBar(ConnectivityResult.none); // Call showSnackBar with no internet connection
-    await tester.pump(); // Rebuild widget tree
-
-    // Check visibility of the SnackBar
-    expect(find.byType(SnackBar), findsOneWidget);
+    // Verify that the 'Connecting' SnackBar is shown
     expect(find.text('No Internet Connection'), findsOneWidget);
-
-    // Hide the SnackBar
-    snackBarPageState.hideSnackBar();
-    await tester.pump();
-
-    // Check visibility of the SnackBar after hiding
-    expect(find.byType(SnackBar), findsNothing);
   });
-}
-
-
-
-
+} //@formatter:off

--- a/test/widgets/snackbar_test.dart
+++ b/test/widgets/snackbar_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/widgets/snackbar.dart';
+
+
+
+
+// void main() {
+//   testWidgets('showSnackBar displays correct SnackBar based on connectivity', (WidgetTester tester) async {
+//     // Create a test widget
+//     await tester.pumpWidget(
+//       MaterialApp(
+//         home: Builder(
+//           builder: (BuildContext context) {
+//             return const SnackBarPage();
+//           },
+//         ),
+//       ),
+//     );
+//
+//
+//     final snackBarPageState = tester.state<SnackBarPageState>(find.byType(SnackBarPage));
+//
+//     // Show SnackBar for connectivity result
+//     snackBarPageState.showSnackBar(ConnectivityResult.wifi);
+//     await tester.pump();
+//
+//
+//     expect(find.text('Connecting'), findsOneWidget);
+//     //expect(find.text('No Internet Connection'), findsOneWidget); // Assuming  no internet connection for wifi
+//
+//     //  Hide the SnackBar
+//     ScaffoldMessenger.of(tester.element(find.byType(SnackBarPage))).hideCurrentSnackBar();
+//
+//     //  SnackBar for no internet connection
+//     snackBarPageState.showSnackBar(ConnectivityResult.none); // Call showSnackBar with no internet connection
+//     await tester.pump(); // Rebuild widget tree
+//
+//
+// //    expect(find.text('Connecting'), findsNothing); // SnackBar for connecting should be hidden
+//     expect(find.text('No Internet Connection'), findsOneWidget);
+//
+//     // Hide the SnackBar
+//     ScaffoldMessenger.of(tester.element(find.byType(SnackBarPage))).hideCurrentSnackBar();
+//   });
+// }
+//
+//
+//
+
+
+void main() {
+  testWidgets('showSnackBar displays correct SnackBar based on connectivity', (WidgetTester tester) async {
+    // Create a test widget
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return const SnackBarPage();
+          },
+        ),
+      ),
+    );
+
+    // Wait for initialization of SnackBarPageState
+    await tester.pump(Duration.zero);
+
+    final snackBarPageState = tester.state<SnackBarPageState>(find.byType(SnackBarPage));
+
+    // Show SnackBar for connectivity result
+    snackBarPageState.showSnackBar(ConnectivityResult.wifi);
+    await tester.pump();
+
+    // Check visibility of the SnackBar
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('Connecting'), findsOneWidget);
+
+    // Hide the SnackBar
+    snackBarPageState.hideSnackBar();
+    await tester.pump();
+
+    // Check visibility of the SnackBar after hiding
+    expect(find.byType(SnackBar), findsNothing);
+
+    // SnackBar for no internet connection
+    snackBarPageState.showSnackBar(ConnectivityResult.none); // Call showSnackBar with no internet connection
+    await tester.pump(); // Rebuild widget tree
+
+    // Check visibility of the SnackBar
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('No Internet Connection'), findsOneWidget);
+
+    // Hide the SnackBar
+    snackBarPageState.hideSnackBar();
+    await tester.pump();
+
+    // Check visibility of the SnackBar after hiding
+    expect(find.byType(SnackBar), findsNothing);
+  });
+}
+
+
+
+

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -13,6 +14,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   firebase_core
   share_plus


### PR DESCRIPTION
PR for issue #465 
This commit introduces a SnackBarPage widget that manages changes in connectivity status and displays corresponding SnackBars. The SnackBarPage widget listens to connectivity changes using the Connectivity package and updates the UI to show a SnackBar indicating either "No Internet Connection" or "Connecting" based on the current connectivity status and the value of the isStale property.

The initState method initializes the connectivity status when the widget is first created, while the didChangeDependencies method subscribes to connectivity changes to update the UI accordingly. To prevent memory leaks, the dispose method cancels the subscription when the widget is disposed.

The showSnackBar method is responsible for displaying the appropriate SnackBar based on the current connectivity status and the value of the isStale property. It utilizes ScaffoldMessenger to manage SnackBar display and dismissal.
![2](https://github.com/zulip/zulip-flutter/assets/112092492/702b66f4-c21a-423a-89c1-861431652af8)
![1](https://github.com/zulip/zulip-flutter/assets/112092492/0fbc966f-7b9b-4e9d-9379-7cdf9d5254f1)
