### PR TITLE
model: Introduce data structures for "recent senders criterion" of user-mention autocomplete

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -403,6 +403,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       numAfter: 0,
     );
     store.reconcileMessages(result.messages);
+    store.recentSenders.handleMessages(result.messages); // TODO(#824)
     for (final message in result.messages) {
       if (_messageVisible(message)) {
         _addMessage(message);
@@ -439,6 +440,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       }
 
       store.reconcileMessages(result.messages);
+      store.recentSenders.handleMessages(result.messages); // TODO(#824)
 
       final fetchedMessages = _allMessagesVisible
         ? result.messages // Avoid unnecessarily copying the list.

--- a/lib/model/recent_senders.dart
+++ b/lib/model/recent_senders.dart
@@ -101,7 +101,7 @@ class RecentSenders {
 
 @visibleForTesting
 class MessageIdTracker {
-  /// A list of distinct message IDs, sorted ascendingly.
+  /// A list of distinct message IDs, sorted ascending.
   @visibleForTesting
   QueueList<int> ids = QueueList();
 
@@ -128,7 +128,7 @@ class MessageIdTracker {
 
   /// Add the messages IDs to the tracker list at the proper place, if not present.
   ///
-  /// [newIds] should be sorted ascendingly.
+  /// [newIds] should be sorted ascending.
   void addAll(QueueList<int> newIds) {
     if (ids.isEmpty) {
       ids = newIds;

--- a/lib/model/recent_senders.dart
+++ b/lib/model/recent_senders.dart
@@ -78,23 +78,23 @@ class RecentSenders {
     }
 
     final DeleteMessageEvent(:streamId!, :topic!) = event;
-    final sendersByStream = streamSenders[streamId];
-    final topicsByStream = topicSenders[streamId];
-    final sendersByTopic = topicsByStream?[topic];
+    final sendersInStream = streamSenders[streamId];
+    final topicsInStream = topicSenders[streamId];
+    final sendersInTopic = topicsInStream?[topic];
     for (final entry in messagesByUser.entries) {
       final MapEntry(key: senderId, value: messages) = entry;
 
-      final messagesBySenderInStream = sendersByStream?[senderId];
-      messagesBySenderInStream?.removeAll(messages);
-      if (messagesBySenderInStream?.maxId == null) sendersByStream?.remove(senderId);
+      final streamTracker = sendersInStream?[senderId];
+      streamTracker?.removeAll(messages);
+      if (streamTracker?.maxId == null) sendersInStream?.remove(senderId);
 
-      final messagesBySenderInTopic = sendersByTopic?[senderId];
-      messagesBySenderInTopic?.removeAll(messages);
-      if (messagesBySenderInTopic?.maxId == null) sendersByTopic?.remove(senderId);
+      final topicTracker = sendersInTopic?[senderId];
+      topicTracker?.removeAll(messages);
+      if (topicTracker?.maxId == null) sendersInTopic?.remove(senderId);
     }
-    if (sendersByStream?.isEmpty ?? false) streamSenders.remove(streamId);
-    if (sendersByTopic?.isEmpty ?? false) topicsByStream?.remove(topic);
-    if (topicsByStream?.isEmpty ?? false) topicSenders.remove(streamId);
+    if (sendersInStream?.isEmpty ?? false) streamSenders.remove(streamId);
+    if (sendersInTopic?.isEmpty ?? false) topicsInStream?.remove(topic);
+    if (topicsInStream?.isEmpty ?? false) topicSenders.remove(streamId);
   }
 }
 

--- a/lib/model/recent_senders.dart
+++ b/lib/model/recent_senders.dart
@@ -34,13 +34,13 @@ class RecentSenders {
   /// [messages] should be sorted by [id] ascendingly, which are, the way app
   /// receives and handles messages.
   void handleMessages(List<Message> messages) {
-    final messagesByUserInStream = <(int, int), List<int>>{};
-    final messagesByUserInTopic = <(int, String, int), List<int>>{};
+    final messagesByUserInStream = <(int, int), QueueList<int>>{};
+    final messagesByUserInTopic = <(int, String, int), QueueList<int>>{};
     for (final message in messages) {
       if (message is! StreamMessage) continue;
       final StreamMessage(:streamId, :topic, :senderId, id: int messageId) = message;
-      (messagesByUserInStream[(streamId, senderId)] ??= []).add(messageId);
-      (messagesByUserInTopic[(streamId, topic, senderId)] ??= []).add(messageId);
+      (messagesByUserInStream[(streamId, senderId)] ??= QueueList()).add(messageId);
+      (messagesByUserInTopic[(streamId, topic, senderId)] ??= QueueList()).add(messageId);
     }
 
     for (final entry in messagesByUserInStream.entries) {
@@ -128,9 +128,9 @@ class MessageIdTracker {
   /// Add the messages IDs to the tracker list at the proper place, if not present.
   ///
   /// [newIds] should be sorted ascendingly.
-  void addAll(List<int> newIds) {
+  void addAll(QueueList<int> newIds) {
     if (ids.isEmpty) {
-      ids = QueueList.from(newIds);
+      ids = newIds;
       return;
     }
     ids = setUnion(ids, newIds);

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -296,6 +296,7 @@ void main() {
     check(done).isFalse();
     for (int i = 0; i < 3; i++) {
       await Future(() {});
+      if (done) break;
     }
     check(done).isTrue();
     final results = view.results

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -71,8 +71,7 @@ void main() {
       setupModel(oldMessages);
       model.handleMessages(newMessages);
       final expectedMessages = [...oldMessages, ...newMessages]
-        ..removeWhere((m) => m is! StreamMessage)
-        ..sort((m1, m2) => m1.id.compareTo(m2.id));
+        ..removeWhere((m) => m is! StreamMessage);
       checkMatchesMessages(model, expectedMessages);
     }
 

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -4,7 +4,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/recent_senders.dart';
 import '../example_data.dart' as eg;
 
-/// [messages] should be sorted by [id] ascendingly.
+/// [messages] should be sorted by [id] ascending.
 void checkMatchesMessages(RecentSenders model, List<Message> messages) {
   final Map<int, Map<int, Set<int>>> messagesByUserInStream = {};
   final Map<int, Map<String, Map<int, Set<int>>>> messagesByUserInTopic = {};

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -77,60 +77,42 @@ void main() {
     }
 
     group('single tracker', () {
-      test('batch goes before the existing messages', () {
+      void checkHandleMessagesSingle(List<int> oldIds, List<int> newIds) {
         checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+          for (final id in oldIds)
+            eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: id),
         ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          for (final id in newIds)
+            eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: id),
         ]);
+      }
+
+      test('batch goes before the existing messages', () {
+        checkHandleMessagesSingle([300, 400], [100, 200]);
       });
 
       test('batch goes after the existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 600),
-        ]);
+        checkHandleMessagesSingle([300, 400], [500, 600]);
       });
 
       test('batch is interspersed among the existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-        ]);
+        checkHandleMessagesSingle([200, 400], [100, 300, 500]);
       });
 
       test('batch contains some of already-existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-        ]);
+        checkHandleMessagesSingle([200, 300, 400], [100, 200, 400, 500]);
       });
+    });
 
-      test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 400),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-        ]);
-      });
+    test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
+      checkHandleMessages([
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+      ], [
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+        eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 400),
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+      ]);
     });
 
     group('multiple trackers', () {

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -58,7 +58,9 @@ void main() {
   group('RecentSenders.handleMessages', () {
     late RecentSenders model;
     final stream1 = eg.stream(streamId: 1);
+    final stream2 = eg.stream(streamId: 2);
     final user10 = eg.user(userId: 10);
+    final user20 = eg.user(userId: 20);
 
     void setupModel(List<Message> messages) {
       model = RecentSenders();
@@ -104,75 +106,39 @@ void main() {
     });
 
     test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
-      checkHandleMessages([
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-      ], [
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-        eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 400),
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+      checkHandleMessages([], [
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
+        eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
       ]);
     });
 
-    group('multiple trackers', () {
-      test('batch goes before the existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-        ]);
-      });
+    test('add new sender', () {
+      checkHandleMessages(
+        [eg.streamMessage(stream: stream1, topic: 'a', sender: user10)],
+        [eg.streamMessage(stream: stream1, topic: 'a', sender: user20)]);
+    });
 
-      test('batch goes after the existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 700),
-        ]);
-      });
+    test('add new topic', () {
+      checkHandleMessages(
+        [eg.streamMessage(stream: stream1, topic: 'a', sender: user10)],
+        [eg.streamMessage(stream: stream1, topic: 'b', sender: user10)]);
+    });
 
-      test('batch is interspersed among the existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 700),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 800),
-        ]);
-      });
+    test('add new stream', () {
+      checkHandleMessages(
+        [eg.streamMessage(stream: stream1, topic: 'a', sender: user10)],
+        [eg.streamMessage(stream: stream2, topic: 'a', sender: user10)]);
+    });
 
