### PR TITLE
tools/upgrade: Avoid system regexps (via Bash); just use Perl

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.0"
+    version: "0.3.1"
   analyzer:
     dependency: transitive
     description:
@@ -701,10 +701,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "56dbee7418e9441a669ae47f72c0a31085a69eee5b42d2163509711a867e2b14"
+      sha256: "6245feb91dfa3693100d2e680f6c5614405b1623b555b4b3cba3cb88a3beb5c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.0"
+    version: "0.1.2-main.3"
   matcher:
     dependency: transitive
     description:
@@ -853,10 +853,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: "direct dev"
     description:
@@ -1358,5 +1358,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.5.0-236.0.dev <4.0.0"
-  flutter: ">=3.23.0-13.0.pre.189"
+  dart: ">=3.5.0-254.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre.234"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.5.0-236.0.dev <4.0.0'
-  flutter: '>=3.23.0-13.0.pre.189'
+  sdk: '>=3.5.0-254.0.dev <4.0.0'
+  flutter: '>=3.23.0-13.0.pre.234'
 
 # To update dependencies, see instructions in README.md.
 dependencies:

--- a/tools/upgrade
+++ b/tools/upgrade
@@ -146,7 +146,7 @@ deps: Update CocoaPods pods (tools/upgrade pod)
 }
 
 upgrade_flutter_local() {
-    local pattern flutter_version_output flutter_version dart_sdk_version
+    local flutter_version_output versions flutter_version dart_sdk_version
 
     check_no_uncommitted_or_untracked
 
@@ -158,19 +158,23 @@ upgrade_flutter_local() {
 
     # TODO upgrade Flutter to latest, rather than what's lying around
 
-    # Sometimes the `flutter --version` output begins with lines like
-    # "Resolving dependencies..."; so the pattern accommodates those.
-    # The pattern requires Dart 3.x, because we'll emit "<4.0.0" below.
-    pattern=$'\nFlutter (\S+) .*\sDart \S+ \(build (3\.\S+)\)'
-
     flutter_version_output=$(run_visibly flutter --version)
-    if ! [[ $'\n'"${flutter_version_output}" =~ $pattern ]]; then
+    # shellcheck disable=SC2207 # output has controlled whitespace
+    versions=( $(echo -n "${flutter_version_output}" | perl -0ne '
+      # Sometimes the `flutter --version` output begins with lines like
+      # "Resolving dependencies..."; so the pattern accommodates those.
+      # And the pattern requires Dart 3.x, because we emit "<4.0.0" below.
+      if (/^Flutter (\S+) .*\sDart \S+ \(build (3\.\S+)\)/ms) {
+        print "$1 $2";
+      }
+    ') )
+    if (( !"${#versions[@]}" )); then
         echo >&2 "error: 'flutter --version' output not recognized"
         printf >&2 "output was:\n-----\n%s\n-----" "${flutter_version_output}"
         return 1
     fi
-    flutter_version="${BASH_REMATCH[1]}"
-    dart_sdk_version="${BASH_REMATCH[2]}"
+    flutter_version="${versions[0]}"
+    dart_sdk_version="${versions[1]}"
 
     yaml_fragment="\
   sdk: '>=${dart_sdk_version} <4.0.0'

--- a/tools/upgrade
+++ b/tools/upgrade
@@ -214,7 +214,7 @@ it requires manual checking:
 
  * The update was to the Flutter version you currently
    have installed at the \`flutter\` command.
-   Check that is is the latest Flutter from main,
+   Check that that is the latest Flutter from main,
    or otherwise the version you intend to upgrade to.
 EOF
 }


### PR DESCRIPTION
This regexp didn't work on macOS, as discovered by Chris:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60tools.2Fupgrade.20flutter-local.60/near/1825388

Specifically it looks like the `\s` and `\S` patterns, which mean "whitespace character" and "not-whitespace character" respectively, don't work there.  If I write things like `[^ ]` instead, then this code works.

From `man 7 re_format` on a Mac, it seems the issue is that those features exist only in "enhanced extended REs", not in mere "extended REs".  (Bash relies for its regexps on the system regexp implementation, which is why its behavior can vary like this.)

On GNU/Linux there's no such distinction... but also the man pages (starting from `man 3 regex`) never actually say just what the regexp language is, so that's hardly better.  The closest is a "see also" to `man 1 grep`, which appears to document a regexp language but is evidently incomplete: it doesn't mention `\s` or `\S`, and empirically `grep -E` accepts both.

(... Ah of course, it's in the Info page: `info grep`.  Still, nothing I can find actually says that that's the language libc's `regcomp` and `regexec` implement.)

Anyway.  Evidently the system regexp implementations Bash relies on come with this mess of subtly different, sometimes half-documented, degrees of ancientness in the languages they accept.  In order to avoid having to care about all that, do the matching in Perl, which brings its own full-featured regexp implementation on all platforms. The cost is a bit of mess in getting the data from Bash to Perl and back; so be it.