### PR TITLE
model [nfc]: Remove StreamColorSwatch; just use ColorSwatch<StreamColorVariant>

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -469,22 +469,10 @@ class StreamColorSwatch extends ColorSwatch<_StreamColorVariant> {
 
   Color get unreadCountBadgeBackground => this[_StreamColorVariant.unreadCountBadgeBackground]!;
 
-  /// The stream icon on a plain-colored surface, such as white.
-  ///
-  /// For the icon on a [barBackground]-colored surface,
-  /// use [iconOnBarBackground] instead.
   Color get iconOnPlainBackground => this[_StreamColorVariant.iconOnPlainBackground]!;
 
-  /// The stream icon on a [barBackground]-colored surface.
-  ///
-  /// For the icon on a plain surface, use [iconOnPlainBackground] instead.
-  /// This color is chosen to enhance contrast with [barBackground]:
-  ///   <https://github.com/zulip/zulip/pull/27485>
   Color get iconOnBarBackground => this[_StreamColorVariant.iconOnBarBackground]!;
 
-  /// The background color of a bar representing a stream, like a recipient bar.
-  ///
-  /// Use this in the message list, the "Inbox" view, and the "Streams" view.
   Color get barBackground => this[_StreamColorVariant.barBackground]!;
 
   static Map<_StreamColorVariant, Color> _compute(int base) {
@@ -540,8 +528,23 @@ class StreamColorSwatch extends ColorSwatch<_StreamColorVariant> {
 enum _StreamColorVariant {
   base,
   unreadCountBadgeBackground,
+
+  /// The stream icon on a plain-colored surface, such as white.
+  ///
+  /// For the icon on a [barBackground]-colored surface,
+  /// use [iconOnBarBackground] instead.
   iconOnPlainBackground,
+
+  /// The stream icon on a [barBackground]-colored surface.
+  ///
+  /// For the icon on a plain surface, use [iconOnPlainBackground] instead.
+  /// This color is chosen to enhance contrast with [barBackground]:
+  ///   <https://github.com/zulip/zulip/pull/27485>
   iconOnBarBackground,
+
+  /// The background color of a bar representing a stream, like a recipient bar.
+  ///
+  /// Use this in the message list, the "Inbox" view, and the "Streams" view.
   barBackground,
 }
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -526,7 +526,9 @@ class StreamColorSwatch extends ColorSwatch<_StreamColorVariant> {
 }
 
 enum _StreamColorVariant {
+  /// The [Subscription.color] int that the swatch is based on.
   base,
+
   unreadCountBadgeBackground,
 
   /// The stream icon on a plain-colored surface, such as white.

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -416,17 +416,17 @@ class Subscription extends ZulipStream {
     return 0xff000000 | int.parse(str.substring(1), radix: 16);
   }
 
-  ColorSwatch<StreamColorVariant>? _swatch;
+  ColorSwatch<StreamColor>? _swatch;
   /// A [ColorSwatch<StreamColorVariant>] for the subscription, memoized.
   // TODO I'm not sure this is the right home for this; it seems like we might
   //   instead have chosen to put it in more UI-centered code, like in a custom
   //   material [ColorScheme] class or something. But it works for now.
-  ColorSwatch<StreamColorVariant> colorSwatch() =>
+  ColorSwatch<StreamColor> colorSwatch() =>
     _swatch ??= streamColorSwatch(color);
 
   @visibleForTesting
   @JsonKey(includeToJson: false)
-  ColorSwatch<StreamColorVariant>? get debugCachedSwatchValue => _swatch;
+  ColorSwatch<StreamColor>? get debugCachedSwatchValue => _swatch;
 
   Subscription({
     required super.streamId,
@@ -463,21 +463,21 @@ class Subscription extends ZulipStream {
 ///
 /// Use this in UI code for colors related to [Subscription.color],
 /// such as the background of an unread count badge.
-ColorSwatch<StreamColorVariant> streamColorSwatch(int base) {
+ColorSwatch<StreamColor> streamColorSwatch(int base) {
   final baseAsColor = Color(base);
 
   final clamped20to75 = clampLchLightness(baseAsColor, 20, 75);
   final clamped20to75AsHsl = HSLColor.fromColor(clamped20to75);
 
   final map = {
-    StreamColorVariant.base: baseAsColor,
+    StreamColor.base: baseAsColor,
 
     // Follows `.unread-count` in Vlad's replit:
     //   <https://replit.com/@VladKorobov/zulip-sidebar#script.js>
     //   <https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/design.3A.20.23F117.20.22Inbox.22.20screen/near/1624484>
     //
     // TODO fix bug where our results differ from the replit's (see unit tests)
-    StreamColorVariant.unreadCountBadgeBackground:
+    StreamColor.unreadCountBadgeBackground:
       clampLchLightness(baseAsColor, 30, 70)
         .withOpacity(0.3),
 
@@ -485,14 +485,14 @@ ColorSwatch<StreamColorVariant> streamColorSwatch(int base) {
     //   <https://replit.com/@VladKorobov/zulip-topic-feed-colors#script.js>
     //
     // TODO fix bug where our results differ from the replit's (see unit tests)
-    StreamColorVariant.iconOnPlainBackground: clamped20to75,
+    StreamColor.iconOnPlainBackground: clamped20to75,
 
     // Follows `.recepeient__icon` in Vlad's replit:
     //   <https://replit.com/@VladKorobov/zulip-topic-feed-colors#script.js>
     //   <https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/design.3A.20.23F117.20.22Inbox.22.20screen/near/1624484>
     //
     // TODO fix bug where our results differ from the replit's (see unit tests)
-    StreamColorVariant.iconOnBarBackground:
+    StreamColor.iconOnBarBackground:
       clamped20to75AsHsl
         .withLightness(clamped20to75AsHsl.lightness - 0.12)
         .toColor(),
@@ -505,16 +505,16 @@ ColorSwatch<StreamColorVariant> streamColorSwatch(int base) {
     //     <https://pub.dev/documentation/flutter_color_models/latest/flutter_color_models/ColorModel/interpolate.html>
     //   which does ordinary RGB mixing. Investigate and send a PR?
     // TODO fix bug where our results differ from the replit's (see unit tests)
-    StreamColorVariant.barBackground:
+    StreamColor.barBackground:
       LabColor.fromColor(const Color(0xfff9f9f9))
         .interpolate(LabColor.fromColor(clamped20to75), 0.22)
         .toColor(),
   };
 
-  return ColorSwatch<StreamColorVariant>(base, map);
+  return ColorSwatch<StreamColor>(base, map);
 }
 
-enum StreamColorVariant {
+enum StreamColor {
   /// The [Subscription.color] int that the swatch is based on.
   base,
 

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -410,12 +410,14 @@ class _StreamHeaderItem extends _HeaderItem {
 
   @override get title => subscription.name;
   @override get icon => iconDataForStream(subscription);
-  @override get collapsedIconColor => subscription.colorSwatch().iconOnPlainBackground;
-  @override get uncollapsedIconColor => subscription.colorSwatch().iconOnBarBackground;
+  @override get collapsedIconColor =>
+    subscription.colorSwatch()[StreamColorVariant.iconOnPlainBackground]!;
+  @override get uncollapsedIconColor =>
+    subscription.colorSwatch()[StreamColorVariant.iconOnBarBackground]!;
   @override get uncollapsedBackgroundColor =>
-    subscription.colorSwatch().barBackground;
+    subscription.colorSwatch()[StreamColorVariant.barBackground]!;
   @override get unreadCountBadgeBackgroundColor =>
-    subscription.colorSwatch().unreadCountBadgeBackground;
+    subscription.colorSwatch()[StreamColorVariant.unreadCountBadgeBackground]!;
 
   @override get onCollapseButtonTap => () async {
     await super.onCollapseButtonTap();

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -411,13 +411,13 @@ class _StreamHeaderItem extends _HeaderItem {
   @override get title => subscription.name;
   @override get icon => iconDataForStream(subscription);
   @override get collapsedIconColor =>
-    subscription.colorSwatch()[StreamColorVariant.iconOnPlainBackground]!;
+    subscription.colorSwatch()[StreamColor.iconOnPlainBackground]!;
   @override get uncollapsedIconColor =>
-    subscription.colorSwatch()[StreamColorVariant.iconOnBarBackground]!;
+    subscription.colorSwatch()[StreamColor.iconOnBarBackground]!;
   @override get uncollapsedBackgroundColor =>
-    subscription.colorSwatch()[StreamColorVariant.barBackground]!;
+    subscription.colorSwatch()[StreamColor.barBackground]!;
   @override get unreadCountBadgeBackgroundColor =>
-    subscription.colorSwatch()[StreamColorVariant.unreadCountBadgeBackground]!;
+    subscription.colorSwatch()[StreamColor.unreadCountBadgeBackground]!;
 
   @override get onCollapseButtonTap => () async {
     await super.onCollapseButtonTap();

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -67,7 +67,7 @@ class _MessageListPageState extends State<MessageListPage> {
       case StreamNarrow(:final streamId):
       case TopicNarrow(:final streamId):
         backgroundColor =
-          store.subscriptions[streamId]?.colorSwatch()[StreamColorVariant.barBackground]!
+          store.subscriptions[streamId]?.colorSwatch()[StreamColor.barBackground]!
           ?? _kUnsubscribedStreamRecipientHeaderColor;
         // All recipient headers will match this color; remove distracting line
         // (but are recipient headers even needed for topic narrows?)
@@ -656,12 +656,12 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     final Color iconColor;
     if (subscription != null) {
       final swatch = subscription.colorSwatch();
-      backgroundColor = swatch[StreamColorVariant.barBackground]!;
+      backgroundColor = swatch[StreamColor.barBackground]!;
       contrastingColor =
         (ThemeData.estimateBrightnessForColor(backgroundColor) == Brightness.dark)
           ? Colors.white
           : Colors.black;
-      iconColor = swatch[StreamColorVariant.iconOnBarBackground]!;
+      iconColor = swatch[StreamColor.iconOnBarBackground]!;
     } else {
       backgroundColor = _kUnsubscribedStreamRecipientHeaderColor;
       contrastingColor = Colors.black;

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -66,7 +66,8 @@ class _MessageListPageState extends State<MessageListPage> {
 
       case StreamNarrow(:final streamId):
       case TopicNarrow(:final streamId):
-        backgroundColor = store.subscriptions[streamId]?.colorSwatch().barBackground
+        backgroundColor =
+          store.subscriptions[streamId]?.colorSwatch()[StreamColorVariant.barBackground]!
           ?? _kUnsubscribedStreamRecipientHeaderColor;
         // All recipient headers will match this color; remove distracting line
         // (but are recipient headers even needed for topic narrows?)
@@ -655,12 +656,12 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     final Color iconColor;
     if (subscription != null) {
       final swatch = subscription.colorSwatch();
-      backgroundColor = swatch.barBackground;
+      backgroundColor = swatch[StreamColorVariant.barBackground]!;
       contrastingColor =
-        (ThemeData.estimateBrightnessForColor(swatch.barBackground) == Brightness.dark)
+        (ThemeData.estimateBrightnessForColor(backgroundColor) == Brightness.dark)
           ? Colors.white
           : Colors.black;
-      iconColor = swatch.iconOnBarBackground;
+      iconColor = swatch[StreamColorVariant.iconOnBarBackground]!;
     } else {
       backgroundColor = _kUnsubscribedStreamRecipientHeaderColor;
       contrastingColor = Colors.black;

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -208,7 +208,7 @@ class SubscriptionItem extends StatelessWidget {
           const SizedBox(width: 16),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 11),
-            child: Icon(size: 18, color: swatch[StreamColorVariant.iconOnPlainBackground]!,
+            child: Icon(size: 18, color: swatch[StreamColor.iconOnPlainBackground]!,
               iconDataForStream(subscription))),
           const SizedBox(width: 5),
           Expanded(

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -208,7 +208,7 @@ class SubscriptionItem extends StatelessWidget {
           const SizedBox(width: 16),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 11),
-            child: Icon(size: 18, color: swatch.iconOnPlainBackground,
+            child: Icon(size: 18, color: swatch[StreamColorVariant.iconOnPlainBackground]!,
               iconDataForStream(subscription))),
           const SizedBox(width: 5),
           Expanded(

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -31,8 +31,8 @@ class UnreadCountBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final backgroundColor = this.backgroundColor;
     final effectiveBackgroundColor = switch (backgroundColor) {
-      ColorSwatch<StreamColorVariant>() =>
-        backgroundColor[StreamColorVariant.unreadCountBadgeBackground]!,
+      ColorSwatch<StreamColor>() =>
+        backgroundColor[StreamColor.unreadCountBadgeBackground]!,
       Color() => backgroundColor,
       null => const Color.fromRGBO(102, 102, 153, 0.15),
     };

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -21,16 +21,18 @@ class UnreadCountBadge extends StatelessWidget {
 
   /// The badge's background color.
   ///
-  /// Pass a [StreamColorSwatch] if this badge represents messages in one
-  /// specific stream. The appropriate color from the swatch will be used.
+  /// Pass a [ColorSwatch<StreamColorVariant>] if this badge represents messages
+  /// in one specific stream. The appropriate color from the swatch will be used.
   ///
   /// If null, the default neutral background will be used.
   final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
+    final backgroundColor = this.backgroundColor;
     final effectiveBackgroundColor = switch (backgroundColor) {
-      StreamColorSwatch(unreadCountBadgeBackground: var color) => color,
+      ColorSwatch<StreamColorVariant>() =>
+        backgroundColor[StreamColorVariant.unreadCountBadgeBackground]!,
       Color() => backgroundColor,
       null => const Color.fromRGBO(102, 102, 153, 0.15),
     };

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:checks/checks.dart';
 import 'package:zulip/api/model/model.dart';
 
@@ -27,14 +25,6 @@ extension UserChecks on Subject<User> {
 
 extension ZulipStreamChecks on Subject<ZulipStream> {
   Subject<int?> get canRemoveSubscribersGroup => has((e) => e.canRemoveSubscribersGroup, 'canRemoveSubscribersGroup');
-}
-
-extension StreamColorSwatchChecks on Subject<StreamColorSwatch> {
-  Subject<Color> get base => has((s) => s.base, 'base');
-  Subject<Color> get unreadCountBadgeBackground => has((s) => s.unreadCountBadgeBackground, 'unreadCountBadgeBackground');
-  Subject<Color> get iconOnPlainBackground => has((s) => s.iconOnPlainBackground, 'iconOnPlainBackground');
-  Subject<Color> get iconOnBarBackground => has((s) => s.iconOnBarBackground, 'iconOnBarBackground');
-  Subject<Color> get barBackground => has((s) => s.barBackground, 'barBackground');
 }
 
 extension MessageChecks on Subject<Message> {

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -5,6 +5,7 @@ import 'package:checks/checks.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/model.dart';
 
+import '../../flutter_checks.dart';
 import '../../example_data.dart' as eg;
 import '../../stdlib_checks.dart';
 import 'model_checks.dart';
@@ -120,21 +121,25 @@ void main() {
       final sub = eg.subscription(eg.stream(), color: 0xffffffff);
       check(sub.debugCachedSwatchValue).isNull();
       sub.colorSwatch();
-      check(sub.debugCachedSwatchValue).isNotNull().base.equals(const Color(0xffffffff));
+      check(sub.debugCachedSwatchValue).isNotNull()
+        [StreamColorVariant.base].equals(const Color(0xffffffff));
       sub.color = 0xffff0000;
       check(sub.debugCachedSwatchValue).isNull();
       sub.colorSwatch();
-      check(sub.debugCachedSwatchValue).isNotNull().base.equals(const Color(0xffff0000));
+      check(sub.debugCachedSwatchValue).isNotNull()
+        [StreamColorVariant.base].equals(const Color(0xffff0000));
     });
 
-    group('StreamColorSwatch', () {
+    group('streamColorSwatch', () {
       test('base', () {
-        check(StreamColorSwatch(0xffffffff)).base.equals(const Color(0xffffffff));
+        check(streamColorSwatch(0xffffffff))[StreamColorVariant.base]
+          .equals(const Color(0xffffffff));
       });
 
       test('unreadCountBadgeBackground', () {
         void runCheck(int base, Color expected) {
-          check(StreamColorSwatch(base)).unreadCountBadgeBackground.equals(expected);
+          check(streamColorSwatch(base))
+            [StreamColorVariant.unreadCountBadgeBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS and EXTREME_COLORS
@@ -196,7 +201,8 @@ void main() {
 
       test('iconOnPlainBackground', () {
         void runCheck(int base, Color expected) {
-          check(StreamColorSwatch(base)).iconOnPlainBackground.equals(expected);
+          check(streamColorSwatch(base))
+            [StreamColorVariant.iconOnPlainBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -237,7 +243,8 @@ void main() {
 
       test('iconOnBarBackground', () {
         void runCheck(int base, Color expected) {
-          check(StreamColorSwatch(base)).iconOnBarBackground.equals(expected);
+          check(streamColorSwatch(base))
+            [StreamColorVariant.iconOnBarBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -278,7 +285,8 @@ void main() {
 
       test('barBackground', () {
         void runCheck(int base, Color expected) {
-          check(StreamColorSwatch(base)).barBackground.equals(expected);
+          check(streamColorSwatch(base))
+            [StreamColorVariant.barBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -122,24 +122,24 @@ void main() {
       check(sub.debugCachedSwatchValue).isNull();
       sub.colorSwatch();
       check(sub.debugCachedSwatchValue).isNotNull()
-        [StreamColorVariant.base].equals(const Color(0xffffffff));
+        [StreamColor.base].equals(const Color(0xffffffff));
       sub.color = 0xffff0000;
       check(sub.debugCachedSwatchValue).isNull();
       sub.colorSwatch();
       check(sub.debugCachedSwatchValue).isNotNull()
-        [StreamColorVariant.base].equals(const Color(0xffff0000));
+        [StreamColor.base].equals(const Color(0xffff0000));
     });
 
     group('streamColorSwatch', () {
       test('base', () {
-        check(streamColorSwatch(0xffffffff))[StreamColorVariant.base]
+        check(streamColorSwatch(0xffffffff))[StreamColor.base]
           .equals(const Color(0xffffffff));
       });
 
       test('unreadCountBadgeBackground', () {
         void runCheck(int base, Color expected) {
           check(streamColorSwatch(base))
-            [StreamColorVariant.unreadCountBadgeBackground].equals(expected);
+            [StreamColor.unreadCountBadgeBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS and EXTREME_COLORS
@@ -202,7 +202,7 @@ void main() {
       test('iconOnPlainBackground', () {
         void runCheck(int base, Color expected) {
           check(streamColorSwatch(base))
-            [StreamColorVariant.iconOnPlainBackground].equals(expected);
+            [StreamColor.iconOnPlainBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -244,7 +244,7 @@ void main() {
       test('iconOnBarBackground', () {
         void runCheck(int base, Color expected) {
           check(streamColorSwatch(base))
-            [StreamColorVariant.iconOnBarBackground].equals(expected);
+            [StreamColor.iconOnBarBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -286,7 +286,7 @@ void main() {
       test('barBackground', () {
         void runCheck(int base, Color expected) {
           check(streamColorSwatch(base))
-            [StreamColorVariant.barBackground].equals(expected);
+            [StreamColor.barBackground].equals(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -5,6 +5,10 @@ import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+extension ColorSwatchChecks<T> on Subject<ColorSwatch<T>> {
+  Subject<Color?> operator [](T index) => has((x) => x[index], '[$index]');
+}
+
 extension RectChecks on Subject<Rect> {
   Subject<double> get top => has((d) => d.top, 'top');
   Subject<double> get bottom => has((d) => d.bottom, 'bottom');

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -412,7 +412,7 @@ void main() {
           check(collapseIcon).icon.equals(ZulipIcons.arrow_down);
           final streamIcon = findStreamHeaderIcon(tester, streamId);
           check(streamIcon).color
-            .equals(subscription.colorSwatch()[StreamColorVariant.iconOnBarBackground]!);
+            .equals(subscription.colorSwatch()[StreamColor.iconOnBarBackground]!);
           // TODO check bar background color
           check(tester.widgetList(findSectionContent)).isNotEmpty();
         }
@@ -434,7 +434,7 @@ void main() {
           check(collapseIcon).icon.equals(ZulipIcons.arrow_right);
           final streamIcon = findStreamHeaderIcon(tester, streamId);
           check(streamIcon).color
-            .equals(subscription.colorSwatch()[StreamColorVariant.iconOnPlainBackground]!);
+            .equals(subscription.colorSwatch()[StreamColor.iconOnPlainBackground]!);
           // TODO check bar background color
           check(tester.widgetList(findSectionContent)).isEmpty();
         }

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -411,7 +411,8 @@ void main() {
           final collapseIcon = findHeaderCollapseIcon(tester, headerRow!);
           check(collapseIcon).icon.equals(ZulipIcons.arrow_down);
           final streamIcon = findStreamHeaderIcon(tester, streamId);
-          check(streamIcon).color.equals(subscription.colorSwatch().iconOnBarBackground);
+          check(streamIcon).color
+            .equals(subscription.colorSwatch()[StreamColorVariant.iconOnBarBackground]!);
           // TODO check bar background color
           check(tester.widgetList(findSectionContent)).isNotEmpty();
         }
@@ -432,7 +433,8 @@ void main() {
           final collapseIcon = findHeaderCollapseIcon(tester, headerRow!);
           check(collapseIcon).icon.equals(ZulipIcons.arrow_right);
           final streamIcon = findStreamHeaderIcon(tester, streamId);
-          check(streamIcon).color.equals(subscription.colorSwatch().iconOnPlainBackground);
+          check(streamIcon).color
+            .equals(subscription.colorSwatch()[StreamColorVariant.iconOnPlainBackground]!);
           // TODO check bar background color
           check(tester.widgetList(findSectionContent)).isEmpty();
         }

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -282,7 +282,7 @@ void main() {
           find.descendant(
             of: find.byType(StreamMessageRecipientHeader),
             matching: find.byType(ColoredBox),
-        ))).color.equals(swatch.barBackground);
+        ))).color.equals(swatch[StreamColorVariant.barBackground]!);
       });
 
       testWidgets('color of stream icon', (tester) async {
@@ -294,7 +294,7 @@ void main() {
           subscriptions: [subscription]);
         await tester.pump();
         check(tester.widget<Icon>(find.byIcon(ZulipIcons.globe)))
-          .color.equals(swatch.iconOnBarBackground);
+          .color.equals(swatch[StreamColorVariant.iconOnBarBackground]!);
       });
 
       testWidgets('normal streams show hash icon', (tester) async {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -282,7 +282,7 @@ void main() {
           find.descendant(
             of: find.byType(StreamMessageRecipientHeader),
             matching: find.byType(ColoredBox),
-        ))).color.equals(swatch[StreamColorVariant.barBackground]!);
+        ))).color.equals(swatch[StreamColor.barBackground]!);
       });
 
       testWidgets('color of stream icon', (tester) async {
@@ -294,7 +294,7 @@ void main() {
           subscriptions: [subscription]);
         await tester.pump();
         check(tester.widget<Icon>(find.byIcon(ZulipIcons.globe)))
-          .color.equals(swatch[StreamColorVariant.iconOnBarBackground]!);
+          .color.equals(swatch[StreamColor.iconOnBarBackground]!);
       });
 
       testWidgets('normal streams show hash icon', (tester) async {

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -186,7 +186,7 @@ void main() {
     ], unreadMsgs: unreadMsgs);
     check(getItemCount()).equals(1);
     check(tester.widget<Icon>(find.byType(Icon)).color)
-      .equals(swatch[StreamColorVariant.iconOnPlainBackground]!);
+      .equals(swatch[StreamColor.iconOnPlainBackground]!);
     check(tester.widget<UnreadCountBadge>(find.byType(UnreadCountBadge)).backgroundColor)
       .equals(swatch);
   });

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -186,7 +186,7 @@ void main() {
     ], unreadMsgs: unreadMsgs);
     check(getItemCount()).equals(1);
     check(tester.widget<Icon>(find.byType(Icon)).color)
-      .equals(swatch.iconOnPlainBackground);
+      .equals(swatch[StreamColorVariant.iconOnPlainBackground]!);
     check(tester.widget<UnreadCountBadge>(find.byType(UnreadCountBadge)).backgroundColor)
       .equals(swatch);
   });

--- a/test/widgets/unread_count_badge_test.dart
+++ b/test/widgets/unread_count_badge_test.dart
@@ -40,7 +40,7 @@ void main() {
       testWidgets('stream color', (WidgetTester tester) async {
         final swatch = streamColorSwatch(0xff76ce90);
         await prepare(tester, swatch);
-        check(findBackgroundColor(tester)).equals(swatch[StreamColorVariant.unreadCountBadgeBackground]!);
+        check(findBackgroundColor(tester)).equals(swatch[StreamColor.unreadCountBadgeBackground]!);
       });
     });
   });

--- a/test/widgets/unread_count_badge_test.dart
+++ b/test/widgets/unread_count_badge_test.dart
@@ -38,9 +38,9 @@ void main() {
       });
 
       testWidgets('stream color', (WidgetTester tester) async {
-        final swatch = StreamColorSwatch(0xff76ce90);
+        final swatch = streamColorSwatch(0xff76ce90);
         await prepare(tester, swatch);
-        check(findBackgroundColor(tester)).equals(swatch.unreadCountBadgeBackground);
+        check(findBackgroundColor(tester)).equals(swatch[StreamColorVariant.unreadCountBadgeBackground]!);
       });
     });
   });


### PR DESCRIPTION
This indirection was mildly helpful; it let us consume these colors
with slightly more concise code, and without needing `!` to satisfy
the analyzer.

But we get the same correct functionality without the indirection,
and a bit more transparently. The more substantive benefit of using
ColorSwatch directly is that we now have a ready-made lerp function
-- `ColorSwatch.lerp` -- that can operate on our swatch instances.
That should be helpful later when we want stream colors to animate
smoothly when dark mode is toggled, along with various other style
attributes that will naturally animate too.

-----

Quoting that [`ColorSwatch.lerp`](https://api.flutter.dev/flutter/painting/ColorSwatch/lerp.html):

```dart
  /// Linearly interpolate between two [ColorSwatch]es.
  ///
  /// It delegates to [Color.lerp] to interpolate the different colors of the
  /// swatch.
  ///
  /// If either color is null, this function linearly interpolates from a
  /// transparent instance of the other color.
  ///
  /// The `t` argument represents position on the timeline, with 0.0 meaning
  /// that the interpolation has not started, returning `a` (or something
  /// equivalent to `a`), 1.0 meaning that the interpolation has finished,
  /// returning `b` (or something equivalent to `b`), and values in between
  /// meaning that the interpolation is at the relevant point on the timeline
  /// between `a` and `b`. The interpolation can be extrapolated beyond 0.0 and
  /// 1.0, so negative values and values greater than 1.0 are valid (and can
  /// easily be generated by curves such as [Curves.elasticInOut]). Each channel
  /// will be clamped to the range 0 to 255.
  ///
  /// Values for `t` are usually obtained from an [Animation<double>], such as
  /// an [AnimationController].
  static ColorSwatch<T>? lerp<T>(ColorSwatch<T>? a, ColorSwatch<T>? b, double t) {
    if (identical(a, b)) {
      return a;
    }
    final Map<T, Color> swatch;
    if (b == null) {
      swatch = a!._swatch.map((T key, Color color) => MapEntry<T, Color>(key, Color.lerp(color, null, t)!));
    } else {
      if (a == null) {
        swatch = b._swatch.map((T key, Color color) => MapEntry<T, Color>(key, Color.lerp(null, color, t)!));
      } else {
        swatch = a._swatch.map((T key, Color color) => MapEntry<T, Color>(key, Color.lerp(color, b[key], t)!));
      }
    }
    return ColorSwatch<T>(Color.lerp(a, b, t)!.value, swatch);
  }
```