### PR TITLE
android: Set launchMode="singleTask" instead of "singleTop"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:networkSecurityConfig="@xml/network_security_config"


### PR DESCRIPTION
This addresses #620 by making it so the whole app state isn't reset when coming back from Firefox in the web-auth flow. Discussion:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/Flutter.20app.20.2B.20SAML.20auth/near/1776828

Later in that discussion, Greg found that this mode is the most appropriate for our app, and that setting taskAffinity="" is probably a good idea as a security-hardening measure.

Fixes: #620