### PR TITLE
content: Put code-block styles in `ContentTheme`; use weightVariableTextStyle for bold spans

### DIFF
--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -15,7 +15,8 @@ class CodeBlockTextStyles {
       plain: kMonospaceTextStyle
         .merge(const TextStyle(
           fontSize: 0.825 * kBaseFontSize,
-          height: 1.4)),
+          height: 1.4))
+        .merge(weightVariableTextStyle(context)),
 
       // .hll { background-color: hsl(60deg 100% 90%); }
       hll: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 60, 1, 0.90).toColor()),

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../model/code_block.dart';
+import 'content.dart';
 import 'text.dart';
 
 /// [TextStyle]s used to render code blocks.
@@ -11,6 +12,11 @@ class CodeBlockTextStyles {
   factory CodeBlockTextStyles(BuildContext context) {
     final bold = weightVariableTextStyle(context, wght: 700);
     return CodeBlockTextStyles._(
+      plain: kMonospaceTextStyle
+        .merge(const TextStyle(
+          fontSize: 0.825 * kBaseFontSize,
+          height: 1.4)),
+
       // .hll { background-color: hsl(60deg 100% 90%); }
       hll: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 60, 1, 0.90).toColor()),
 
@@ -204,6 +210,7 @@ class CodeBlockTextStyles {
   }
 
   CodeBlockTextStyles._({
+    required this.plain,
     required TextStyle hll,
     required TextStyle c,
     required TextStyle err,
@@ -329,6 +336,9 @@ class CodeBlockTextStyles {
     _vg = vg,
     _vi = vi,
     _il = il;
+
+  /// The baseline style that the [forSpan] styles get applied on top of.
+  final TextStyle plain;
 
   final TextStyle _hll;
   final TextStyle _c;
@@ -471,6 +481,7 @@ class CodeBlockTextStyles {
     if (identical(this, other)) return this;
 
     return CodeBlockTextStyles._(
+      plain: TextStyle.lerp(plain, other?.plain, t)!,
       hll: TextStyle.lerp(_hll, other?._hll, t)!,
       c: TextStyle.lerp(_c, other?._c, t)!,
       err: TextStyle.lerp(_err, other?._err, t)!,

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -2,266 +2,535 @@ import 'package:flutter/material.dart';
 
 import '../model/code_block.dart';
 
-// Highlighted code block styles adapted from:
-// https://github.com/zulip/zulip/blob/213387249e7ba7772084411b22d8cef64b135dd0/web/styles/pygments.css
-
+/// [TextStyle]s used to render code blocks.
+///
+/// Use [forSpan] for syntax highlighting.
 // TODO(#95) follow web for dark-theme colors
+class CodeBlockTextStyles {
+  factory CodeBlockTextStyles() {
+    return CodeBlockTextStyles._(
+      // .hll { background-color: hsl(60deg 100% 90%); }
+      hll: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 60, 1, 0.90).toColor()),
 
-// .hll { background-color: hsl(60deg 100% 90%); }
-final _kCodeBlockStyleHll = TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 60, 1, 0.90).toColor());
+      // .c { color: hsl(180deg 33% 37%); font-style: italic; }
+      c: TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic),
 
-// .c { color: hsl(180deg 33% 37%); font-style: italic; }
-final _kCodeBlockStyleC = TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic);
+      // TODO: Borders are hard in TextSpan, see the comment in `_buildInlineCode`
+      // So, using a lighter background color for now (precisely it's
+      // the text color used in web app in `.err` class in dark mode)
+      //
+      // .err { border: 1px solid hsl(0deg 100% 50%); }
+      err: const TextStyle(backgroundColor: Color(0xffe2706e)),
 
-// TODO: Borders are hard in TextSpan, see the comment in `_buildInlineCode`
-// So, using a lighter background color for now (precisely it's
-// the text color used in web app in `.err` class in dark mode)
-//
-// .err { border: 1px solid hsl(0deg 100% 50%); }
-const _kCodeBlockStyleErr = TextStyle(backgroundColor: Color(0xffe2706e));
+      // .k { color: hsl(332deg 70% 38%); }
+      k: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.7, 0.38).toColor()),
 
-// .k { color: hsl(332deg 70% 38%); }
-final _kCodeBlockStyleK = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.7, 0.38).toColor());
+      // .o { color: hsl(332deg 70% 38%); }
+      o: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.7, 0.38).toColor()),
 
-// .o { color: hsl(332deg 70% 38%); }
-final _kCodeBlockStyleO = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.7, 0.38).toColor());
+      // .cm { color: hsl(180deg 33% 37%); font-style: italic; }
+      cm: TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic),
 
-// .cm { color: hsl(180deg 33% 37%); font-style: italic; }
-final _kCodeBlockStyleCm = TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic);
+      // .cp { color: hsl(38deg 100% 36%); }
+      cp: TextStyle(color: const HSLColor.fromAHSL(1, 38, 1, 0.36).toColor()),
 
-// .cp { color: hsl(38deg 100% 36%); }
-final _kCodeBlockStyleCp = TextStyle(color: const HSLColor.fromAHSL(1, 38, 1, 0.36).toColor());
+      // .c1 { color: hsl(0deg 0% 67%); font-style: italic; }
+      c1: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.67).toColor(), fontStyle: FontStyle.italic),
 
-// .c1 { color: hsl(0deg 0% 67%); font-style: italic; }
-final _kCodeBlockStyleC1 = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.67).toColor(), fontStyle: FontStyle.italic);
+      // .cs { color: hsl(180deg 33% 37%); font-style: italic; }
+      cs: TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic),
 
-// .cs { color: hsl(180deg 33% 37%); font-style: italic; }
-final _kCodeBlockStyleCs = TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic);
+      // .gd { color: hsl(0deg 100% 31%); }
+      gd: TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.31).toColor()),
 
-// .gd { color: hsl(0deg 100% 31%); }
-final _kCodeBlockStyleGd = TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.31).toColor());
+      // .ge { font-style: italic; }
+      ge: const TextStyle(fontStyle: FontStyle.italic),
 
-// .ge { font-style: italic; }
-const _kCodeBlockStyleGe = TextStyle(fontStyle: FontStyle.italic);
+      // .gr { color: hsl(0deg 100% 50%); }
+      gr: TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.50).toColor()),
 
-// .gr { color: hsl(0deg 100% 50%); }
-final _kCodeBlockStyleGr = TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.50).toColor());
+      // .gh { color: hsl(240deg 100% 25%); font-weight: bold; }
+      gh: TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
 
