### PR TITLE
content: Handle blank text nodes after code blocks.

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1124,6 +1124,8 @@ class _ZulipContentParser {
     return result;
   }
 
+  static final _redundantLineBreaksRegexp = RegExp(r'^\n+$');
+
   List<BlockContentNode> parseBlockContentList(dom.NodeList nodes) {
     assert(_debugParserContext == _ParserContext.block);
     final List<BlockContentNode> result = [];
@@ -1131,7 +1133,9 @@ class _ZulipContentParser {
     for (final node in nodes) {
       // We get a bunch of newline Text nodes between paragraphs.
       // A browser seems to ignore these; let's do the same.
-      if (node is dom.Text && (node.text == '\n')) continue;
+      if (node is dom.Text && _redundantLineBreaksRegexp.hasMatch(node.text)) {
+        continue;
+      }
 
       final block = parseBlockContent(node);
       if (block is ImageNode) {

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -301,6 +301,17 @@ class ContentExample {
         '\n</code></pre></div>'),
     ]);
 
+  static const codeBlockFollowedByMultipleLineBreaks = ContentExample(
+    'blank text nodes after code blocks',
+    '    code block.\n\nsome content',
+    // https://chat.zulip.org/#narrow/stream/7-test-here/near/1774823
+    '<div class="codehilite">'
+      '<pre><span></span><code>code block.\n</code></pre></div>\n\n'
+    '<p>some content</p>', [
+      CodeBlockNode([CodeBlockSpanNode(text: "code block.", type: CodeBlockSpanType.text)]),
+      ParagraphNode(links: null, nodes: [TextNode("some content")]),
+    ]);
+
   static final mathInline = ContentExample.inline(
     'inline math',
     r"$$ \lambda $$",
@@ -865,6 +876,7 @@ void main() {
   testParseExample(ContentExample.codeBlockHighlightedMultiline);
   testParseExample(ContentExample.codeBlockWithHighlightedLines);
   testParseExample(ContentExample.codeBlockWithUnknownSpanType);
+  testParseExample(ContentExample.codeBlockFollowedByMultipleLineBreaks);
 
   testParseExample(ContentExample.mathBlock);
   testParseExample(ContentExample.mathBlockInQuote);


### PR DESCRIPTION
|before|after|
|-----|----|
|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-30 at 02 18 02](https://github.com/zulip/zulip-flutter/assets/63330019/0f4b12b6-f51d-4ac3-8767-0a5b458215ec)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-30 at 02 18 45](https://github.com/zulip/zulip-flutter/assets/63330019/bfbcda89-a487-4d12-a4e3-ba91895962db)|

Fixes: #355
