### PR TITLE
content: Make **bold** bolder even in spoiler headers and h1/h2/etc.

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -723,6 +723,12 @@ class InlineContent extends StatelessWidget {
     required this.nodes,
   }) {
     assert(style.fontSize != null);
+    assert(
+      style.debugLabel!.contains('weightVariableTextStyle')
+      // ([ContentTheme.textStylePlainParagraph] applies [weightVariableTextStyle])
+      || style.debugLabel!.contains('ContentTheme.textStylePlainParagraph')
+      || style.debugLabel!.contains('bolderWghtTextStyle')
+    );
     _builder = _InlineContentBuilder(this);
   }
 
@@ -733,6 +739,7 @@ class InlineContent extends StatelessWidget {
   ///
   /// Must set [TextStyle.fontSize]. Some descendant spans will consume it,
   /// e.g., to make their content slightly smaller than surrounding text.
+  /// Similarly must set a font weight using [weightVariableTextStyle].
   final TextStyle style;
 
   final List<InlineContentNode> nodes;
@@ -832,7 +839,7 @@ class _InlineContentBuilder {
   }
 
   InlineSpan _buildStrong(StrongNode node) => _buildNodes(node.nodes,
-    style: weightVariableTextStyle(_context!, wght: 600));
+    style: bolderWghtTextStyle(widget.style, by: 200));
 
   InlineSpan _buildDeleted(DeletedNode node) => _buildNodes(node.nodes,
     style: const TextStyle(decoration: TextDecoration.lineThrough));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -252,6 +252,11 @@ class Heading extends StatelessWidget {
           fontSize: kBaseFontSize * emHeight,
           height: 1.4,
         )
+          // Could set boldness relative to ambient text style, which itself
+          // might be bolder than normal (e.g. in spoiler headers).
+          // But this didn't seem like a clear improvement and would make inline
+          // **bold** spans less distinct; discussion:
+          //   https://github.com/zulip/zulip-flutter/pull/706#issuecomment-2141326257
           .merge(weightVariableTextStyle(context, wght: 600)),
         node: node));
   }

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -209,7 +209,7 @@ TextStyle weightVariableTextStyle(BuildContext context, {
   double? wght,
   double? wghtIfPlatformRequestsBold,
 }) {
-  double value = wght ?? FontWeight.normal.value.toDouble();
+  double value = wght ?? wghtFromFontWeight(FontWeight.normal);
   if (MediaQuery.boldTextOf(context)) {
     // The framework has a condition on [MediaQueryData.boldText]
     // in the [Text] widget, but that only affects `fontWeight`.

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -284,6 +285,23 @@ FontWeight clampVariableFontWeight(double wght) {
       else                 return FontWeight.w900;
     }
   }
+}
+
+/// A "wght" value extracted from a [TextStyle].
+///
+/// Returns the value in [TextStyle.fontVariations] if present.
+/// If that's absent but a [TextStyle.fontWeight] is present,
+/// returns [wghtFromFontWeight] for that value.
+///
+/// The returned value already reflects any response to the system bold-text
+/// setting, so if the [TextStyle] was built using [weightVariableTextStyle],
+/// this value might be larger than the `wght` that was passed to that function.
+double? wghtFromTextStyle(TextStyle style) {
+  double? result = style.fontVariations?.firstWhereOrNull((v) => v.axis == 'wght')?.value;
+  if (result == null && style.fontWeight != null) {
+    result = wghtFromFontWeight(style.fontWeight!);
+  }
+  return result;
 }
 
 /// A good guess at a font's "wght" value to match a given [FontWeight].

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -264,6 +264,44 @@ double bolderWght(double baseWght, {double by = 300}) {
   return clampDouble(baseWght + by, kWghtMin, kWghtMax);
 }
 