-// .gh { color: hsl(240deg 100% 25%); font-weight: bold; }
-final _kCodeBlockStyleGh = TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor(), fontWeight: FontWeight.bold);
+      // .gi { color: hsl(120deg 100% 31%); }
+      gi: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.31).toColor()),
 
-// .gi { color: hsl(120deg 100% 31%); }
-final _kCodeBlockStyleGi = TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.31).toColor());
+      // .go { color: hsl(0deg 0% 50%); }
+      go: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.50).toColor()),
 
-// .go { color: hsl(0deg 0% 50%); }
-final _kCodeBlockStyleGo = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.50).toColor());
+      // .gp { color: hsl(240deg 100% 25%); font-weight: bold; }
+      gp: TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
 
-// .gp { color: hsl(240deg 100% 25%); font-weight: bold; }
-final _kCodeBlockStyleGp = TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor(), fontWeight: FontWeight.bold);
+      // .gs { font-weight: bold; }
+      gs: const TextStyle(fontWeight: FontWeight.bold),
 
-// .gs { font-weight: bold; }
-const _kCodeBlockStyleGs = TextStyle(fontWeight: FontWeight.bold);
+      // .gu { color: hsl(300deg 100% 25%); font-weight: bold; }
+      gu: TextStyle(color: const HSLColor.fromAHSL(1, 300, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
 
-// .gu { color: hsl(300deg 100% 25%); font-weight: bold; }
-final _kCodeBlockStyleGu = TextStyle(color: const HSLColor.fromAHSL(1, 300, 1, 0.25).toColor(), fontWeight: FontWeight.bold);
+      // .gt { color: hsl(221deg 100% 40%); }
+      gt: TextStyle(color: const HSLColor.fromAHSL(1, 221, 1, 0.40).toColor()),
 
-// .gt { color: hsl(221deg 100% 40%); }
-final _kCodeBlockStyleGt = TextStyle(color: const HSLColor.fromAHSL(1, 221, 1, 0.40).toColor());
+      // .kc { color: hsl(332deg 70% 38%); font-weight: bold; }
+      kc: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold),
 
-// .kc { color: hsl(332deg 70% 38%); font-weight: bold; }
-final _kCodeBlockStyleKc = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold);
+      // .kd { color: hsl(332deg 70% 38%); }
+      kd: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
 
-// .kd { color: hsl(332deg 70% 38%); }
-final _kCodeBlockStyleKd = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor());
+      // .kn { color: hsl(332deg 70% 38%); font-weight: bold; }
+      kn: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold),
 
-// .kn { color: hsl(332deg 70% 38%); font-weight: bold; }
-final _kCodeBlockStyleKn = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold);
+      // .kp { color: hsl(332deg 70% 38%); }
+      kp: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
 
-// .kp { color: hsl(332deg 70% 38%); }
-final _kCodeBlockStyleKp = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor());
+      // .kr { color: hsl(332deg 70% 38%); font-weight: bold; }
+      kr: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold),
 
-// .kr { color: hsl(332deg 70% 38%); font-weight: bold; }
-final _kCodeBlockStyleKr = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold);
+      // .kt { color: hsl(332deg 70% 38%); }
+      kt: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
 
-// .kt { color: hsl(332deg 70% 38%); }
-final _kCodeBlockStyleKt = TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor());
+      // .m { color: hsl(0deg 0% 40%); }
+      m: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor()),
 
-// .m { color: hsl(0deg 0% 40%); }
-final _kCodeBlockStyleM = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor());
+      // .s { color: hsl(86deg 57% 40%); }
+      s: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
-// .s { color: hsl(86deg 57% 40%); }
-final _kCodeBlockStyleS = TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor());
+      // .na { color: hsl(71deg 55% 36%); }
+      na: TextStyle(color: const HSLColor.fromAHSL(1, 71, 0.55, 0.36).toColor()),
 
-// .na { color: hsl(71deg 55% 36%); }
-final _kCodeBlockStyleNa = TextStyle(color: const HSLColor.fromAHSL(1, 71, 0.55, 0.36).toColor());
+      // .nb { color: hsl(195deg 100% 35%); }
+      nb: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
-// .nb { color: hsl(195deg 100% 35%); }
-final _kCodeBlockStyleNb = TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor());
+      // .nc { color: hsl(264deg 27% 50%); font-weight: bold; }
+      nc: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor(), fontWeight: FontWeight.bold),
 
-// .nc { color: hsl(264deg 27% 50%); font-weight: bold; }
-final _kCodeBlockStyleNc = TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor(), fontWeight: FontWeight.bold);
+      // .no { color: hsl(0deg 100% 26%); }
+      no: TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.26).toColor()),
 
-// .no { color: hsl(0deg 100% 26%); }
-final _kCodeBlockStyleNo = TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.26).toColor());
+      // .nd { color: hsl(276deg 100% 56%); }
+      nd: TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor()),
 
-// .nd { color: hsl(276deg 100% 56%); }
-final _kCodeBlockStyleNd = TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor());
+      // .ni { color: hsl(0deg 0% 60%); font-weight: bold; }
+      ni: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.60).toColor(), fontWeight: FontWeight.bold),
 
-// .ni { color: hsl(0deg 0% 60%); font-weight: bold; }
-final _kCodeBlockStyleNi = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.60).toColor(), fontWeight: FontWeight.bold);
+      // .ne { color: hsl(2deg 62% 52%); font-weight: bold; }
+      ne: TextStyle(color: const HSLColor.fromAHSL(1, 2, 0.62, 0.52).toColor(), fontWeight: FontWeight.bold),
 
-// .ne { color: hsl(2deg 62% 52%); font-weight: bold; }
-final _kCodeBlockStyleNe = TextStyle(color: const HSLColor.fromAHSL(1, 2, 0.62, 0.52).toColor(), fontWeight: FontWeight.bold);
+      // .nf { color: hsl(264deg 27% 50%); }
+      nf: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor()),
 
-// .nf { color: hsl(264deg 27% 50%); }
-final _kCodeBlockStyleNf = TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor());
+      // .nl { color: hsl(60deg 100% 31%); }
+      nl: TextStyle(color: const HSLColor.fromAHSL(1, 60, 1, 0.31).toColor()),
 
-// .nl { color: hsl(60deg 100% 31%); }
-final _kCodeBlockStyleNl = TextStyle(color: const HSLColor.fromAHSL(1, 60, 1, 0.31).toColor());
+      // .nn { color: hsl(264deg 27% 50%); font-weight: bold; }
+      nn: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor(), fontWeight: FontWeight.bold),
 
