### PR TITLE
autocomplete: In user-mention autocomplete results give priority to users in DM conversations

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -125,23 +125,11 @@ class AutocompleteViewManager {
     assert(removed);
   }
 
-  void handleRealmUserAddEvent(RealmUserAddEvent event) {
-    for (final view in _mentionAutocompleteViews) {
-      view.refreshStaleUserResults();
-    }
-  }
-
   void handleRealmUserRemoveEvent(RealmUserRemoveEvent event) {
-    for (final view in _mentionAutocompleteViews) {
-      view.refreshStaleUserResults();
-    }
     autocompleteDataCache.invalidateUser(event.userId);
   }
 
   void handleRealmUserUpdateEvent(RealmUserUpdateEvent event) {
-    for (final view in _mentionAutocompleteViews) {
-      view.refreshStaleUserResults();
-    }
     autocompleteDataCache.invalidateUser(event.userId);
   }
 
@@ -205,15 +193,6 @@ class MentionAutocompleteView extends ChangeNotifier {
     _query = query;
     if (query != null) {
       _startSearch(query);
-    }
-  }
-
-  /// Recompute user results for the current query, if any.
-  ///
-  /// Called in particular when we get a [RealmUserEvent].
-  void refreshStaleUserResults() {
-    if (_query != null) {
-      _startSearch(_query!);
     }
   }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -418,7 +418,6 @@ class PerAccountStore extends ChangeNotifier with StreamStore, MessageStore {
     } else if (event is RealmUserAddEvent) {
       assert(debugLog("server event: realm_user/add"));
       users[event.person.userId] = event.person;
-      autocompleteViewManager.handleRealmUserAddEvent(event);
       notifyListeners();
     } else if (event is RealmUserRemoveEvent) {
       assert(debugLog("server event: realm_user/remove"));

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -292,6 +292,8 @@ void main() {
     await Future(() {});
     check(done).isFalse();
     await Future(() {});
+    check(done).isFalse();
+    await Future(() {});
     check(done).isTrue();
     check(view.results).single
       .isA<UserMentionAutocompleteResult>()

--- a/test/model/recent_dm_conversations_checks.dart
+++ b/test/model/recent_dm_conversations_checks.dart
@@ -6,4 +6,6 @@ import 'package:zulip/model/recent_dm_conversations.dart';
 extension RecentDmConversationsViewChecks on Subject<RecentDmConversationsView> {
   Subject<Map<DmNarrow, int>> get map => has((v) => v.map, 'map');
   Subject<QueueList<DmNarrow>> get sorted => has((v) => v.sorted, 'sorted');
+  Subject<Map<int, int>> get latestMessagesByRecipient => has(
+    (v) => v.latestMessagesByRecipient, 'latestMessagesByRecipient');
 }

--- a/test/model/recent_dm_conversations_test.dart
+++ b/test/model/recent_dm_conversations_test.dart
@@ -129,13 +129,17 @@ void main() {
       });
 
       test('existing conversation, not newest in conversation', () {
+        // bool listenersNotified = false;
         final message = eg.dmMessage(id: 99, from: eg.selfUser,
           to: [eg.user(userId: 1), eg.user(userId: 2)]);
         final expected = setupView();
         check(setupView()
+          // ..addListener(() { listenersNotified = true; })
           ..handleMessageEvent(MessageEvent(id: 1, message: message))
         ) ..map.deepEquals(expected.map)
           ..sorted.deepEquals(expected.sorted);
+        // (listeners are notified unnecessarily, but that's OK)
+        // check(listenersNotified).isFalse();
       });
     });
   });


### PR DESCRIPTION
In @-mention autocomplete users with whom recent DMs are exchanged are given priority.

Other criteria will be added in separate PRs.

_**Note:** This is the first PR in the series of PRs #608 is divided into._

Fixes part of: #228 