### PR TITLE
ide: Include .idea/zulip.iml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ migrate_working_dir/
 /.idea/*
 /android/.idea/*
 !/.idea/inspectionProfiles/
+!/.idea/modules.xml
+!/.idea/zulip.iml
 !/android/.idea/inspectionProfiles/
 
 # The .vscode folder contains launch configuration and tasks you configure in

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/zulip.iml" filepath="$PROJECT_DIR$/.idea/zulip.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/zulip.iml
+++ b/.idea/zulip.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/ios/.symlinks" />
+      <excludeFolder url="file://$MODULE_DIR$/linux/flutter/ephemeral" />
+      <excludeFolder url="file://$MODULE_DIR$/macos/Flutter/ephemeral" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/zulip_plugin/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/zulip_plugin/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/zulip_plugin/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tools/icons/node_modules" />
+      <excludeFolder url="file://$MODULE_DIR$/windows/flutter/ephemeral" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,3 +1,7 @@
+<!-- To view the "merged manifest" in Android Studio,
+     open the android/ subtree as its own project
+     and follow these instructions:
+       https://developer.android.com/build/manage-manifests#inspect_the_merged_manifest_and_find_conflicts -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <uses-permission android:name="android.permission.INTERNET"/>
    <application


### PR DESCRIPTION
This has some useful `excludeFolder` items that should help Android Studio see that certain files are not part of our project and should be excluded in searches that are supposed to be limited to "project files".