-// .nn { color: hsl(264deg 27% 50%); font-weight: bold; }
-final _kCodeBlockStyleNn = TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor(), fontWeight: FontWeight.bold);
+      // .nt { color: hsl(120deg 100% 25%); font-weight: bold; }
+      nt: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
 
-// .nt { color: hsl(120deg 100% 25%); font-weight: bold; }
-final _kCodeBlockStyleNt = TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor(), fontWeight: FontWeight.bold);
+      // .nv { color: hsl(241deg 68% 28%); }
+      nv: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
 
-// .nv { color: hsl(241deg 68% 28%); }
-final _kCodeBlockStyleNv = TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor());
+      // .nx { color: hsl(0deg 0% 26%); }
+      nx: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.26).toColor()),
 
-// .nx { color: hsl(0deg 0% 26%); }
-final _kCodeBlockStyleNx = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.26).toColor());
+      // .ow { color: hsl(276deg 100% 56%); font-weight: bold; }
+      ow: TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor(), fontWeight: FontWeight.bold),
 
-// .ow { color: hsl(276deg 100% 56%); font-weight: bold; }
-final _kCodeBlockStyleOw = TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor(), fontWeight: FontWeight.bold);
+      // .w { color: hsl(0deg 0% 73%); }
+      w: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.73).toColor()),
 
-// .w { color: hsl(0deg 0% 73%); }
-final _kCodeBlockStyleW = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.73).toColor());
+      // .mf { color: hsl(195deg 100% 35%); }
+      mf: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
-// .mf { color: hsl(195deg 100% 35%); }
-final _kCodeBlockStyleMf = TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor());
+      // .mh { color: hsl(195deg 100% 35%); }
+      mh: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
-// .mh { color: hsl(195deg 100% 35%); }
-final _kCodeBlockStyleMh = TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor());
+      // .mi { color: hsl(195deg 100% 35%); }
+      mi: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
-// .mi { color: hsl(195deg 100% 35%); }
-final _kCodeBlockStyleMi = TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor());
+      // .mo { color: hsl(195deg 100% 35%); }
+      mo: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
-// .mo { color: hsl(195deg 100% 35%); }
-final _kCodeBlockStyleMo = TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor());
+      // .sb { color: hsl(86deg 57% 40%); }
+      sb: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
-// .sb { color: hsl(86deg 57% 40%); }
-final _kCodeBlockStyleSb = TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor());
+      // .sc { color: hsl(86deg 57% 40%); }
+      sc: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
-// .sc { color: hsl(86deg 57% 40%); }
-final _kCodeBlockStyleSc = TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor());
+      // .sd { color: hsl(86deg 57% 40%); font-style: italic; }
+      sd: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor(), fontStyle: FontStyle.italic),
 
-// .sd { color: hsl(86deg 57% 40%); font-style: italic; }
-final _kCodeBlockStyleSd = TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor(), fontStyle: FontStyle.italic);
+      // .s2 { color: hsl(225deg 71% 33%); }
+      s2: TextStyle(color: const HSLColor.fromAHSL(1, 225, 0.71, 0.33).toColor()),
 
-// .s2 { color: hsl(225deg 71% 33%); }
-final _kCodeBlockStyleS2 = TextStyle(color: const HSLColor.fromAHSL(1, 225, 0.71, 0.33).toColor());
+      // .se { color: hsl(26deg 69% 43%); font-weight: bold; }
+      se: TextStyle(color: const HSLColor.fromAHSL(1, 26, 0.69, 0.43).toColor(), fontWeight: FontWeight.bold),
 
-// .se { color: hsl(26deg 69% 43%); font-weight: bold; }
-final _kCodeBlockStyleSe = TextStyle(color: const HSLColor.fromAHSL(1, 26, 0.69, 0.43).toColor(), fontWeight: FontWeight.bold);
+      // .sh { color: hsl(86deg 57% 40%); }
+      sh: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
-// .sh { color: hsl(86deg 57% 40%); }
-final _kCodeBlockStyleSh = TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor());
+      // .si { color: hsl(336deg 38% 56%); font-weight: bold; }
+      si: TextStyle(color: const HSLColor.fromAHSL(1, 336, 0.38, 0.56).toColor(), fontWeight: FontWeight.bold),
 
-// .si { color: hsl(336deg 38% 56%); font-weight: bold; }
-final _kCodeBlockStyleSi = TextStyle(color: const HSLColor.fromAHSL(1, 336, 0.38, 0.56).toColor(), fontWeight: FontWeight.bold);
+      // .sx { color: hsl(120deg 100% 25%); }
+      sx: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor()),
 
-// .sx { color: hsl(120deg 100% 25%); }
-final _kCodeBlockStyleSx = TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor());
+      // .sr { color: hsl(189deg 54% 49%); }
+      sr: TextStyle(color: const HSLColor.fromAHSL(1, 189, 0.54, 0.49).toColor()),
 
-// .sr { color: hsl(189deg 54% 49%); }
-final _kCodeBlockStyleSr = TextStyle(color: const HSLColor.fromAHSL(1, 189, 0.54, 0.49).toColor());
+      // .s1 { color: hsl(86deg 57% 40%); }
+      s1: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
-// .s1 { color: hsl(86deg 57% 40%); }
-final _kCodeBlockStyleS1 = TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor());
+      // .ss { color: hsl(241deg 68% 28%); }
+      ss: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
 
-// .ss { color: hsl(241deg 68% 28%); }
-final _kCodeBlockStyleSs = TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor());
+      // .bp { color: hsl(120deg 100% 25%); }
+      bp: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor()),
 
-// .bp { color: hsl(120deg 100% 25%); }
-final _kCodeBlockStyleBp = TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor());
+      // .vc { color: hsl(241deg 68% 28%); }
+      vc: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
 
-// .vc { color: hsl(241deg 68% 28%); }
-final _kCodeBlockStyleVc = TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor());
+      // .vg { color: hsl(241deg 68% 28%); }
+      vg: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
 
-// .vg { color: hsl(241deg 68% 28%); }
-final _kCodeBlockStyleVg = TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor());
+      // .vi { color: hsl(241deg 68% 28%); }
+      vi: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
 
-// .vi { color: hsl(241deg 68% 28%); }
-final _kCodeBlockStyleVi = TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor());
+      // .il { color: hsl(0deg 0% 40%); }
+      il: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor())
+    );
+  }
 
