### PR TITLE
content: Consolidate message-content base style and apply it more accurately

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -39,7 +39,6 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
       fontSize: kBaseFontSize,
       letterSpacing: 0,
-      textBaseline: TextBaseline.alphabetic,
       height: (22 / kBaseFontSize),
       leadingDistribution: TextLeadingDistribution.even,
       decoration: TextDecoration.none,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -34,6 +34,8 @@ import 'text.dart';
 class ContentTheme extends ThemeExtension<ContentTheme> {
   ContentTheme() :
     textStylePlainParagraph = TextStyle(
+      debugLabel: 'ContentTheme.textStylePlainParagraph',
+
       color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
       fontSize: kBaseFontSize,
       height: (22 / kBaseFontSize),

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -32,14 +32,22 @@ import 'text.dart';
 /// background. For what this is in the message list, see
 /// widgets/message_list.dart.
 class ContentTheme extends ThemeExtension<ContentTheme> {
-  ContentTheme() :
+  ContentTheme(BuildContext context) :
     textStylePlainParagraph = TextStyle(
-      debugLabel: 'ContentTheme.textStylePlainParagraph',
+      inherit: false,
 
       color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
       fontSize: kBaseFontSize,
+      letterSpacing: 0,
+      textBaseline: TextBaseline.alphabetic,
       height: (22 / kBaseFontSize),
-    );
+      leadingDistribution: TextLeadingDistribution.even,
+      decoration: TextDecoration.none,
+      fontFamily: kDefaultFontFamily,
+      fontFamilyFallback: defaultFontFamilyFallback,
+    )
+      .merge(weightVariableTextStyle(context))
+      .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph');
 
   ContentTheme._({
     required this.textStylePlainParagraph,
@@ -55,9 +63,12 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return extension!;
   }
 
-  /// The [TextStyle] we use for plain, unstyled paragraphs.
+  /// The complete [TextStyle] we use for plain, unstyled paragraphs.
   ///
   /// Also the base style that all other text content should inherit from.
+  ///
+  /// This is the complete style for plain paragraphs. Plain-paragraph content
+  /// should not need styles from other sources, such as Material defaults.
   final TextStyle textStylePlainParagraph;
 
   @override
@@ -96,7 +107,7 @@ class MessageContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InheritedMessage(message: message,
-      child: DefaultTextStyle.merge(
+      child: DefaultTextStyle(
         style: ContentTheme.of(context).textStylePlainParagraph,
         child: BlockContentList(nodes: content.nodes)));
   }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -36,7 +36,9 @@ class MessageContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InheritedMessage(message: message,
-      child: BlockContentList(nodes: content.nodes));
+      child: DefaultTextStyle.merge(
+        style: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor()),
+        child: BlockContentList(nodes: content.nodes)));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -23,6 +23,8 @@ import 'text.dart';
 /// The font size for message content in a plain unstyled paragraph.
 const double kBaseFontSize = 17;
 
+final baseContentTextStyle = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor());
+
 /// The entire content of a message, aka its body.
 ///
 /// This does not include metadata like the sender's name and avatar, the time,
@@ -37,7 +39,7 @@ class MessageContent extends StatelessWidget {
   Widget build(BuildContext context) {
     return InheritedMessage(message: message,
       child: DefaultTextStyle.merge(
-        style: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor()),
+        style: baseContentTextStyle,
         child: BlockContentList(nodes: content.nodes)));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -23,7 +23,14 @@ import 'text.dart';
 /// The font size for message content in a plain unstyled paragraph.
 const double kBaseFontSize = 17;
 
-final baseContentTextStyle = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor());
+/// The [TextStyle] we use for plain, unstyled paragraphs.
+///
+/// Also the base style that all other text content should inherit from.
+final plainParagraphContentTextStyle = TextStyle(
+  color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
+  fontSize: kBaseFontSize,
+  height: (22 / kBaseFontSize),
+);
 
 /// The entire content of a message, aka its body.
 ///
