### PR TITLE
choose-account: Put 8px top padding on scrollable content, not its viewport

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -218,12 +218,13 @@ class ChooseAccountPage extends StatelessWidget {
         title: Text(zulipLocalizations.chooseAccountPageTitle),
         actions: const [ChooseAccountPageOverflowButton()]),
       body: SafeArea(
-        minimum: const EdgeInsets.all(8),
+        minimum: const EdgeInsets.fromLTRB(8, 0, 8, 8),
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400),
             child: Column(mainAxisSize: MainAxisSize.min, children: [
               Flexible(child: SingleChildScrollView(
+                padding: const EdgeInsets.only(top: 8),
                 child: Column(mainAxisSize: MainAxisSize.min, children: [
                   for (final (:accountId, :account) in globalStore.accountEntries)
                     _buildAccountItem(context,


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![76E88B36-C44D-4737-AAB7-F0F2C84FBBB0](https://github.com/zulip/zulip-flutter/assets/22248748/c153ca4f-adf4-4261-9662-4a56b1e6ce4d) | ![A90C589F-09E5-48B8-9B5A-A86757D5EA17](https://github.com/zulip/zulip-flutter/assets/22248748/eddee67a-353f-4312-bea3-5702968f21c2) |
| ![1A282E68-F6FF-4FBA-89F8-A1D5CF0C9504](https://github.com/zulip/zulip-flutter/assets/22248748/d4273e87-3420-4329-a5cf-b227629f6721) | ![9EE2200B-5463-4332-9CD7-00D0EA0B4143](https://github.com/zulip/zulip-flutter/assets/22248748/3a6694c4-d820-4acc-8349-091d48e6e4f9) |

Fixes: #606