### PR TITLE
android: Trust user-supplied CAs, take 2

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,9 @@
                 <data android:scheme="zulip" android:host="login" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="io.flutter.network-policy"
+            android:resource="@xml/network_security_config" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data


### PR DESCRIPTION
The previous attempt at this (cffb112fd, #474) set the configuration used by the HTTP implementation from the Android SDK, and by some third-party HTTP implementations.  But in the bulk of the app's code, we use the HTTP implementation from the Dart standard library, and by default that does not consult the Android configuration.

Happily, Flutter has an opt-in feature to apply the same configuration to the Dart standard library:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/flutter.3A.20user-added.20certs/near/1716845

So use that.

Fixes: #461