-// .il { color: hsl(0deg 0% 40%); }
-final _kCodeBlockStyleIl = TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor());
+  CodeBlockTextStyles._({
+    required TextStyle hll,
+    required TextStyle c,
+    required TextStyle err,
+    required TextStyle k,
+    required TextStyle o,
+    required TextStyle cm,
+    required TextStyle cp,
+    required TextStyle c1,
+    required TextStyle cs,
+    required TextStyle gd,
+    required TextStyle ge,
+    required TextStyle gr,
+    required TextStyle gh,
+    required TextStyle gi,
+    required TextStyle go,
+    required TextStyle gp,
+    required TextStyle gs,
+    required TextStyle gu,
+    required TextStyle gt,
+    required TextStyle kc,
+    required TextStyle kd,
+    required TextStyle kn,
+    required TextStyle kp,
+    required TextStyle kr,
+    required TextStyle kt,
+    required TextStyle m,
+    required TextStyle s,
+    required TextStyle na,
+    required TextStyle nb,
+    required TextStyle nc,
+    required TextStyle no,
+    required TextStyle nd,
+    required TextStyle ni,
+    required TextStyle ne,
+    required TextStyle nf,
+    required TextStyle nl,
+    required TextStyle nn,
+    required TextStyle nt,
+    required TextStyle nv,
+    required TextStyle nx,
+    required TextStyle ow,
+    required TextStyle w,
+    required TextStyle mf,
+    required TextStyle mh,
+    required TextStyle mi,
+    required TextStyle mo,
+    required TextStyle sb,
+    required TextStyle sc,
+    required TextStyle sd,
+    required TextStyle s2,
+    required TextStyle se,
+    required TextStyle sh,
+    required TextStyle si,
+    required TextStyle sx,
+    required TextStyle sr,
+    required TextStyle s1,
+    required TextStyle ss,
+    required TextStyle bp,
+    required TextStyle vc,
+    required TextStyle vg,
+    required TextStyle vi,
+    required TextStyle il,
+  }) :
+    _hll = hll,
+    _c = c,
+    _err = err,
+    _k = k,
+    _o = o,
+    _cm = cm,
+    _cp = cp,
+    _c1 = c1,
+    _cs = cs,
+    _gd = gd,
+    _ge = ge,
+    _gr = gr,
+    _gh = gh,
+    _gi = gi,
+    _go = go,
+    _gp = gp,
+    _gs = gs,
+    _gu = gu,
+    _gt = gt,
+    _kc = kc,
+    _kd = kd,
+    _kn = kn,
+    _kp = kp,
+    _kr = kr,
+    _kt = kt,
+    _m = m,
+    _s = s,
+    _na = na,
+    _nb = nb,
+    _nc = nc,
+    _no = no,
+    _nd = nd,
+    _ni = ni,
+    _ne = ne,
+    _nf = nf,
+    _nl = nl,
+    _nn = nn,
+    _nt = nt,
+    _nv = nv,
+    _nx = nx,
+    _ow = ow,
+    _w = w,
+    _mf = mf,
+    _mh = mh,
+    _mi = mi,
+    _mo = mo,
+    _sb = sb,
+    _sc = sc,
+    _sd = sd,
+    _s2 = s2,
+    _se = se,
+    _sh = sh,
+    _si = si,
+    _sx = sx,
+    _sr = sr,
+    _s1 = s1,
+    _ss = ss,
+    _bp = bp,
+    _vc = vc,
+    _vg = vg,
+    _vi = vi,
+    _il = il;
 
