### PR TITLE
ui: Adjust star icon position in message list

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -971,13 +971,13 @@ class MessageWithPossibleSender extends StatelessWidget {
                   if ((message.reactions?.total ?? 0) > 0)
                     ReactionChipsList(messageId: message.id, reactions: message.reactions!)
                 ])),
-            SizedBox(width: 16,
+            SizedBox(width: 17,
               child: message.flags.contains(MessageFlag.starred)
                 // TODO(#157): fix how star marker aligns with message content
                 // Design from Figma at:
                 //   https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=813%3A28817&mode=dev .
-                ? Padding(padding: const EdgeInsets.only(top: 4),
-                    child: Icon(ZulipIcons.star_filled, size: 16, color: _starColor))
+                ? Padding(padding: const EdgeInsets.only(top: 5.5),
+                    child: Icon(ZulipIcons.star_filled, size: 17, color: _starColor))
                 : null),
           ]),
         ])));


### PR DESCRIPTION
This pull request addresses issue #616, where the star icon appeared too high relative to the message text in the message list. The issue was resolved by adjusting the position of the star icon so that its "shoulders" align with the x-height of the first line of text, ensuring better visual alignment with the message content.
I added padding to adjust the position of the star icon so that its "shoulders" are aligned with the x-height of the first line of text. This ensures better visual alignment with the message content. 
Also, its an update for this pull request #625

before 

![image](https://github.com/zulip/zulip-flutter/assets/152219936/ed9311d7-3917-42a3-9b28-9a80b1e9f1cb)

after

![2024-05-08 (3)](https://github.com/zulip/zulip-flutter/assets/152219936/d61e4bfb-f5ba-41dc-a613-0f825f79f558)
![2024-05-08 (4)](https://github.com/zulip/zulip-flutter/assets/152219936/210acba2-a825-4f12-b9b2-7e68240e3a5f)

Fixes: #616
@sm-sayedi
@gnprice