+/// A [TextStyle] whose [FontVariation] "wght" and [TextStyle.fontWeight]
+/// have been raised using [bolderWght].
+///
+/// [style] must have already been processed with [weightVariableTextStyle],
+/// and [by] must be positive.
+///
+/// The increase done here will commute with any increase that was done by
+/// [weightVariableTextStyle] to respond to the device bold-text setting,
+/// because both adjustments are done with [bolderWght] with positive `by`.
+///
+/// [by] defaults to 300.
+TextStyle bolderWghtTextStyle(TextStyle style, {double by = 300}) {
+  assert(
+    style.debugLabel!.contains('weightVariableTextStyle')
+    // ([ContentTheme.textStylePlainParagraph] applies [weightVariableTextStyle])
+    || style.debugLabel!.contains('ContentTheme.textStylePlainParagraph')
+    || style.debugLabel!.contains('bolderWghtTextStyle')
+  );
+  assert(by > 0);
+  assert(style.fontVariations!.where((v) => v.axis == 'wght').length == 1);
+
+  final newWght = bolderWght(wghtFromTextStyle(style)!, by: by);
+
+  TextStyle result = style.copyWith(
+    fontVariations: style.fontVariations!.map((v) => v.axis == 'wght'
+      ? FontVariation('wght', newWght)
+      : v).toList(),
+    fontWeight: clampVariableFontWeight(newWght),
+  );
+
+  assert(() {
+    result = result.copyWith(debugLabel: 'bolderWghtTextStyle(by: $by)');
+    return true;
+  }());
+
+  return result;
+}
+
 /// Find the nearest [FontWeight] constant for a variable-font "wght"-axis value.
 ///
 /// Use this for a reasonable [TextStyle.fontWeight] for glyphs that need to be

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -256,6 +256,8 @@ const kWghtMax = 1000.0;
 
 /// A [FontVariation] "wght" value that's 300 above a given, clamped to [kWghtMax].
 ///