-TextStyle? codeBlockTextStyle(CodeBlockSpanType type) {
-  return switch (type) {
-    CodeBlockSpanType.text => null, // A span with type of text is always unstyled.
-    CodeBlockSpanType.highlightedLines => _kCodeBlockStyleHll,
-    CodeBlockSpanType.comment => _kCodeBlockStyleC,
-    CodeBlockSpanType.error => _kCodeBlockStyleErr,
-    CodeBlockSpanType.keyword => _kCodeBlockStyleK,
-    CodeBlockSpanType.operator => _kCodeBlockStyleO,
-    CodeBlockSpanType.commentMultiline => _kCodeBlockStyleCm,
-    CodeBlockSpanType.commentPreproc => _kCodeBlockStyleCp,
-    CodeBlockSpanType.commentSingle => _kCodeBlockStyleC1,
-    CodeBlockSpanType.commentSpecial => _kCodeBlockStyleCs,
-    CodeBlockSpanType.genericDeleted => _kCodeBlockStyleGd,
-    CodeBlockSpanType.genericEmph => _kCodeBlockStyleGe,
-    CodeBlockSpanType.genericError => _kCodeBlockStyleGr,
-    CodeBlockSpanType.genericHeading => _kCodeBlockStyleGh,
-    CodeBlockSpanType.genericInserted => _kCodeBlockStyleGi,
-    CodeBlockSpanType.genericOutput => _kCodeBlockStyleGo,
-    CodeBlockSpanType.genericPrompt => _kCodeBlockStyleGp,
-    CodeBlockSpanType.genericStrong => _kCodeBlockStyleGs,
-    CodeBlockSpanType.genericSubheading => _kCodeBlockStyleGu,
-    CodeBlockSpanType.genericTraceback => _kCodeBlockStyleGt,
-    CodeBlockSpanType.keywordConstant => _kCodeBlockStyleKc,
-    CodeBlockSpanType.keywordDeclaration => _kCodeBlockStyleKd,
-    CodeBlockSpanType.keywordNamespace => _kCodeBlockStyleKn,
-    CodeBlockSpanType.keywordPseudo => _kCodeBlockStyleKp,
-    CodeBlockSpanType.keywordReserved => _kCodeBlockStyleKr,
-    CodeBlockSpanType.keywordType => _kCodeBlockStyleKt,
-    CodeBlockSpanType.number => _kCodeBlockStyleM,
-    CodeBlockSpanType.string => _kCodeBlockStyleS,
-    CodeBlockSpanType.nameAttribute => _kCodeBlockStyleNa,
-    CodeBlockSpanType.nameBuiltin => _kCodeBlockStyleNb,
-    CodeBlockSpanType.nameClass => _kCodeBlockStyleNc,
-    CodeBlockSpanType.nameConstant => _kCodeBlockStyleNo,
-    CodeBlockSpanType.nameDecorator => _kCodeBlockStyleNd,
-    CodeBlockSpanType.nameEntity => _kCodeBlockStyleNi,
-    CodeBlockSpanType.nameException => _kCodeBlockStyleNe,
-    CodeBlockSpanType.nameFunction => _kCodeBlockStyleNf,
-    CodeBlockSpanType.nameLabel => _kCodeBlockStyleNl,
-    CodeBlockSpanType.nameNamespace => _kCodeBlockStyleNn,
-    CodeBlockSpanType.nameTag => _kCodeBlockStyleNt,
-    CodeBlockSpanType.nameVariable => _kCodeBlockStyleNv,
-    CodeBlockSpanType.nameOther => _kCodeBlockStyleNx,
-    CodeBlockSpanType.operatorWord => _kCodeBlockStyleOw,
-    CodeBlockSpanType.whitespace => _kCodeBlockStyleW,
-    CodeBlockSpanType.numberFloat => _kCodeBlockStyleMf,
-    CodeBlockSpanType.numberHex => _kCodeBlockStyleMh,
-    CodeBlockSpanType.numberInteger => _kCodeBlockStyleMi,
-    CodeBlockSpanType.numberOct => _kCodeBlockStyleMo,
-    CodeBlockSpanType.stringBacktick => _kCodeBlockStyleSb,
-    CodeBlockSpanType.stringChar => _kCodeBlockStyleSc,
-    CodeBlockSpanType.stringDoc => _kCodeBlockStyleSd,
-    CodeBlockSpanType.stringDouble => _kCodeBlockStyleS2,
-    CodeBlockSpanType.stringEscape => _kCodeBlockStyleSe,
-    CodeBlockSpanType.stringHeredoc => _kCodeBlockStyleSh,
-    CodeBlockSpanType.stringInterpol => _kCodeBlockStyleSi,
-    CodeBlockSpanType.stringOther => _kCodeBlockStyleSx,
-    CodeBlockSpanType.stringRegex => _kCodeBlockStyleSr,
-    CodeBlockSpanType.stringSingle => _kCodeBlockStyleS1,
-    CodeBlockSpanType.stringSymbol => _kCodeBlockStyleSs,
-    CodeBlockSpanType.nameBuiltinPseudo => _kCodeBlockStyleBp,
-    CodeBlockSpanType.nameVariableClass => _kCodeBlockStyleVc,
-    CodeBlockSpanType.nameVariableGlobal => _kCodeBlockStyleVg,
-    CodeBlockSpanType.nameVariableInstance => _kCodeBlockStyleVi,
-    CodeBlockSpanType.numberIntegerLong => _kCodeBlockStyleIl,
-    _ => null, // not every token is styled
-  };
+  final TextStyle _hll;
+  final TextStyle _c;
+  final TextStyle _err;
+  final TextStyle _k;
+  final TextStyle _o;
+  final TextStyle _cm;
+  final TextStyle _cp;
+  final TextStyle _c1;
+  final TextStyle _cs;
+  final TextStyle _gd;
+  final TextStyle _ge;
+  final TextStyle _gr;
+  final TextStyle _gh;
+  final TextStyle _gi;
+  final TextStyle _go;
+  final TextStyle _gp;
+  final TextStyle _gs;
+  final TextStyle _gu;
+  final TextStyle _gt;
+  final TextStyle _kc;
+  final TextStyle _kd;
+  final TextStyle _kn;
+  final TextStyle _kp;
+  final TextStyle _kr;
+  final TextStyle _kt;
+  final TextStyle _m;
+  final TextStyle _s;
+  final TextStyle _na;
+  final TextStyle _nb;
+  final TextStyle _nc;
+  final TextStyle _no;
+  final TextStyle _nd;
+  final TextStyle _ni;
+  final TextStyle _ne;
+  final TextStyle _nf;
+  final TextStyle _nl;
+  final TextStyle _nn;
+  final TextStyle _nt;
+  final TextStyle _nv;
+  final TextStyle _nx;
+  final TextStyle _ow;
+  final TextStyle _w;
+  final TextStyle _mf;
+  final TextStyle _mh;
+  final TextStyle _mi;
+  final TextStyle _mo;
+  final TextStyle _sb;
+  final TextStyle _sc;
+  final TextStyle _sd;
+  final TextStyle _s2;
+  final TextStyle _se;
+  final TextStyle _sh;
+  final TextStyle _si;
+  final TextStyle _sx;
+  final TextStyle _sr;
+  final TextStyle _s1;
+  final TextStyle _ss;
+  final TextStyle _bp;
+  final TextStyle _vc;
+  final TextStyle _vg;
+  final TextStyle _vi;
+  final TextStyle _il;
+
+  /// The [TextStyle] for a [CodeBlockSpanType], if there is one.
+  ///
+  /// Used to render syntax highlighting.
+  // Span styles adapted from:
+  //   https://github.com/zulip/zulip/blob/213387249e7ba7772084411b22d8cef64b135dd0/web/styles/pygments.css
+  TextStyle? forSpan(CodeBlockSpanType type) {
+    return switch (type) {
+      CodeBlockSpanType.text => null, // A span with type of text is always unstyled.
+      CodeBlockSpanType.highlightedLines => _hll,
+      CodeBlockSpanType.comment => _c,
+      CodeBlockSpanType.error => _err,
+      CodeBlockSpanType.keyword => _k,
+      CodeBlockSpanType.operator => _o,
+      CodeBlockSpanType.commentMultiline => _cm,
+      CodeBlockSpanType.commentPreproc => _cp,
+      CodeBlockSpanType.commentSingle => _c1,
+      CodeBlockSpanType.commentSpecial => _cs,
+      CodeBlockSpanType.genericDeleted => _gd,
+      CodeBlockSpanType.genericEmph => _ge,
+      CodeBlockSpanType.genericError => _gr,
+      CodeBlockSpanType.genericHeading => _gh,
+      CodeBlockSpanType.genericInserted => _gi,
+      CodeBlockSpanType.genericOutput => _go,
+      CodeBlockSpanType.genericPrompt => _gp,
+      CodeBlockSpanType.genericStrong => _gs,
+      CodeBlockSpanType.genericSubheading => _gu,
+      CodeBlockSpanType.genericTraceback => _gt,
+      CodeBlockSpanType.keywordConstant => _kc,
+      CodeBlockSpanType.keywordDeclaration => _kd,
+      CodeBlockSpanType.keywordNamespace => _kn,
+      CodeBlockSpanType.keywordPseudo => _kp,
+      CodeBlockSpanType.keywordReserved => _kr,
+      CodeBlockSpanType.keywordType => _kt,
+      CodeBlockSpanType.number => _m,
+      CodeBlockSpanType.string => _s,
+      CodeBlockSpanType.nameAttribute => _na,
+      CodeBlockSpanType.nameBuiltin => _nb,
+      CodeBlockSpanType.nameClass => _nc,
+      CodeBlockSpanType.nameConstant => _no,
+      CodeBlockSpanType.nameDecorator => _nd,
+      CodeBlockSpanType.nameEntity => _ni,
+      CodeBlockSpanType.nameException => _ne,
+      CodeBlockSpanType.nameFunction => _nf,
+      CodeBlockSpanType.nameLabel => _nl,
+      CodeBlockSpanType.nameNamespace => _nn,
+      CodeBlockSpanType.nameTag => _nt,
+      CodeBlockSpanType.nameVariable => _nv,
+      CodeBlockSpanType.nameOther => _nx,
+      CodeBlockSpanType.operatorWord => _ow,
+      CodeBlockSpanType.whitespace => _w,
+      CodeBlockSpanType.numberFloat => _mf,
+      CodeBlockSpanType.numberHex => _mh,
+      CodeBlockSpanType.numberInteger => _mi,
+      CodeBlockSpanType.numberOct => _mo,
+      CodeBlockSpanType.stringBacktick => _sb,
+      CodeBlockSpanType.stringChar => _sc,
+      CodeBlockSpanType.stringDoc => _sd,
+      CodeBlockSpanType.stringDouble => _s2,
+      CodeBlockSpanType.stringEscape => _se,
+      CodeBlockSpanType.stringHeredoc => _sh,
+      CodeBlockSpanType.stringInterpol => _si,
+      CodeBlockSpanType.stringOther => _sx,
+      CodeBlockSpanType.stringRegex => _sr,
+      CodeBlockSpanType.stringSingle => _s1,
+      CodeBlockSpanType.stringSymbol => _ss,
+      CodeBlockSpanType.nameBuiltinPseudo => _bp,
+      CodeBlockSpanType.nameVariableClass => _vc,
+      CodeBlockSpanType.nameVariableGlobal => _vg,
+      CodeBlockSpanType.nameVariableInstance => _vi,
+      CodeBlockSpanType.numberIntegerLong => _il,
+      _ => null, // not every token is styled
+    };
+  }
+
+  CodeBlockTextStyles lerp(CodeBlockTextStyles? other, double t) {
+    if (identical(this, other)) return this;
+
+    return CodeBlockTextStyles._(
+      hll: TextStyle.lerp(_hll, other?._hll, t)!,
+      c: TextStyle.lerp(_c, other?._c, t)!,
+      err: TextStyle.lerp(_err, other?._err, t)!,
+      k: TextStyle.lerp(_k, other?._k, t)!,
+      o: TextStyle.lerp(_o, other?._o, t)!,
+      cm: TextStyle.lerp(_cm, other?._cm, t)!,
+      cp: TextStyle.lerp(_cp, other?._cp, t)!,
+      c1: TextStyle.lerp(_c1, other?._c1, t)!,
+      cs: TextStyle.lerp(_cs, other?._cs, t)!,
+      gd: TextStyle.lerp(_gd, other?._gd, t)!,
+      ge: TextStyle.lerp(_ge, other?._ge, t)!,
+      gr: TextStyle.lerp(_gr, other?._gr, t)!,
+      gh: TextStyle.lerp(_gh, other?._gh, t)!,
+      gi: TextStyle.lerp(_gi, other?._gi, t)!,
+      go: TextStyle.lerp(_go, other?._go, t)!,
+      gp: TextStyle.lerp(_gp, other?._gp, t)!,
+      gs: TextStyle.lerp(_gs, other?._gs, t)!,
+      gu: TextStyle.lerp(_gu, other?._gu, t)!,
+      gt: TextStyle.lerp(_gt, other?._gt, t)!,
+      kc: TextStyle.lerp(_kc, other?._kc, t)!,
+      kd: TextStyle.lerp(_kd, other?._kd, t)!,
+      kn: TextStyle.lerp(_kn, other?._kn, t)!,
+      kp: TextStyle.lerp(_kp, other?._kp, t)!,
+      kr: TextStyle.lerp(_kr, other?._kr, t)!,
+      kt: TextStyle.lerp(_kt, other?._kt, t)!,
+      m: TextStyle.lerp(_m, other?._m, t)!,
+      s: TextStyle.lerp(_s, other?._s, t)!,
+      na: TextStyle.lerp(_na, other?._na, t)!,
+      nb: TextStyle.lerp(_nb, other?._nb, t)!,
+      nc: TextStyle.lerp(_nc, other?._nc, t)!,
+      no: TextStyle.lerp(_no, other?._no, t)!,
+      nd: TextStyle.lerp(_nd, other?._nd, t)!,
+      ni: TextStyle.lerp(_ni, other?._ni, t)!,
+      ne: TextStyle.lerp(_ne, other?._ne, t)!,
+      nf: TextStyle.lerp(_nf, other?._nf, t)!,
+      nl: TextStyle.lerp(_nl, other?._nl, t)!,
+      nn: TextStyle.lerp(_nn, other?._nn, t)!,
+      nt: TextStyle.lerp(_nt, other?._nt, t)!,
+      nv: TextStyle.lerp(_nv, other?._nv, t)!,
+      nx: TextStyle.lerp(_nx, other?._nx, t)!,
+      ow: TextStyle.lerp(_ow, other?._ow, t)!,
+      w: TextStyle.lerp(_w, other?._w, t)!,
+      mf: TextStyle.lerp(_mf, other?._mf, t)!,
+      mh: TextStyle.lerp(_mh, other?._mh, t)!,
+      mi: TextStyle.lerp(_mi, other?._mi, t)!,
+      mo: TextStyle.lerp(_mo, other?._mo, t)!,
+      sb: TextStyle.lerp(_sb, other?._sb, t)!,
+      sc: TextStyle.lerp(_sc, other?._sc, t)!,
+      sd: TextStyle.lerp(_sd, other?._sd, t)!,
+      s2: TextStyle.lerp(_s2, other?._s2, t)!,
+      se: TextStyle.lerp(_se, other?._se, t)!,
+      sh: TextStyle.lerp(_sh, other?._sh, t)!,
+      si: TextStyle.lerp(_si, other?._si, t)!,
+      sx: TextStyle.lerp(_sx, other?._sx, t)!,
+      sr: TextStyle.lerp(_sr, other?._sr, t)!,
+      s1: TextStyle.lerp(_s1, other?._s1, t)!,
+      ss: TextStyle.lerp(_ss, other?._ss, t)!,
+      bp: TextStyle.lerp(_bp, other?._bp, t)!,
+      vc: TextStyle.lerp(_vc, other?._vc, t)!,
+      vg: TextStyle.lerp(_vg, other?._vg, t)!,
+      vi: TextStyle.lerp(_vi, other?._vi, t)!,
+      il: TextStyle.lerp(_il, other?._il, t)!,
+    );
+  }
 }

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 
 import '../model/code_block.dart';
