### PR TITLE
lint: Enable strict-casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,5 @@
 # For docs on this file, see:
-#   https://dart.dev/guides/language/analysis-options
+#   https://dart.dev/tools/analysis
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
@@ -11,6 +11,12 @@ analyzer:
     # if Pigeon tripped them it'd immediately get caught.)
     # TODO(pigeon) re-enable lints once clean: https://github.com/flutter/flutter/issues/145633
     - lib/host/*.g.dart
+
+  language:
+    # TODO(#719): Enable these strict-* options.
+    # strict-casts: true
+    # strict-inference: true
+    # strict-raw-types: true
 
 linter:
   # For a list of all available lints, with docs, see:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,10 +13,9 @@ analyzer:
     - lib/host/*.g.dart
 
   language:
-    # TODO(#719): Enable these strict-* options.
     strict-inference: true
     strict-raw-types: true
-    # strict-casts: true
+    strict-casts: true
 
 linter:
   # For a list of all available lints, with docs, see:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,9 +14,9 @@ analyzer:
 
   language:
     # TODO(#719): Enable these strict-* options.
-    # strict-casts: true
     strict-inference: true
-    # strict-raw-types: true
+    strict-raw-types: true
+    # strict-casts: true
 
 linter:
   # For a list of all available lints, with docs, see:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,7 +15,7 @@ analyzer:
   language:
     # TODO(#719): Enable these strict-* options.
     # strict-casts: true
-    # strict-inference: true
+    strict-inference: true
     # strict-raw-types: true
 
 linter:

--- a/integration_test/perf_driver.dart
+++ b/integration_test/perf_driver.dart
@@ -11,7 +11,7 @@ Future<void> main() {
   return integrationDriver(
     responseDataCallback: (data) async {
       if (data == null) return;
-      final timeline = driver.Timeline.fromJson(data['timeline']);
+      final timeline = driver.Timeline.fromJson(data['timeline'] as Map<String, dynamic>);
       final summary = driver.TimelineSummary.summarize(timeline);
       await summary.writeTimelineToFile(
         'trace_output',

--- a/lib/api/backoff.dart
+++ b/lib/api/backoff.dart
@@ -45,7 +45,7 @@ class BackoffMachine {
       * min(_durationCeiling,
             _firstDuration * pow(_base, _waitsCompleted));
 
-    await Future.delayed(Duration(milliseconds: duration.round()));
+    await Future<void>.delayed(Duration(milliseconds: duration.round()));
 
     _waitsCompleted++;
   }

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -188,8 +188,8 @@ ApiRequestException _makeApiException(String routeName, int httpStatus, Map<Stri
         // When `code` is missing, we fall back to `BAD_REQUEST`,
         // the same value the server uses when nobody's made it more specific.
         // TODO(server): `code` should always be present.  Get the "Invalid API key" case fixed.
-        code: json.remove('code') ?? 'BAD_REQUEST',
-        message: json.remove('msg'),
+        code: (json.remove('code') as String?) ?? 'BAD_REQUEST',
+        message: json.remove('msg') as String,
         data: json,
       );
     }

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -148,7 +148,7 @@ class UserSettingsUpdateEvent extends Event {
 
   /// [value], with a check that its type corresponds to [property]
   /// (e.g., `value as bool`).
-  static Object? _readValue(Map json, String key) {
+  static Object? _readValue(Map<dynamic, dynamic> json, String key) {
     final value = json['value'];
     switch (UserSettingName.fromRawString(json['property'] as String)) {
       case UserSettingName.twentyFourHourTime:
@@ -279,7 +279,7 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   @JsonKey(readValue: _readFromPerson) final RealmUserUpdateCustomProfileField? customProfileField;
   @JsonKey(readValue: _readFromPerson) final String? newEmail;
 
-  static Object? _readFromPerson(Map json, String key) {
+  static Object? _readFromPerson(Map<dynamic, dynamic> json, String key) {
     return (json['person'] as Map<String, dynamic>)[key];
   }
 
@@ -402,7 +402,7 @@ class SubscriptionRemoveEvent extends SubscriptionEvent {
   @JsonKey(readValue: _readStreamIds)
   final List<int> streamIds;
 
-  static List<int> _readStreamIds(Map json, String key) {
+  static List<int> _readStreamIds(Map<dynamic, dynamic> json, String key) {
     return (json['subscriptions'] as List<dynamic>)
       .map((e) => (e as Map<String, dynamic>)['stream_id'] as int)
       .toList();
@@ -438,7 +438,7 @@ class SubscriptionUpdateEvent extends SubscriptionEvent {
 
   /// [value], with a check that its type corresponds to [property]
   /// (e.g., `value as bool`).
-  static Object? _readValue(Map json, String key) {
+  static Object? _readValue(Map<dynamic, dynamic> json, String key) {
     final value = json['value'];
     switch (SubscriptionProperty.fromRawString(json['property'] as String)) {
       case SubscriptionProperty.color:

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -249,7 +249,7 @@ class UnreadDmSnapshot {
   final List<int> unreadMessageIds;
 
   // TODO(server-5): Simplify away.
-  static _readOtherUserId(Map json, String key) {
+  static dynamic _readOtherUserId(Map json, String key) {
     return json[key] ?? json['sender_id'];
   }
 

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -65,15 +65,15 @@ class InitialSnapshot {
   // But for our model it's convenient to always have it; so, fill it in.
   static Object? _readUsersIsActiveFallbackTrue(Map<dynamic, dynamic> json, String key) {
     final list = (json[key] as List<dynamic>);
-    for (final Map<String, dynamic> user in list) {
-      user.putIfAbsent('is_active', () => true);
+    for (final user in list) {
+      (user as Map<String, dynamic>).putIfAbsent('is_active', () => true);
     }
     return list;
   }
   static Object? _readUsersIsActiveFallbackFalse(Map<dynamic, dynamic> json, String key) {
     final list = (json[key] as List<dynamic>);
-    for (final Map<String, dynamic> user in list) {
-      user.putIfAbsent('is_active', () => false);
+    for (final user in list) {
+      (user as Map<String, dynamic>).putIfAbsent('is_active', () => false);
     }
     return list;
   }

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -63,14 +63,14 @@ class InitialSnapshot {
   // `is_active` is sometimes absent:
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371603
   // But for our model it's convenient to always have it; so, fill it in.
-  static Object? _readUsersIsActiveFallbackTrue(Map json, String key) {
+  static Object? _readUsersIsActiveFallbackTrue(Map<dynamic, dynamic> json, String key) {
     final list = (json[key] as List<dynamic>);
     for (final Map<String, dynamic> user in list) {
       user.putIfAbsent('is_active', () => true);
     }
     return list;
   }
-  static Object? _readUsersIsActiveFallbackFalse(Map json, String key) {
+  static Object? _readUsersIsActiveFallbackFalse(Map<dynamic, dynamic> json, String key) {
     final list = (json[key] as List<dynamic>);
     for (final Map<String, dynamic> user in list) {
       user.putIfAbsent('is_active', () => false);
@@ -249,7 +249,7 @@ class UnreadDmSnapshot {
   final List<int> unreadMessageIds;
 
   // TODO(server-5): Simplify away.
-  static dynamic _readOtherUserId(Map json, String key) {
+  static dynamic _readOtherUserId(Map<dynamic, dynamic> json, String key) {
     return json[key] ?? json['sender_id'];
   }
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -798,14 +798,14 @@ class DmRecipientListConverter extends JsonConverter<List<DmRecipient>, List<dyn
   const DmRecipientListConverter();
 
   @override
-  List<DmRecipient> fromJson(List json) {
+  List<DmRecipient> fromJson(List<dynamic> json) {
     return json.map((e) => DmRecipient.fromJson(e as Map<String, dynamic>))
       .toList(growable: false)
       ..sort((a, b) => a.id.compareTo(b.id));
   }
 
   @override
-  List toJson(List<DmRecipient> object) => object;
+  List<dynamic> toJson(List<DmRecipient> object) => object;
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -85,7 +85,7 @@ class CustomProfileFieldChoiceDataItem {
   Map<String, dynamic> toJson() => _$CustomProfileFieldChoiceDataItemToJson(this);
 
   static Map<String, CustomProfileFieldChoiceDataItem> parseFieldDataChoices(Map<String, dynamic> json) =>
-    json.map((k, v) => MapEntry(k, CustomProfileFieldChoiceDataItem.fromJson(v)));
+    json.map((k, v) => MapEntry(k, CustomProfileFieldChoiceDataItem.fromJson(v as Map<String, dynamic>)));
 }
 
 /// The realm-level field data for an "external account" custom profile field.
@@ -232,8 +232,8 @@ class User {
   static bool _readIsSystemBot(Map<dynamic, dynamic> json, String key) {
     // This field is absent in `realm_users` and `realm_non_active_users`,
     // which contain no system bots; it's present in `cross_realm_bots`.
-    return json[key]
-        ?? json['is_cross_realm_bot'] // TODO(server-5): renamed to `is_system_bot`
+    return (json[key] as bool?)
+        ?? (json['is_cross_realm_bot'] as bool?) // TODO(server-5): renamed to `is_system_bot`
         ?? false;
   }
 
@@ -337,7 +337,8 @@ class ZulipStream {
   final int? streamWeeklyTraffic;
 
   static int? _readCanRemoveSubscribersGroup(Map<dynamic, dynamic> json, String key) {
-    return json[key] ?? json['can_remove_subscribers_group_id'];
+    return (json[key] as int?)
+      ?? (json['can_remove_subscribers_group_id'] as int?);
   }
 
   ZulipStream({

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -220,7 +220,7 @@ class User {
   @JsonKey(readValue: _readIsSystemBot)
   bool isSystemBot;
 
-  static Map<String, dynamic>? _readProfileData(Map json, String key) {
+  static Map<String, dynamic>? _readProfileData(Map<dynamic, dynamic> json, String key) {
     final value = (json[key] as Map<String, dynamic>?);
     // Represent `{}` as `null`, to avoid allocating a huge number
     // of LinkedHashMap data structures that we can do without.
@@ -229,7 +229,7 @@ class User {
     return (value != null && value.isNotEmpty) ? value : null;
   }
 
-  static bool _readIsSystemBot(Map json, String key) {
+  static bool _readIsSystemBot(Map<dynamic, dynamic> json, String key) {
     // This field is absent in `realm_users` and `realm_non_active_users`,
     // which contain no system bots; it's present in `cross_realm_bots`.
     return json[key]
@@ -336,7 +336,7 @@ class ZulipStream {
   // TODO(server-8): added in FL 199, was previously only on [Subscription] objects
   final int? streamWeeklyTraffic;
 
-  static int? _readCanRemoveSubscribersGroup(Map json, String key) {
+  static int? _readCanRemoveSubscribersGroup(Map<dynamic, dynamic> json, String key) {
     return json[key] ?? json['can_remove_subscribers_group_id'];
   }
 
@@ -410,7 +410,7 @@ class Subscription extends ZulipStream {
     _color = value;
     _swatch = null;
   }
-  static Object? _readColor(Map json, String key) {
+  static Object? _readColor(Map<dynamic, dynamic> json, String key) {
     final str = (json[key] as String);
     assert(RegExp(r'^#[0-9a-f]{6}$').hasMatch(str));
     return 0xff000000 | int.parse(str.substring(1), radix: 16);

--- a/lib/api/notifications.dart
+++ b/lib/api/notifications.dart
@@ -112,7 +112,7 @@ class MessageFcmMessage extends FcmMessageWithIdentity {
   /// zulip/zulip:zerver/lib/push_notifications.py .
   final String content;
 
-  static Object? _readWhole(Map json, String key) => json;
+  static Object? _readWhole(Map<dynamic, dynamic> json, String key) => json;
 
   MessageFcmMessage({
     required super.server,

--- a/lib/api/notifications.dart
+++ b/lib/api/notifications.dart
@@ -199,11 +199,11 @@ class FcmMessageDmRecipient extends FcmMessageRecipient {
       // Group DM conversations ("huddles") are represented with `pm_users`,
       // which lists all the user IDs in the conversation.
       // TODO check they're sorted.
-      {'pm_users': var pmUsers} => const _IntListConverter().fromJson(pmUsers),
+      {'pm_users': String pmUsers} => const _IntListConverter().fromJson(pmUsers),
 
       // 1:1 DM conversations have no `pm_users`.  Knowing that it's a
       // 1:1 DM, `sender_id` is enough to identify the conversation.
-      {'sender_id': var senderId, 'user_id': var userId} =>
+      {'sender_id': String senderId, 'user_id': String userId} =>
         _pairSet(_parseInt(senderId), _parseInt(userId)),
 
       _ => throw Exception("bad recipient"),

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -229,7 +229,7 @@ class MentionAutocompleteView extends ChangeNotifier {
   Iterable<MentionAutocompleteResult> get results => _results;
   List<MentionAutocompleteResult> _results = [];
 
-  _startSearch(MentionAutocompleteQuery query) async {
+  Future<void> _startSearch(MentionAutocompleteQuery query) async {
     List<MentionAutocompleteResult>? newResults;
 
     while (true) {

--- a/lib/model/recent_dm_conversations.dart
+++ b/lib/model/recent_dm_conversations.dart
@@ -13,7 +13,7 @@ import 'narrow.dart';
 class RecentDmConversationsView extends ChangeNotifier {
   factory RecentDmConversationsView({
     required List<RecentDmConversation> initial,
-    required selfUserId,
+    required int selfUserId,
   }) {
     final entries = initial.map((conversation) => MapEntry(
         DmNarrow.ofRecentDmConversation(conversation, selfUserId: selfUserId),

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -264,7 +264,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore {
     required this.selfUserId,
     required this.userSettings,
     required this.users,
-    required streams,
+    required StreamStoreImpl streams,
     required this.unreads,
     required this.recentDmConversationsView,
   }) : assert(selfUserId == globalStore.getAccount(accountId)!.userId),

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -447,9 +447,9 @@ class Unreads extends ChangeNotifier {
 
   // TODO use efficient model lookups
   void _slowRemoveAllInStreams(Set<int> idsToRemove) {
-    final newlyEmptyStreams = [];
+    final newlyEmptyStreams = <int>[];
     for (final MapEntry(key: streamId, value: topics) in streams.entries) {
-      final newlyEmptyTopics = [];
+      final newlyEmptyTopics = <String>[];
       for (final MapEntry(key: topic, value: messageIds) in topics.entries) {
         messageIds.removeWhere((id) => idsToRemove.contains(id));
         if (messageIds.isEmpty) {
@@ -506,7 +506,7 @@ class Unreads extends ChangeNotifier {
 
   // TODO use efficient model lookups
   void _slowRemoveAllInDms(Set<int> idsToRemove) {
-    final newlyEmptyDms = [];
+    final newlyEmptyDms = <DmNarrow>[];
     for (final MapEntry(key: dmNarrow, value: messageIds) in dms.entries) {
       messageIds.removeWhere((id) => idsToRemove.contains(id));
       if (messageIds.isEmpty) {

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -38,7 +38,7 @@ import 'stream.dart';
 class Unreads extends ChangeNotifier {
   factory Unreads({
     required UnreadMessagesSnapshot initial,
-    required selfUserId,
+    required int selfUserId,
     required StreamStore streamStore,
   }) {
     final streams = <int, Map<String, QueueList<int>>>{};

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -173,7 +173,8 @@ class NotificationDisplayManager {
   }
 
   static void _onNotificationOpened(NotificationResponse response) async {
-    final data = MessageFcmMessage.fromJson(jsonDecode(response.payload!));
+    final payload = jsonDecode(response.payload!) as Map<String, dynamic>;
+    final data = MessageFcmMessage.fromJson(payload);
     assert(debugLog('opened notif: message ${data.zulipMessageId}, content ${data.content}'));
     _navigateForNotification(data);
   }
@@ -182,7 +183,8 @@ class NotificationDisplayManager {
     assert(response != null);
     if (response == null) return; // TODO(log) seems like a bug in flutter_local_notifications if this can happen
 
-    final data = MessageFcmMessage.fromJson(jsonDecode(response.payload!));
+    final payload = jsonDecode(response.payload!) as Map<String, dynamic>;
+    final data = MessageFcmMessage.fromJson(payload);
     assert(debugLog('launched from notif: message ${data.zulipMessageId}, content ${data.content}'));
     _navigateForNotification(data);
   }

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -207,7 +207,7 @@ class NotificationDisplayManager {
 
     assert(debugLog('  account: $account, narrow: $narrow'));
     // TODO(nav): Better interact with existing nav stack on notif open
-    navigator.push(MaterialAccountWidgetRoute(accountId: account.id,
+    navigator.push(MaterialAccountWidgetRoute<void>(accountId: account.id,
       // TODO(#82): Open at specific message, not just conversation
       page: MessageListPage(narrow: narrow)));
     return;

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -33,7 +33,7 @@ void showMessageActionSheet({required BuildContext context, required Message mes
       && reactionWithVotes.userIds.contains(store.selfUserId))
     ?? false;
 
-  showDraggableScrollableModalBottomSheet(
+  showDraggableScrollableModalBottomSheet<void>(
     context: context,
     builder: (BuildContext _) {
       return Column(children: [

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -82,7 +82,7 @@ class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
     required super.messageListContext,
   });
 
-  @override get icon => Icons.add_reaction_outlined;
+  @override IconData get icon => Icons.add_reaction_outlined;
 
   @override
   String label(ZulipLocalizations zulipLocalizations) {
@@ -123,7 +123,7 @@ class StarButton extends MessageActionSheetMenuItemButton {
     required super.messageListContext,
   });
 
-  @override get icon => ZulipIcons.star_filled;
+  @override IconData get icon => ZulipIcons.star_filled;
 
   @override
   String label(ZulipLocalizations zulipLocalizations) {
@@ -171,7 +171,7 @@ class ShareButton extends MessageActionSheetMenuItemButton {
     required super.messageListContext,
   });
 
-  @override get icon => Icons.adaptive.share;
+  @override IconData get icon => Icons.adaptive.share;
 
   @override
   String label(ZulipLocalizations zulipLocalizations) {
@@ -276,7 +276,7 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     required super.messageListContext,
   });
 
-  @override get icon => Icons.format_quote_outlined;
+  @override IconData get icon => Icons.format_quote_outlined;
 
   @override
   String label(ZulipLocalizations zulipLocalizations) {
@@ -337,7 +337,7 @@ class CopyButton extends MessageActionSheetMenuItemButton {
     required super.messageListContext,
   });
 
-  @override get icon => Icons.copy;
+  @override IconData get icon => Icons.copy;
 
   @override
   String label(ZulipLocalizations zulipLocalizations) {

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -58,7 +58,7 @@ abstract class MessageActionSheetMenuItemButton extends StatelessWidget {
 
   IconData get icon;
   String label(ZulipLocalizations zulipLocalizations);
-  void Function(BuildContext) get onPressed;
+  void onPressed(BuildContext context);
 
   final Message message;
   final BuildContext messageListContext;
@@ -89,7 +89,7 @@ class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
     return 'React with 👍'; // TODO(i18n) skip translation for now
   }
 
-  @override get onPressed => (BuildContext context) async {
+  @override void onPressed(BuildContext context) async {
     Navigator.of(context).pop();
     String? errorMessage;
     try {
@@ -113,7 +113,7 @@ class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
       await showErrorDialog(context: context,
         title: 'Adding reaction failed', message: errorMessage);
     }
-  };
+  }
 }
 
 class StarButton extends MessageActionSheetMenuItemButton {
@@ -132,7 +132,7 @@ class StarButton extends MessageActionSheetMenuItemButton {
       : zulipLocalizations.actionSheetOptionStarMessage;
   }
 
-  @override get onPressed => (BuildContext context) async {
+  @override void onPressed(BuildContext context) async {
     Navigator.of(context).pop();
     final zulipLocalizations = ZulipLocalizations.of(messageListContext);
     final op = message.flags.contains(MessageFlag.starred)
@@ -161,7 +161,7 @@ class StarButton extends MessageActionSheetMenuItemButton {
           UpdateMessageFlagsOp.add    => zulipLocalizations.errorStarMessageFailedTitle,
         }, message: errorMessage);
     }
-  };
+  }
 }
 
 class ShareButton extends MessageActionSheetMenuItemButton {
@@ -178,7 +178,7 @@ class ShareButton extends MessageActionSheetMenuItemButton {
     return zulipLocalizations.actionSheetOptionShare;
   }
 
-  @override get onPressed => (BuildContext context) async {
+  @override void onPressed(BuildContext context) async {
     // Close the message action sheet; we're about to show the share
     // sheet. (We could do this after the sharing Future settles
     // with [ShareResultStatus.success], but on iOS I get impatient with
@@ -218,7 +218,7 @@ class ShareButton extends MessageActionSheetMenuItemButton {
       case ShareResultStatus.dismissed:
         // nothing to do
     }
-  };
+  }
 }
 
 /// Fetch and return the raw Markdown content for [messageId],
@@ -283,10 +283,10 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     return zulipLocalizations.actionSheetOptionQuoteAndReply;
   }
 
-  @override get onPressed => (BuildContext bottomSheetContext) async {
+  @override void onPressed(BuildContext context) async {
     // Close the message action sheet. We'll show the request progress
     // in the compose-box content input with a "[Quoting…]" placeholder.
-    Navigator.of(bottomSheetContext).pop();
+    Navigator.of(context).pop();
     final zulipLocalizations = ZulipLocalizations.of(messageListContext);
 
     // This will be null only if the compose box disappeared after the
@@ -327,7 +327,7 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     if (!composeBoxController.contentFocusNode.hasFocus) {
       composeBoxController.contentFocusNode.requestFocus();
     }
-  };
+  }
 }
 
 class CopyButton extends MessageActionSheetMenuItemButton {
@@ -344,7 +344,7 @@ class CopyButton extends MessageActionSheetMenuItemButton {
     return zulipLocalizations.actionSheetOptionCopy;
   }
 
-  @override get onPressed => (BuildContext context) async {
+  @override void onPressed(BuildContext context) async {
     // Close the message action sheet. We won't be showing request progress,
     // but hopefully it won't take long at all, and
     // fetchRawContentWithFeedback has a TODO for giving feedback if it does.
@@ -364,5 +364,5 @@ class CopyButton extends MessageActionSheetMenuItemButton {
     copyWithPopup(context: context,
       successContent: Text(zulipLocalizations.successMessageCopied),
       data: ClipboardData(text: rawContent));
-  };
+  }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -720,7 +720,8 @@ class _SendButtonState extends State<_SendButton> {
     if (_hasValidationErrors) {
       final zulipLocalizations = ZulipLocalizations.of(context);
       List<String> validationErrorMessages = [
-        for (final error in widget.topicController?.validationErrors ?? const [])
+        for (final error in widget.topicController?.validationErrors
+                            ?? const <TopicValidationError>[])
           error.message(zulipLocalizations),
         for (final error in widget.contentController.validationErrors)
           error.message(zulipLocalizations),

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -330,7 +330,7 @@ class _StreamContentInput extends StatefulWidget {
 class _StreamContentInputState extends State<_StreamContentInput> {
   late String _topicTextNormalized;
 
-  _topicChanged() {
+  void _topicChanged() {
     setState(() {
       _topicTextNormalized = widget.topicController.textNormalized;
     });
@@ -678,7 +678,7 @@ class _SendButton extends StatefulWidget {
 }
 
 class _SendButtonState extends State<_SendButton> {
-  _hasErrorsChanged() {
+  void _hasErrorsChanged() {
     setState(() {
       // Update disabled/non-disabled state
     });

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -47,7 +47,7 @@ void showSuggestedActionDialog({
   required VoidCallback onActionButtonPress,
 }) {
   final zulipLocalizations = ZulipLocalizations.of(context);
-  showDialog(
+  showDialog<void>(
     context: context,
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -293,15 +293,15 @@ class _AllDmsHeaderItem extends _HeaderItem {
     required super.sectionContext,
   });
 
-  @override get title => 'Direct messages'; // TODO(i18n)
-  @override get icon => ZulipIcons.user;
+  @override String get title => 'Direct messages'; // TODO(i18n)
+  @override IconData get icon => ZulipIcons.user;
 
   // TODO(#95) need dark-theme colors
-  @override get collapsedIconColor => const Color(0xFF222222);
-  @override get uncollapsedIconColor => const Color(0xFF222222);
+  @override Color get collapsedIconColor => const Color(0xFF222222);
+  @override Color get uncollapsedIconColor => const Color(0xFF222222);
 
-  @override get uncollapsedBackgroundColor => const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor();
-  @override get unreadCountBadgeBackgroundColor => null;
+  @override Color get uncollapsedBackgroundColor => const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor();
+  @override Color? get unreadCountBadgeBackgroundColor => null;
 
   @override Future<void> onCollapseButtonTap() async {
     await super.onCollapseButtonTap();
@@ -416,13 +416,13 @@ class _StreamHeaderItem extends _HeaderItem {
     required super.sectionContext,
   });
 
-  @override get title => subscription.name;
-  @override get icon => iconDataForStream(subscription);
-  @override get collapsedIconColor => subscription.colorSwatch().iconOnPlainBackground;
-  @override get uncollapsedIconColor => subscription.colorSwatch().iconOnBarBackground;
-  @override get uncollapsedBackgroundColor =>
+  @override String get title => subscription.name;
+  @override IconData get icon => iconDataForStream(subscription);
+  @override Color get collapsedIconColor => subscription.colorSwatch().iconOnPlainBackground;
+  @override Color get uncollapsedIconColor => subscription.colorSwatch().iconOnBarBackground;
+  @override Color get uncollapsedBackgroundColor =>
     subscription.colorSwatch().barBackground;
-  @override get unreadCountBadgeBackgroundColor =>
+  @override Color? get unreadCountBadgeBackgroundColor =>
     subscription.colorSwatch().unreadCountBadgeBackground;
 
   @override Future<void> onCollapseButtonTap() async {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -28,15 +28,15 @@ class _InboxPageState extends State<InboxPage> with PerAccountStoreAwareStateMix
   Unreads? unreadsModel;
   RecentDmConversationsView? recentDmConversationsModel;
 
-  get allDmsCollapsed => _allDmsCollapsed;
+  bool get allDmsCollapsed => _allDmsCollapsed;
   bool _allDmsCollapsed = false;
-  set allDmsCollapsed(value) {
+  set allDmsCollapsed(bool value) {
     setState(() {
       _allDmsCollapsed = value;
     });
   }
 
-  get collapsedStreamIds => _collapsedStreamIds;
+  Set<int> get collapsedStreamIds => _collapsedStreamIds;
   final Set<int> _collapsedStreamIds = {};
   void collapseStream(int streamId) {
     setState(() {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -231,16 +231,16 @@ abstract class _HeaderItem extends StatelessWidget {
   Color get uncollapsedBackgroundColor;
   Color? get unreadCountBadgeBackgroundColor;
 
-  Future<void> Function() get onCollapseButtonTap => () async {
+  Future<void> onCollapseButtonTap() async {
     if (!collapsed) {
       await Scrollable.ensureVisible(
         sectionContext,
         alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
       );
     }
-  };
+  }
 
-  void Function() get onRowTap;
+  Future<void> onRowTap();
 
   @override
   Widget build(BuildContext context) {
@@ -303,11 +303,11 @@ class _AllDmsHeaderItem extends _HeaderItem {
   @override get uncollapsedBackgroundColor => const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor();
   @override get unreadCountBadgeBackgroundColor => null;
 
-  @override get onCollapseButtonTap => () async {
+  @override Future<void> onCollapseButtonTap() async {
     await super.onCollapseButtonTap();
     pageState.allDmsCollapsed = !collapsed;
-  };
-  @override get onRowTap => onCollapseButtonTap; // TODO open all-DMs narrow?
+  }
+  @override Future<void> onRowTap() => onCollapseButtonTap(); // TODO open all-DMs narrow?
 }
 
 class _AllDmsSection extends StatelessWidget {
@@ -425,15 +425,15 @@ class _StreamHeaderItem extends _HeaderItem {
   @override get unreadCountBadgeBackgroundColor =>
     subscription.colorSwatch().unreadCountBadgeBackground;
 
-  @override get onCollapseButtonTap => () async {
+  @override Future<void> onCollapseButtonTap() async {
     await super.onCollapseButtonTap();
     if (collapsed) {
       pageState.uncollapseStream(subscription.streamId);
     } else {
       pageState.collapseStream(subscription.streamId);
     }
-  };
-  @override get onRowTap => onCollapseButtonTap; // TODO open stream narrow
+  }
+  @override Future<void> onRowTap() => onCollapseButtonTap(); // TODO open stream narrow
 }
 
 class _StreamSection extends StatelessWidget {

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -474,7 +474,7 @@ enum MediaType {
   image
 }
 
-Route getLightboxRoute({
+Route<void> getLightboxRoute({
   int? accountId,
   BuildContext? context,
   required Message message,

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -95,7 +95,7 @@ class _LightboxPageLayout extends StatefulWidget {
     required this.child,
   });
 
-  final Animation routeEntranceAnimation;
+  final Animation<double> routeEntranceAnimation;
   final Message message;
   final Widget? Function(
     BuildContext context, Color color, double elevation) buildBottomAppBar;
@@ -211,7 +211,7 @@ class _ImageLightboxPage extends StatefulWidget {
     required this.src,
   });
 
-  final Animation routeEntranceAnimation;
+  final Animation<double> routeEntranceAnimation;
   final Message message;
   final Uri src;
 
@@ -351,7 +351,7 @@ class VideoLightboxPage extends StatefulWidget {
     required this.src,
   });
 
-  final Animation routeEntranceAnimation;
+  final Animation<double> routeEntranceAnimation;
   final Message message;
   final Uri src;
 

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -122,7 +122,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
   final ServerUrlTextEditingController _controller = ServerUrlTextEditingController();
   late ServerUrlParseResult _parseResult;
 
-  _serverUrlChanged() {
+  void _serverUrlChanged() {
     setState(() {
       _parseResult = _controller.tryParse();
     });

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -398,7 +398,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
-  Future<int> _getUserId(String email, apiKey) async {
+  Future<int> _getUserId(String email, String apiKey) async {
     final globalStore = GlobalStoreWidget.of(context);
     final connection = globalStore.apiConnection(
       realmUrl: widget.serverSettings.realmUrl,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -335,7 +335,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
             // have state that needs to be preserved have not been given keys
             // and will not trigger this callback.
             findChildIndexCallback: (Key key) {
-              final valueKey = key as ValueKey;
+              final valueKey = key as ValueKey<int>;
               final index = model!.findItemWithMessageId(valueKey.value);
               if (index == -1) return null;
               return length - 1 - (index - 2);

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -295,7 +295,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
               ])))));
   }
 
-  Widget _buildListView(context) {
+  Widget _buildListView(BuildContext context) {
     final length = model!.items.length;
     const centerSliverKey = ValueKey('center sliver');
     return CustomScrollView(

--- a/lib/widgets/page.dart
+++ b/lib/widgets/page.dart
@@ -6,7 +6,7 @@ import 'store.dart';
 /// A page route that always builds the same widget.
 ///
 /// This is useful for making the route more transparent for a test to inspect.
-abstract class WidgetRoute<T> extends PageRoute<T> {
+abstract class WidgetRoute<T extends Object?> extends PageRoute<T> {
   /// The widget that this page route always builds.
   Widget get page;
 }
@@ -18,7 +18,7 @@ abstract class WidgetRoute<T> extends PageRoute<T> {
 /// See also:
 ///  * [MaterialAccountWidgetRoute], a subclass which automates providing a
 ///    per-account store on the new route.
-class MaterialWidgetRoute<T> extends MaterialPageRoute<T> implements WidgetRoute<T> {
+class MaterialWidgetRoute<T extends Object?> extends MaterialPageRoute<T> implements WidgetRoute<T> {
   MaterialWidgetRoute({
     required this.page,
     super.settings,
@@ -32,7 +32,7 @@ class MaterialWidgetRoute<T> extends MaterialPageRoute<T> implements WidgetRoute
 }
 
 /// A mixin for providing a given account's per-account store on a page route.
-mixin AccountPageRouteMixin<T> on PageRoute<T> {
+mixin AccountPageRouteMixin<T extends Object?> on PageRoute<T> {
   int get accountId;
 
   @override
@@ -51,7 +51,7 @@ mixin AccountPageRouteMixin<T> on PageRoute<T> {
 ///    for tests.
 ///  * [AccountPageRouteBuilder], for defining one-off page routes
 ///    in terms of callbacks.
-class MaterialAccountPageRoute<T> extends MaterialPageRoute<T> with AccountPageRouteMixin<T> {
+class MaterialAccountPageRoute<T extends Object?> extends MaterialPageRoute<T> with AccountPageRouteMixin<T> {
   /// Construct a [MaterialAccountPageRoute] using either the given account ID,
   /// or the ambient one from the given context.
   ///
@@ -89,7 +89,7 @@ class MaterialAccountPageRoute<T> extends MaterialPageRoute<T> with AccountPageR
 ///
 /// See also:
 ///  * [MaterialWidgetRoute], for routes that need no per-account store.
-class MaterialAccountWidgetRoute<T> extends MaterialAccountPageRoute<T> implements WidgetRoute<T> {
+class MaterialAccountWidgetRoute<T extends Object?> extends MaterialAccountPageRoute<T> implements WidgetRoute<T> {
   /// Construct a [MaterialAccountWidgetRoute] using either the given account ID,
   /// or the ambient one from the given context.
   ///
@@ -118,7 +118,7 @@ class MaterialAccountWidgetRoute<T> extends MaterialAccountPageRoute<T> implemen
 /// A [PageRouteBuilder] providing a per-account store for a given account.
 ///
 /// This is the [PageRouteBuilder] analogue of [MaterialAccountPageRoute].
-class AccountPageRouteBuilder<T> extends PageRouteBuilder<T> with AccountPageRouteMixin<T> {
+class AccountPageRouteBuilder<T extends Object?> extends PageRouteBuilder<T> with AccountPageRouteMixin<T> {
   /// Construct an [AccountPageRouteBuilder] using either the given account ID,
   /// or the ambient one from the given context.
   ///

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -114,7 +114,7 @@ class _ProfileDataTable extends StatelessWidget {
 
   static T? _tryDecode<T, U>(T Function(U) fromJson, String data) {
     try {
-      return fromJson(jsonDecode(data));
+      return fromJson(jsonDecode(data) as U);
     } on FormatException {
       return null;
     } on TypeError {

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -273,7 +273,8 @@ void main() {
           ..data.deepEquals(json));
     }
 
-    await check(tryRequest<Map>(json: {})).completes((it) => it.deepEquals({}));
+    await check(tryRequest<Map<String, dynamic>>(json: {}))
+      .completes((it) => it.deepEquals({}));
 
     await checkMalformed(body: jsonEncode([]));
     await checkMalformed(body: jsonEncode(null));

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -313,7 +313,7 @@ class DistinctiveError extends Error {
   String toString() => message;
 }
 
-Future<T> tryRequest<T>({
+Future<T> tryRequest<T extends Object?>({
   Object? exception,
   int? httpStatus,
   Map<String, dynamic>? json,

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -83,7 +83,7 @@ void main() {
 
     check(() => DeleteMessageEvent.fromJson({
       ...baseJsonStream
-    })).throws();
+    })).throws<void>();
 
     check(() => DeleteMessageEvent.fromJson({
       ...baseJsonStream, 'stream_id': 1, 'topic': 'some topic',
@@ -91,11 +91,11 @@ void main() {
 
     check(() => DeleteMessageEvent.fromJson({
       ...baseJsonStream, 'stream_id': 1,
-    })).throws();
+    })).throws<void>();
 
     check(() => DeleteMessageEvent.fromJson({
       ...baseJsonStream, 'topic': 'some topic',
-    })).throws();
+    })).throws<void>();
   });
 
   test('update_message_flags/remove: require messageDetails in mark-as-unread', () {
@@ -110,7 +110,7 @@ void main() {
     check(() => UpdateMessageFlagsRemoveEvent.fromJson(baseJson)).returnsNormally();
     check(() => UpdateMessageFlagsRemoveEvent.fromJson({
       ...baseJson, 'flag': 'read',
-    })).throws();
+    })).throws<void>();
     check(() => UpdateMessageFlagsRemoveEvent.fromJson({
       ...baseJson,
       'flag': 'read',

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -67,7 +67,7 @@ extension ReactionWithVotesChecks on Subject<ReactionWithVotes> {
     // Same emoji for all reactions
     assert(reactions.every((r) => r.reactionType == first.reactionType && r.emojiCode == first.emojiCode));
 
-    final userIds = Set.from(reactions.map((r) => r.userId));
+    final userIds = Set<int>.from(reactions.map((r) => r.userId));
 
     // No double-votes from one person (we don't expect this from servers)
     assert(userIds.length == reactions.length);

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -16,7 +16,8 @@ void main() {
       "1": {"text": "Option 1", "order": 2},
       "2": {"text": "Option 2", "order": 3}
     }''';
-    final choices = CustomProfileFieldChoiceDataItem.parseFieldDataChoices(jsonDecode(input));
+    final decoded = jsonDecode(input) as Map<String, dynamic>;
+    final choices = CustomProfileFieldChoiceDataItem.parseFieldDataChoices(decoded);
     check(choices).jsonEquals({
       '0': const CustomProfileFieldChoiceDataItem(text: 'Option 0'),
       '1': const CustomProfileFieldChoiceDataItem(text: 'Option 1'),

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -56,7 +56,7 @@ void main() {
       check(mkUser({'profile_data': <String, dynamic>{}}).profileData).isNull();
       check(mkUser({'profile_data': null}).profileData).isNull();
       check(mkUser({'profile_data': {'1': {'value': 'foo'}}}).profileData)
-        .isNotNull().deepEquals({1: (it) => it});
+        .isNotNull().keys.single.equals(1);
     });
 
     test('is_system_bot', () {

--- a/test/api/model/web_auth_test.dart
+++ b/test/api/model/web_auth_test.dart
@@ -83,7 +83,7 @@ void main() {
       // each with probability 1/256; so the probability of missing all of those
       // is exp(- n * 32 / 256) < 2e-12, and there are 256 such possible
       // byte values so the probability that any of them gets missed is < 1e-9.
-      for (final byteValue in Iterable.generate(256)) {
+      for (final byteValue in Iterable<int>.generate(256)) {
         check(bytesThatAppear).contains(byteValue);
       }
     });

--- a/test/api/notifications_test.dart
+++ b/test/api/notifications_test.dart
@@ -13,7 +13,7 @@ void main() {
   };
 
   void checkParseFails(Map<String, String> data) {
-    check(() => FcmMessage.fromJson(data)).throws();
+    check(() => FcmMessage.fromJson(data)).throws<void>();
   }
 
   group('FcmMessage', () {

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -313,7 +313,7 @@ StreamMessage streamMessage({
     ..._messagePropertiesFromContent(content, contentMarkdown),
     'display_recipient': effectiveStream.name,
     'stream_id': effectiveStream.streamId,
-    'reactions': reactions == null ? [] : Reactions(reactions),
+    'reactions': reactions == null ? <Reaction>[] : Reactions(reactions),
     'flags': flags ?? [],
     'id': id ?? _nextMessageId(),
     'last_edit_timestamp': lastEditTimestamp,
@@ -351,7 +351,7 @@ DmMessage dmMessage({
     'display_recipient': [from, ...to]
       .map((u) => {'id': u.userId, 'email': u.email, 'full_name': u.fullName})
       .toList(growable: false),
-    'reactions': [],
+    'reactions': <Reaction>[],
     'flags': flags ?? [],
     'id': id ?? _nextMessageId(),
     'last_edit_timestamp': lastEditTimestamp,

--- a/test/fake_async.dart
+++ b/test/fake_async.dart
@@ -24,7 +24,7 @@ T awaitFakeAsync<T>(Future<T> Function(FakeAsync async) callback,
   FakeAsync(initialTime: initialTime)
     ..run((async) {
         callback(async).then<void>((v) { value = v; completed = true; },
-          onError: (e, s) { error = e; stackTrace = s; completed = true; });
+          onError: (Object? e, StackTrace? s) { error = e; stackTrace = s; completed = true; });
       })
     ..flushTimers();
 

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -12,7 +12,7 @@ void main() {
       const duration = Duration(milliseconds: 100);
       check(awaitFakeAsync((async) async {
         final start = clock.now();
-        await Future.delayed(duration);
+        await Future<void>.delayed(duration);
         return clock.now().difference(start);
       })).equals(duration);
     });
@@ -41,7 +41,7 @@ void main() {
 
     test('TimeoutException on deadlocked callback', () {
       check(() => awaitFakeAsync((async) async {
-        await Completer().future;
+        await Completer<void>().future;
       })).throws().isA<TimeoutException>();
     });
   });

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -42,7 +42,7 @@ void main() {
     test('TimeoutException on deadlocked callback', () {
       check(() => awaitFakeAsync((async) async {
         await Completer<void>().future;
-      })).throws().isA<TimeoutException>();
+      })).throws<TimeoutException>();
     });
   });
 }

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -42,7 +42,7 @@ extension RouteChecks<T> on Subject<Route<T>> {
   Subject<RouteSettings> get settings => has((r) => r.settings, 'settings');
 }
 
-extension PageRouteChecks on Subject<PageRoute> {
+extension PageRouteChecks<T> on Subject<PageRoute<T>> {
   Subject<bool> get fullscreenDialog => has((x) => x.fullscreenDialog, 'fullscreenDialog');
 }
 

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -20,7 +20,7 @@ void main() {
       final TextSelection selection;
       int? expectedSyntaxStart;
       final textBuffer = StringBuffer();
-      final caretPositions = [];
+      final caretPositions = <int>[];
       int i = 0;
       for (final char in markedText.codeUnits) {
         if (char == 94 /* ^ */) {

--- a/test/model/database_test.dart
+++ b/test/model/database_test.dart
@@ -37,7 +37,7 @@ void main() {
           .first;
       check(account.toCompanion(false).toJson()).deepEquals({
         ...accountData.toJson(),
-        'id': (it) => it,
+        'id': (Subject<Object?> it) => it.isA<int>(),
         'acked_push_token': null,
       });
     });

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -336,7 +336,7 @@ void main() {
       final stream = eg.stream(name: "general");
 
       group('basic', () {
-        String mkUrlString(operand) {
+        String mkUrlString(String operand) {
           return '#narrow/stream/${stream.streamId}-${stream.name}/topic/$operand';
         }
         final testCases = [
@@ -347,7 +347,7 @@ void main() {
       });
 
       group('on old topic link, with dot-encoding', () {
-        String mkUrlString(operand) {
+        String mkUrlString(String operand) {
           return '#narrow/stream/${stream.name}/topic/$operand';
         }
         final testCases = [

--- a/test/model/narrow_test.dart
+++ b/test/model/narrow_test.dart
@@ -36,10 +36,10 @@ void main() {
       check(() => DmNarrow(allRecipientIds: [2, 12], selfUserId: 2)).returnsNormally();
       check(() => DmNarrow(allRecipientIds: [2],     selfUserId: 2)).returnsNormally();
 
-      check(() => DmNarrow(allRecipientIds: [12, 2], selfUserId: 2)).throws();
-      check(() => DmNarrow(allRecipientIds: [2, 2],  selfUserId: 2)).throws();
-      check(() => DmNarrow(allRecipientIds: [2, 12], selfUserId: 1)).throws();
-      check(() => DmNarrow(allRecipientIds: [],      selfUserId: 2)).throws();
+      check(() => DmNarrow(allRecipientIds: [12, 2], selfUserId: 2)).throws<void>();
+      check(() => DmNarrow(allRecipientIds: [2, 2],  selfUserId: 2)).throws<void>();
+      check(() => DmNarrow(allRecipientIds: [2, 12], selfUserId: 1)).throws<void>();
+      check(() => DmNarrow(allRecipientIds: [],      selfUserId: 2)).throws<void>();
     });
 
     test('ofMessage: self-dm', () {

--- a/test/model/recent_dm_conversations_test.dart
+++ b/test/model/recent_dm_conversations_test.dart
@@ -11,7 +11,7 @@ import 'recent_dm_conversations_checks.dart';
 void main() {
   group('RecentDmConversationsView', () {
     /// Get a [DmNarrow] from a list of recipient IDs excluding self.
-    DmNarrow key(userIds) {
+    DmNarrow key(Iterable<int> userIds) {
       return DmNarrow(
         allRecipientIds: [eg.selfUser.userId, ...userIds]..sort(),
         selfUserId: eg.selfUser.userId,

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -326,7 +326,7 @@ void main() {
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
       checkLastRequest(lastEventId: 1);
-      await Future.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
       check(updateMachine.lastEventId).equals(2);
 
       // Loop makes second request, and processes result.
@@ -336,7 +336,7 @@ void main() {
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
       checkLastRequest(lastEventId: 2);
-      await Future.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
       check(updateMachine.lastEventId).equals(3);
     }));
 
@@ -353,7 +353,7 @@ void main() {
       ], queueId: null).toJson());
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
-      await Future.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
       check(store.userSettings!.twentyFourHourTime).isTrue();
     }));
 
@@ -371,7 +371,7 @@ void main() {
       });
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
-      await Future.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
       // The global store has a new store.
       check(globalStore.perAccountSync(store.accountId)).not((it) => it.identicalTo(store));
@@ -387,7 +387,7 @@ void main() {
       ], queueId: null).toJson());
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
-      await Future.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
       check(store.userSettings!.twentyFourHourTime).isTrue();
     }));
 

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -827,7 +827,8 @@ void main() {
     });
 
     group('mark as unread', () {
-      mkEvent(messages) => eg.updateMessageFlagsRemoveEvent(MessageFlag.read, messages);
+      mkEvent(Iterable<Message> messages) =>
+        eg.updateMessageFlagsRemoveEvent(MessageFlag.read, messages);
 
       test('usual cases', () {
         final stream1 = eg.stream(streamId: 1);

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -205,7 +205,7 @@ void main() {
   });
 
   group('NotificationDisplayManager open', () {
-    late List<Route<dynamic>> pushedRoutes;
+    late List<Route<void>> pushedRoutes;
 
     void takeStartingRoutes({bool withAccount = true}) {
       final expected = <Condition<Object?>>[
@@ -247,7 +247,7 @@ void main() {
       await tester.idle(); // let _navigateForNotification find navigator
     }
 
-    void matchesNavigation(Subject<Route> route, Account account, Message message) {
+    void matchesNavigation(Subject<Route<void>> route, Account account, Message message) {
       route.isA<MaterialAccountWidgetRoute>()
         ..accountId.equals(account.id)
         ..page.isA<MessageListPage>()

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -208,13 +208,13 @@ void main() {
     late List<Route<dynamic>> pushedRoutes;
 
     void takeStartingRoutes({bool withAccount = true}) {
-      final expected = [
-        (Subject it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
+      final expected = <Condition<Object?>>[
+        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
         if (withAccount) ...[
-          (Subject it) => it.isA<MaterialAccountWidgetRoute>()
+          (it) => it.isA<MaterialAccountWidgetRoute>()
             ..accountId.equals(eg.selfAccount.id)
             ..page.isA<HomePage>(),
-          (Subject it) => it.isA<MaterialAccountWidgetRoute>()
+          (it) => it.isA<MaterialAccountWidgetRoute>()
             ..accountId.equals(eg.selfAccount.id)
             ..page.isA<InboxPage>(),
         ],

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -82,9 +82,9 @@ extension JsonChecks on Subject<Object?> {
       case null || bool() || String() || num():
         return actualJson.equals(expectedJson);
       case List():
-        return actualJson.isA<List>().deepEquals(expectedJson);
+        return actualJson.isA<List<dynamic>>().deepEquals(expectedJson);
       case Map():
-        return actualJson.isA<Map>().deepEquals(expectedJson);
+        return actualJson.isA<Map<dynamic, dynamic>>().deepEquals(expectedJson);
       case _:
         assert(false);
     }

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -62,7 +62,7 @@ Object? deepToJson(Object? object) {
     case List():
       result = object.map((x) => deepToJson(x)).toList();
     case Map() when object.keys.every((k) => k is String):
-      result = object.map((k, v) => MapEntry<String, dynamic>(k, deepToJson(v)));
+      result = object.map((k, v) => MapEntry<String, dynamic>(k as String, deepToJson(v)));
     default:
       return (null, false);
   }

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -31,8 +31,8 @@ void main() {
 
     testWidgets('when no accounts, go to choose account', (tester) async {
       addTearDown(testBinding.reset);
-      check(await initialRoutes(tester)).deepEquals([
-        (Subject it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
+      check(await initialRoutes(tester)).deepEquals(<Condition<Object?>>[
+        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
       ]);
     });
 
@@ -44,12 +44,12 @@ void main() {
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       await testBinding.globalStore.insertAccount(eg.otherAccount.toCompanion(false));
 
-      check(await initialRoutes(tester)).deepEquals([
-        (Subject it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
-        (Subject it) => it.isA<MaterialAccountWidgetRoute>()
+      check(await initialRoutes(tester)).deepEquals(<Condition<Object?>>[
+        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
+        (it) => it.isA<MaterialAccountWidgetRoute>()
           ..accountId.equals(eg.selfAccount.id)
           ..page.isA<HomePage>(),
-        (Subject it) => it.isA<MaterialAccountWidgetRoute>()
+        (it) => it.isA<MaterialAccountWidgetRoute>()
           ..accountId.equals(eg.selfAccount.id)
           ..page.isA<InboxPage>(),
       ]);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -284,7 +284,7 @@ void main() {
       await prepare(tester, example.html);
       // The image indeed has an invalid URL.
       final expectedImages = (example.expectedNodes[0] as ImageNodeList).images;
-      check(() => Uri.parse(expectedImages.single.srcUrl)).throws();
+      check(() => Uri.parse(expectedImages.single.srcUrl)).throws<void>();
       check(tryResolveUrl(eg.realmUrl, expectedImages.single.srcUrl)).isNull();
       // The MessageImage has shown up, but it doesn't attempt a RealmContentNetworkImage.
       check(tester.widgetList(find.byType(MessageImage))).isNotEmpty();
@@ -763,7 +763,7 @@ void main() {
     testWidgets('smoke: custom emoji with invalid URL', (tester) async {
       await prepare(tester, ContentExample.emojiCustomInvalidUrl.html);
       final url = tester.widget<MessageImageEmoji>(find.byType(MessageImageEmoji)).node.src;
-      check(() => Uri.parse(url)).throws();
+      check(() => Uri.parse(url)).throws<void>();
       debugNetworkImageHttpClientProvider = null;
     });
 

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -68,9 +68,9 @@ void main() {
     late List<Route<dynamic>> pushedRoutes;
 
     void takeStartingRoutes() {
-      final expected = [
-        (Subject it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
-        (Subject it) => it.isA<WidgetRoute>().page.isA<LoginPage>(),
+      final expected = <Condition<Object?>>[
+        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
+        (it) => it.isA<WidgetRoute>().page.isA<LoginPage>(),
       ];
       check(pushedRoutes.take(expected.length)).deepEquals(expected);
       pushedRoutes.removeRange(0, expected.length);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -241,7 +241,7 @@ void main() {
       final stream = eg.stream(name: 'stream name');
       final message = eg.streamMessage(stream: stream, topic: 'topic name');
 
-      FinderResult findInMessageList(String text) {
+      FinderResult<Element> findInMessageList(String text) {
         // Stream name shows up in [AppBar] so need to avoid matching that
         return find.descendant(
           of: find.byType(MessageList),

--- a/test/widgets/page_checks.dart
+++ b/test/widgets/page_checks.dart
@@ -2,10 +2,10 @@ import 'package:checks/checks.dart';
 import 'package:flutter/widgets.dart';
 import 'package:zulip/widgets/page.dart';
 
-extension WidgetRouteChecks on Subject<WidgetRoute> {
+extension WidgetRouteChecks<T> on Subject<WidgetRoute<T>> {
   Subject<Widget> get page => has((x) => x.page, 'page');
 }
 
-extension AccountPageRouteMixinChecks on Subject<AccountPageRouteMixin> {
+extension AccountPageRouteMixinChecks<T> on Subject<AccountPageRouteMixin<T>> {
   Subject<int> get accountId => has((x) => x.accountId, 'accountId');
 }


### PR DESCRIPTION
This prevents implicitly casting from `dynamic` to another type. Where the use of `dynamic` was intended, that helps us make the cast explicit; it also turns out to find a few places where it wasn't intended.

A couple of those places where it wasn't intended seem like they should have been flagged by one of the analyzer options previously enabled in this series: `strict-inference` and `strict-raw-types`. So there may be some remaining implicit `dynamic` types that also slipped through those, and don't happen to have triggered this. Still, these three together should greatly reduce our number of implicit `dynamic` types.

(Where using `dynamic` is intended, that's often only due to the constraints of an external API, like in JSON decoding; I think a preferable version of that API would use `Object?` instead. I'm not sure there's anywhere in our codebase where we'd actually want `dynamic` absent constraints like that one.)

This PR is stacked atop #722, which is atop #721.

Fixes: #719

