### PR TITLE
macos: Take automatic migration away from `@NSApplicationMain`

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true


### PR DESCRIPTION
This change was made automatically by `flutter run`, along with the following warning:

```
macos/Runner/AppDelegate.swift uses the deprecated @NSApplicationMain attribute, updating.
```

This change is the macOS counterpart of a previous commit for iOS: https://github.com/zulip/zulip-flutter/commit/5f111cbaf1b92d4cfc315bfc0dd60aef2ef5fe0f