+import 'text.dart';
 
 /// [TextStyle]s used to render code blocks.
 ///
 /// Use [forSpan] for syntax highlighting.
 // TODO(#95) follow web for dark-theme colors
 class CodeBlockTextStyles {
-  factory CodeBlockTextStyles() {
+  factory CodeBlockTextStyles(BuildContext context) {
+    final bold = weightVariableTextStyle(context, wght: 700);
     return CodeBlockTextStyles._(
       // .hll { background-color: hsl(60deg 100% 90%); }
       hll: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 60, 1, 0.90).toColor()),
@@ -50,7 +52,7 @@ class CodeBlockTextStyles {
       gr: TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.50).toColor()),
 
       // .gh { color: hsl(240deg 100% 25%); font-weight: bold; }
-      gh: TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
+      gh: TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor()).merge(bold),
 
       // .gi { color: hsl(120deg 100% 31%); }
       gi: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.31).toColor()),
@@ -59,31 +61,31 @@ class CodeBlockTextStyles {
       go: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.50).toColor()),
 
       // .gp { color: hsl(240deg 100% 25%); font-weight: bold; }
-      gp: TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
+      gp: TextStyle(color: const HSLColor.fromAHSL(1, 240, 1, 0.25).toColor()).merge(bold),
 
       // .gs { font-weight: bold; }
