### PR TITLE
notif: Enable autoCancel flag for summary notification

### DIFF
--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -158,6 +158,10 @@ class NotificationDisplayManager {
       inboxStyle: InboxStyle(
         // TODO(#570) Show organization name, not URL
         summaryText: data.realmUri.toString()),
+      // On Android 11 and lower, if autoCancel is not specified,
+      // the summary notification may linger even after all child
+      // notifications have been opened and cleared.
+      autoCancel: true,
     );
   }
 

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -158,9 +158,11 @@ class NotificationDisplayManager {
       inboxStyle: InboxStyle(
         // TODO(#570) Show organization name, not URL
         summaryText: data.realmUri.toString()),
+
       // On Android 11 and lower, if autoCancel is not specified,
       // the summary notification may linger even after all child
       // notifications have been opened and cleared.
+      // TODO(android-12): cut this autoCancel workaround
       autoCancel: true,
     );
   }

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -150,7 +150,7 @@ void main() {
             ..isGroupSummary.equals(true)
             ..inboxStyle.which((it) => it.isNotNull()
               ..summaryText.equals(data.realmUri.toString()))
-            ..autoCancel.isNull()
+            ..autoCancel.equals(true)
             ..contentIntent.isNull()
         ]);
     }


### PR DESCRIPTION
While trying out the release build from main on a relatively older (Android 11) device, I found that it results in lingering summary notif:

| Android 14 | Android 11 |
| - | - |
| <video src="https://github.com/zulip/zulip-flutter/assets/36819268/17c44e0e-0317-47b9-b379-68817bc32e4b" /> | <video src="https://github.com/zulip/zulip-flutter/assets/36819268/0a4a0850-7630-410a-8dc8-7b8ab774c52f" /> |

Specifying `autoCancel: true` fixes this behavior on the older device.