### PR TITLE
content: Handle bold-text setting in code blocks and error-unimplementeds

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -847,18 +847,10 @@ const _kInlineCodeFontSizeFactor = 0.825;
 /// Inline code should use this and also apply [_kInlineCodeFontSizeFactor]
 /// to the font size of the surrounding text
 /// (which might be a Paragraph, a Heading, etc.).
-// Even though [kMonospaceTextStyle] is a variable-weight font,
-// it's acceptable to skip [weightVariableTextStyle] here,
-// assuming the text gets the effect of [weightVariableTextStyle]
-// through inheritance, e.g., from a [DefaultTextStyle].
 final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(TextStyle(
     backgroundColor: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor()));
 
-// Even though [kMonospaceTextStyle] is a variable-weight font,
-// it's acceptable to skip [weightVariableTextStyle] here,
-// assuming the text gets the effect of [weightVariableTextStyle]
-// through inheritance, e.g., from a [DefaultTextStyle].
 final _kCodeBlockStyle = kMonospaceTextStyle
   .merge(const TextStyle(fontSize: 0.825 * kBaseFontSize));
 
@@ -1282,9 +1274,5 @@ InlineSpan _errorUnimplemented(UnimplementedNode node) {
 const errorStyle = TextStyle(
   fontSize: kBaseFontSize, fontWeight: FontWeight.bold, color: Colors.red);
 
-// Even though [kMonospaceTextStyle] is a variable-weight font,
-// it's acceptable to skip [weightVariableTextStyle] here,
-// assuming the text gets the effect of [weightVariableTextStyle]
-// through inheritance, e.g., from a [DefaultTextStyle].
 final errorCodeStyle = kMonospaceTextStyle
   .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -765,7 +765,7 @@ class _InlineContentBuilder {
   }
 
   InlineSpan _buildStrong(StrongNode node) => _buildNodes(node.nodes,
-    style: weightVariableTextStyle(_context!, wght: 600, wghtIfPlatformRequestsBold: 900));
+    style: weightVariableTextStyle(_context!, wght: 600));
 
   InlineSpan _buildDeleted(DeletedNode node) => _buildNodes(node.nodes,
     style: const TextStyle(decoration: TextDecoration.lineThrough));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -855,15 +855,12 @@ final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(TextStyle(
     backgroundColor: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor()));
 
+// Even though [kMonospaceTextStyle] is a variable-weight font,
+// it's acceptable to skip [weightVariableTextStyle] here,
+// assuming the text gets the effect of [weightVariableTextStyle]
+// through inheritance, e.g., from a [DefaultTextStyle].
 final _kCodeBlockStyle = kMonospaceTextStyle
-  .merge(const TextStyle(fontSize: 0.825 * kBaseFontSize))
-  .merge(
-    // TODO(a11y) pass a BuildContext, to handle platform request for bold text.
-    //   To get one, the result of this whole computation (to the TextStyle
-    //   we get at the end) could live on one [InheritedWidget], at the
-    //   MessageList or higher, so the computation doesn't get repeated
-    //   frequently. Then consumers can just look it up on the InheritedWidget.
-    weightVariableTextStyle(null));
+  .merge(const TextStyle(fontSize: 0.825 * kBaseFontSize));
 
 // const _kInlineCodeLeftBracket = '⸤';
 // const _kInlineCodeRightBracket = '⸣';
