### PR TITLE
reactions: Increase prominence of own reactions, following web

### DIFF
--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -44,11 +44,11 @@ const _backgroundColorSelected = Colors.white;
 //   Until then use a solid color; a much-lightened version of the shadow color.
 //   Also adapt by making [_borderColorUnselected] more transparent, so we'll
 //   want to check that against web when implementing the shadow.
-final _backgroundColorUnselected = const HSLColor.fromAHSL(0.15, 210, 0.50, 0.875).toColor();
+final _backgroundColorUnselected = const HSLColor.fromAHSL(0.08, 210, 0.50, 0.875).toColor();
 
-final _borderColorSelected = Colors.black.withOpacity(0.40);
+final _borderColorSelected = Colors.black.withOpacity(0.45);
 // TODO see TODO on [_backgroundColorUnselected] about shadow effect
-final _borderColorUnselected = Colors.black.withOpacity(0.06);
+final _borderColorUnselected = Colors.black.withOpacity(0.05);
 
 class ReactionChip extends StatelessWidget {
   final bool showName;
@@ -91,7 +91,10 @@ class ReactionChip extends StatelessWidget {
     final splashColor =     selfVoted ? _backgroundColorUnselected : _backgroundColorSelected;
     final highlightColor =  splashColor.withOpacity(0.5);
 
-    final borderSide = BorderSide(color: borderColor, width: 1);
+    final borderSide = BorderSide(
+      color: borderColor,
+      width: selfVoted ? 1.5 : 1.0,
+    );
     final shape = StadiumBorder(side: borderSide);
 
     final Widget emoji;


### PR DESCRIPTION
This follows zulip/zulip@793020992, which landed after we implemented reaction chips here. (That commit makes some padding adjustments, which we don't need because changing a chip's border width doesn't affect the chip's size.)

| Before | After |
| --- | --- |
| <img width="449" alt="Screenshot 2024-05-15 at 2 46 13 PM" src="https://github.com/zulip/zulip-flutter/assets/22248748/f38fbb26-07e9-4475-9151-186736810a9f"> | <img width="449" alt="Screenshot 2024-05-15 at 2 46 37 PM" src="https://github.com/zulip/zulip-flutter/assets/22248748/00657370-e6ae-4b4a-bc94-98cb9899ef00"> |