### PR TITLE
lint: Enable unnecessary_statements

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,3 +23,4 @@ linter:
   rules:
     no_literal_bool_comparisons: true
     prefer_relative_imports: true
+    unnecessary_statements: true


### PR DESCRIPTION
I was just rereading a draft commit I'd written a little while ago, and realized it had the following code:

    bool updated = false;
    updated |= _handleUpdateMessageEventTimestamp(event);
    updated |= _handleUpdateMessageEventContent(event);
    updated != _handleUpdateMessageEventMove(event);
    if (!updated) return;

Do you see the bug?

.

.

.

There's two different operators there after "updated".  They differ by about three or four pixels.  Only one of them makes any sense to use in this context, as the top-level expression of an expression statement.  When I first reread the diff, I thought I was seeing a speck of dust on my monitor breaking up the last `|`.

Fortunately there is a lint rule that would catch this.  I don't know why it's not in the recommended lists from the Dart or Flutter teams; but it currently makes zero complaints in our codebase. So enable it.