### PR TITLE
msglist: Distinguish `isBot: true` message senders with a bot marker

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -896,7 +896,10 @@ class MessageWithPossibleSender extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+
     final message = item.message;
+    final sender = store.users[message.senderId];
 
     Widget? senderRow;
     if (item.showSender) {
@@ -926,6 +929,14 @@ class MessageWithPossibleSender extends StatelessWidget {
                       ).merge(weightVariableTextStyle(context, wght: 600,
                                 wghtIfPlatformRequestsBold: 900)),
                       overflow: TextOverflow.ellipsis)),
+                  if (sender?.isBot ?? false) ...[
+                    const SizedBox(width: 5),
+                    const Icon(
+                      ZulipIcons.bot,
+                      size: 15,
+                      color: Color.fromARGB(255, 159, 173, 173),
+                    ),
+                  ],
                 ]))),
           const SizedBox(width: 4),
           Text(time,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -75,6 +75,7 @@ User user({
   String? email,
   String? fullName,
   bool? isActive,
+  bool? isBot,
   String? avatarUrl,
   Map<int, ProfileFieldUserData>? profileData,
 }) {
@@ -89,7 +90,7 @@ User user({
     isAdmin: false,
     isGuest: false,
     isBillingAdmin: false,
-    isBot: false,
+    isBot: isBot ?? false,
     botType: null,
     botOwnerId: null,
     role: UserRole.member,

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
@@ -467,11 +466,7 @@ void main() {
         await tester.pump();
       }
 
-      final httpClient = FakeImageHttpClient();
-      debugNetworkImageHttpClientProvider = () => httpClient;
-      httpClient.request.response
-        ..statusCode = HttpStatus.ok
-        ..content = kSolidBlueAvatar;
+      prepareBoringImageHttpClient();
 
       await setupMessageListPage(tester, messageCount: 10);
       checkResultForSender(eg.selfUser.avatarUrl);


### PR DESCRIPTION
A bot icon is shown with the name of the bot users.

<table>
    <tr>
        <td><b>Before</b></td>
        <td><b>After</b></td>
    </tr>
    <tr>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/cdaad5f4-e1dc-4b7d-bb31-33e83f603241" width="300"/></td>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/2444131d-dd0e-4c23-a26d-20d567025c7a" width="300"/></td>
    </tr>
</table>

Fixes: #156