### PR TITLE
msglist: Add "Copy message link" button to action sheet

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -43,8 +43,8 @@
   "@permissionsDeniedReadExternalStorage": {
     "description": "Message for dialog asking the user to grant permissions for external storage read access."
   },
-  "actionSheetOptionCopy": "Copy message text",
-  "@actionSheetOptionCopy":  {
+  "actionSheetOptionCopyMessageText": "Copy message text",
+  "@actionSheetOptionCopyMessageText":  {
     "description": "Label for copy message text button on action sheet."
   },
   "actionSheetOptionShare": "Share",
@@ -168,8 +168,8 @@
   "@successLinkCopied": {
     "description": "Success message after copy link action completed."
   },
-  "successMessageCopied": "Message Copied",
-  "@successMessageCopied": {
+  "successMessageTextCopied": "Message text copied",
+  "@successMessageTextCopied": {
     "description": "Message when content of a message was copied to the user's system clipboard."
   },
   "composeBoxAttachFilesTooltip": "Attach files",

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -47,6 +47,10 @@
   "@actionSheetOptionCopyMessageText":  {
     "description": "Label for copy message text button on action sheet."
   },
+  "actionSheetOptionCopyMessageLink": "Copy link to message",
+  "@actionSheetOptionCopyMessageLink": {
+    "description": "Label for copy message link button on action sheet."
+  },
   "actionSheetOptionShare": "Share",
   "@actionSheetOptionShare":  {
     "description": "Label for share button on action sheet."
@@ -171,6 +175,10 @@
   "successMessageTextCopied": "Message text copied",
   "@successMessageTextCopied": {
     "description": "Message when content of a message was copied to the user's system clipboard."
+  },
+  "successMessageLinkCopied": "Message link copied",
+  "@successMessageLinkCopied": {
+    "description": "Message when link of a message was copied to the user's system clipboard."
   },
   "composeBoxAttachFilesTooltip": "Attach files",
   "@composeBoxAttachFilesTooltip": {

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -6,6 +6,8 @@ import 'package:share_plus/share_plus.dart';
 import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
+import '../model/internal_link.dart';
+import '../model/narrow.dart';
 import 'clipboard.dart';
 import 'compose_box.dart';
 import 'dialog.dart';
@@ -44,6 +46,7 @@ void showMessageActionSheet({required BuildContext context, required Message mes
           messageListContext: context,
         ),
         CopyMessageTextButton(message: message, messageListContext: context),
+        CopyMessageLinkButton(message: message, messageListContext: context),
         ShareButton(message: message, messageListContext: context),
       ]);
     });
@@ -307,6 +310,37 @@ class CopyMessageTextButton extends MessageActionSheetMenuItemButton {
     copyWithPopup(context: messageListContext,
       successContent: Text(zulipLocalizations.successMessageTextCopied),
       data: ClipboardData(text: rawContent));
+  }
+}
+
+class CopyMessageLinkButton extends MessageActionSheetMenuItemButton {
+  CopyMessageLinkButton({
+    super.key,
+    required super.message,
+    required super.messageListContext,
+  });
+
+  @override IconData get icon => Icons.link;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.actionSheetOptionCopyMessageLink;
+  }
+
+  @override void onPressed(BuildContext context) {
+    Navigator.of(context).pop();
+    final zulipLocalizations = ZulipLocalizations.of(messageListContext);
+
+    final store = PerAccountStoreWidget.of(messageListContext);
+    final messageLink = narrowLink(
+      store,
+      SendableNarrow.ofMessage(message, selfUserId: store.selfUserId),
+      nearMessageId: message.id,
+    );
+
+    copyWithPopup(context: messageListContext,
+      successContent: Text(zulipLocalizations.successMessageLinkCopied),
+      data: ClipboardData(text: messageLink.toString()));
   }
 }
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -361,7 +361,7 @@ class CopyMessageTextButton extends MessageActionSheetMenuItemButton {
 
     if (!messageListContext.mounted) return;
 
-    copyWithPopup(context: context,
+    copyWithPopup(context: messageListContext,
       successContent: Text(zulipLocalizations.successMessageTextCopied),
       data: ClipboardData(text: rawContent));
   }

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -44,7 +44,7 @@ void showMessageActionSheet({required BuildContext context, required Message mes
           message: message,
           messageListContext: context,
         ),
-        CopyButton(message: message, messageListContext: context),
+        CopyMessageTextButton(message: message, messageListContext: context),
       ]);
     });
 }