@@ -39,7 +46,7 @@ class MessageContent extends StatelessWidget {
   Widget build(BuildContext context) {
     return InheritedMessage(message: message,
       child: DefaultTextStyle.merge(
-        style: baseContentTextStyle,
+        style: plainParagraphContentTextStyle,
         child: BlockContentList(nodes: content.nodes)));
   }
 }
@@ -138,11 +145,6 @@ class Paragraph extends StatelessWidget {
 
   final ParagraphNode node;
 
-  static const textStyle = TextStyle(
-    fontSize: kBaseFontSize,
-    height: (22 / kBaseFontSize),
-  );
-
   @override
   Widget build(BuildContext context) {
     // Empty paragraph winds up with zero height.
@@ -151,7 +153,7 @@ class Paragraph extends StatelessWidget {
 
     final text = _buildBlockInlineContainer(
       node: node,
-      style: textStyle,
+      style: DefaultTextStyle.of(context).style,
     );
 
     // If the paragraph didn't actually have a `p` element in the HTML,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -741,7 +741,7 @@ class _InlineContentBuilder {
       return _buildInlineCode(node);
     } else if (node is UserMentionNode) {
       return WidgetSpan(alignment: PlaceholderAlignment.middle,
-        child: UserMention(surroundingTextStyle: widget.style, node: node));
+        child: UserMention(ambientTextStyle: widget.style, node: node));
     } else if (node is UnicodeEmojiNode) {
       return TextSpan(text: node.emojiUnicode, recognizer: _recognizer);
     } else if (node is ImageEmojiNode) {
@@ -755,7 +755,7 @@ class _InlineContentBuilder {
         children: [TextSpan(text: node.texSource)]);
     } else if (node is GlobalTimeNode) {
       return WidgetSpan(alignment: PlaceholderAlignment.middle,
-        child: GlobalTime(node: node, surroundingTextStyle: widget.style));
+        child: GlobalTime(node: node, ambientTextStyle: widget.style));
     } else if (node is UnimplementedInlineContentNode) {
       return _errorUnimplemented(node);
     } else {
@@ -873,11 +873,11 @@ final _kCodeBlockStyle = kMonospaceTextStyle
 class UserMention extends StatelessWidget {
   const UserMention({
     super.key,
-    required this.surroundingTextStyle,
+    required this.ambientTextStyle,
     required this.node,
   });
 
-  final TextStyle surroundingTextStyle;
+  final TextStyle ambientTextStyle;
   final UserMentionNode node;
 
   @override
@@ -898,7 +898,7 @@ class UserMention extends StatelessWidget {
         // TODO(#647) when self-user is non-silently mentioned, make bold, and:
         // TODO(#646) when self-user is non-silently mentioned,
         //   distinguish font color between direct and wildcard mentions
-        style: surroundingTextStyle,
+        style: ambientTextStyle,
 
         nodes: node.nodes));
   }
@@ -960,11 +960,11 @@ class GlobalTime extends StatelessWidget {
   const GlobalTime({
     super.key,
     required this.node,
-    required this.surroundingTextStyle,
+    required this.ambientTextStyle,
   });
 
   final GlobalTimeNode node;
-  final TextStyle surroundingTextStyle;
+  final TextStyle ambientTextStyle;
 
   static final _backgroundColor = const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor();
   static final _borderColor = const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor();
@@ -972,7 +972,7 @@ class GlobalTime extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final surroundingFontSize = surroundingTextStyle.fontSize!;
+    final ambientFontSize = ambientTextStyle.fontSize!;
 
     // Design taken from css for `.rendered_markdown & time` in web,
     //   see zulip:web/styles/rendered_markdown.css .
@@ -990,13 +990,13 @@ class GlobalTime extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(
-                size: surroundingFontSize,
+                size: ambientFontSize,
                 color: DefaultTextStyle.of(context).style.color!,
                 ZulipIcons.clock),
               // Ad-hoc spacing adjustment per feedback:
               //   https://chat.zulip.org/#narrow/stream/101-design/topic/clock.20icons/near/1729345
               const SizedBox(width: 1),
-              Text(text, style: surroundingTextStyle),
+              Text(text, style: ambientTextStyle),
             ]))));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -858,7 +858,10 @@ final _kInlineCodeStyle = kMonospaceTextStyle
     backgroundColor: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor()));
 
 final _kCodeBlockStyle = kMonospaceTextStyle
