### PR TITLE
content/msglist: Fix vertical position of horizontal scrollbar in codeblock

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -301,7 +301,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     final length = model!.items.length;
     const centerSliverKey = ValueKey('center sliver');
 
-    final sliver = SliverStickyHeaderList(
+    Widget sliver = SliverStickyHeaderList(
       headerPlacement: HeaderPlacement.scrollingStart,
       delegate: SliverChildBuilderDelegate(
         // To preserve state across rebuilds for individual [MessageItem]
@@ -336,6 +336,12 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           final data = model!.items[length - 1 - (i - 2)];
           return _buildItem(data, i);
         }));
+
+    if (widget.narrow is CombinedFeedNarrow) {
+      // TODO(#311) If we have a bottom nav, it will pad the bottom
+      //   inset, and this shouldn't be necessary
+      sliver = SliverSafeArea(sliver: sliver);
+    }
 
     return CustomScrollView(
       // TODO: Offer `ScrollViewKeyboardDismissBehavior.interactive` (or

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -300,6 +300,43 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   Widget _buildListView(BuildContext context) {
     final length = model!.items.length;
     const centerSliverKey = ValueKey('center sliver');
+
+    final sliver = SliverStickyHeaderList(
+      headerPlacement: HeaderPlacement.scrollingStart,
+      delegate: SliverChildBuilderDelegate(
+        // To preserve state across rebuilds for individual [MessageItem]
+        // widgets as the size of [MessageListView.items] changes we need
+        // to match old widgets by their key to their new position in
+        // the list.
+        //
+        // The keys are of type [ValueKey] with a value of [Message.id]
+        // and here we use a O(log n) binary search method. This could
+        // be improved but for now it only triggers for materialized
+        // widgets. As a simple test, flinging through Combined feed in
+        // CZO on a Pixel 5, this only runs about 10 times per rebuild
+        // and the timing for each call is <100 microseconds.
+        //
+        // Non-message items (e.g., start and end markers) that do not
+        // have state that needs to be preserved have not been given keys
+        // and will not trigger this callback.
+        findChildIndexCallback: (Key key) {
+          final valueKey = key as ValueKey<int>;
+          final index = model!.findItemWithMessageId(valueKey.value);
+          if (index == -1) return null;
+          return length - 1 - (index - 2);
+        },
+        childCount: length + 2,
+        (context, i) {
+          // To reinforce that the end of the feed has been reached:
+          //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680603
+          if (i == 0) return const SizedBox(height: 36);
+
+          if (i == 1) return MarkAsReadWidget(narrow: widget.narrow);
+
+          final data = model!.items[length - 1 - (i - 2)];
+          return _buildItem(data, i);
+        }));
+
     return CustomScrollView(
       // TODO: Offer `ScrollViewKeyboardDismissBehavior.interactive` (or
       //   similar) if that is ever offered:
@@ -318,41 +355,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       center: centerSliverKey,
 
       slivers: [
-        SliverStickyHeaderList(
-          headerPlacement: HeaderPlacement.scrollingStart,
-          delegate: SliverChildBuilderDelegate(
-            // To preserve state across rebuilds for individual [MessageItem]
-            // widgets as the size of [MessageListView.items] changes we need
-            // to match old widgets by their key to their new position in
-            // the list.
-            //
-            // The keys are of type [ValueKey] with a value of [Message.id]
-            // and here we use a O(log n) binary search method. This could
-            // be improved but for now it only triggers for materialized
-            // widgets. As a simple test, flinging through Combined feed in
-            // CZO on a Pixel 5, this only runs about 10 times per rebuild
-            // and the timing for each call is <100 microseconds.
-            //
-            // Non-message items (e.g., start and end markers) that do not
-            // have state that needs to be preserved have not been given keys
-            // and will not trigger this callback.
-            findChildIndexCallback: (Key key) {
-              final valueKey = key as ValueKey<int>;
-              final index = model!.findItemWithMessageId(valueKey.value);
-              if (index == -1) return null;
-              return length - 1 - (index - 2);
-            },
-            childCount: length + 2,
-            (context, i) {
-              // To reinforce that the end of the feed has been reached:
-              //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680603
-              if (i == 0) return const SizedBox(height: 36);
-
-              if (i == 1) return MarkAsReadWidget(narrow: widget.narrow);
-
-              final data = model!.items[length - 1 - (i - 2)];
-              return _buildItem(data, i);
-            })),
+        sliver,
 
         // This is a trivial placeholder that occupies no space.  Its purpose is
         // to have the key that's passed to [ScrollView.center], and so to cause

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -86,6 +86,22 @@ void main() {
     return scrollView.controller;
   }
 
+  group('presents message content appropriately', () {
+    // regression test for https://github.com/zulip/zulip-flutter/issues/736
+    testWidgets('content in "Combined feed" not asked to consume insets (including bottom)', (tester) async {
+      const fakePadding = FakeViewPadding(left: 10, top: 10, right: 10, bottom: 10);
+      tester.view.viewInsets = fakePadding;
+      tester.view.padding = fakePadding;
+
+      await setupMessageListPage(tester, narrow: const CombinedFeedNarrow(),
+        messages: [eg.streamMessage(content: ContentExample.codeBlockPlain.html)]);
+
+      final element = tester.element(find.byType(CodeBlock));
+      final padding = MediaQuery.of(element).padding;
+      check(padding).equals(EdgeInsets.zero);
+    });
+  });
+
   group('fetch older messages on scroll', () {
     int? itemCount(WidgetTester tester) =>
       tester.widget<CustomScrollView>(find.byType(CustomScrollView)).semanticChildCount;


### PR DESCRIPTION
In the issue, Greg said:

https://github.com/zulip/zulip-flutter/issues/736#issuecomment-2169118690
> Wrapping in a `SliverSafeArea` would mean that the actual list stays out of the bottom inset area, right? That doesn't seem like the desired behavior — I think it's expected that the messages scroll visibly through that bottom area.

But that's not what I'm seeing. There is a visible change: the blank space that you can scroll into view, under the messages, is now taller by the height of the bottom inset. (Before, the height was just 36px hard-coded.) But you can still scroll this blank space out of view, and when you do, the messages scroll visibly through that bottom area.

| Before | After |
| --- | --- |
| <img width="542" alt="image" src="https://github.com/zulip/zulip-flutter/assets/22248748/918be370-2e24-409b-a686-e9fccdb3e9c3"> | <img width="542" alt="image" src="https://github.com/zulip/zulip-flutter/assets/22248748/a2f60672-d765-49d6-9361-0fd33ac9dc23"> |

GIF from after:

<img width=400 src="https://github.com/zulip/zulip-flutter/assets/22248748/06205197-9abb-4c17-a6e2-08192133fceb">

Fixes: #736