### PR TITLE
Make handleEvent an async method

### DIFF
--- a/integration_test/unreadmarker_test.dart
+++ b/integration_test/unreadmarker_test.dart
@@ -51,11 +51,11 @@ void main() {
 
     final messages = await setupMessageListPage(tester, 500);
     await binding.traceAction(() async {
-      store.handleEvent(eg.updateMessageFlagsRemoveEvent(
+      await store.handleEvent(eg.updateMessageFlagsRemoveEvent(
         MessageFlag.read,
         messages));
       await tester.pumpAndSettle();
-      store.handleEvent(UpdateMessageFlagsAddEvent(
+      await store.handleEvent(UpdateMessageFlagsAddEvent(
         id: 1,
         flag: MessageFlag.read,
         messages: messages.map((e) => e.id).toList(),

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -353,7 +353,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     super.dispose();
   }
 
-  void handleEvent(Event event) {
+  Future<void> handleEvent(Event event) async {
     if (event is HeartbeatEvent) {
       assert(debugLog("server event: heartbeat"));
     } else if (event is RealmEmojiUpdateEvent) {
@@ -711,7 +711,7 @@ class UpdateMachine {
 
       final events = result.events;
       for (final event in events) {
-        store.handleEvent(event);
+        await store.handleEvent(event);
       }
       if (events.isNotEmpty) {
         lastEventId = events.last.id;

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -221,7 +221,7 @@ void main() {
     const narrow = AllMessagesNarrow();
     final store = eg.store();
     for (int i = 0; i < 2500; i++) {
-      store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
+      await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
@@ -244,7 +244,7 @@ void main() {
     const narrow = AllMessagesNarrow();
     final store = eg.store();
     for (int i = 0; i < 1500; i++) {
-      store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
+      await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
@@ -278,7 +278,7 @@ void main() {
     const narrow = AllMessagesNarrow();
     final store = eg.store();
     for (int i = 0; i < 1500; i++) {
-      store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
+      await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
@@ -288,7 +288,7 @@ void main() {
 
     await Future(() {});
     check(done).isFalse();
-    store.addUser(eg.user(userId: 10000, email: 'user10000@example.com', fullName: 'User 10000'));
+    await store.addUser(eg.user(userId: 10000, email: 'user10000@example.com', fullName: 'User 10000'));
     await Future(() {});
     check(done).isFalse();
     await Future(() {});

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -167,8 +167,8 @@ void main() {
 
   test('MentionAutocompleteView misc', () async {
     const narrow = AllMessagesNarrow();
-    final store = eg.store()
-      ..addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
+    final store = eg.store();
+    await store.addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
     bool done = false;
@@ -182,10 +182,10 @@ void main() {
   });
 
   test('MentionAutocompleteView not starve timers', () {
-    fakeAsync((binding) {
+    fakeAsync((binding) async {
       const narrow = AllMessagesNarrow();
-      final store = eg.store()
-        ..addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
+      final store = eg.store();
+      await store.addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
       final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
       bool searchDone = false;

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -335,13 +335,13 @@ hello
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
   });
 
-  test('quoteAndReply / quoteAndReplyPlaceholder', () {
+  test('quoteAndReply / quoteAndReplyPlaceholder', () async {
     final sender = eg.user(userId: 123, fullName: 'Full Name');
     final stream = eg.stream(streamId: 1, name: 'test here');
     final message = eg.streamMessage(sender: sender, stream: stream, topic: 'some topic');
     final store = eg.store();
     store.addStream(stream);
-    store.addUser(sender);
+    await store.addUser(sender);
 
     check(quoteAndReplyPlaceholder(store, message: message)).equals('''
 @_**Full Name|123** [said](${eg.selfAccount.realmUrl}#narrow/stream/1-test-here/topic/some.20topic/near/${message.id}): *(loading message ${message.id})*

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -311,19 +311,19 @@ hello
     test('silent', () {
       check(mention(user, silent: true)).equals('@_**Full Name|123**');
     });
-    test('`users` passed; has two users with same fullName', () {
+    test('`users` passed; has two users with same fullName', () async {
       final store = eg.store();
-      store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName)]);
+      await store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName)]);
       check(mention(user, silent: true, users: store.users)).equals('@_**Full Name|123**');
     });
-    test('`users` passed; has two same-name users but one of them is deactivated', () {
+    test('`users` passed; has two same-name users but one of them is deactivated', () async {
       final store = eg.store();
-      store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName, isActive: false)]);
+      await store.addUsers([user, eg.user(userId: 5), eg.user(userId: 234, fullName: user.fullName, isActive: false)]);
       check(mention(user, silent: true, users: store.users)).equals('@_**Full Name|123**');
     });
-    test('`users` passed; user has unique fullName', () {
+    test('`users` passed; user has unique fullName', () async {
       final store = eg.store();
-      store.addUsers([user, eg.user(userId: 234, fullName: 'Another Name')]);
+      await store.addUsers([user, eg.user(userId: 234, fullName: 'Another Name')]);
       check(mention(user, silent: true, users: store.users)).equals('@_**Full Name**');
     });
   });

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -237,10 +237,10 @@ hello
         required String name,
         String? topic,
         int? nearMessageId,
-      }) {
+      }) async {
         assert(expectedFragment.startsWith('#'), 'wrong-looking expectedFragment');
         final store = eg.store();
-        store.addStream(eg.stream(streamId: streamId, name: name));
+        await store.addStream(eg.stream(streamId: streamId, name: name));
         final narrow = topic == null
           ? StreamNarrow(streamId)
           : TopicNarrow(streamId, topic);
@@ -340,7 +340,7 @@ hello
     final stream = eg.stream(streamId: 1, name: 'test here');
     final message = eg.streamMessage(sender: sender, stream: stream, topic: 'some topic');
     final store = eg.store();
-    store.addStream(stream);
+    await store.addStream(stream);
     await store.addUser(sender);
 
     check(quoteAndReplyPlaceholder(store, message: message)).equals('''

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -31,17 +31,16 @@ void main() {
 
   void testExpectedNarrows(List<(String, Narrow?)> testCases, {
     List<ZulipStream>? streams,
-    PerAccountStore? store,
     List<User>? users,
   }) {
-    assert((streams != null || users != null) ^ (store != null));
-    store ??= setupStore(realmUrl: realmUrl, streams: streams, users: users);
+    assert(streams != null || users != null);
     for (final testCase in testCases) {
       final String urlString = testCase.$1;
-      final Uri url = store.tryResolveUrl(urlString)!;
       final Narrow? expected = testCase.$2;
       test(urlString, () {
-        check(parseInternalLink(url, store!)).equals(expected);
+        final store = setupStore(realmUrl: realmUrl, streams: streams, users: users);
+        final url = store.tryResolveUrl(urlString)!;
+        check(parseInternalLink(url, store)).equals(expected);
       });
     }
   }

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -9,11 +9,11 @@ import 'package:zulip/model/store.dart';
 import '../example_data.dart' as eg;
 import 'test_store.dart';
 
-PerAccountStore setupStore({
+Future<PerAccountStore> setupStore({
   required Uri realmUrl,
   List<ZulipStream>? streams,
   List<User>? users,
-}) {
+}) async {
   final account = eg.selfAccount.copyWith(realmUrl: realmUrl);
   final store = eg.store(account: account);
   if (streams != null) {
@@ -21,7 +21,7 @@ PerAccountStore setupStore({
   }
   store.addUser(eg.selfUser);
   if (users != null) {
-    store.addUsers(users);
+    await store.addUsers(users);
   }
   return store;
 }
@@ -37,8 +37,8 @@ void main() {
     for (final testCase in testCases) {
       final String urlString = testCase.$1;
       final Narrow? expected = testCase.$2;
-      test(urlString, () {
-        final store = setupStore(realmUrl: realmUrl, streams: streams, users: users);
+      test(urlString, () async {
+        final store = await setupStore(realmUrl: realmUrl, streams: streams, users: users);
         final url = store.tryResolveUrl(urlString)!;
         check(parseInternalLink(url, store)).equals(expected);
       });
@@ -131,8 +131,8 @@ void main() {
       final String description = testCase.$2;
       final String urlString = testCase.$3;
       final Uri realmUrl = testCase.$4;
-      test('${expected ? 'accepts': 'rejects'} $description: $urlString', () {
-        final store = setupStore(realmUrl: realmUrl, streams: streams);
+      test('${expected ? 'accepts': 'rejects'} $description: $urlString', () async {
+        final store = await setupStore(realmUrl: realmUrl, streams: streams);
         final url = store.tryResolveUrl(urlString)!;
         final result = parseInternalLink(url, store);
         check(result != null).equals(expected);

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -17,7 +17,7 @@ Future<PerAccountStore> setupStore({
   final account = eg.selfAccount.copyWith(realmUrl: realmUrl);
   final store = eg.store(account: account);
   if (streams != null) {
-    store.addStreams(streams);
+    await store.addStreams(streams);
   }
   await store.addUser(eg.selfUser);
   if (users != null) {

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -19,7 +19,7 @@ Future<PerAccountStore> setupStore({
   if (streams != null) {
     store.addStreams(streams);
   }
-  store.addUser(eg.selfUser);
+  await store.addUser(eg.selfUser);
   if (users != null) {
     await store.addUsers(users);
   }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -561,9 +561,9 @@ void main() async {
       await prepare(narrow: const AllMessagesNarrow());
       await store.addStreams([stream1, stream2]);
       await store.addSubscription(eg.subscription(stream1));
-      store.addUserTopic(stream1, 'B', UserTopicVisibilityPolicy.muted);
+      await store.addUserTopic(stream1, 'B', UserTopicVisibilityPolicy.muted);
       await store.addSubscription(eg.subscription(stream2, isMuted: true));
-      store.addUserTopic(stream2, 'C', UserTopicVisibilityPolicy.unmuted);
+      await store.addUserTopic(stream2, 'C', UserTopicVisibilityPolicy.unmuted);
 
       // Check filtering on fetchInitial…
       await prepareMessages(foundOldest: false, messages: [
@@ -618,8 +618,8 @@ void main() async {
       await prepare(narrow: StreamNarrow(stream.streamId));
       await store.addStream(stream);
       await store.addSubscription(eg.subscription(stream, isMuted: true));
-      store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.unmuted);
-      store.addUserTopic(stream, 'C', UserTopicVisibilityPolicy.muted);
+      await store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.unmuted);
+      await store.addUserTopic(stream, 'C', UserTopicVisibilityPolicy.muted);
 
       // Check filtering on fetchInitial…
       await prepareMessages(foundOldest: false, messages: [
@@ -662,7 +662,7 @@ void main() async {
       await prepare(narrow: TopicNarrow(stream.streamId, 'A'));
       await store.addStream(stream);
       await store.addSubscription(eg.subscription(stream, isMuted: true));
-      store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.muted);
+      await store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.muted);
 
       // Check filtering on fetchInitial…
       await prepareMessages(foundOldest: false, messages: [

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -41,7 +41,7 @@ void main() async {
     subscription = eg.subscription(stream);
     store = eg.store();
     await store.addStream(stream);
-    store.addSubscription(subscription);
+    await store.addSubscription(subscription);
     connection = store.connection as FakeApiConnection;
     notifiedCount = 0;
     model = MessageListView.init(store: store, narrow: narrow)
@@ -560,9 +560,9 @@ void main() async {
       final stream2 = eg.stream(streamId: 2, name: 'stream 2');
       await prepare(narrow: const AllMessagesNarrow());
       await store.addStreams([stream1, stream2]);
-      store.addSubscription(eg.subscription(stream1));
+      await store.addSubscription(eg.subscription(stream1));
       store.addUserTopic(stream1, 'B', UserTopicVisibilityPolicy.muted);
-      store.addSubscription(eg.subscription(stream2, isMuted: true));
+      await store.addSubscription(eg.subscription(stream2, isMuted: true));
       store.addUserTopic(stream2, 'C', UserTopicVisibilityPolicy.unmuted);
 
       // Check filtering on fetchInitial…
@@ -617,7 +617,7 @@ void main() async {
       final stream = eg.stream(streamId: 1, name: 'stream 1');
       await prepare(narrow: StreamNarrow(stream.streamId));
       await store.addStream(stream);
-      store.addSubscription(eg.subscription(stream, isMuted: true));
+      await store.addSubscription(eg.subscription(stream, isMuted: true));
       store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.unmuted);
       store.addUserTopic(stream, 'C', UserTopicVisibilityPolicy.muted);
 
@@ -661,7 +661,7 @@ void main() async {
       final stream = eg.stream(streamId: 1, name: 'stream 1');
       await prepare(narrow: TopicNarrow(stream.streamId, 'A'));
       await store.addStream(stream);
-      store.addSubscription(eg.subscription(stream, isMuted: true));
+      await store.addSubscription(eg.subscription(stream, isMuted: true));
       store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.muted);
 
       // Check filtering on fetchInitial…

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -559,7 +559,7 @@ void main() async {
       final stream1 = eg.stream(streamId: 1, name: 'stream 1');
       final stream2 = eg.stream(streamId: 2, name: 'stream 2');
       await prepare(narrow: const AllMessagesNarrow());
-      store.addStreams([stream1, stream2]);
+      await store.addStreams([stream1, stream2]);
       store.addSubscription(eg.subscription(stream1));
       store.addUserTopic(stream1, 'B', UserTopicVisibilityPolicy.muted);
       store.addSubscription(eg.subscription(stream2, isMuted: true));

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -39,8 +39,9 @@ void main() async {
   Future<void> prepare({Narrow narrow = const AllMessagesNarrow()}) async {
     final stream = eg.stream();
     subscription = eg.subscription(stream);
-    store = eg.store()
-      ..addStream(stream)..addSubscription(subscription);
+    store = eg.store();
+    await store.addStream(stream);
+    store.addSubscription(subscription);
     connection = store.connection as FakeApiConnection;
     notifiedCount = 0;
     model = MessageListView.init(store: store, narrow: narrow)
@@ -615,7 +616,7 @@ void main() async {
     test('in StreamNarrow', () async {
       final stream = eg.stream(streamId: 1, name: 'stream 1');
       await prepare(narrow: StreamNarrow(stream.streamId));
-      store.addStream(stream);
+      await store.addStream(stream);
       store.addSubscription(eg.subscription(stream, isMuted: true));
       store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.unmuted);
       store.addUserTopic(stream, 'C', UserTopicVisibilityPolicy.muted);
@@ -659,7 +660,7 @@ void main() async {
     test('in TopicNarrow', () async {
       final stream = eg.stream(streamId: 1, name: 'stream 1');
       await prepare(narrow: TopicNarrow(stream.streamId, 'A'));
-      store.addStream(stream);
+      await store.addStream(stream);
       store.addSubscription(eg.subscription(stream, isMuted: true));
       store.addUserTopic(stream, 'A', UserTopicVisibilityPolicy.muted);
 

--- a/test/model/stream_test.dart
+++ b/test/model/stream_test.dart
@@ -62,42 +62,42 @@ void main() {
   group('SubscriptionEvent', () {
     final stream = eg.stream();
 
-    test('SubscriptionProperty.color updates with an int value', () {
+    test('SubscriptionProperty.color updates with an int value', () async {
       final store = eg.store(initialSnapshot: eg.initialSnapshot(
         streams: [stream],
         subscriptions: [eg.subscription(stream, color: 0xFFFF0000)],
       ));
       check(store.subscriptions[stream.streamId]!.color).equals(0xFFFF0000);
 
-      store.handleEvent(SubscriptionUpdateEvent(id: 1,
+      await store.handleEvent(SubscriptionUpdateEvent(id: 1,
         streamId: stream.streamId,
         property: SubscriptionProperty.color,
         value: 0xFFFF00FF));
       check(store.subscriptions[stream.streamId]!.color).equals(0xFFFF00FF);
     });
 
-    test('SubscriptionProperty.isMuted updates with a boolean value', () {
+    test('SubscriptionProperty.isMuted updates with a boolean value', () async {
       final store = eg.store(initialSnapshot: eg.initialSnapshot(
         streams: [stream],
         subscriptions: [eg.subscription(stream, isMuted: false)],
       ));
       check(store.subscriptions[stream.streamId]!.isMuted).isFalse();
 
-      store.handleEvent(SubscriptionUpdateEvent(id: 1,
+      await store.handleEvent(SubscriptionUpdateEvent(id: 1,
         streamId: stream.streamId,
         property: SubscriptionProperty.isMuted,
         value: true));
       check(store.subscriptions[stream.streamId]!.isMuted).isTrue();
     });
 
-    test('SubscriptionProperty.inHomeView updates isMuted instead', () {
+    test('SubscriptionProperty.inHomeView updates isMuted instead', () async {
       final store = eg.store(initialSnapshot: eg.initialSnapshot(
         streams: [stream],
         subscriptions: [eg.subscription(stream, isMuted: false)],
       ));
       check(store.subscriptions[stream.streamId]!.isMuted).isFalse();
 
-      store.handleEvent(SubscriptionUpdateEvent(id: 1,
+      await store.handleEvent(SubscriptionUpdateEvent(id: 1,
         streamId: stream.streamId,
         property: SubscriptionProperty.inHomeView,
         value: false));

--- a/test/model/stream_test.dart
+++ b/test/model/stream_test.dart
@@ -116,21 +116,21 @@ void main() {
           .equals(UserTopicVisibilityPolicy.none);
       });
 
-      test('with nothing for topic', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'other topic', UserTopicVisibilityPolicy.muted);
+      test('with nothing for topic', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'other topic', UserTopicVisibilityPolicy.muted);
         check(store.topicVisibilityPolicy(stream1.streamId, 'topic'))
           .equals(UserTopicVisibilityPolicy.none);
       });
 
-      test('with topic present', () {
+      test('with topic present', () async {
         final store = eg.store();
         for (final policy in [
           UserTopicVisibilityPolicy.muted,
           UserTopicVisibilityPolicy.unmuted,
           UserTopicVisibilityPolicy.followed,
         ]) {
-          store.addUserTopic(stream1, 'topic', policy);
+          await store.addUserTopic(stream1, 'topic', policy);
           check(store.topicVisibilityPolicy(stream1.streamId, 'topic'))
             .equals(policy);
         }
@@ -165,7 +165,7 @@ void main() {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
-        store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isFalse();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isFalse();
       });
@@ -174,7 +174,7 @@ void main() {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
-        store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
       });
@@ -183,7 +183,7 @@ void main() {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
-        store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.followed);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.followed);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
       });
@@ -229,55 +229,55 @@ void main() {
     });
 
     group('events', () {
-      test('add with new stream', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+      test('add with new stream', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
         compareTopicVisibility(store, [
           makeUserTopicItem(stream1, 'topic', UserTopicVisibilityPolicy.muted),
         ]);
       });
 
-      test('add in existing stream', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted)
-          ..addUserTopic(stream1, 'other topic', UserTopicVisibilityPolicy.unmuted);
+      test('add in existing stream', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream1, 'other topic', UserTopicVisibilityPolicy.unmuted);
         compareTopicVisibility(store, [
           makeUserTopicItem(stream1, 'topic', UserTopicVisibilityPolicy.muted),
           makeUserTopicItem(stream1, 'other topic', UserTopicVisibilityPolicy.unmuted),
         ]);
       });
 
-      test('update existing policy', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted)
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
+      test('update existing policy', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
         compareTopicVisibility(store, [
           makeUserTopicItem(stream1, 'topic', UserTopicVisibilityPolicy.unmuted),
         ]);
       });
 
-      test('remove, with others in stream', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted)
-          ..addUserTopic(stream1, 'other topic', UserTopicVisibilityPolicy.unmuted)
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.none);
+      test('remove, with others in stream', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream1, 'other topic', UserTopicVisibilityPolicy.unmuted);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.none);
         compareTopicVisibility(store, [
           makeUserTopicItem(stream1, 'other topic', UserTopicVisibilityPolicy.unmuted),
         ]);
       });
 
-      test('remove, as last in stream', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted)
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.none);
+      test('remove, as last in stream', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.none);
         compareTopicVisibility(store, [
         ]);
       });
 
-      test('treat unknown enum value as removing', () {
-        final store = eg.store()
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted)
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unknown);
+      test('treat unknown enum value as removing', () async {
+        final store = eg.store();
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unknown);
         compareTopicVisibility(store, [
         ]);
       });

--- a/test/model/stream_test.dart
+++ b/test/model/stream_test.dart
@@ -54,7 +54,7 @@ void main() {
       await store.addStream(stream2);
       checkUnified(store);
 
-      store.addSubscription(eg.subscription(stream1));
+      await store.addSubscription(eg.subscription(stream1));
       checkUnified(store);
     });
   });
@@ -141,7 +141,7 @@ void main() {
       test('with policy none, stream not muted', () async {
         final store = eg.store();
         await store.addStream(stream1);
-        store.addSubscription(eg.subscription(stream1));
+        await store.addSubscription(eg.subscription(stream1));
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
       });
@@ -149,7 +149,7 @@ void main() {
       test('with policy none, stream muted', () async {
         final store = eg.store();
         await store.addStream(stream1);
-        store.addSubscription(eg.subscription(stream1, isMuted: true));
+        await store.addSubscription(eg.subscription(stream1, isMuted: true));
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isFalse();
       });
@@ -164,7 +164,7 @@ void main() {
       test('with policy muted', () async {
         final store = eg.store();
         await store.addStream(stream1);
-        store.addSubscription(eg.subscription(stream1));
+        await store.addSubscription(eg.subscription(stream1));
         store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isFalse();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isFalse();
@@ -173,7 +173,7 @@ void main() {
       test('with policy unmuted', () async {
         final store = eg.store();
         await store.addStream(stream1);
-        store.addSubscription(eg.subscription(stream1, isMuted: true));
+        await store.addSubscription(eg.subscription(stream1, isMuted: true));
         store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
@@ -182,7 +182,7 @@ void main() {
       test('with policy followed', () async {
         final store = eg.store();
         await store.addStream(stream1);
-        store.addSubscription(eg.subscription(stream1, isMuted: true));
+        await store.addSubscription(eg.subscription(stream1, isMuted: true));
         store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.followed);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();

--- a/test/model/stream_test.dart
+++ b/test/model/stream_test.dart
@@ -42,14 +42,20 @@ void main() {
       )));
     });
 
-    test('added by events', () {
+    test('added by events', () async {
       final stream1 = eg.stream(streamId: 1, name: 'stream 1');
       final stream2 = eg.stream(streamId: 2, name: 'stream 2');
       final store = eg.store();
       checkUnified(store);
-      checkUnified(store..addStream(stream1));
-      checkUnified(store..addStream(stream2));
-      checkUnified(store..addSubscription(eg.subscription(stream1)));
+
+      await store.addStream(stream1);
+      checkUnified(store);
+
+      await store.addStream(stream2);
+      checkUnified(store);
+
+      store.addSubscription(eg.subscription(stream1));
+      checkUnified(store);
     });
   });
 
@@ -132,46 +138,52 @@ void main() {
     });
 
     group('isTopicVisible/InStream', () {
-      test('with policy none, stream not muted', () {
-        final store = eg.store()..addStream(stream1)
-          ..addSubscription(eg.subscription(stream1));
+      test('with policy none, stream not muted', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        store.addSubscription(eg.subscription(stream1));
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
       });
 
-      test('with policy none, stream muted', () {
-        final store = eg.store()..addStream(stream1)
-          ..addSubscription(eg.subscription(stream1, isMuted: true));
+      test('with policy none, stream muted', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        store.addSubscription(eg.subscription(stream1, isMuted: true));
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isFalse();
       });
 
-      test('with policy none, stream unsubscribed', () {
-        final store = eg.store()..addStream(stream1);
+      test('with policy none, stream unsubscribed', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isFalse();
       });
 
-      test('with policy muted', () {
-        final store = eg.store()..addStream(stream1)
-          ..addSubscription(eg.subscription(stream1))
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
+      test('with policy muted', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        store.addSubscription(eg.subscription(stream1));
+        store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isFalse();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isFalse();
       });
 
-      test('with policy unmuted', () {
-        final store = eg.store()..addStream(stream1)
-          ..addSubscription(eg.subscription(stream1, isMuted: true))
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
+      test('with policy unmuted', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        store.addSubscription(eg.subscription(stream1, isMuted: true));
+        store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
       });
 
-      test('with policy followed', () {
-        final store = eg.store()..addStream(stream1)
-          ..addSubscription(eg.subscription(stream1, isMuted: true))
-          ..addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.followed);
+      test('with policy followed', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        store.addSubscription(eg.subscription(stream1, isMuted: true));
+        store.addUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.followed);
         check(store.isTopicVisibleInStream(stream1.streamId, 'topic')).isTrue();
         check(store.isTopicVisible        (stream1.streamId, 'topic')).isTrue();
       });

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -133,10 +133,10 @@ extension PerAccountStoreTestExtension on PerAccountStore {
   }
 
   Future<void> addSubscription(Subscription subscription) async {
-    addSubscriptions([subscription]);
+    await addSubscriptions([subscription]);
   }
 
-  void addSubscriptions(List<Subscription> subscriptions) {
+  Future<void> addSubscriptions(List<Subscription> subscriptions) async {
     handleEvent(SubscriptionAddEvent(id: 1, subscriptions: subscriptions));
   }
 

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -124,7 +124,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     }
   }
 
-  void addStream(ZulipStream stream) {
+  Future<void> addStream(ZulipStream stream) async {
     addStreams([stream]);
   }
 

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -115,7 +115,7 @@ class TestGlobalStore extends GlobalStore {
 
 extension PerAccountStoreTestExtension on PerAccountStore {
   Future<void> addUser(User user) async {
-    handleEvent(RealmUserAddEvent(id: 1, person: user));
+    await handleEvent(RealmUserAddEvent(id: 1, person: user));
   }
 
   Future<void> addUsers(Iterable<User> users) async {
@@ -129,7 +129,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
   }
 
   Future<void> addStreams(List<ZulipStream> streams) async {
-    handleEvent(StreamCreateEvent(id: 1, streams: streams));
+    await handleEvent(StreamCreateEvent(id: 1, streams: streams));
   }
 
   Future<void> addSubscription(Subscription subscription) async {
@@ -137,11 +137,11 @@ extension PerAccountStoreTestExtension on PerAccountStore {
   }
 
   Future<void> addSubscriptions(List<Subscription> subscriptions) async {
-    handleEvent(SubscriptionAddEvent(id: 1, subscriptions: subscriptions));
+    await handleEvent(SubscriptionAddEvent(id: 1, subscriptions: subscriptions));
   }
 
   Future<void> addUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy visibilityPolicy) async {
-    handleEvent(UserTopicEvent(
+    await handleEvent(UserTopicEvent(
       id: 1,
       streamId: stream.streamId,
       topicName: topic,

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -118,7 +118,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     handleEvent(RealmUserAddEvent(id: 1, person: user));
   }
 
-  void addUsers(Iterable<User> users) {
+  Future<void> addUsers(Iterable<User> users) async {
     for (final user in users) {
       addUser(user);
     }

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -140,7 +140,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     handleEvent(SubscriptionAddEvent(id: 1, subscriptions: subscriptions));
   }
 
-  void addUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy visibilityPolicy) {
+  Future<void> addUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy visibilityPolicy) async {
     handleEvent(UserTopicEvent(
       id: 1,
       streamId: stream.streamId,

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -125,10 +125,10 @@ extension PerAccountStoreTestExtension on PerAccountStore {
   }
 
   Future<void> addStream(ZulipStream stream) async {
-    addStreams([stream]);
+    await addStreams([stream]);
   }
 
-  void addStreams(List<ZulipStream> streams) {
+  Future<void> addStreams(List<ZulipStream> streams) async {
     handleEvent(StreamCreateEvent(id: 1, streams: streams));
   }
 

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -132,7 +132,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     handleEvent(StreamCreateEvent(id: 1, streams: streams));
   }
 
-  void addSubscription(Subscription subscription) {
+  Future<void> addSubscription(Subscription subscription) async {
     addSubscriptions([subscription]);
   }
 

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -114,13 +114,13 @@ class TestGlobalStore extends GlobalStore {
 }
 
 extension PerAccountStoreTestExtension on PerAccountStore {
-  void addUser(User user) {
+  Future<void> addUser(User user) async {
     handleEvent(RealmUserAddEvent(id: 1, person: user));
   }
 
   Future<void> addUsers(Iterable<User> users) async {
     for (final user in users) {
-      addUser(user);
+      await addUser(user);
     }
   }
 

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -192,7 +192,8 @@ void main() {
       check(model.countInStream      (stream.streamId)).equals(5);
       check(model.countInStreamNarrow(stream.streamId)).equals(5);
 
-      streamStore.handleEvent(SubscriptionUpdateEvent(id: 1, streamId: stream.streamId,
+      await streamStore.handleEvent(SubscriptionUpdateEvent(id: 1,
+        streamId: stream.streamId,
         property: SubscriptionProperty.isMuted, value: true));
       check(model.countInStream      (stream.streamId)).equals(2);
       check(model.countInStreamNarrow(stream.streamId)).equals(5);

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -174,10 +174,10 @@ void main() {
       check(model.countInAllMessagesNarrow()).equals(5);
     });
 
-    test('countInStream/Narrow', () {
+    test('countInStream/Narrow', () async {
       final stream = eg.stream();
       prepare();
-      streamStore.addStream(stream);
+      await streamStore.addStream(stream);
       streamStore.addSubscription(eg.subscription(stream));
       streamStore.addUserTopic(stream, 'a', UserTopicVisibilityPolicy.unmuted);
       streamStore.addUserTopic(stream, 'c', UserTopicVisibilityPolicy.muted);

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -158,9 +158,9 @@ void main() {
       final stream3 = eg.stream(streamId: 3, name: 'stream 3');
       prepare();
       await streamStore.addStreams([stream1, stream2, stream3]);
-      streamStore.addSubscription(eg.subscription(stream1));
-      streamStore.addSubscription(eg.subscription(stream2));
-      streamStore.addSubscription(eg.subscription(stream3, isMuted: true));
+      await streamStore.addSubscription(eg.subscription(stream1));
+      await streamStore.addSubscription(eg.subscription(stream2));
+      await streamStore.addSubscription(eg.subscription(stream3, isMuted: true));
       streamStore.addUserTopic(stream1, 'a', UserTopicVisibilityPolicy.muted);
       fillWithMessages([
         eg.streamMessage(stream: stream1, topic: 'a', flags: []),
@@ -178,7 +178,7 @@ void main() {
       final stream = eg.stream();
       prepare();
       await streamStore.addStream(stream);
-      streamStore.addSubscription(eg.subscription(stream));
+      await streamStore.addSubscription(eg.subscription(stream));
       streamStore.addUserTopic(stream, 'a', UserTopicVisibilityPolicy.unmuted);
       streamStore.addUserTopic(stream, 'c', UserTopicVisibilityPolicy.muted);
       fillWithMessages([

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -152,12 +152,12 @@ void main() {
   });
 
   group('count helpers', () {
-    test('countInAllMessagesNarrow', () {
+    test('countInAllMessagesNarrow', () async {
       final stream1 = eg.stream(streamId: 1, name: 'stream 1');
       final stream2 = eg.stream(streamId: 2, name: 'stream 2');
       final stream3 = eg.stream(streamId: 3, name: 'stream 3');
       prepare();
-      streamStore.addStreams([stream1, stream2, stream3]);
+      await streamStore.addStreams([stream1, stream2, stream3]);
       streamStore.addSubscription(eg.subscription(stream1));
       streamStore.addSubscription(eg.subscription(stream2));
       streamStore.addSubscription(eg.subscription(stream3, isMuted: true));

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -161,7 +161,7 @@ void main() {
       await streamStore.addSubscription(eg.subscription(stream1));
       await streamStore.addSubscription(eg.subscription(stream2));
       await streamStore.addSubscription(eg.subscription(stream3, isMuted: true));
-      streamStore.addUserTopic(stream1, 'a', UserTopicVisibilityPolicy.muted);
+      await streamStore.addUserTopic(stream1, 'a', UserTopicVisibilityPolicy.muted);
       fillWithMessages([
         eg.streamMessage(stream: stream1, topic: 'a', flags: []),
         eg.streamMessage(stream: stream1, topic: 'b', flags: []),
@@ -179,8 +179,8 @@ void main() {
       prepare();
       await streamStore.addStream(stream);
       await streamStore.addSubscription(eg.subscription(stream));
-      streamStore.addUserTopic(stream, 'a', UserTopicVisibilityPolicy.unmuted);
-      streamStore.addUserTopic(stream, 'c', UserTopicVisibilityPolicy.muted);
+      await streamStore.addUserTopic(stream, 'a', UserTopicVisibilityPolicy.unmuted);
+      await streamStore.addUserTopic(stream, 'c', UserTopicVisibilityPolicy.muted);
       fillWithMessages([
         eg.streamMessage(stream: stream, topic: 'a', flags: []),
         eg.streamMessage(stream: stream, topic: 'a', flags: []),

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -42,7 +42,8 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   await store.addUser(eg.user(userId: message.senderId));
   if (message is StreamMessage) {
     final stream = eg.stream(streamId: message.streamId);
-    store..addStream(stream)..addSubscription(eg.subscription(stream));
+    await store.addStream(stream);
+    store.addSubscription(eg.subscription(stream));
   }
   final connection = store.connection as FakeApiConnection;
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -43,7 +43,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   if (message is StreamMessage) {
     final stream = eg.stream(streamId: message.streamId);
     await store.addStream(stream);
-    store.addSubscription(eg.subscription(stream));
+    await store.addSubscription(eg.subscription(stream));
   }
   final connection = store.connection as FakeApiConnection;
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -39,7 +39,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
 
   await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
   final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-  store.addUser(eg.user(userId: message.senderId));
+  await store.addUser(eg.user(userId: message.senderId));
   if (message is StreamMessage) {
     final stream = eg.stream(streamId: message.streamId);
     store..addStream(stream)..addSubscription(eg.subscription(stream));

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -31,8 +31,8 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
   addTearDown(testBinding.reset);
   await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
   final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-  store.addUsers([eg.selfUser, eg.otherUser]);
-  store.addUsers(users);
+  await store.addUsers([eg.selfUser, eg.otherUser]);
+  await store.addUsers(users);
   final connection = store.connection as FakeApiConnection;
 
   // prepare message list data

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -823,7 +823,7 @@ void main() {
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
       final user = eg.user(avatarUrl: avatarUrl);
-      store.addUser(user);
+      await store.addUser(user);
 
       prepareBoringImageHttpClient();
       await tester.pumpWidget(GlobalStoreWidget(

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -627,7 +627,7 @@ void main() {
       pushedRoutes.removeLast();
 
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-      store.addStream(eg.stream(name: 'stream'));
+      await store.addStream(eg.stream(name: 'stream'));
       return pushedRoutes;
     }
 

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -29,7 +29,7 @@ void main() {
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-      store.addUser(eg.selfUser);
+      await store.addUser(eg.selfUser);
 
       // TODO do this more centrally, or put in reusable helper
       final Future<ByteData> font = rootBundle.load('assets/Source_Sans_3/SourceSans3VF-Upright.otf');

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -101,16 +101,15 @@ void main() {
 
                 await prepare();
 
-                store
-                  ..addUsers(users)
-                  ..handleEvent(RealmEmojiUpdateEvent(id: 1,
-                      realmEmoji: realmEmoji))
-                  ..handleEvent(UserSettingsUpdateEvent(id: 1,
-                      property: UserSettingName.displayEmojiReactionUsers,
-                      value: displayEmojiReactionUsers))
-                  ..handleEvent(UserSettingsUpdateEvent(id: 1,
-                      property: UserSettingName.emojiset,
-                      value: emojiset));
+                await store.addUsers(users);
+                store.handleEvent(RealmEmojiUpdateEvent(id: 1,
+                  realmEmoji: realmEmoji));
+                store.handleEvent(UserSettingsUpdateEvent(id: 1,
+                  property: UserSettingName.displayEmojiReactionUsers,
+                  value: displayEmojiReactionUsers));
+                store.handleEvent(UserSettingsUpdateEvent(id: 1,
+                  property: UserSettingName.emojiset,
+                  value: emojiset));
 
                 // This does mean that all image emoji will look the same…
                 // shrug, at least for now.

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -102,12 +102,12 @@ void main() {
                 await prepare();
 
                 await store.addUsers(users);
-                store.handleEvent(RealmEmojiUpdateEvent(id: 1,
+                await store.handleEvent(RealmEmojiUpdateEvent(id: 1,
                   realmEmoji: realmEmoji));
-                store.handleEvent(UserSettingsUpdateEvent(id: 1,
+                await store.handleEvent(UserSettingsUpdateEvent(id: 1,
                   property: UserSettingName.displayEmojiReactionUsers,
                   value: displayEmojiReactionUsers));
-                store.handleEvent(UserSettingsUpdateEvent(id: 1,
+                await store.handleEvent(UserSettingsUpdateEvent(id: 1,
                   property: UserSettingName.emojiset,
                   value: emojiset));
 

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -199,7 +199,7 @@ void main() {
           streams: [stream],
           subscriptions: [subscription],
           unreadMessages: [eg.streamMessage(stream: stream, topic: 'lunch')]);
-        store.addUserTopic(stream, 'lunch', UserTopicVisibilityPolicy.muted);
+        await store.addUserTopic(stream, 'lunch', UserTopicVisibilityPolicy.muted);
         await tester.pump();
         check(tester.widgetList(find.text('lunch'))).length.equals(0);
       });
@@ -221,7 +221,7 @@ void main() {
           streams: [stream],
           subscriptions: [subscription],
           unreadMessages: [eg.streamMessage(stream: stream, topic: 'lunch')]);
-        store.addUserTopic(stream, 'lunch', UserTopicVisibilityPolicy.unmuted);
+        await store.addUserTopic(stream, 'lunch', UserTopicVisibilityPolicy.unmuted);
         await tester.pump();
         check(tester.widgetList(find.text('lunch'))).length.equals(1);
       });

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -61,7 +61,7 @@ void main() {
     await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
     store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-    store.addStreams(streams ?? []);
+    await store.addStreams(streams ?? []);
     store.addSubscriptions(subscriptions ?? []);
     await store.addUsers(users ?? [eg.selfUser]);
 

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -62,7 +62,7 @@ void main() {
     store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
     await store.addStreams(streams ?? []);
-    store.addSubscriptions(subscriptions ?? []);
+    await store.addSubscriptions(subscriptions ?? []);
     await store.addUsers(users ?? [eg.selfUser]);
 
     for (final message in unreadMessages) {

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -61,10 +61,9 @@ void main() {
     await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
     store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-    store
-      ..addStreams(streams ?? [])
-      ..addSubscriptions(subscriptions ?? [])
-      ..addUsers(users ?? [eg.selfUser]);
+    store.addStreams(streams ?? []);
+    store.addSubscriptions(subscriptions ?? []);
+    await store.addUsers(users ?? [eg.selfUser]);
 
     for (final message in unreadMessages) {
       assert(!message.flags.contains(MessageFlag.read));

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -67,7 +67,7 @@ void main() {
 
     for (final message in unreadMessages) {
       assert(!message.flags.contains(MessageFlag.read));
-      store.handleEvent(MessageEvent(id: 1, message: message));
+      await store.handleEvent(MessageEvent(id: 1, message: message));
     }
 
     await tester.pumpWidget(

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -58,7 +58,7 @@ void main() {
 
     // prepare message list data
     store.addUser(eg.selfUser);
-    store.addUsers(users ?? []);
+    await store.addUsers(users ?? []);
     assert((messageCount == null) != (messages == null));
     messages ??= List.generate(messageCount!, (index) {
       return eg.streamMessage(sender: eg.selfUser);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -57,7 +57,7 @@ void main() {
     connection = store.connection as FakeApiConnection;
 
     // prepare message list data
-    store.addUser(eg.selfUser);
+    await store.addUser(eg.selfUser);
     await store.addUsers(users ?? []);
     assert((messageCount == null) != (messages == null));
     messages ??= List.generate(messageCount!, (index) {
@@ -378,8 +378,8 @@ void main() {
           eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
           eg.dmMessage(from: eg.thirdUser, to: [eg.selfUser, eg.otherUser]),
         ]);
-        store.addUser(eg.otherUser);
-        store.addUser(eg.thirdUser);
+        await store.addUser(eg.otherUser);
+        await store.addUser(eg.thirdUser);
         await tester.pump();
         tester.widget(find.text(zulipLocalizations.messageListGroupYouWithYourself));
         tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
@@ -394,7 +394,7 @@ void main() {
           eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
           eg.dmMessage(from: eg.thirdUser, to: [eg.selfUser, eg.otherUser]),
         ]);
-        store.addUser(eg.thirdUser);
+        await store.addUser(eg.thirdUser);
         await tester.pump();
         tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
           zulipLocalizations.unknownUserName)));

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -481,7 +481,7 @@ void main() {
       }
 
       Future<void> handleNewAvatarEventAndPump(WidgetTester tester, String avatarUrl) async {
-        store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId, avatarUrl: avatarUrl));
+        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId, avatarUrl: avatarUrl));
         await tester.pump();
       }
 
@@ -575,7 +575,7 @@ void main() {
         ..value.equals(0.0)
         ..status.equals(AnimationStatus.dismissed);
 
-      store.handleEvent(eg.updateMessageFlagsRemoveEvent(
+      await store.handleEvent(eg.updateMessageFlagsRemoveEvent(
         MessageFlag.read, [message]));
       await tester.pump(); // process handleEvent
       check(getAnimation(tester, message.id))
@@ -595,7 +595,7 @@ void main() {
         ..value.equals(1.0)
         ..status.equals(AnimationStatus.dismissed);
 
-      store.handleEvent(UpdateMessageFlagsAddEvent(
+      await store.handleEvent(UpdateMessageFlagsAddEvent(
         id: 1,
         flag: MessageFlag.read,
         messages: [message.id],
@@ -623,7 +623,7 @@ void main() {
         ..value.equals(1.0)
         ..status.equals(AnimationStatus.dismissed);
 
-      store.handleEvent(UpdateMessageFlagsAddEvent(
+      await store.handleEvent(UpdateMessageFlagsAddEvent(
         id: 0,
         flag: MessageFlag.read,
         messages: [message.id],
@@ -643,7 +643,7 @@ void main() {
 
       // introduce new message
       final newMessage = eg.streamMessage(flags:[MessageFlag.read]);
-      store.handleEvent(MessageEvent(id: 0, message: newMessage));
+      await store.handleEvent(MessageEvent(id: 0, message: newMessage));
       await tester.pump(); // process handleEvent
       check(find.byType(MessageItem).evaluate()).length.equals(2);
       check(getAnimation(tester, message.id))
@@ -678,7 +678,7 @@ void main() {
       await setupMessageListPage(tester, messages: [message]);
       check(isMarkAsReadButtonVisible(tester)).isFalse();
 
-      store.handleEvent(eg.updateMessageFlagsRemoveEvent(
+      await store.handleEvent(eg.updateMessageFlagsRemoveEvent(
         MessageFlag.read, [message]));
       await tester.pumpAndSettle();
       check(isMarkAsReadButtonVisible(tester)).isTrue();
@@ -692,7 +692,7 @@ void main() {
       await setupMessageListPage(tester, messages: [message], unreadMsgs: unreadMsgs);
       check(isMarkAsReadButtonVisible(tester)).isTrue();
 
-      store.handleEvent(UpdateMessageFlagsAddEvent(
+      await store.handleEvent(UpdateMessageFlagsAddEvent(
         id: 1,
         flag: MessageFlag.read,
         messages: [message.id],
@@ -714,7 +714,7 @@ void main() {
       check(tester.widgetList(find.byType(MessageItem))).length.equals(1);
       final before = tester.getTopLeft(find.byType(MessageItem)).dy;
 
-      store.handleEvent(UpdateMessageFlagsAddEvent(
+      await store.handleEvent(UpdateMessageFlagsAddEvent(
         id: 1,
         flag: MessageFlag.read,
         messages: [message.id],

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -35,7 +35,7 @@ Future<void> setupPage(WidgetTester tester, {
   await testBinding.globalStore.add(eg.selfAccount, initialSnapshot);
   final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-  store.addUser(eg.selfUser);
+  await store.addUser(eg.selfUser);
   if (users != null) {
     await store.addUsers(users);
   }

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -37,7 +37,7 @@ Future<void> setupPage(WidgetTester tester, {
 
   store.addUser(eg.selfUser);
   if (users != null) {
-    store.addUsers(users);
+    await store.addUsers(users);
   }
 
   await tester.pumpWidget(

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -39,11 +39,11 @@ Future<void> setupPage(WidgetTester tester, {
   }
 
   for (final dmMessage in dmMessages) {
-    store.handleEvent(MessageEvent(id: 1, message: dmMessage));
+    await store.handleEvent(MessageEvent(id: 1, message: dmMessage));
   }
 
   if (newNameForSelfUser != null) {
-    store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId,
+    await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId,
       fullName: newNameForSelfUser));
   }
 
@@ -151,7 +151,7 @@ void main() {
 
       Future<void> markMessageAsRead(WidgetTester tester, Message message) async {
         final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-        store.handleEvent(UpdateMessageFlagsAddEvent(
+        await store.handleEvent(UpdateMessageFlagsAddEvent(
           id: 1, flag: MessageFlag.read, all: false, messages: [message.id]));
         await tester.pump();
       }

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -33,9 +33,9 @@ Future<void> setupPage(WidgetTester tester, {
   await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
   final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-  store.addUser(eg.selfUser);
+  await store.addUser(eg.selfUser);
   for (final user in users) {
-    store.addUser(user);
+    await store.addUser(user);
   }
 
   for (final dmMessage in dmMessages) {


### PR DESCRIPTION
With #458, we'll want this method to write changes to the database
on certain events, to update the metadata we keep about the user's
Zulip servers.

When it does that, we'll want it to wait for that write to finish
before it moves on to make other changes, and for its caller
[UpdateMachine.poll] to similarly wait.  That saves us from having
to worry about potential races if some later event also wants to
make database changes while the first changes haven't finished yet.
It also gives us a good foundation for generally not showing the
user a confirmation that some change has been made until we've
actually saved the change.

So to do that, we'll need the method to be async, and to return a
Future which its call sites should wait for.

This PR does that, after a series of commits donig the same for its
callers, recursively.
