### PR TITLE
content test: Skip source-file-reading test on Windows

### DIFF
--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -1087,5 +1087,7 @@ void main() {
       r'^\s*testParseExample\s*\(\s*ContentExample\s*\.\s*(\w+)\);',
     ).allMatches(source).map((m) => m.group(1));
     check(testedExamples).unorderedEquals(declaredExamples);
-  });
+  }, skip: Platform.isWindows, // [intended] purely analyzes source, so
+       // any one platform is enough; avoid dealing with Windows file paths
+  );
 }


### PR DESCRIPTION
This fails there, or at least does in the `flutter/tests` CI environment, with an error like:

    ::group::❌ C:/Users/RUNNER~1/AppData/Local/Temp/flutter_customer_testing.zulip.4a7c3de6/tests/test/model/content_test.dart: all content examples are tested (failed)
    FileSystemException: Cannot open file, path = '/C:/Users/RUNNER~1/AppData/Local/Temp/flutter_customer_testing.zulip.4a7c3de6/tests/test/model/content_test.dart' (OS Error: The filename, directory name, or volume label syntax is incorrect.
    , errno = 123)
    dart:io                               _File.readAsStringSync
    test\model\content_test.dart 1082:39  main.<fn>
    ::endgroup::

I'm not sure what's wrong, but don't really feel like finding out (or working out how to fix it) -- and, conveniently, there's really no need to do so.  See comment.

---

This is needed for #239. See https://github.com/flutter/tests/pull/368 and its CI result at https://github.com/flutter/tests/actions/runs/9197725826/job/25298839228?pr=368#step:3:9762 .
