### PR TITLE
Add skeleton of handling a move UpdateMessageEvent

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -611,6 +611,7 @@ class MessageEvent extends Event {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class UpdateMessageEvent extends Event {
   @override
+  @JsonKey(includeToJson: true)
   String get type => 'update_message';
 
   final int? userId; // TODO(server-5)
@@ -683,6 +684,7 @@ enum PropagateMode {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class DeleteMessageEvent extends Event {
   @override
+  @JsonKey(includeToJson: true)
   String get type => 'delete_message';
 
   final List<int> messageIds;

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -379,6 +379,7 @@ UpdateMessageEvent _$UpdateMessageEventFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$UpdateMessageEventToJson(UpdateMessageEvent instance) =>
     <String, dynamic>{
       'id': instance.id,
+      'type': instance.type,
       'user_id': instance.userId,
       'rendering_only': instance.renderingOnly,
       'message_id': instance.messageId,
@@ -428,6 +429,7 @@ DeleteMessageEvent _$DeleteMessageEventFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$DeleteMessageEventToJson(DeleteMessageEvent instance) =>
     <String, dynamic>{
       'id': instance.id,
+      'type': instance.type,
       'message_ids': instance.messageIds,
       'message_type': _$MessageTypeEnumMap[instance.messageType]!,
       'stream_id': instance.streamId,

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -467,11 +467,14 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     }
   }
 
+  /// Update data derived from the content of the given message.
+  ///
+  /// This does not notify listeners.
+  /// The caller should ensure that happens later.
   void messageContentChanged(int messageId) {
     final index = _findMessageWithId(messageId);
     if (index != -1) {
       _reparseContent(index);
-      notifyListeners();
     }
   }
 


### PR DESCRIPTION
This PR is stacked atop #751.

Main commit:

The way the Zulip server API expresses whether there was a move,
and if so what kind of move, is a bit quirky.  This change adds
logic to interpret that information into a more canonical form.

The logic here is translated from what we have in zulip-mobile:
  https://github.com/zulip/zulip-mobile/blob/e352f563e/src/api/misc.js#L26

This doesn't yet do anything to actually update our data structures,
and it's an NFC change for release builds.  The only behavior change
is new asserts that fire when the event from the server is malformed.

---

This is based on part of my draft branch for handling moved messages, #150. This covers the portion of that branch that's involved in just interpreting what an `UpdateMessageEvent` is saying about a message move, which is logic that will be needed in #171 / #750 too — so @PIG208 you'll want to rebase atop this.

The remainder of the draft branch is about actually updating `Message.topic` and `Message.streamId` to reflect a message move, and starting to update the data structures in `MessageListView` accordingly. So those changes will be needed for #150 but aren't involved in #171, and I'll leave them be for now and return to them sometime later.
