### PR TITLE
content test: Deduplicate ad hoc content-preparing code

### DIFF
--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -93,16 +93,17 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   Future<void> prepareContentBare(WidgetTester tester, String html) async {
-    await tester.pumpWidget(Builder(
-      builder: (context) {
-        return MaterialApp(
+    Widget widget = BlockContentList(nodes: parseContent(html).nodes);
+
+    widget = Scaffold(body: widget);
+
+    await tester.pumpWidget(
+      Builder(builder: (context) =>
+        MaterialApp(
           theme: ThemeData(typography: zulipTypography(context)),
           localizationsDelegates: ZulipLocalizations.localizationsDelegates,
           supportedLocales: ZulipLocalizations.supportedLocales,
-          home: Scaffold(body: BlockContentList(nodes: parseContent(html).nodes)),
-        );
-      }
-    ));
+          home: widget)));
   }
 
   /// Test that the given content example renders without throwing an exception.

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -689,8 +689,7 @@ void main() {
     final renderedTextRegexp = RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$');
 
     testWidgets('smoke', (tester) async {
-      await tester.pumpWidget(MaterialApp(home: BlockContentList(nodes:
-        parseContent('<p>$timeSpanHtml</p>').nodes)));
+      await prepareContentBare(tester, '<p>$timeSpanHtml</p>');
       tester.widget(find.textContaining(renderedTextRegexp));
     });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -180,7 +180,7 @@ void main() {
     testContentSmoke(ContentExample.spoilerRichHeaderAndContent);
 
     group('interactions: spoiler with tappable content (an image) in the header', () {
-      Future<List<Route<dynamic>>> prepareContent(WidgetTester tester, String html) async {
+      Future<List<Route<dynamic>>> prepare(WidgetTester tester, String html) async {
         final pushedRoutes = <Route<dynamic>>[];
         final testNavObserver = TestNavigatorObserver()
           ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
@@ -213,7 +213,7 @@ void main() {
       const example = ContentExample.spoilerHeaderHasImage;
 
       testWidgets('tap image', (tester) async {
-        final pushedRoutes = await prepareContent(tester, example.html);
+        final pushedRoutes = await prepare(tester, example.html);
 
         await tester.tap(find.byType(RealmContentNetworkImage));
         check(pushedRoutes).single.isA<AccountPageRouteBuilder>()
@@ -221,7 +221,7 @@ void main() {
       });
 
       testWidgets('tap header on expand/collapse icon', (tester) async {
-        final pushedRoutes = await prepareContent(tester, example.html);
+        final pushedRoutes = await prepare(tester, example.html);
         checkIsExpanded(tester, false);
 
         await tester.tap(find.byIcon(Icons.expand_more));
@@ -236,7 +236,7 @@ void main() {
       });
 
       testWidgets('tap header away from expand/collapse icon (and image)', (tester) async {
-        final pushedRoutes = await prepareContent(tester, example.html);
+        final pushedRoutes = await prepare(tester, example.html);
         checkIsExpanded(tester, false);
 
         await tester.tapAt(
@@ -257,7 +257,7 @@ void main() {
   testContentSmoke(ContentExample.quotation);
 
   group('MessageImage, MessageImageList', () {
-    Future<void> prepareContent(WidgetTester tester, String html) async {
+    Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContentBare(tester,
         // Message is needed for an image's lightbox.
         messageContent(html),
@@ -268,7 +268,7 @@ void main() {
 
     testWidgets('single image', (tester) async {
       const example = ContentExample.imageSingle;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       final expectedImages = (example.expectedNodes[0] as ImageNodeList).images;
       final images = tester.widgetList<RealmContentNetworkImage>(
         find.byType(RealmContentNetworkImage));
@@ -278,7 +278,7 @@ void main() {
 
     testWidgets('image with invalid src URL', (tester) async {
       const example = ContentExample.imageInvalidUrl;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       // The image indeed has an invalid URL.
       final expectedImages = (example.expectedNodes[0] as ImageNodeList).images;
       check(() => Uri.parse(expectedImages.single.srcUrl)).throws();
@@ -290,7 +290,7 @@ void main() {
 
     testWidgets('multiple images', (tester) async {
       const example = ContentExample.imageCluster;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       final expectedImages = (example.expectedNodes[1] as ImageNodeList).images;
       final images = tester.widgetList<RealmContentNetworkImage>(
         find.byType(RealmContentNetworkImage));
@@ -300,7 +300,7 @@ void main() {
 
     testWidgets('content after image cluster', (tester) async {
       const example = ContentExample.imageClusterThenContent;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       final expectedImages = (example.expectedNodes[1] as ImageNodeList).images;
       final images = tester.widgetList<RealmContentNetworkImage>(
         find.byType(RealmContentNetworkImage));
@@ -310,7 +310,7 @@ void main() {
 
     testWidgets('multiple clusters of images', (tester) async {
       const example = ContentExample.imageMultipleClusters;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       final expectedImages = (example.expectedNodes[1] as ImageNodeList).images
         + (example.expectedNodes[4] as ImageNodeList).images;
       final images = tester.widgetList<RealmContentNetworkImage>(
@@ -321,7 +321,7 @@ void main() {
 
     testWidgets('image as immediate child in implicit paragraph', (tester) async {
       const example = ContentExample.imageInImplicitParagraph;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       final expectedImages = ((example.expectedNodes[0] as ListNode)
         .items[0][0] as ImageNodeList).images;
       final images = tester.widgetList<RealmContentNetworkImage>(
@@ -332,7 +332,7 @@ void main() {
 
     testWidgets('image cluster in implicit paragraph', (tester) async {
       const example = ContentExample.imageClusterInImplicitParagraph;
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
       final expectedImages = ((example.expectedNodes[0] as ListNode)
         .items[0][1] as ImageNodeList).images;
       final images = tester.widgetList<RealmContentNetworkImage>(
@@ -343,7 +343,7 @@ void main() {
   });
 
   group("MessageInlineVideo", () {
-    Future<List<Route<dynamic>>> prepareContent(WidgetTester tester, String html) async {
+    Future<List<Route<dynamic>>> prepare(WidgetTester tester, String html) async {
       final pushedRoutes = <Route<dynamic>>[];
       final testNavObserver = TestNavigatorObserver()
         ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
@@ -366,7 +366,7 @@ void main() {
 
     testWidgets('tapping on preview opens lightbox', (tester) async {
       const example = ContentExample.videoInline;
-      final pushedRoutes = await prepareContent(tester, example.html);
+      final pushedRoutes = await prepare(tester, example.html);
 
       await tester.tap(find.byIcon(Icons.play_arrow_rounded));
       check(pushedRoutes).single.isA<AccountPageRouteBuilder>()
@@ -375,7 +375,7 @@ void main() {
   });
 
   group("MessageEmbedVideo", () {
-    Future<void> prepareContent(WidgetTester tester, String html) async {
+    Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContentBare(tester,
         // Message is needed for a video's lightbox.
         messageContent(html),
@@ -384,7 +384,7 @@ void main() {
     }
 
     Future<void> checkEmbedVideo(WidgetTester tester, ContentExample example) async {
-      await prepareContent(tester, example.html);
+      await prepare(tester, example.html);
 
       final expectedTitle = (((example.expectedNodes[0] as ParagraphNode)
         .nodes.single as LinkNode).nodes.single as TextNode).text;
@@ -519,14 +519,14 @@ void main() {
     //   https://github.com/flutter/flutter/wiki/Flutter-Test-Fonts
     // We use this to simulate taps on specific glyphs.
 
-    Future<void> prepareContent(WidgetTester tester, String html) async {
+    Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContentBare(tester, plainContent(html),
         // We try to resolve relative links on the self-account's realm.
         wrapWithPerAccountStoreWidget: true);
     }
 
     testWidgets('can tap a link to open URL', (tester) async {
-      await prepareContent(tester,
+      await prepare(tester,
         '<p><a href="https://example/">hello</a></p>');
 
       await tapText(tester, find.text('hello'));
@@ -540,7 +540,7 @@ void main() {
     testWidgets('multiple links in paragraph', (tester) async {
       final fontSize = Paragraph.textStyle.fontSize!;
 
-      await prepareContent(tester,
+      await prepare(tester,
         '<p><a href="https://a/">foo</a> bar <a href="https://b/">baz</a></p>');
       final base = tester.getTopLeft(find.text('foo bar baz'))
         .translate(fontSize/2, fontSize/2); // middle of first letter
@@ -558,7 +558,7 @@ void main() {
     });
 
     testWidgets('link nested in other spans', (tester) async {
-      await prepareContent(tester,
+      await prepare(tester,
         '<p><strong><em><a href="https://a/">word</a></em></strong></p>');
       await tapText(tester, find.text('word'));
       check(testBinding.takeLaunchUrlCalls())
@@ -568,7 +568,7 @@ void main() {
     testWidgets('link containing other spans', (tester) async {
       final fontSize = Paragraph.textStyle.fontSize!;
 
-      await prepareContent(tester,
+      await prepare(tester,
         '<p><a href="https://a/">two <strong><em><code>words</code></em></strong></a></p>');
       final base = tester.getTopLeft(find.text('two words'))
         .translate(fontSize/2, fontSize/2); // middle of first letter
@@ -583,7 +583,7 @@ void main() {
     });
 
     testWidgets('relative links are resolved', (tester) async {
-      await prepareContent(tester,
+      await prepare(tester,
         '<p><a href="/a/b?c#d">word</a></p>');
       await tapText(tester, find.text('word'));
       check(testBinding.takeLaunchUrlCalls())
@@ -591,7 +591,7 @@ void main() {
     });
 
     testWidgets('link inside HeadingNode', (tester) async {
-      await prepareContent(tester,
+      await prepare(tester,
         '<h6><a href="https://a/">word</a></h6>');
       await tapText(tester, find.text('word'));
       check(testBinding.takeLaunchUrlCalls())
@@ -599,7 +599,7 @@ void main() {
     });
 
     testWidgets('error dialog if invalid link', (tester) async {
-      await prepareContent(tester,
+      await prepare(tester,
         '<p><a href="file:///etc/bad">word</a></p>');
       testBinding.launchUrlResult = false;
       await tapText(tester, find.text('word'));
@@ -611,7 +611,7 @@ void main() {
   });
 
   group('LinkNode on internal links', () {
-    Future<List<Route<dynamic>>> prepareContent(WidgetTester tester, String html) async {
+    Future<List<Route<dynamic>>> prepare(WidgetTester tester, String html) async {
       final pushedRoutes = <Route<dynamic>>[];
       final testNavObserver = TestNavigatorObserver()
         ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
@@ -632,7 +632,7 @@ void main() {
     }
 
     testWidgets('valid internal links are navigated to within app', (tester) async {
-      final pushedRoutes = await prepareContent(tester,
+      final pushedRoutes = await prepare(tester,
         '<p><a href="/#narrow/stream/1-check">stream</a></p>');
 
       await tapText(tester, find.text('stream'));
@@ -643,7 +643,7 @@ void main() {
 
     testWidgets('invalid internal links are opened in browser', (tester) async {
       // Link is invalid due to `topic` operator missing an operand.
-      final pushedRoutes = await prepareContent(tester,
+      final pushedRoutes = await prepare(tester,
         '<p><a href="/#narrow/stream/1-check/topic">invalid</a></p>');
 
       await tapText(tester, find.text('invalid'));
@@ -748,7 +748,7 @@ void main() {
   });
 
   group('MessageImageEmoji', () {
-    Future<void> prepareContent(WidgetTester tester, String html) async {
+    Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContentBare(tester, plainContent(html),
         // We try to resolve image-emoji URLs on the self-account's realm.
         // For URLs on the self-account's realm, we include the auth credential.
@@ -756,20 +756,20 @@ void main() {
     }
 
     testWidgets('smoke: custom emoji', (tester) async {
-      await prepareContent(tester, ContentExample.emojiCustom.html);
+      await prepare(tester, ContentExample.emojiCustom.html);
       tester.widget(find.byType(MessageImageEmoji));
       debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('smoke: custom emoji with invalid URL', (tester) async {
-      await prepareContent(tester, ContentExample.emojiCustomInvalidUrl.html);
+      await prepare(tester, ContentExample.emojiCustomInvalidUrl.html);
       final url = tester.widget<MessageImageEmoji>(find.byType(MessageImageEmoji)).node.src;
       check(() => Uri.parse(url)).throws();
       debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('smoke: Zulip extra emoji', (tester) async {
-      await prepareContent(tester, ContentExample.emojiZulipExtra.html);
+      await prepare(tester, ContentExample.emojiZulipExtra.html);
       tester.widget(find.byType(MessageImageEmoji));
       debugNetworkImageHttpClientProvider = null;
     });

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -717,8 +717,8 @@ void main() {
         ..equals(Colors.green);
     });
 
-    testWidgets('maintains font-size ratio with surrounding text', (tester) async {
-      Future<void> doCheck(double Function(GlobalTime widget) sizeFromWidget) async {
+    group('maintains font-size ratio with surrounding text', () {
+      Future<void> doCheck(WidgetTester tester, double Function(GlobalTime widget) sizeFromWidget) async {
         await checkFontSizeRatio(tester,
           targetHtml: '<time datetime="2024-01-30T17:33:00Z">2024-01-30T17:33:00Z</time>',
           targetFontSizeFinder: (rootSpan) {
@@ -734,21 +734,23 @@ void main() {
           });
       }
 
-      // Text is scaled
-      await doCheck((widget) {
-        final textSpan = tester.renderObject<RenderParagraph>(
-          find.descendant(of: find.byWidget(widget),
-            matching: find.textContaining(renderedTextRegexp)
-        )).text;
-        return mergedStyleOfSubstring(textSpan, renderedTextRegexp)!.fontSize!;
+      testWidgets('text is scaled', (tester) async {
+        await doCheck(tester, (widget) {
+          final textSpan = tester.renderObject<RenderParagraph>(
+            find.descendant(of: find.byWidget(widget),
+              matching: find.textContaining(renderedTextRegexp)
+          )).text;
+          return mergedStyleOfSubstring(textSpan, renderedTextRegexp)!.fontSize!;
+        });
       });
 
-      // Clock icon is scaled
-      await doCheck((widget) {
-        final icon = tester.widget<Icon>(
-          find.descendant(of: find.byWidget(widget),
-            matching: find.byIcon(ZulipIcons.clock)));
-        return icon.size!;
+      testWidgets('clock icon is scaled', (tester) async {
+        await doCheck(tester, (widget) {
+          final icon = tester.widget<Icon>(
+            find.descendant(of: find.byWidget(widget),
+              matching: find.byIcon(ZulipIcons.clock)));
+          return icon.size!;
+        });
       });
     });
   });

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -92,8 +92,15 @@ void main() {
 
   TestZulipBinding.ensureInitialized();
 
-  Future<void> prepareContentBare(WidgetTester tester, String html) async {
+  Future<void> prepareContentBare(WidgetTester tester, String html, {
+    bool wrapWithPerAccountStoreWidget = false,
+  }) async {
     Widget widget = BlockContentList(nodes: parseContent(html).nodes);
+
+    if (wrapWithPerAccountStoreWidget) {
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      widget = PerAccountStoreWidget(accountId: eg.selfAccount.id, child: widget);
+    }
 
     widget = GlobalStoreWidget(child: widget);
     addTearDown(testBinding.reset);
@@ -106,6 +113,9 @@ void main() {
           supportedLocales: ZulipLocalizations.supportedLocales,
           home: widget)));
     await tester.pump(); // global store
+    if (wrapWithPerAccountStoreWidget) {
+      await tester.pump();
+    }
   }
 
   /// Test that the given content example renders without throwing an exception.

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -92,11 +92,15 @@ void main() {
 
   TestZulipBinding.ensureInitialized();
 
-  Future<void> prepareContentBare(WidgetTester tester, String html, {
+  Widget plainContent(String html) {
+    return BlockContentList(nodes: parseContent(html).nodes);
+  }
+
+  Future<void> prepareContentBare(WidgetTester tester, Widget child, {
     List<NavigatorObserver> navObservers = const [],
     bool wrapWithPerAccountStoreWidget = false,
   }) async {
-    Widget widget = BlockContentList(nodes: parseContent(html).nodes);
+    Widget widget = child;
 
     if (wrapWithPerAccountStoreWidget) {
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
@@ -132,7 +136,7 @@ void main() {
   /// and write an appropriate content-has-rendered check directly.
   void testContentSmoke(ContentExample example) {
     testWidgets('smoke: ${example.description}', (tester) async {
-      await prepareContentBare(tester, example.html);
+      await prepareContentBare(tester, plainContent(example.html));
       assert(example.expectedText != null,
         'testContentExample requires expectedText');
       tester.widget(find.text(example.expectedText!));
@@ -141,7 +145,7 @@ void main() {
 
   group('ThematicBreak', () {
     testWidgets('smoke ThematicBreak', (tester) async {
-      await prepareContentBare(tester, ContentExample.thematicBreak.html);
+      await prepareContentBare(tester, plainContent(ContentExample.thematicBreak.html));
       tester.widget(find.byType(ThematicBreak));
     });
   });
@@ -150,14 +154,14 @@ void main() {
     testWidgets('plain h6', (tester) async {
       await prepareContentBare(tester,
         // "###### six"
-        '<h6>six</h6>');
+        plainContent('<h6>six</h6>'));
       tester.widget(find.text('six'));
     });
 
     testWidgets('smoke test for h1, h2, h3, h4, h5', (tester) async {
       await prepareContentBare(tester,
         // "# one\n## two\n### three\n#### four\n##### five"
-        '<h1>one</h1>\n<h2>two</h2>\n<h3>three</h3>\n<h4>four</h4>\n<h5>five</h5>');
+        plainContent('<h1>one</h1>\n<h2>two</h2>\n<h3>three</h3>\n<h4>four</h4>\n<h5>five</h5>'));
       check(find.byType(Heading).evaluate()).length.equals(5);
     });
   });
@@ -454,9 +458,9 @@ void main() {
     required String targetHtml,
     required double Function(InlineSpan rootSpan) targetFontSizeFinder,
   }) async {
-    await prepareContentBare(tester,
+    await prepareContentBare(tester, plainContent(
       '<h1>header-plain $targetHtml</h1>\n'
-      '<p>paragraph-plain $targetHtml</p>');
+      '<p>paragraph-plain $targetHtml</p>'));
 
     final headerRootSpan = tester.renderObject<RenderParagraph>(find.textContaining('header')).text;
     final headerPlainStyle = mergedStyleOfSubstring(headerRootSpan, 'header-plain ');
@@ -708,7 +712,7 @@ void main() {
     final renderedTextRegexp = RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$');
 
     testWidgets('smoke', (tester) async {
-      await prepareContentBare(tester, '<p>$timeSpanHtml</p>');
+      await prepareContentBare(tester, plainContent('<p>$timeSpanHtml</p>'));
       tester.widget(find.textContaining(renderedTextRegexp));
     });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -95,6 +95,9 @@ void main() {
   Future<void> prepareContentBare(WidgetTester tester, String html) async {
     Widget widget = BlockContentList(nodes: parseContent(html).nodes);
 
+    widget = GlobalStoreWidget(child: widget);
+    addTearDown(testBinding.reset);
+
     await tester.pumpWidget(
       Builder(builder: (context) =>
         MaterialApp(
@@ -102,6 +105,7 @@ void main() {
           localizationsDelegates: ZulipLocalizations.localizationsDelegates,
           supportedLocales: ZulipLocalizations.supportedLocales,
           home: widget)));
+    await tester.pump(); // global store
   }
 
   /// Test that the given content example renders without throwing an exception.

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -106,6 +106,8 @@ void main() {
     widget = GlobalStoreWidget(child: widget);
     addTearDown(testBinding.reset);
 
+    prepareBoringImageHttpClient();
+
     await tester.pumpWidget(
       Builder(builder: (context) =>
         MaterialApp(
@@ -118,6 +120,8 @@ void main() {
     if (wrapWithPerAccountStoreWidget) {
       await tester.pump();
     }
+
+    debugNetworkImageHttpClientProvider = null;
   }
 
   /// Test that the given content example renders without throwing an exception.

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -93,6 +93,7 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   Future<void> prepareContentBare(WidgetTester tester, String html, {
+    List<NavigatorObserver> navObservers = const [],
     bool wrapWithPerAccountStoreWidget = false,
   }) async {
     Widget widget = BlockContentList(nodes: parseContent(html).nodes);
@@ -111,6 +112,7 @@ void main() {
           theme: ThemeData(typography: zulipTypography(context)),
           localizationsDelegates: ZulipLocalizations.localizationsDelegates,
           supportedLocales: ZulipLocalizations.supportedLocales,
+          navigatorObservers: navObservers,
           home: widget)));
     await tester.pump(); // global store
     if (wrapWithPerAccountStoreWidget) {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -104,7 +104,7 @@ void main() {
   // TODO(#488) For content that we need to show outside a per-message context
   //   or a context without a full PerAccountStore, make sure to include tests
   //   that don't provide such context.
-  Future<void> prepareContentBare(WidgetTester tester, Widget child, {
+  Future<void> prepareContent(WidgetTester tester, Widget child, {
     List<NavigatorObserver> navObservers = const [],
     bool wrapWithPerAccountStoreWidget = false,
   }) async {
@@ -140,11 +140,11 @@ void main() {
   ///
   /// This requires [ContentExample.expectedText] to be non-null in order to
   /// check that the content has actually rendered.  For examples where there's
-  /// no suitable value for [ContentExample.expectedText], use [prepareContentBare]
+  /// no suitable value for [ContentExample.expectedText], use [prepareContent]
   /// and write an appropriate content-has-rendered check directly.
   void testContentSmoke(ContentExample example) {
     testWidgets('smoke: ${example.description}', (tester) async {
-      await prepareContentBare(tester, plainContent(example.html));
+      await prepareContent(tester, plainContent(example.html));
       assert(example.expectedText != null,
         'testContentExample requires expectedText');
       tester.widget(find.text(example.expectedText!));
@@ -153,21 +153,21 @@ void main() {
 
   group('ThematicBreak', () {
     testWidgets('smoke ThematicBreak', (tester) async {
-      await prepareContentBare(tester, plainContent(ContentExample.thematicBreak.html));
+      await prepareContent(tester, plainContent(ContentExample.thematicBreak.html));
       tester.widget(find.byType(ThematicBreak));
     });
   });
 
   group('Heading', () {
     testWidgets('plain h6', (tester) async {
-      await prepareContentBare(tester,
+      await prepareContent(tester,
         // "###### six"
         plainContent('<h6>six</h6>'));
       tester.widget(find.text('six'));
     });
 
     testWidgets('smoke test for h1, h2, h3, h4, h5', (tester) async {
-      await prepareContentBare(tester,
+      await prepareContent(tester,
         // "# one\n## two\n### three\n#### four\n##### five"
         plainContent('<h1>one</h1>\n<h2>two</h2>\n<h3>three</h3>\n<h4>four</h4>\n<h5>five</h5>'));
       check(find.byType(Heading).evaluate()).length.equals(5);
@@ -184,13 +184,13 @@ void main() {
         final pushedRoutes = <Route<dynamic>>[];
         final testNavObserver = TestNavigatorObserver()
           ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
-        await prepareContentBare(tester,
+        await prepareContent(tester,
           // Message is needed for the image's lightbox.
           messageContent(html),
           navObservers: [testNavObserver],
           // We try to resolve the image's URL on the self-account's realm.
           wrapWithPerAccountStoreWidget: true);
-        // `tester.pumpWidget` in prepareContentBare introduces an initial route;
+        // `tester.pumpWidget` in prepareContent introduces an initial route;
         // remove it so consumers only have newly pushed routes.
         assert(pushedRoutes.length == 1);
         pushedRoutes.removeLast();
@@ -258,7 +258,7 @@ void main() {
 
   group('MessageImage, MessageImageList', () {
     Future<void> prepare(WidgetTester tester, String html) async {
-      await prepareContentBare(tester,
+      await prepareContent(tester,
         // Message is needed for an image's lightbox.
         messageContent(html),
         // We try to resolve image URLs on the self-account's realm.
@@ -347,7 +347,7 @@ void main() {
       final pushedRoutes = <Route<dynamic>>[];
       final testNavObserver = TestNavigatorObserver()
         ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
-      await prepareContentBare(tester,
+      await prepareContent(tester,
         // Message is needed for a video's lightbox.
         messageContent(html),
         navObservers: [testNavObserver],
@@ -357,7 +357,7 @@ void main() {
         // self-account's realm, we'll request it with the auth credential.
         // TODO(#656) in above comment, change "we will" to "we do"
         wrapWithPerAccountStoreWidget: true);
-      // `tester.pumpWidget` in prepareContentBare introduces an initial route;
+      // `tester.pumpWidget` in prepareContent introduces an initial route;
       // remove it so consumers only have newly pushed routes.
       assert(pushedRoutes.length == 1);
       pushedRoutes.removeLast();
@@ -376,7 +376,7 @@ void main() {
 
   group("MessageEmbedVideo", () {
     Future<void> prepare(WidgetTester tester, String html) async {
-      await prepareContentBare(tester,
+      await prepareContent(tester,
         // Message is needed for a video's lightbox.
         messageContent(html),
         // We try to resolve a video preview URL on the self-account's realm.
@@ -441,7 +441,7 @@ void main() {
     required String targetHtml,
     required double Function(InlineSpan rootSpan) targetFontSizeFinder,
   }) async {
-    await prepareContentBare(tester, plainContent(
+    await prepareContent(tester, plainContent(
       '<h1>header-plain $targetHtml</h1>\n'
       '<p>paragraph-plain $targetHtml</p>'));
 
@@ -520,7 +520,7 @@ void main() {
     // We use this to simulate taps on specific glyphs.
 
     Future<void> prepare(WidgetTester tester, String html) async {
-      await prepareContentBare(tester, plainContent(html),
+      await prepareContent(tester, plainContent(html),
         // We try to resolve relative links on the self-account's realm.
         wrapWithPerAccountStoreWidget: true);
     }
@@ -616,12 +616,12 @@ void main() {
       final testNavObserver = TestNavigatorObserver()
         ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
 
-      await prepareContentBare(tester, plainContent(html),
+      await prepareContent(tester, plainContent(html),
         navObservers: [testNavObserver],
         // We try to resolve relative links on the self-account's realm.
         wrapWithPerAccountStoreWidget: true);
 
-      // `tester.pumpWidget` in prepareContentBare introduces an initial route;
+      // `tester.pumpWidget` in prepareContent introduces an initial route;
       // remove it so consumers only have newly pushed routes.
       assert(pushedRoutes.length == 1);
       pushedRoutes.removeLast();
@@ -684,12 +684,12 @@ void main() {
     final renderedTextRegexp = RegExp(r'^(Tue, Jan 30|Wed, Jan 31), 2024, \d+:\d\d [AP]M$');
 
     testWidgets('smoke', (tester) async {
-      await prepareContentBare(tester, plainContent('<p>$timeSpanHtml</p>'));
+      await prepareContent(tester, plainContent('<p>$timeSpanHtml</p>'));
       tester.widget(find.textContaining(renderedTextRegexp));
     });
 
     testWidgets('clock icon and text are the same color', (tester) async {
-      await prepareContentBare(tester,
+      await prepareContent(tester,
         DefaultTextStyle(style: const TextStyle(color: Colors.green),
           child: plainContent('<p>$timeSpanHtml</p>')));
 
@@ -749,7 +749,7 @@ void main() {
 
   group('MessageImageEmoji', () {
     Future<void> prepare(WidgetTester tester, String html) async {
-      await prepareContentBare(tester, plainContent(html),
+      await prepareContent(tester, plainContent(html),
         // We try to resolve image-emoji URLs on the self-account's realm.
         // For URLs on the self-account's realm, we include the auth credential.
         wrapWithPerAccountStoreWidget: true);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -95,8 +95,6 @@ void main() {
   Future<void> prepareContentBare(WidgetTester tester, String html) async {
     Widget widget = BlockContentList(nodes: parseContent(html).nodes);
 
-    widget = Scaffold(body: widget);
-
     await tester.pumpWidget(
       Builder(builder: (context) =>
         MaterialApp(


### PR DESCRIPTION
This PR makes it so all our tests of Zulip content widgets go through `prepareContentBare`, which has grown some explicit params that let callers opt in to extra dependencies, such as a `PerAccountStoreWidget` ancestor. With this, I have two benefits in mind:

1. As Zulip content widgets gain natural dependencies (such as a ThemeExtension for custom light- and dark-theme colors), we can provide them easily, by just adding to this one function.
2. It will be more obvious when a content widget has "extra" dependencies that will become problematic with #488.

Related: #95
Related: #488