-      test('batch contains some of already-existing messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 300),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
-        ]);
-      });
-
-      test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
-        checkHandleMessages([
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 200),
-        ], [
-          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 200),
-          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-        ]);
-      });
+    test('multiple conversations and senders interspersed', () {
+      checkHandleMessages([], [
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
+        eg.streamMessage(stream: stream1, topic: 'b', sender: user10),
+        eg.streamMessage(stream: stream2, topic: 'a', sender: user10),
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user20),
+        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
+      ]);
     });
   });
 

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -57,10 +57,10 @@ void main() {
 
   group('RecentSenders.handleMessages', () {
     late RecentSenders model;
-    final stream1 = eg.stream(streamId: 1);
-    final stream2 = eg.stream(streamId: 2);
-    final user10 = eg.user(userId: 10);
-    final user20 = eg.user(userId: 20);
+    final streamA = eg.stream();
+    final streamB = eg.stream();
+    final userX = eg.user();
+    final userY = eg.user();
 
     void setupModel(List<Message> messages) {
       model = RecentSenders();
@@ -81,10 +81,10 @@ void main() {
       void checkHandleMessagesSingle(List<int> oldIds, List<int> newIds) {
         checkHandleMessages([
           for (final id in oldIds)
-            eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: id),
+            eg.streamMessage(stream: streamA, topic: 'a', sender: userX, id: id),
         ], [
           for (final id in newIds)
-            eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: id),
+            eg.streamMessage(stream: streamA, topic: 'a', sender: userX, id: id),
         ]);
       }
 
@@ -107,51 +107,51 @@ void main() {
 
     test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
       checkHandleMessages([], [
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
+        eg.streamMessage(stream: streamA, topic: 'thing', sender: userX),
         eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
+        eg.streamMessage(stream: streamA, topic: 'thing', sender: userX),
       ]);
     });
 
     test('add new sender', () {
       checkHandleMessages(
-        [eg.streamMessage(stream: stream1, topic: 'a', sender: user10)],
-        [eg.streamMessage(stream: stream1, topic: 'a', sender: user20)]);
+        [eg.streamMessage(stream: streamA, topic: 'thing', sender: userX)],
+        [eg.streamMessage(stream: streamA, topic: 'thing', sender: userY)]);
     });
 
     test('add new topic', () {
       checkHandleMessages(
-        [eg.streamMessage(stream: stream1, topic: 'a', sender: user10)],
-        [eg.streamMessage(stream: stream1, topic: 'b', sender: user10)]);
+        [eg.streamMessage(stream: streamA, topic: 'thing', sender: userX)],
+        [eg.streamMessage(stream: streamA, topic: 'other', sender: userX)]);
     });
 
     test('add new stream', () {
       checkHandleMessages(
-        [eg.streamMessage(stream: stream1, topic: 'a', sender: user10)],
-        [eg.streamMessage(stream: stream2, topic: 'a', sender: user10)]);
+        [eg.streamMessage(stream: streamA, topic: 'thing', sender: userX)],
+        [eg.streamMessage(stream: streamB, topic: 'thing', sender: userX)]);
     });
 
     test('multiple conversations and senders interspersed', () {
       checkHandleMessages([], [
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
-        eg.streamMessage(stream: stream1, topic: 'b', sender: user10),
-        eg.streamMessage(stream: stream2, topic: 'a', sender: user10),
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user20),
-        eg.streamMessage(stream: stream1, topic: 'a', sender: user10),
+        eg.streamMessage(stream: streamA, topic: 'thing', sender: userX),
+        eg.streamMessage(stream: streamA, topic: 'other', sender: userX),
+        eg.streamMessage(stream: streamB, topic: 'thing', sender: userX),
+        eg.streamMessage(stream: streamA, topic: 'thing', sender: userY),
+        eg.streamMessage(stream: streamA, topic: 'thing', sender: userX),
       ]);
     });
   });
 
   test('RecentSenders.handleDeleteMessageEvent', () {
     final model = RecentSenders();
-    final stream1 = eg.stream(streamId: 1);
-    final user1 = eg.user(userId: 1);
-    final user2 = eg.user(userId: 2);
+    final stream = eg.stream();
+    final userX = eg.user();
+    final userY = eg.user();
 
     final messages = [
-      eg.streamMessage(stream: stream1, topic: 'a', sender: user1, id: 100),
-      eg.streamMessage(stream: stream1, topic: 'b', sender: user1, id: 200),
-      eg.streamMessage(stream: stream1, topic: 'a', sender: user2, id: 300),
+      eg.streamMessage(stream: stream, topic: 'thing', sender: userX),
+      eg.streamMessage(stream: stream, topic: 'other', sender: userX),
+      eg.streamMessage(stream: stream, topic: 'thing', sender: userY),
     ];
 
     model.handleMessages(messages);

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -67,193 +67,130 @@ void main() {
       }
     }
 
+    void checkHandleMessages(List<Message> oldMessages, List<Message> newMessages) {
+      setupModel(oldMessages);
+      model.handleMessages(newMessages);
+      final expectedMessages = [...oldMessages, ...newMessages]
+        ..removeWhere((m) => m is! StreamMessage)
+        ..sort((m1, m2) => m1.id.compareTo(m2.id));
+      checkMatchesMessages(model, expectedMessages);
+    }
+
     group('single tracker', () {
       test('batch goes before the existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch goes after the existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 600),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch is interspersed among the existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch contains some of already-existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
-        ];
-        setupModel(existingMessages);
-
-        final dmMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 400);
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          dmMessage,
+          eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 400),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages..remove(dmMessage)]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
     });
 
     group('multiple trackers', () {
       test('batch goes before the existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch goes after the existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 700),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch is interspersed among the existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 700),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 800),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch contains some of already-existing messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 300),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-        ];
-        setupModel(existingMessages);
-
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
 
       test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
-        final existingMessages = [
+        checkHandleMessages([
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 200),
-        ];
-        setupModel(existingMessages);
-
-        final dmMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 200);
-        final messages = [
+        ], [
           eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
-          dmMessage,
+          eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 200),
           eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
-        ];
-        model.handleMessages(messages);
-
-        checkMatchesMessages(model,
-          [...existingMessages, ...messages..remove(dmMessage)]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+        ]);
       });
     });
   });

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -1,0 +1,329 @@
+import 'package:checks/checks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/model/model.dart';
+import 'package:zulip/model/recent_senders.dart';
+import '../example_data.dart' as eg;
+
+/// [messages] should be sorted by [id] ascendingly.
+void checkMatchesMessages(RecentSenders model, List<Message> messages) {
+  final Map<int, Map<int, Set<int>>> messagesByUserInStream = {};
+  final Map<int, Map<String, Map<int, Set<int>>>> messagesByUserInTopic = {};
+  for (final message in messages) {
+    if (message is! StreamMessage) {
+      throw UnsupportedError('Message of type ${message.runtimeType} is not expected.');
+    }
+
+    final StreamMessage(:streamId, :topic, :senderId, id: int messageId) = message;
+
+    ((messagesByUserInStream[streamId] ??= {})
+      [senderId] ??= {}).add(messageId);
+    (((messagesByUserInTopic[streamId] ??= {})[topic] ??= {})
+      [senderId] ??= {}).add(messageId);
+  }
+
+  final actualMessagesByUserInStream = model.streamSenders.map((streamId, sendersByStream) =>
+    MapEntry(streamId, sendersByStream.map((senderId, tracker) =>
+      MapEntry(senderId, Set<int>.from(tracker.ids)))));
+  final actualMessagesByUserInTopic = model.topicSenders.map((streamId, topicsByStream) =>
+    MapEntry(streamId, topicsByStream.map((topic, sendersByTopic) =>
+      MapEntry(topic, sendersByTopic.map((senderId, tracker) =>
+        MapEntry(senderId, Set<int>.from(tracker.ids)))))));
+
+  check(actualMessagesByUserInStream).deepEquals(messagesByUserInStream);
+  check(actualMessagesByUserInTopic).deepEquals(messagesByUserInTopic);
+}
+
+void main() {
+  test('starts with empty stream and topic senders', () {
+    final model = RecentSenders();
+    checkMatchesMessages(model, []);
+  });
+
+  group('RecentSenders.handleMessage', () {
+    test('stream message gets included', () {
+      final model = RecentSenders();
+      final streamMessage = eg.streamMessage();
+      model.handleMessage(streamMessage);
+      checkMatchesMessages(model, [streamMessage]);
+    });
+
+    test('DM message gets ignored', () {
+      final model = RecentSenders();
+      final dmMessage = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
+      model.handleMessage(dmMessage);
+      checkMatchesMessages(model, []);
+    });
+  });
+
+  group('RecentSenders.handleMessages', () {
+    late RecentSenders model;
+    final stream1 = eg.stream(streamId: 1);
+    final user10 = eg.user(userId: 10);
+
+    void setupModel(List<Message> messages) {
+      model = RecentSenders();
+      for (final message in messages) {
+        model.handleMessage(message);
+      }
+    }
+
+    group('single tracker', () {
+      test('batch goes before the existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch goes after the existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 600),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch is interspersed among the existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch contains some of already-existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+        ];
+        setupModel(existingMessages);
+
+        final dmMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 400);
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          dmMessage,
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages..remove(dmMessage)]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+    });
+
+    group('multiple trackers', () {
+      test('batch goes before the existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch goes after the existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 400),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 500),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 700),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch is interspersed among the existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 700),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 600),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 800),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch contains some of already-existing messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 300),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
+        ];
+        setupModel(existingMessages);
+
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 500),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+
+      test('batch with both DM and stream messages -> ignores DM, processes stream messages', () {
+        final existingMessages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 100),
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 200),
+        ];
+        setupModel(existingMessages);
+
+        final dmMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser], id: 200);
+        final messages = [
+          eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+          dmMessage,
+          eg.streamMessage(stream: stream1, topic: 'b', sender: user10, id: 400),
+        ];
+        model.handleMessages(messages);
+
+        checkMatchesMessages(model,
+          [...existingMessages, ...messages..remove(dmMessage)]..sort((m1, m2) => m1.id.compareTo(m2.id)));
+      });
+    });
+  });
+
+  test('RecentSenders.handleDeleteMessageEvent', () {
+    final model = RecentSenders();
+    final stream1 = eg.stream(streamId: 1);
+    final user1 = eg.user(userId: 1);
+    final user2 = eg.user(userId: 2);
+
+    final messages = [
+      eg.streamMessage(stream: stream1, topic: 'a', sender: user1, id: 100),
+      eg.streamMessage(stream: stream1, topic: 'b', sender: user1, id: 200),
+      eg.streamMessage(stream: stream1, topic: 'a', sender: user2, id: 300),
+    ];
+
+    model.handleMessages(messages);
+    checkMatchesMessages(model, messages);
+
+    model.handleDeleteMessageEvent(eg.deleteMessageEvent([messages[0], messages[2]]),
+      Map.fromEntries(messages.map((msg) => MapEntry(msg.id, msg))));
+
+    checkMatchesMessages(model, [messages[1]]);
+  });
+
+  test('RecentSenders.latestMessageIdOfSenderInStream', () {
+    final model = RecentSenders();
+    final stream1 = eg.stream(streamId: 1);
+    final user10 = eg.user(userId: 10);
+
+    final messages = [
+      eg.streamMessage(stream: stream1, sender: user10, id: 100),
+      eg.streamMessage(stream: stream1, sender: user10, id: 200),
+      eg.streamMessage(stream: stream1, sender: user10, id: 300),
+    ];
+
+    model.handleMessages(messages);
+
+    check(model.latestMessageIdOfSenderInStream(
+      streamId: 1, senderId: 10)).equals(300);
+    // No message of user 20 in stream1.
+    check(model.latestMessageIdOfSenderInStream(
+      streamId: 1, senderId: 20)).equals(null);
+    // No message in stream 2 at all.
+    check(model.latestMessageIdOfSenderInStream(
+      streamId: 2, senderId: 10)).equals(null);
+  });
+
+  test('RecentSenders.latestMessageIdOfSenderInTopic', () {
+    final model = RecentSenders();
+    final stream1 = eg.stream(streamId: 1);
+    final user10 = eg.user(userId: 10);
+
+    final messages = [
+      eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 200),
+      eg.streamMessage(stream: stream1, topic: 'a', sender: user10, id: 300),
+    ];
+
+    model.handleMessages(messages);
+
+    check(model.latestMessageIdOfSenderInTopic(streamId: 1,
+      topic: 'a', senderId: 10)).equals(300);
+    // No message of user 20 in topic "a".
+    check(model.latestMessageIdOfSenderInTopic(streamId: 1,
+      topic: 'a', senderId: 20)).equals(null);
+    // No message in topic "b" at all.
+    check(model.latestMessageIdOfSenderInTopic(streamId: 1,
+      topic: 'b', senderId: 10)).equals(null);
+    // No message in stream 2 at all.
+    check(model.latestMessageIdOfSenderInTopic(streamId: 2,
+      topic: 'a', senderId: 10)).equals(null);
+  });
+}


### PR DESCRIPTION
This is the second PR in the series of PRs #608 is divided into. This solely focuses on bringing the data structures for the upcoming "recent senders" criterion of @-mention autocomplete. #828 is the next PR in the series.

Fixes part of: #228