+/// The input value must be between [kWghtMin] and [kWghtMax].
+///
 /// Pass [by] to use a value other than 300.
 double bolderWght(double baseWght, {double by = 300}) {
   assert(kWghtMin <= baseWght && baseWght <= kWghtMax);

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -255,9 +255,11 @@ const kWghtMin = 1.0;
 const kWghtMax = 1000.0;
 
 /// A [FontVariation] "wght" value that's 300 above a given, clamped to [kWghtMax].
-double bolderWght(double baseWght) {
+///
+/// Pass [by] to use a value other than 300.
+double bolderWght(double baseWght, {double by = 300}) {
   assert(kWghtMin <= baseWght && baseWght <= kWghtMax);
-  return clampDouble(baseWght + 300, kWghtMin, kWghtMax);
+  return clampDouble(baseWght + by, kWghtMin, kWghtMax);
 }
 
 /// Find the nearest [FontWeight] constant for a variable-font "wght"-axis value.

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -77,6 +77,10 @@ extension TextStyleChecks on Subject<TextStyle> {
   // TODO others
 }
 
+extension FontVariationChecks on Subject<FontVariation> {
+  Subject<String> get axis => has((x) => x.axis, 'axis');
+  Subject<double> get value => has((x) => x.value, 'value');
+}
 
 extension TextThemeChecks on Subject<TextTheme> {
   Subject<TextStyle?> get displayLarge => has((t) => t.displayLarge, 'displayLarge');

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -469,7 +469,9 @@ void main() {
     check((ratioInHeader - ratioInParagraph).abs()).isLessThan(0.001);
   }
 
-  testContentSmoke(ContentExample.strong);
+  group('strong (bold)', () {
+    testContentSmoke(ContentExample.strong);
+  });
 
   testContentSmoke(ContentExample.emphasis);
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -519,6 +519,54 @@ void main() {
       content: plainContent('<p><strong>bold</strong></p>'),
       styleFinder: findWordBold,
     );
+
+    for (final level in HeadingLevel.values) {
+      final name = level.name;
+      assert(RegExp(r'^h[1-6]$').hasMatch(name));
+      testFontWeight('in $name',
+        expectedWght: 800,
+        // # **bold**, ## **bold**, ### **bold**, etc.
+        content: plainContent('<$name><strong>bold</strong></$name>'),
+        styleFinder: findWordBold,
+      );
+    }
+
+    testFontWeight('in different kind of span in h1',
+      expectedWght: 800,
+      // # ~~**bold**~~
+      content: plainContent('<h1><del><strong>bold</strong></del></h1>'),
+      styleFinder: findWordBold,
+    );
+
+    testFontWeight('in spoiler header',
+      expectedWght: 900,
+      // ```spoiler regular **bold**
+      // content
+      // ```
+      content: plainContent(
+        '<div class="spoiler-block"><div class="spoiler-header">\n'
+          '<p>regular <strong>bold</strong></p>\n'
+          '</div><div class="spoiler-content" aria-hidden="true">\n'
+          '<p>content</p>\n'
+          '</div></div>'
+      ),
+      styleFinder: findWordBold,
+    );
+
+    testFontWeight('in different kind of span in spoiler header',
+      expectedWght: 900,
+      // ```spoiler *italic **bold***
+      // content
+      // ```
+      content: plainContent(
+        '<div class="spoiler-block"><div class="spoiler-header">\n'
+          '<p><em>italic <strong>bold</strong></em></p>\n'
+          '</div><div class="spoiler-content" aria-hidden="true">\n'
+          '<p>content</p>\n'
+          '</div></div>'
+      ),
+      styleFinder: findWordBold,
+    );
   });
 
   testContentSmoke(ContentExample.emphasis);

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -155,6 +155,15 @@ void main() {
     check(bolderWght(400)).equals(700);
     check(bolderWght(600)).equals(900);
     check(bolderWght(900)).equals(1000);
+
+    check(bolderWght(1,    by: -200)).equals(1);
+    check(bolderWght(201,  by: -200)).equals(1);
+    check(bolderWght(1000, by: -200)).equals(800);
+
+    check(bolderWght(1,   by: 200)).equals(201);
+    check(bolderWght(400, by: 200)).equals(600);
+    check(bolderWght(600, by: 200)).equals(800);
+    check(bolderWght(900, by: 200)).equals(1000);
   });
 
   test('clampVariableFontWeight: FontWeight has the assumed list of values', () {

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -151,6 +151,9 @@ void main() {
   });
 
   test('bolderWght', () {
+    check(() => bolderWght(kWghtMin - 1)).throws<void>();
+    check(() => bolderWght(kWghtMax + 1)).throws<void>();
+
     check(bolderWght(1)).equals(301);
     check(bolderWght(400)).equals(700);
     check(bolderWght(600)).equals(900);

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -209,6 +209,38 @@ void main() {
     check(clampVariableFontWeight(1000)) .equals(FontWeight.w900);
   });
 
+  test('wghtFromTextStyle', () {
+    doCheck(TextStyle style, double? expected) {
+      check(wghtFromTextStyle(style)).equals(expected);
+    }
+
+    doCheck(const TextStyle(), null);
+    doCheck(const TextStyle(fontVariations: []), null);
+    doCheck(const TextStyle(fontVariations: [FontVariation.slant(45)]), null);
+
+    doCheck(const TextStyle(fontVariations: [FontVariation('wght', 100)]), 100);
+    doCheck(const TextStyle(
+      fontVariations: [FontVariation('wght', 160)],
+      fontWeight: FontWeight.w200,
+    ), 160);
+    doCheck(const TextStyle(
+      fontVariations: [FontVariation('wght', 100), FontVariation('wght', 200)]
+    ), 100);
+    doCheck(const TextStyle(
+      fontVariations: [FontVariation('wght', 100), FontVariation('wght', 100)],
+      fontWeight: FontWeight.w900,
+    ), 100);
+
+    doCheck(const TextStyle(
+      fontVariations: [],
+      fontWeight: FontWeight.w900,
+    ), 900);
+    doCheck(const TextStyle(
+      fontVariations: [FontVariation.slant(45)],
+      fontWeight: FontWeight.w900,
+    ), 900);
+  });
+
   group('proportionalLetterSpacing', () {
     Future<void> testLetterSpacing(
       String description, {


### PR DESCRIPTION
This fixes #705 by making boldness context-dependent, much like we did for some font sizes in #544.

That user-facing change is nice but fairly subtle. I'm also hoping this will be helpful by adding content tests for boldness in the first place; we didn't have any before. And I've set a pattern in the `UserMention` tests that should help reduce confusion when we write boldness tests for #647. (Confusion mainly related to the fact that `UserMention` is in a `WidgetSpan`.)

The need for more helpers in lib/widgets/text.dart is another reminder that it'll be great to have https://github.com/flutter/flutter/issues/148026 fixed upstream. But (as with the existing helpers there) I'm hoping this handles things in a way that makes it straightforward to migrate once that's done.

Fixes: #705

| Before | After |
| --- | --- |
| ![75927CB2-41BB-415B-9530-CE418DBB9368](https://github.com/zulip/zulip-flutter/assets/22248748/c21677b2-4b15-4513-8b70-16354ffe48ff) | ![445F7D01-3E38-4A19-B5CD-7746474655D5](https://github.com/zulip/zulip-flutter/assets/22248748/c4c49bcd-e103-47dd-9b94-af7ecc10b5ab) |