-  .merge(const TextStyle(fontSize: 0.825 * kBaseFontSize));
+  .merge(const TextStyle(
+    fontSize: 0.825 * kBaseFontSize,
+    height: 1.4,
+  ));
 
 // const _kInlineCodeLeftBracket = '⸤';
 // const _kInlineCodeRightBracket = '⸣';

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -972,8 +972,6 @@ class GlobalTime extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ambientFontSize = ambientTextStyle.fontSize!;
-
     // Design taken from css for `.rendered_markdown & time` in web,
     //   see zulip:web/styles/rendered_markdown.css .
     final text = _dateFormat.format(node.datetime.toLocal());
@@ -990,7 +988,7 @@ class GlobalTime extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(
-                size: ambientFontSize,
+                size: ambientTextStyle.fontSize!,
                 color: DefaultTextStyle.of(context).style.color!,
                 ZulipIcons.clock),
               // Ad-hoc spacing adjustment per feedback:

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -266,35 +266,33 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     assert(model != null);
     if (!model!.fetched) return const Center(child: CircularProgressIndicator());
 
-    return DefaultTextStyle.merge(
-      style: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor()),
-      // Pad the left and right insets, for small devices in landscape.
-      child: SafeArea(
-        // Don't let this be the place we pad the bottom inset. When there's
-        // no compose box, we want to let the message-list content pad it.
-        // TODO(#311) Remove as unnecessary if we do a bottom nav.
-        //   The nav will pad the bottom inset, and an ancestor of this widget
-        //   will have a `MediaQuery.removePadding` with `removeBottom: true`.
-        bottom: false,
+    // Pad the left and right insets, for small devices in landscape.
+    return SafeArea(
+      // Don't let this be the place we pad the bottom inset. When there's
+      // no compose box, we want to let the message-list content pad it.
+      // TODO(#311) Remove as unnecessary if we do a bottom nav.
+      //   The nav will pad the bottom inset, and an ancestor of this widget
+      //   will have a `MediaQuery.removePadding` with `removeBottom: true`.
+      bottom: false,
 
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 760),
-            child: NotificationListener<ScrollMetricsNotification>(
-              onNotification: _handleScrollMetricsNotification,
-              child: Stack(
-                children: <Widget>[
-                  _buildListView(context),
-                  Positioned(
-                    bottom: 0,
-                    right: 0,
-                    // TODO(#311) SafeArea shouldn't be needed if we have a
-                    //   bottom nav. That will pad the bottom inset.
-                    child: SafeArea(
-                      child: ScrollToBottomButton(
-                        scrollController: scrollController,
-                        visibleValue: _scrollToBottomVisibleValue))),
-                ]))))));
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 760),
+          child: NotificationListener<ScrollMetricsNotification>(
+            onNotification: _handleScrollMetricsNotification,
+            child: Stack(
+              children: <Widget>[
+                _buildListView(context),
+                Positioned(
+                  bottom: 0,
+                  right: 0,
+                  // TODO(#311) SafeArea shouldn't be needed if we have a
+                  //   bottom nav. That will pad the bottom inset.
+                  child: SafeArea(
+                    child: ScrollToBottomButton(
+                      scrollController: scrollController,
+                      visibleValue: _scrollToBottomVisibleValue))),
+              ])))));
   }
 
   Widget _buildListView(context) {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -915,10 +915,11 @@ class MessageWithPossibleSender extends StatelessWidget {
                   const SizedBox(width: 8),
                   Flexible(
                     child: Text(message.senderFullName, // TODO get from user data
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontFamily: 'Source Sans 3',
                         fontSize: 18,
                         height: (22 / 18),
+                        color: const HSLColor.fromAHSL(1, 0, 0, 0.2).toColor(),
                       ).merge(weightVariableTextStyle(context, wght: 600)),
                       overflow: TextOverflow.ellipsis)),
                   if (sender?.isBot ?? false) ...[

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -218,7 +218,7 @@ class _LinkWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final linkNode = LinkNode(url: url, nodes: [TextNode(text)]);
     final paragraph = DefaultTextStyle.merge(
-      style: baseContentTextStyle,
+      style: plainParagraphContentTextStyle,
       child: Paragraph(node: ParagraphNode(nodes: [linkNode], links: [linkNode])));
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -218,7 +218,7 @@ class _LinkWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final linkNode = LinkNode(url: url, nodes: [TextNode(text)]);
     final paragraph = DefaultTextStyle.merge(
-      style: plainParagraphContentTextStyle,
+      style: ContentTheme.of(context).textStylePlainParagraph,
       child: Paragraph(node: ParagraphNode(nodes: [linkNode], links: [linkNode])));
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -217,7 +217,9 @@ class _LinkWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final linkNode = LinkNode(url: url, nodes: [TextNode(text)]);
-    final paragraph = Paragraph(node: ParagraphNode(nodes: [linkNode], links: [linkNode]));
+    final paragraph = DefaultTextStyle.merge(
+      style: baseContentTextStyle,
+      child: Paragraph(node: ParagraphNode(nodes: [linkNode], links: [linkNode])));
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),
       child: MouseRegion(

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -217,7 +217,7 @@ class _LinkWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final linkNode = LinkNode(url: url, nodes: [TextNode(text)]);
-    final paragraph = DefaultTextStyle.merge(
+    final paragraph = DefaultTextStyle(
       style: ContentTheme.of(context).textStylePlainParagraph,
       child: Paragraph(node: ParagraphNode(nodes: [linkNode], links: [linkNode])));
     return Padding(

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -156,9 +156,8 @@ List<String> get defaultFontFamilyFallback => [
 ///
 /// Callers should also call [weightVariableTextStyle] and merge that in too,
 /// because for this font, we use "variable font" assets with a "wght" axis.
-/// That is, unless it would be redundant with another step that applies
-/// [weightVariableTextStyle]; for example, a [DefaultTextStyle] that specifies
-/// a different variable-weight font that we're overriding with this one.
+/// That is, unless we've already applied [weightVariableTextStyle]
+/// for a different variable-weight font that we're overriding with this one.
 ///
 /// Example:
 ///

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -15,6 +15,9 @@ import 'package:flutter/material.dart';
 /// We often see this in the child of a [Material], for example,
 /// since by default [Material] applies an [AnimatedDefaultTextStyle]
 /// with the [TextTheme.bodyMedium] that gets its value from here.
+/// A notable exception is the base style for message content.
+/// That style is self-contained and is not meant to inherit from this;
+/// see [ContentTheme.textStylePlainParagraph].
 ///
 /// Applies [kDefaultFontFamily] and [kDefaultFontFamilyFallback],
 /// being faithful to the Material-default font weights

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -6,7 +6,7 @@ import 'text.dart';
 ThemeData zulipThemeData(BuildContext context) {
   return ThemeData(
     typography: zulipTypography(context),
-    extensions: [ContentTheme()],
+    extensions: [ContentTheme(context)],
     appBarTheme: const AppBarTheme(
       // Set these two fields to prevent a color change in [AppBar]s when
       // there is something scrolled under it. If an app bar hasn't been

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
+import 'content.dart';
 import 'text.dart';
 
 ThemeData zulipThemeData(BuildContext context) {
   return ThemeData(
     typography: zulipTypography(context),
+    extensions: [ContentTheme()],
     appBarTheme: const AppBarTheme(
       // Set these two fields to prevent a color change in [AppBar]s when
       // there is something scrolled under it. If an app bar hasn't been

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -18,6 +18,7 @@ import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/store.dart';
 import 'package:share_plus_platform_interface/method_channel/method_channel_share.dart';
+import 'package:zulip/widgets/theme.dart';
 import '../api/fake_api.dart';
 
 import '../example_data.dart' as eg;
@@ -57,15 +58,15 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
     messages: [message],
   ).toJson());
 
-  await tester.pumpWidget(
+  await tester.pumpWidget(Builder(builder: (context) =>
     MaterialApp(
-      theme: ThemeData(extensions: [ContentTheme()]),
+      theme: zulipThemeData(context),
       localizationsDelegates: ZulipLocalizations.localizationsDelegates,
       supportedLocales: ZulipLocalizations.supportedLocales,
       home: GlobalStoreWidget(
         child: PerAccountStoreWidget(
           accountId: eg.selfAccount.id,
-          child: MessageListPage(narrow: narrow)))));
+          child: MessageListPage(narrow: narrow))))));
 
   // global store, per-account store, and message list get loaded
   await tester.pumpAndSettle();

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -59,6 +59,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
 
   await tester.pumpWidget(
     MaterialApp(
+      theme: ThemeData(extensions: [ContentTheme()]),
       localizationsDelegates: ZulipLocalizations.localizationsDelegates,
       supportedLocales: ZulipLocalizations.supportedLocales,
       home: GlobalStoreWidget(

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -7,6 +7,7 @@ import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/compose.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
+import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/store.dart';
 
@@ -50,6 +51,7 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
 
   await tester.pumpWidget(
     MaterialApp(
+      theme: ThemeData(extensions: [ContentTheme()]),
       localizationsDelegates: ZulipLocalizations.localizationsDelegates,
       supportedLocales: ZulipLocalizations.supportedLocales,
       home: GlobalStoreWidget(

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -7,9 +7,9 @@ import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/compose.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
-import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/store.dart';
+import 'package:zulip/widgets/theme.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
@@ -49,9 +49,9 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
 
   prepareBoringImageHttpClient();
 
-  await tester.pumpWidget(
+  await tester.pumpWidget(Builder(builder: (context) =>
     MaterialApp(
-      theme: ThemeData(extensions: [ContentTheme()]),
+      theme: zulipThemeData(context),
       localizationsDelegates: ZulipLocalizations.localizationsDelegates,
       supportedLocales: ZulipLocalizations.supportedLocales,
       home: GlobalStoreWidget(
@@ -61,7 +61,7 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
             narrow: DmNarrow(
               allRecipientIds: [eg.selfUser.userId, eg.otherUser.userId],
               selfUserId: eg.selfUser.userId,
-            ))))));
+            )))))));
 
   // global store, per-account store, and message list get loaded
   await tester.pumpAndSettle();

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -94,7 +94,7 @@ void main() {
 
   Widget plainContent(String html) {
     return DefaultTextStyle.merge(
-      style: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor()),
+      style: plainParagraphContentTextStyle,
       child: BlockContentList(nodes: parseContent(html).nodes));
   }
 
@@ -540,7 +540,7 @@ void main() {
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
     testWidgets('multiple links in paragraph', (tester) async {
-      final fontSize = Paragraph.textStyle.fontSize!;
+      final fontSize = plainParagraphContentTextStyle.fontSize!;
 
       await prepare(tester,
         '<p><a href="https://a/">foo</a> bar <a href="https://b/">baz</a></p>');
@@ -568,7 +568,7 @@ void main() {
     });
 
     testWidgets('link containing other spans', (tester) async {
-      final fontSize = Paragraph.textStyle.fontSize!;
+      final fontSize = plainParagraphContentTextStyle.fontSize!;
 
       await prepare(tester,
         '<p><a href="https://a/">two <strong><em><code>words</code></em></strong></a></p>');

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -93,7 +93,9 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   Widget plainContent(String html) {
-    return BlockContentList(nodes: parseContent(html).nodes);
+    return DefaultTextStyle.merge(
+      style: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor()),
+      child: BlockContentList(nodes: parseContent(html).nodes));
   }
 
   Widget messageContent(String html) {
@@ -689,9 +691,7 @@ void main() {
     });
 
     testWidgets('clock icon and text are the same color', (tester) async {
-      await prepareContent(tester,
-        DefaultTextStyle(style: const TextStyle(color: Colors.green),
-          child: plainContent('<p>$timeSpanHtml</p>')));
+      await prepareContent(tester, plainContent('<p>$timeSpanHtml</p>'));
 
       final icon = tester.widget<Icon>(
         find.descendant(of: find.byType(GlobalTime),
@@ -704,9 +704,7 @@ void main() {
       final textColor = mergedStyleOfSubstring(textSpan, renderedTextRegexp)!.color;
       check(textColor).isNotNull();
 
-      check(icon).color
-        ..equals(textColor!)
-        ..equals(Colors.green);
+      check(icon).color.equals(textColor!);
     });
 
     group('maintains font-size ratio with surrounding text', () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -94,7 +94,7 @@ void main() {
 
   Widget plainContent(String html) {
     return Builder(builder: (context) =>
-      DefaultTextStyle.merge(
+      DefaultTextStyle(
         style: ContentTheme.of(context).textStylePlainParagraph,
         child: BlockContentList(nodes: parseContent(html).nodes)));
   }

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -93,9 +93,10 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   Widget plainContent(String html) {
-    return DefaultTextStyle.merge(
-      style: plainParagraphContentTextStyle,
-      child: BlockContentList(nodes: parseContent(html).nodes));
+    return Builder(builder: (context) =>
+      DefaultTextStyle.merge(
+        style: ContentTheme.of(context).textStylePlainParagraph,
+        child: BlockContentList(nodes: parseContent(html).nodes)));
   }
 
   Widget messageContent(String html) {
@@ -125,7 +126,10 @@ void main() {
     await tester.pumpWidget(
       Builder(builder: (context) =>
         MaterialApp(
-          theme: ThemeData(typography: zulipTypography(context)),
+          theme: ThemeData(
+            typography: zulipTypography(context),
+            extensions: [ContentTheme()],
+          ),
           localizationsDelegates: ZulipLocalizations.localizationsDelegates,
           supportedLocales: ZulipLocalizations.supportedLocales,
           navigatorObservers: navObservers,
@@ -540,7 +544,7 @@ void main() {
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
     testWidgets('multiple links in paragraph', (tester) async {
-      final fontSize = plainParagraphContentTextStyle.fontSize!;
+      const fontSize = kBaseFontSize;
 
       await prepare(tester,
         '<p><a href="https://a/">foo</a> bar <a href="https://b/">baz</a></p>');
@@ -568,7 +572,7 @@ void main() {
     });
 
     testWidgets('link containing other spans', (tester) async {
-      final fontSize = plainParagraphContentTextStyle.fontSize!;
+      const fontSize = kBaseFontSize;
 
       await prepare(tester,
         '<p><a href="https://a/">two <strong><em><code>words</code></em></strong></a></p>');

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -14,7 +14,7 @@ import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/store.dart';
-import 'package:zulip/widgets/text.dart';
+import 'package:zulip/widgets/theme.dart';
 
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
@@ -126,10 +126,7 @@ void main() {
     await tester.pumpWidget(
       Builder(builder: (context) =>
         MaterialApp(
-          theme: ThemeData(
-            typography: zulipTypography(context),
-            extensions: [ContentTheme()],
-          ),
+          theme: zulipThemeData(context),
           localizationsDelegates: ZulipLocalizations.localizationsDelegates,
           supportedLocales: ZulipLocalizations.supportedLocales,
           navigatorObservers: navObservers,

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -68,6 +68,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(extensions: [ContentTheme()]),
         localizationsDelegates: ZulipLocalizations.localizationsDelegates,
         supportedLocales: ZulipLocalizations.supportedLocales,
         home: GlobalStoreWidget(

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -19,6 +19,7 @@ import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/store.dart';
+import 'package:zulip/widgets/theme.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
@@ -66,15 +67,15 @@ void main() {
     connection.prepare(json:
       newestResult(foundOldest: foundOldest, messages: messages).toJson());
 
-    await tester.pumpWidget(
+    await tester.pumpWidget(Builder(builder: (context) =>
       MaterialApp(
-        theme: ThemeData(extensions: [ContentTheme()]),
+        theme: zulipThemeData(context),
         localizationsDelegates: ZulipLocalizations.localizationsDelegates,
         supportedLocales: ZulipLocalizations.supportedLocales,
         home: GlobalStoreWidget(
           child: PerAccountStoreWidget(
             accountId: eg.selfAccount.id,
-            child: MessageListPage(narrow: narrow)))));
+            child: MessageListPage(narrow: narrow))))));
 
     // global store, per-account store, and message list get loaded
     await tester.pumpAndSettle();

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -11,6 +11,7 @@ import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/profile.dart';
 import 'package:zulip/widgets/store.dart';
+import 'package:zulip/widgets/theme.dart';
 
 import '../example_data.dart' as eg;
 import '../model/binding.dart';
@@ -41,15 +42,15 @@ Future<void> setupPage(WidgetTester tester, {
   }
 
   await tester.pumpWidget(
-    GlobalStoreWidget(
-      child: MaterialApp(
-        theme: ThemeData(extensions: [ContentTheme()]),
+    GlobalStoreWidget(child: Builder(builder: (context) =>
+      MaterialApp(
+        theme: zulipThemeData(context),
         navigatorObservers: navigatorObserver != null ? [navigatorObserver] : [],
         localizationsDelegates: ZulipLocalizations.localizationsDelegates,
         supportedLocales: ZulipLocalizations.supportedLocales,
         home: PerAccountStoreWidget(
           accountId: eg.selfAccount.id,
-          child: ProfilePage(userId: pageUserId)))));
+          child: ProfilePage(userId: pageUserId))))));
 
   // global store, per-account store, and page get loaded
   await tester.pumpAndSettle();

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -43,6 +43,7 @@ Future<void> setupPage(WidgetTester tester, {
   await tester.pumpWidget(
     GlobalStoreWidget(
       child: MaterialApp(
+        theme: ThemeData(extensions: [ContentTheme()]),
         navigatorObservers: navigatorObserver != null ? [navigatorObserver] : [],
         localizationsDelegates: ZulipLocalizations.localizationsDelegates,
         supportedLocales: ZulipLocalizations.supportedLocales,


### PR DESCRIPTION
I have four main goals for this PR:

- Stop applying the Zulip-message text color to things that aren't Zulip-message text (and refactor to make these errors easy to avoid)
- Don't regress on performance in the message list (for example by making a `DefaultTextStyle` for every message)
- Define and use a consolidated "base message text style" for content widgets to inherit from (which I do by lumping together the text color and the `Paragraph` styles)
- Add a `ThemeExtension` to our app's `ThemeData`, as a home for certain content styles (that we don't want to recompute for each message, or that differ between light and dark theme and will need to be `lerp`ed for the fade animation)

Along the way, I make some small changes/fixes:

- Message sender name was `hsl(0deg 0% 15%)`; it now matches web at `hsl(0deg 0% 20%)`
- #697 (which I filed just now)
- `<br>` in a block context, a.k.a. `LineBreakNode`, has the proper/expected font size and line height, instead of values from a Material default. (Inconspicuous and not worth filing an issue for; I don't know how to make one of these except with help from the server bug that causes #641.)
- Code blocks, and our basic math-block implementation, now have 1.4x line height instead of 1.43x. (This is to match web instead of a Material default, and is inconspicuous.)

(edit: Scroll down for up-to-date screenshots.)

Fixes: #697
Related: #95 