### PR TITLE
text: Convert the last uses of `FontWeight.bold` to `weightVariableTextStyle`

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -15,6 +15,7 @@ import 'page.dart';
 import 'recent_dm_conversations.dart';
 import 'store.dart';
 import 'subscription_list.dart';
+import 'text.dart';
 import 'theme.dart';
 
 class ZulipApp extends StatefulWidget {
@@ -242,7 +243,8 @@ class HomePage extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
 
     InlineSpan bold(String text) => TextSpan(
-      text: text, style: const TextStyle(fontWeight: FontWeight.bold));
+      style: const TextStyle().merge(weightVariableTextStyle(context, wght: 700)),
+      text: text);
 
     int? testStreamId;
     if (store.connection.realmUrl.origin == 'https://chat.zulip.org') {

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -47,8 +47,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     )
       .merge(weightVariableTextStyle(context))
       .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
-    textStyleError = const TextStyle(
-      fontSize: kBaseFontSize, fontWeight: FontWeight.bold, color: Colors.red),
+    textStyleError = const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
+      .merge(weightVariableTextStyle(context, wght: 700)),
     textStyleErrorCode = kMonospaceTextStyle
       .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red));
 

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -197,7 +197,7 @@ class _ProfileDataTable extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.baseline,
         textBaseline: TextBaseline.alphabetic,
         children: [
-          SizedBox(width: 96,
+          SizedBox(width: 100,
             child: Text(style: _TextStyles.customProfileFieldLabel(context),
               realmField.name)),
           const SizedBox(width: 8),

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -10,10 +10,15 @@ import 'content.dart';
 import 'message_list.dart';
 import 'page.dart';
 import 'store.dart';
+import 'text.dart';
 
 class _TextStyles {
   static const primaryFieldText = TextStyle(fontSize: 20);
-  static const customProfileFieldLabel = TextStyle(fontSize: 15, fontWeight: FontWeight.bold);
+
+  static TextStyle customProfileFieldLabel(BuildContext context) =>
+    const TextStyle(fontSize: 15)
+      .merge(weightVariableTextStyle(context, wght: 700));
+
   static const customProfileFieldText = TextStyle(fontSize: 15);
 }
 
@@ -43,7 +48,8 @@ class ProfilePage extends StatelessWidget {
       const SizedBox(height: 16),
       Text(user.fullName,
         textAlign: TextAlign.center,
-        style: _TextStyles.primaryFieldText.merge(const TextStyle(fontWeight: FontWeight.bold))),
+        style: _TextStyles.primaryFieldText
+          .merge(weightVariableTextStyle(context, wght: 700))),
       // TODO(#291) render email field
       Text(roleToLabel(user.role, zulipLocalizations),
         textAlign: TextAlign.center,
@@ -192,7 +198,8 @@ class _ProfileDataTable extends StatelessWidget {
         textBaseline: TextBaseline.alphabetic,
         children: [
           SizedBox(width: 96,
-            child: Text(realmField.name, style: _TextStyles.customProfileFieldLabel)),
+            child: Text(style: _TextStyles.customProfileFieldLabel(context),
+              realmField.name)),
           const SizedBox(width: 8),
           Flexible(child: widget),
         ]));


### PR DESCRIPTION
(That is, the last uses except the ones in code-block styles, which are treated in #727.)

| Before | After |
| --- | --- |
| ![6EEB5903-E8FC-46D4-84CE-083ACE1C1E59](https://github.com/zulip/zulip-flutter/assets/22248748/5e7d1d52-88b0-435d-92f9-a23b53082738) | ![2CF00F52-126B-4950-88A8-69E65A531044](https://github.com/zulip/zulip-flutter/assets/22248748/1c7449d2-3695-4752-99f6-ec14281f3f84) |
| ![2F7D6B2C-E328-4AE5-AC0A-2CE5AEB23A7A](https://github.com/zulip/zulip-flutter/assets/22248748/05845fb9-e790-4db6-992f-cd39eeaf5053) | ![C8BDEB92-A391-4316-AB36-6EED5586DCFE](https://github.com/zulip/zulip-flutter/assets/22248748/864e9903-3ebc-410a-81d5-44f1577a0774) |
| ![56A0F77C-578E-4D22-8A30-7D4AEFD26450](https://github.com/zulip/zulip-flutter/assets/22248748/d4a0c427-7e38-4264-ab72-d0d27e5a293a) | ![C0EF8351-7DFD-4CAC-B7AE-3049A039E5A7](https://github.com/zulip/zulip-flutter/assets/22248748/4311bf8c-11b0-4fb2-a5f0-dc4c9be5b35b) |