-      gs: const TextStyle(fontWeight: FontWeight.bold),
+      gs: const TextStyle().merge(bold),
 
       // .gu { color: hsl(300deg 100% 25%); font-weight: bold; }
-      gu: TextStyle(color: const HSLColor.fromAHSL(1, 300, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
+      gu: TextStyle(color: const HSLColor.fromAHSL(1, 300, 1, 0.25).toColor()).merge(bold),
 
       // .gt { color: hsl(221deg 100% 40%); }
       gt: TextStyle(color: const HSLColor.fromAHSL(1, 221, 1, 0.40).toColor()),
 
       // .kc { color: hsl(332deg 70% 38%); font-weight: bold; }
-      kc: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold),
+      kc: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()).merge(bold),
 
       // .kd { color: hsl(332deg 70% 38%); }
       kd: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
 
       // .kn { color: hsl(332deg 70% 38%); font-weight: bold; }
-      kn: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold),
+      kn: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()).merge(bold),
 
       // .kp { color: hsl(332deg 70% 38%); }
       kp: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
 
       // .kr { color: hsl(332deg 70% 38%); font-weight: bold; }
-      kr: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor(), fontWeight: FontWeight.bold),
+      kr: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()).merge(bold),
 
       // .kt { color: hsl(332deg 70% 38%); }
       kt: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
@@ -101,7 +103,7 @@ class CodeBlockTextStyles {
       nb: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
       // .nc { color: hsl(264deg 27% 50%); font-weight: bold; }
-      nc: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor(), fontWeight: FontWeight.bold),
+      nc: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor()).merge(bold),
 
       // .no { color: hsl(0deg 100% 26%); }
       no: TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.26).toColor()),
@@ -110,10 +112,10 @@ class CodeBlockTextStyles {
       nd: TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor()),
 
       // .ni { color: hsl(0deg 0% 60%); font-weight: bold; }
-      ni: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.60).toColor(), fontWeight: FontWeight.bold),
+      ni: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.60).toColor()).merge(bold),
 
       // .ne { color: hsl(2deg 62% 52%); font-weight: bold; }
-      ne: TextStyle(color: const HSLColor.fromAHSL(1, 2, 0.62, 0.52).toColor(), fontWeight: FontWeight.bold),
+      ne: TextStyle(color: const HSLColor.fromAHSL(1, 2, 0.62, 0.52).toColor()).merge(bold),
 
       // .nf { color: hsl(264deg 27% 50%); }
       nf: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor()),
@@ -122,10 +124,10 @@ class CodeBlockTextStyles {
       nl: TextStyle(color: const HSLColor.fromAHSL(1, 60, 1, 0.31).toColor()),
 
       // .nn { color: hsl(264deg 27% 50%); font-weight: bold; }
-      nn: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor(), fontWeight: FontWeight.bold),
+      nn: TextStyle(color: const HSLColor.fromAHSL(1, 264, 0.27, 0.50).toColor()).merge(bold),
 
       // .nt { color: hsl(120deg 100% 25%); font-weight: bold; }
-      nt: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor(), fontWeight: FontWeight.bold),
+      nt: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor()).merge(bold),
 
       // .nv { color: hsl(241deg 68% 28%); }
       nv: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
@@ -134,7 +136,7 @@ class CodeBlockTextStyles {
       nx: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.26).toColor()),
 
       // .ow { color: hsl(276deg 100% 56%); font-weight: bold; }
-      ow: TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor(), fontWeight: FontWeight.bold),
+      ow: TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor()).merge(bold),
 
       // .w { color: hsl(0deg 0% 73%); }
       w: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.73).toColor()),
@@ -164,13 +166,13 @@ class CodeBlockTextStyles {
       s2: TextStyle(color: const HSLColor.fromAHSL(1, 225, 0.71, 0.33).toColor()),
 
       // .se { color: hsl(26deg 69% 43%); font-weight: bold; }
-      se: TextStyle(color: const HSLColor.fromAHSL(1, 26, 0.69, 0.43).toColor(), fontWeight: FontWeight.bold),
+      se: TextStyle(color: const HSLColor.fromAHSL(1, 26, 0.69, 0.43).toColor()).merge(bold),
 
       // .sh { color: hsl(86deg 57% 40%); }
       sh: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
       // .si { color: hsl(336deg 38% 56%); font-weight: bold; }
-      si: TextStyle(color: const HSLColor.fromAHSL(1, 336, 0.38, 0.56).toColor(), fontWeight: FontWeight.bold),
+      si: TextStyle(color: const HSLColor.fromAHSL(1, 336, 0.38, 0.56).toColor()).merge(bold),
 
       // .sx { color: hsl(120deg 100% 25%); }
       sx: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor()),

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -47,7 +47,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     )
       .merge(weightVariableTextStyle(context))
       .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