@@ -330,8 +330,8 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
   }
 }
 
-class CopyButton extends MessageActionSheetMenuItemButton {
-  CopyButton({
+class CopyMessageTextButton extends MessageActionSheetMenuItemButton {
+  CopyMessageTextButton({
     super.key,
     required super.message,
     required super.messageListContext,
@@ -341,7 +341,7 @@ class CopyButton extends MessageActionSheetMenuItemButton {
 
   @override
   String label(ZulipLocalizations zulipLocalizations) {
-    return zulipLocalizations.actionSheetOptionCopy;
+    return zulipLocalizations.actionSheetOptionCopyMessageText;
   }
 
   @override void onPressed(BuildContext context) async {
@@ -362,7 +362,7 @@ class CopyButton extends MessageActionSheetMenuItemButton {
     if (!messageListContext.mounted) return;
 
     copyWithPopup(context: context,
-      successContent: Text(zulipLocalizations.successMessageCopied),
+      successContent: Text(zulipLocalizations.successMessageTextCopied),
       data: ClipboardData(text: rawContent));
   }
 }

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -449,7 +449,7 @@ void main() {
     });
   });
 
-  group('CopyButton', () {
+  group('CopyMessageTextButton', () {
     setUp(() async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.platform,
@@ -457,7 +457,7 @@ void main() {
       );
     });
 
-    Future<void> tapCopyButton(WidgetTester tester) async {
+    Future<void> tapCopyMessageTextButton(WidgetTester tester) async {
       await tester.ensureVisible(find.byIcon(Icons.copy, skipOffstage: false));
       await tester.tap(find.byIcon(Icons.copy));
       await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
@@ -469,7 +469,7 @@ void main() {
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
-      await tapCopyButton(tester);
+      await tapCopyMessageTextButton(tester);
       await tester.pump(Duration.zero);
       check(await Clipboard.getData('text/plain')).isNotNull().text.equals('Hello world');
     });
@@ -480,7 +480,7 @@ void main() {
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseError(store);
-      await tapCopyButton(tester);
+      await tapCopyMessageTextButton(tester);
       await tester.pump(Duration.zero); // error arrives; error dialog shows
 
       await tester.tap(find.byWidget(checkErrorDialog(tester,

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -10,6 +10,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/binding.dart';
 import 'package:zulip/model/compose.dart';
+import 'package:zulip/model/internal_link.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
@@ -451,6 +452,33 @@ void main() {
         expectedMessage: 'That message does not seem to exist.',
       )));
       check(await Clipboard.getData('text/plain')).isNull();
+    });
+  });
+
+  group('CopyMessageLinkButton', () {
+    setUp(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        MockClipboard().handleMethodCall,
+      );
+    });
+
+    Future<void> tapCopyMessageLinkButton(WidgetTester tester) async {
+      await tester.ensureVisible(find.byIcon(Icons.link, skipOffstage: false));
+      await tester.tap(find.byIcon(Icons.link));
+      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+    }
+
+    testWidgets('copies message link to clipboard', (tester) async {
+      final message = eg.streamMessage();
+      final narrow = TopicNarrow.ofMessage(message);
+      await setupToMessageActionSheet(tester, message: message, narrow: narrow);
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+
+      await tapCopyMessageLinkButton(tester);
+      await tester.pump(Duration.zero);
+      final expectedLink = narrowLink(store, narrow, nearMessageId: message.id).toString();
+      check(await Clipboard.getData('text/plain')).isNotNull().text.equals(expectedLink);
     });
   });
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -247,70 +247,6 @@ void main() {
     });
   });
 
-  group('ShareButton', () {
-    // Tests should call this.
-    MockSharePlus setupMockSharePlus() {
-      final mock = MockSharePlus();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-        MethodChannelShare.channel,
-        mock.handleMethodCall,
-      );
-      return mock;
-    }
-
-    Future<void> tapShareButton(WidgetTester tester) async {
-      await tester.ensureVisible(find.byIcon(Icons.adaptive.share, skipOffstage: false));
-      await tester.tap(find.byIcon(Icons.adaptive.share));
-      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
-    }
-
-    testWidgets('request succeeds; sharing succeeds', (WidgetTester tester) async {
-      final mockSharePlus = setupMockSharePlus();
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
-      await tapShareButton(tester);
-      await tester.pump(Duration.zero);
-      check(mockSharePlus.sharedString).equals('Hello world');
-    });
-
-    testWidgets('request succeeds; sharing fails', (WidgetTester tester) async {
-      final mockSharePlus = setupMockSharePlus();
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
-      mockSharePlus.resultString = 'dev.fluttercommunity.plus/share/unavailable';
-      await tapShareButton(tester);
-      await tester.pump(Duration.zero);
-      check(mockSharePlus.sharedString).equals('Hello world');
-      await tester.pump();
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: 'Sharing failed')));
-    });
-
-    testWidgets('request has an error', (WidgetTester tester) async {
-      final mockSharePlus = setupMockSharePlus();
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-
-      prepareRawContentResponseError(store);
-      await tapShareButton(tester);
-      await tester.pump(Duration.zero); // error arrives; error dialog shows
-
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: 'Sharing failed',
-        expectedMessage: 'That message does not seem to exist.',
-      )));
-
-      check(mockSharePlus.sharedString).isNull();
-    });
-  });
-
   group('QuoteAndReplyButton', () {
     ComposeBoxController? findComposeBoxController(WidgetTester tester) {
       return tester.widget<ComposeBox>(find.byType(ComposeBox))
@@ -515,6 +451,70 @@ void main() {
         expectedMessage: 'That message does not seem to exist.',
       )));
       check(await Clipboard.getData('text/plain')).isNull();
+    });
+  });
+
+  group('ShareButton', () {
+    // Tests should call this.
+    MockSharePlus setupMockSharePlus() {
+      final mock = MockSharePlus();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        MethodChannelShare.channel,
+        mock.handleMethodCall,
+      );
+      return mock;
+    }
+
+    Future<void> tapShareButton(WidgetTester tester) async {
+      await tester.ensureVisible(find.byIcon(Icons.adaptive.share, skipOffstage: false));
+      await tester.tap(find.byIcon(Icons.adaptive.share));
+      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+    }
+
+    testWidgets('request succeeds; sharing succeeds', (WidgetTester tester) async {
+      final mockSharePlus = setupMockSharePlus();
+      final message = eg.streamMessage();
+      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+
+      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      await tapShareButton(tester);
+      await tester.pump(Duration.zero);
+      check(mockSharePlus.sharedString).equals('Hello world');
+    });
+
+    testWidgets('request succeeds; sharing fails', (WidgetTester tester) async {
+      final mockSharePlus = setupMockSharePlus();
+      final message = eg.streamMessage();
+      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+
+      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      mockSharePlus.resultString = 'dev.fluttercommunity.plus/share/unavailable';
+      await tapShareButton(tester);
+      await tester.pump(Duration.zero);
+      check(mockSharePlus.sharedString).equals('Hello world');
+      await tester.pump();
+      await tester.tap(find.byWidget(checkErrorDialog(tester,
+        expectedTitle: 'Sharing failed')));
+    });
+
+    testWidgets('request has an error', (WidgetTester tester) async {
+      final mockSharePlus = setupMockSharePlus();
+      final message = eg.streamMessage();
+      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+
+      prepareRawContentResponseError(store);
+      await tapShareButton(tester);
+      await tester.pump(Duration.zero); // error arrives; error dialog shows
+
+      await tester.tap(find.byWidget(checkErrorDialog(tester,
+        expectedTitle: 'Sharing failed',
+        expectedMessage: 'That message does not seem to exist.',
+      )));
+
+      check(mockSharePlus.sharedString).isNull();
     });
   });
 }


### PR DESCRIPTION
A new option is added to the long press action sheet of a message to copy the message link to the clipboard.

Here's an illustration:
<table>
  <tr>
    <td><b>Photo</b></td>
    <td><b>Video</b></td>
  </tr>
  <tr>
    <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/9c4a0df9-5ced-45f9-bfc4-7f37ce229f7a" width="300" /></td>
    <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/39cdaa20-1144-4984-8b35-b0b173e7ef57" width="300" /></td>
  </tr>
</table>

Fixes: #673
Fixes: #732 