@@ -1285,6 +1282,9 @@ InlineSpan _errorUnimplemented(UnimplementedNode node) {
 const errorStyle = TextStyle(
   fontSize: kBaseFontSize, fontWeight: FontWeight.bold, color: Colors.red);
 
+// Even though [kMonospaceTextStyle] is a variable-weight font,
+// it's acceptable to skip [weightVariableTextStyle] here,
+// assuming the text gets the effect of [weightVariableTextStyle]
+// through inheritance, e.g., from a [DefaultTextStyle].
 final errorCodeStyle = kMonospaceTextStyle
-  .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red))
-  .merge(weightVariableTextStyle(null)); // TODO(a11y) pass a BuildContext
+  .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -765,7 +765,7 @@ class _InlineContentBuilder {
   }
 
   InlineSpan _buildStrong(StrongNode node) => _buildNodes(node.nodes,
-    style: weightVariableTextStyle(_context, wght: 600, wghtIfPlatformRequestsBold: 900));
+    style: weightVariableTextStyle(_context!, wght: 600, wghtIfPlatformRequestsBold: 900));
 
   InlineSpan _buildDeleted(DeletedNode node) => _buildNodes(node.nodes,
     style: const TextStyle(decoration: TextDecoration.lineThrough));

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -926,8 +926,7 @@ class MessageWithPossibleSender extends StatelessWidget {
                         fontFamily: 'Source Sans 3',
                         fontSize: 18,
                         height: (22 / 18),
-                      ).merge(weightVariableTextStyle(context, wght: 600,
-                                wghtIfPlatformRequestsBold: 900)),
+                      ).merge(weightVariableTextStyle(context, wght: 600)),
                       overflow: TextOverflow.ellipsis)),
                   if (sender?.isBot ?? false) ...[
                     const SizedBox(width: 5),

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -203,13 +203,12 @@ const kButtonTextLetterSpacingProportion = 0.01;
 /// ```
 ///
 /// See also [FontVariation] for more background on variable fonts.
-// TODO(a11y) make `context` required when callers can adapt?
-TextStyle weightVariableTextStyle(BuildContext? context, {
+TextStyle weightVariableTextStyle(BuildContext context, {
   double? wght,
   double? wghtIfPlatformRequestsBold,
 }) {
   double value = wght ?? FontWeight.normal.value.toDouble();
-  if (context != null && MediaQuery.boldTextOf(context)) {
+  if (MediaQuery.boldTextOf(context)) {
     // The framework has a condition on [MediaQueryData.boldText]
     // in the [Text] widget, but that only affects `fontWeight`.
     // [Text] doesn't know where to land on the chosen font's "wght" axis if any,

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -156,6 +156,9 @@ List<String> get defaultFontFamilyFallback => [
 ///
 /// Callers should also call [weightVariableTextStyle] and merge that in too,
 /// because for this font, we use "variable font" assets with a "wght" axis.
+/// That is, unless it would be redundant with another step that applies
+/// [weightVariableTextStyle]; for example, a [DefaultTextStyle] that specifies
+/// a different variable-weight font that we're overriding with this one.
 ///
 /// Example:
 ///

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -105,15 +105,6 @@ void main() {
       });
     }
 
-    testWeights('no context passed; default wght values',
-      styleBuilder: (context) => weightVariableTextStyle(null),
-      expectedFontVariations: const [FontVariation('wght', 400)],
-      expectedFontWeight: FontWeight.normal);
-    testWeights('no context passed; specific wght',
-      styleBuilder: (context) => weightVariableTextStyle(null, wght: 225, wghtIfPlatformRequestsBold: 425),
-      expectedFontVariations: const [FontVariation('wght', 225)],
-      expectedFontWeight: FontWeight.w200);
-
     testWeights('default values; platform does not request bold',
       styleBuilder: (context) => weightVariableTextStyle(context),
       platformRequestsBold: false,


### PR DESCRIPTION
Screenshots show the app with the system bold text setting on.

Fixes: #690

| Before | After |
| --- | --- |
| ![728B9036-3F4C-4E00-AAA5-4ED34CDD88CE](https://github.com/zulip/zulip-flutter/assets/22248748/4ac26fe7-69e3-4bc3-b1cf-ea259e824902) | ![B6815335-22C0-4B2F-9A21-D2190A67018B](https://github.com/zulip/zulip-flutter/assets/22248748/3a56a3fb-d6c2-4420-affb-a2885dcdf518) |