### PR TITLE
deps: Unpin intl, to follow Flutter's pinning; trim comments

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,17 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  # For some packages that are pinned by the Flutter SDK, we write no
+  # constraint, to avoid unnecessarily breaking when Flutter takes a
+  # new version.  (This risks getting a new version that really is
+  # incompatible; but that's true of Flutter itself on each upgrade.)
+  # We only do this for packages with a history of major-version bumps
+  # that caused more churn than real incompatibilities.
+  intl: any  # pinned by flutter_localizations; churn history:
+             # https://github.com/dart-lang/i18n/issues/458#issuecomment-1513231235
+             # https://github.com/dart-lang/i18n/issues/759#issuecomment-1864316701
+             # https://github.com/flutter/flutter/issues/117163
+
   app_settings: ^5.0.0
   collection: ^1.17.2
   convert: ^3.1.1
@@ -41,7 +52,6 @@ dependencies:
   html: ^0.15.1
   http: ^1.0.0
   image_picker: ^1.0.0
-  intl: ^0.19.0
   json_annotation: ^4.8.1
   package_info_plus: ^8.0.0
   path: ^1.8.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,13 @@
+# For docs on this file format, see:
+#   https://dart.dev/tools/pub/pubspec
+#   https://docs.flutter.dev/tools/pubspec
+#   https://github.com/flutter/flutter/blob/main/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+
 name: zulip
 description: A Zulip client for Android and iOS
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
+# Keep the last two numbers equal; see docs/release.md.
 version: 0.0.15+15
 
 environment:
@@ -27,12 +19,7 @@ environment:
   sdk: '>=3.5.0-138.0.dev <4.0.0'
   flutter: '>=3.22.0-28.0.pre.10'
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
+# To update dependencies, see instructions in README.md.
 dependencies:
   flutter:
     sdk: flutter
@@ -92,20 +79,12 @@ dev_dependencies:
   video_player_platform_interface: ^6.2.2
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
 
   # Generate localization bindings from ARB files in lib/l10n/.
   # This happens automatically with `flutter run`
   # but can be manually run with `flutter gen-l10n`
   generate: true
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
 
   assets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,10 +80,6 @@ dev_dependencies:
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 
 flutter:
-
-  # Generate localization bindings from ARB files in lib/l10n/.
-  # This happens automatically with `flutter run`
-  # but can be manually run with `flutter gen-l10n`
   generate: true
   uses-material-design: true
 


### PR DESCRIPTION
Unpinning `package:intl` is required for adding our tests to Flutter's "customer tests", #239:
https://github.com/flutter/tests/commit/a047b7a5e6184969d943f88887bbe32658ed99c1
See comment added in the last commit here for background.

Also cut some unnecessary (or no-longer-necessary) verbose comments that we've had in this file, mostly left by the `flutter create` template.