-    codeBlockTextStyles = CodeBlockTextStyles(),
+    codeBlockTextStyles = CodeBlockTextStyles(context),
     textStyleError = const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
       .merge(weightVariableTextStyle(context, wght: 700)),
     textStyleErrorCode = kMonospaceTextStyle

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -582,17 +582,11 @@ class CodeBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     return _CodeBlockContainer(
       borderColor: Colors.transparent,
-      child: Text.rich(_buildNodes(node.spans)));
-  }
-
-  InlineSpan _buildNodes(List<CodeBlockSpanNode> nodes) {
-    return TextSpan(
-      style: _kCodeBlockStyle,
-      children: nodes.map(_buildNode).toList(growable: false));
-  }
-
-  InlineSpan _buildNode(CodeBlockSpanNode node) {
-    return TextSpan(text: node.text, style: codeBlockTextStyle(node.type));
+      child: Text.rich(TextSpan(
+        style: _kCodeBlockStyle,
+        children: node.spans
+          .map((node) => TextSpan(style: codeBlockTextStyle(node.type), text: node.text))
+          .toList(growable: false))));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -47,6 +47,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     )
       .merge(weightVariableTextStyle(context))
       .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
+    codeBlockTextStyles = CodeBlockTextStyles(),
     textStyleError = const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
       .merge(weightVariableTextStyle(context, wght: 700)),
     textStyleErrorCode = kMonospaceTextStyle
@@ -54,6 +55,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   ContentTheme._({
     required this.textStylePlainParagraph,
+    required this.codeBlockTextStyles,
     required this.textStyleError,
     required this.textStyleErrorCode,
   });
@@ -76,17 +78,20 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   /// should not need styles from other sources, such as Material defaults.
   final TextStyle textStylePlainParagraph;
 
+  final CodeBlockTextStyles codeBlockTextStyles;
   final TextStyle textStyleError;
   final TextStyle textStyleErrorCode;
 
   @override
   ContentTheme copyWith({
     TextStyle? textStylePlainParagraph,
+    CodeBlockTextStyles? codeBlockTextStyles,
     TextStyle? textStyleError,
     TextStyle? textStyleErrorCode,
   }) {
     return ContentTheme._(
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
+      codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
       textStyleError: textStyleError ?? this.textStyleError,
       textStyleErrorCode: textStyleErrorCode ?? this.textStyleErrorCode,
     );
@@ -99,6 +104,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     }
     return ContentTheme._(
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other?.textStylePlainParagraph, t)!,
+      codeBlockTextStyles: codeBlockTextStyles.lerp(other?.codeBlockTextStyles, t),
       textStyleError: TextStyle.lerp(textStyleError, other?.textStyleError, t)!,
       textStyleErrorCode: TextStyle.lerp(textStyleErrorCode, other?.textStyleErrorCode, t)!,
     );
@@ -580,12 +586,13 @@ class CodeBlock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final styles = ContentTheme.of(context).codeBlockTextStyles;
     return _CodeBlockContainer(
       borderColor: Colors.transparent,
       child: Text.rich(TextSpan(
         style: _kCodeBlockStyle,
         children: node.spans
-          .map((node) => TextSpan(style: codeBlockTextStyle(node.type), text: node.text))
+          .map((node) => TextSpan(style: styles.forSpan(node.type), text: node.text))
           .toList(growable: false))));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -590,7 +590,7 @@ class CodeBlock extends StatelessWidget {
     return _CodeBlockContainer(
       borderColor: Colors.transparent,
       child: Text.rich(TextSpan(
-        style: _kCodeBlockStyle,
+        style: styles.plain,
         children: node.spans
           .map((node) => TextSpan(style: styles.forSpan(node.type), text: node.text))
           .toList(growable: false))));
@@ -659,7 +659,7 @@ class MathBlock extends StatelessWidget {
     return _CodeBlockContainer(
       borderColor: _borderColor,
       child: Text.rich(TextSpan(
-        style: _kCodeBlockStyle,
+        style: ContentTheme.of(context).codeBlockTextStyles.plain,
         children: [TextSpan(text: node.texSource)])));
   }
 }
@@ -945,12 +945,6 @@ const _kInlineCodeFontSizeFactor = 0.825;
 final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(TextStyle(
     backgroundColor: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor()));
-
-final _kCodeBlockStyle = kMonospaceTextStyle
-  .merge(const TextStyle(
-    fontSize: 0.825 * kBaseFontSize,
-    height: 1.4,
-  ));
 
 // const _kInlineCodeLeftBracket = '⸤';
 // const _kInlineCodeRightBracket = '⸣';

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -465,6 +465,14 @@ void main() {
         final root = tester.renderObject<RenderParagraph>(find.textContaining('class')).text;
         return mergedStyleOfSubstring(root, 'class')!;
       });
+
+    testFontWeight('syntax highlighting: bold span',
+      expectedWght: 700,
+      content: plainContent(ContentExample.codeBlockHighlightedShort.html),
+      styleFinder: (WidgetTester tester) {
+        final root = tester.renderObject<RenderParagraph>(find.textContaining('A')).text;
+        return mergedStyleOfSubstring(root, 'A')!;
+      });
   });
 
   testContentSmoke(ContentExample.mathBlock);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -457,6 +457,14 @@ void main() {
     testContentSmoke(ContentExample.codeBlockPlain);
     testContentSmoke(ContentExample.codeBlockHighlightedShort);
     testContentSmoke(ContentExample.codeBlockHighlightedMultiline);
+
+    testFontWeight('syntax highlighting: non-bold span',
+      expectedWght: 400,
+      content: plainContent(ContentExample.codeBlockHighlightedShort.html),
+      styleFinder: (WidgetTester tester) {
+        final root = tester.renderObject<RenderParagraph>(find.textContaining('class')).text;
+        return mergedStyleOfSubstring(root, 'class')!;
+      });
   });
 
   testContentSmoke(ContentExample.mathBlock);


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![34AB2CF1-E279-4702-A855-80722BE9056A](https://github.com/zulip/zulip-flutter/assets/22248748/88e7058a-3e4a-4749-96f2-6fc9f8b2b3ba) | ![17039B63-B706-4F85-9253-CC5DF863DFB3](https://github.com/zulip/zulip-flutter/assets/22248748/66700f1c-e227-4626-91dc-28d559083b35) |

Related: #95