### PR TITLE
content: Implement Pygments Monokai, for upcoming dark theme

### DIFF
--- a/assets/Pygments/AUTHORS.txt
+++ b/assets/Pygments/AUTHORS.txt
@@ -1,0 +1,283 @@
+Pygments is written and maintained by Georg Brandl <georg@python.org>.
+
+Major developers are Tim Hatch <tim@timhatch.com> and Armin Ronacher
+<armin.ronacher@active-4.com>.
+
+Other contributors, listed alphabetically, are:
+
+* Sam Aaron -- Ioke lexer
+* Jean Abou Samra -- LilyPond lexer
+* João Abecasis -- JSLT lexer
+* Ali Afshar -- image formatter
+* Thomas Aglassinger -- Easytrieve, JCL, Rexx, Transact-SQL and VBScript
+  lexers
+* Maxence Ahlouche -- PostgreSQL Explain lexer
+* Muthiah Annamalai -- Ezhil lexer
+* Nikolay Antipov -- OpenSCAD lexer
+* Kumar Appaiah -- Debian control lexer
+* Andreas Amann -- AppleScript lexer
+* Timothy Armstrong -- Dart lexer fixes
+* Jeffrey Arnold -- R/S, Rd, BUGS, Jags, and Stan lexers
+* Eiríkr Åsheim -- Uxntal lexer
+* Jeremy Ashkenas -- CoffeeScript lexer
+* José Joaquín Atria -- Praat lexer
+* Stefan Matthias Aust -- Smalltalk lexer
+* Lucas Bajolet -- Nit lexer
+* Ben Bangert -- Mako lexers
+* Max Battcher -- Darcs patch lexer
+* Thomas Baruchel -- APL lexer
+* Tim Baumann -- (Literate) Agda lexer
+* Paul Baumgart, 280 North, Inc. -- Objective-J lexer
+* Michael Bayer -- Myghty lexers
+* Thomas Beale -- Archetype lexers
+* John Benediktsson -- Factor lexer
+* David Benjamin, Google LLC -- TLS lexer
+* Trevor Bergeron -- mIRC formatter
+* Vincent Bernat -- LessCSS lexer
+* Christopher Bertels -- Fancy lexer
+* Sébastien Bigaret -- QVT Operational lexer
+* Jarrett Billingsley -- MiniD lexer
+* Adam Blinkinsop -- Haskell, Redcode lexers
+* Stéphane Blondon -- Procfile, SGF and Sieve lexers
+* Frits van Bommel -- assembler lexers
+* Pierre Bourdon -- bugfixes
+* Martijn Braam -- Kernel log lexer, BARE lexer
+* Matthias Bussonnier -- ANSI style handling for terminal-256 formatter
+* chebee7i -- Python traceback lexer improvements
+* Hiram Chirino -- Scaml and Jade lexers
+* Mauricio Caceres -- SAS and Stata lexers.
+* Michael Camilleri, John Gabriele, sogaiu -- Janet lexer
+* Ian Cooper -- VGL lexer
+* David Corbett -- Inform, Jasmin, JSGF, Snowball, and TADS 3 lexers
+* Leaf Corcoran -- MoonScript lexer
+* Gabriel Corona -- ASN.1 lexer
+* Christopher Creutzig -- MuPAD lexer
+* Daniël W. Crompton -- Pike lexer
+* Pete Curry -- bugfixes
+* Bryan Davis -- EBNF lexer
+* Bruno Deferrari -- Shen lexer
+* Walter Dörwald -- UL4 lexer
+* Luke Drummond -- Meson lexer
+* Giedrius Dubinskas -- HTML formatter improvements
+* Owen Durni -- Haxe lexer
+* Alexander Dutton, Oxford University Computing Services -- SPARQL lexer
+* James Edwards -- Terraform lexer
+* Nick Efford -- Python 3 lexer
+* Sven Efftinge -- Xtend lexer
+* Artem Egorkine -- terminal256 formatter
+* Matthew Fernandez -- CAmkES lexer
+* Paweł Fertyk -- GDScript lexer, HTML formatter improvements
+* Michael Ficarra -- CPSA lexer
+* James H. Fisher -- PostScript lexer
+* William S. Fulton -- SWIG lexer
+* Carlos Galdino -- Elixir and Elixir Console lexers
+* Michael Galloy -- IDL lexer
+* Naveen Garg -- Autohotkey lexer
+* Simon Garnotel -- FreeFem++ lexer
+* Laurent Gautier -- R/S lexer
+* Alex Gaynor -- PyPy log lexer
+* Richard Gerkin -- Igor Pro lexer
+* Alain Gilbert -- TypeScript lexer
+* Alex Gilding -- BlitzBasic lexer
+* GitHub, Inc -- DASM16, Augeas, TOML, and Slash lexers
+* Bertrand Goetzmann -- Groovy lexer
+* Krzysiek Goj -- Scala lexer
+* Rostyslav Golda -- FloScript lexer
+* Andrey Golovizin -- BibTeX lexers
+* Matt Good -- Genshi, Cheetah lexers
+* Michał Górny -- vim modeline support
+* Alex Gosse -- TrafficScript lexer
+* Patrick Gotthardt -- PHP namespaces support
+* Hubert Gruniaux -- C and C++ lexer improvements
+* Olivier Guibe -- Asymptote lexer
+* Phil Hagelberg -- Fennel lexer
+* Florian Hahn -- Boogie lexer
+* Martin Harriman -- SNOBOL lexer
+* Matthew Harrison -- SVG formatter
+* Steven Hazel -- Tcl lexer
+* Dan Michael Heggø -- Turtle lexer
+* Aslak Hellesøy -- Gherkin lexer
+* Greg Hendershott -- Racket lexer
+* Justin Hendrick -- ParaSail lexer
+* Jordi Gutiérrez Hermoso -- Octave lexer
+* David Hess, Fish Software, Inc. -- Objective-J lexer
+* Ken Hilton -- Typographic Number Theory and Arrow lexers
+* Varun Hiremath -- Debian control lexer
+* Rob Hoelz -- Perl 6 lexer
+* Doug Hogan -- Mscgen lexer
+* Ben Hollis -- Mason lexer
+* Max Horn -- GAP lexer
+* Fred Hornsey -- OMG IDL Lexer
+* Alastair Houghton -- Lexer inheritance facility
+* Tim Howard -- BlitzMax lexer
+* Dustin Howett -- Logos lexer
+* Ivan Inozemtsev -- Fantom lexer
+* Hiroaki Itoh -- Shell console rewrite, Lexers for PowerShell session,
+  MSDOS session, BC, WDiff
+* Brian R. Jackson -- Tea lexer
+* Christian Jann -- ShellSession lexer
+* Jonas Camillus Jeppesen -- Line numbers and line highlighting for 
+  RTF-formatter
+* Dennis Kaarsemaker -- sources.list lexer
+* Dmitri Kabak -- Inferno Limbo lexer
+* Igor Kalnitsky -- vhdl lexer
+* Colin Kennedy - USD lexer
+* Alexander Kit -- MaskJS lexer
+* Pekka Klärck -- Robot Framework lexer
+* Gerwin Klein -- Isabelle lexer
+* Eric Knibbe -- Lasso lexer
+* Stepan Koltsov -- Clay lexer
+* Oliver Kopp - Friendly grayscale style
+* Adam Koprowski -- Opa lexer
+* Benjamin Kowarsch -- Modula-2 lexer
+* Domen Kožar -- Nix lexer
+* Oleh Krekel -- Emacs Lisp lexer
+* Alexander Kriegisch -- Kconfig and AspectJ lexers
+* Marek Kubica -- Scheme lexer
+* Jochen Kupperschmidt -- Markdown processor
+* Gerd Kurzbach -- Modelica lexer
+* Jon Larimer, Google Inc. -- Smali lexer
+* Olov Lassus -- Dart lexer
+* Matt Layman -- TAP lexer
+* Kristian Lyngstøl -- Varnish lexers
+* Sylvestre Ledru -- Scilab lexer
+* Chee Sing Lee -- Flatline lexer
+* Mark Lee -- Vala lexer
+* Thomas Linder Puls -- Visual Prolog lexer
+* Pete Lomax -- Phix lexer
+* Valentin Lorentz -- C++ lexer improvements
+* Ben Mabey -- Gherkin lexer
+* Angus MacArthur -- QML lexer
+* Louis Mandel -- X10 lexer
+* Louis Marchand -- Eiffel lexer
+* Simone Margaritelli -- Hybris lexer
+* Tim Martin - World of Warcraft TOC lexer
+* Kirk McDonald -- D lexer
+* Gordon McGregor -- SystemVerilog lexer
+* Stephen McKamey -- Duel/JBST lexer
+* Brian McKenna -- F# lexer
+* Charles McLaughlin -- Puppet lexer
+* Kurt McKee -- Tera Term macro lexer, PostgreSQL updates, MySQL overhaul, JSON lexer
+* Joe Eli McIlvain -- Savi lexer
+* Lukas Meuser -- BBCode formatter, Lua lexer
+* Cat Miller -- Pig lexer
+* Paul Miller -- LiveScript lexer
+* Hong Minhee -- HTTP lexer
+* Michael Mior -- Awk lexer
+* Bruce Mitchener -- Dylan lexer rewrite
+* Reuben Morais -- SourcePawn lexer
+* Jon Morton -- Rust lexer
+* Paulo Moura -- Logtalk lexer
+* Mher Movsisyan -- DTD lexer
+* Dejan Muhamedagic -- Crmsh lexer
+* Adrien Nayrat -- PostgreSQL Explain lexer
+* Ana Nelson -- Ragel, ANTLR, R console lexers
+* David Neto, Google LLC -- WebGPU Shading Language lexer
+* Kurt Neufeld -- Markdown lexer
+* Nam T. Nguyen -- Monokai style
+* Jesper Noehr -- HTML formatter "anchorlinenos"
+* Mike Nolta -- Julia lexer
+* Avery Nortonsmith -- Pointless lexer
+* Jonas Obrist -- BBCode lexer
+* Edward O'Callaghan -- Cryptol lexer
+* David Oliva -- Rebol lexer
+* Pat Pannuto -- nesC lexer
+* Jon Parise -- Protocol buffers and Thrift lexers
+* Benjamin Peterson -- Test suite refactoring
+* Ronny Pfannschmidt -- BBCode lexer
+* Dominik Picheta -- Nimrod lexer
+* Andrew Pinkham -- RTF Formatter Refactoring
+* Clément Prévost -- UrbiScript lexer
+* Tanner Prynn -- cmdline -x option and loading lexers from files
+* Oleh Prypin -- Crystal lexer (based on Ruby lexer)
+* Nick Psaris -- K and Q lexers
+* Xidorn Quan -- Web IDL lexer
+* Elias Rabel -- Fortran fixed form lexer
+* raichoo -- Idris lexer
+* Daniel Ramirez -- GDScript lexer
+* Kashif Rasul -- CUDA lexer
+* Nathan Reed -- HLSL lexer
+* Justin Reidy -- MXML lexer
+* Jonathon Reinhart, Google LLC -- Soong lexer
+* Norman Richards -- JSON lexer
+* Corey Richardson -- Rust lexer updates
+* Fabrizio Riguzzi -- cplint leder
+* Lubomir Rintel -- GoodData MAQL and CL lexers
+* Andre Roberge -- Tango style
+* Georg Rollinger -- HSAIL lexer
+* Michiel Roos -- TypoScript lexer
+* Konrad Rudolph -- LaTeX formatter enhancements
+* Mario Ruggier -- Evoque lexers
+* Miikka Salminen -- Lovelace style, Hexdump lexer, lexer enhancements
+* Stou Sandalski -- NumPy, FORTRAN, tcsh and XSLT lexers
+* Matteo Sasso -- Common Lisp lexer
+* Joe Schafer -- Ada lexer
+* Max Schillinger -- TiddlyWiki5 lexer
+* Andrew Schmidt -- X++ lexer
+* Ken Schutte -- Matlab lexers
+* René Schwaiger -- Rainbow Dash style
+* Sebastian Schweizer -- Whiley lexer
+* Tassilo Schweyer -- Io, MOOCode lexers
+* Pablo Seminario -- PromQL lexer
+* Ted Shaw -- AutoIt lexer
+* Joerg Sieker -- ABAP lexer
+* Robert Simmons -- Standard ML lexer
+* Kirill Simonov -- YAML lexer
+* Corbin Simpson -- Monte lexer
+* Ville Skyttä -- ASCII armored lexer
+* Alexander Smishlajev -- Visual FoxPro lexer
+* Steve Spigarelli -- XQuery lexer
+* Jerome St-Louis -- eC lexer
+* Camil Staps -- Clean and NuSMV lexers; Solarized style
+* James Strachan -- Kotlin lexer
+* Tom Stuart -- Treetop lexer
+* Colin Sullivan -- SuperCollider lexer
+* Ben Swift -- Extempore lexer
+* tatt61880 -- Kuin lexer
+* Edoardo Tenani -- Arduino lexer
+* Tiberius Teng -- default style overhaul
+* Jeremy Thurgood -- Erlang, Squid config lexers
+* Brian Tiffin -- OpenCOBOL lexer
+* Bob Tolbert -- Hy lexer
+* Doug Torrance -- Macaulay2 lexer
+* Matthias Trute -- Forth lexer
+* Tuoa Spi T4 -- Bdd lexer
+* Erick Tryzelaar -- Felix lexer
+* Alexander Udalov -- Kotlin lexer improvements
+* Thomas Van Doren -- Chapel lexer
+* Dave Van Ee -- Uxntal lexer updates
+* Daniele Varrazzo -- PostgreSQL lexers
+* Abe Voelker -- OpenEdge ABL lexer
+* Pepijn de Vos -- HTML formatter CTags support
+* Matthias Vallentin -- Bro lexer
+* Benoît Vinot -- AMPL lexer
+* Linh Vu Hong -- RSL lexer
+* Immanuel Washington -- Smithy lexer
+* Nathan Weizenbaum -- Haml and Sass lexers
+* Nathan Whetsell -- Csound lexers
+* Dietmar Winkler -- Modelica lexer
+* Nils Winter -- Smalltalk lexer
+* Davy Wybiral -- Clojure lexer
+* Whitney Young -- ObjectiveC lexer
+* Diego Zamboni -- CFengine3 lexer
+* Enrique Zamudio -- Ceylon lexer
+* Alex Zimin -- Nemerle lexer
+* Rob Zimmerman -- Kal lexer
+* Vincent Zurczak -- Roboconf lexer
+* Hubert Gruniaux -- C and C++ lexer improvements
+* Thomas Symalla -- AMDGPU Lexer
+* 15b3 -- Image Formatter improvements
+* Fabian Neumann -- CDDL lexer
+* Thomas Duboucher -- CDDL lexer
+* Philipp Imhof -- Pango Markup formatter
+* Thomas Voss -- Sed lexer
+* Martin Fischer -- WCAG contrast testing
+* Marc Auberer -- Spice lexer
+* Amr Hesham -- Carbon lexer
+* diskdance -- Wikitext lexer
+* vanillajonathan -- PRQL lexer
+* Nikolay Antipov -- OpenSCAD lexer
+* Markus Meyer, Nextron Systems -- YARA lexer
+* Hannes Römer -- Mojo lexer
+
+Many thanks for all contributions!

--- a/assets/Pygments/LICENSE.txt
+++ b/assets/Pygments/LICENSE.txt
@@ -1,0 +1,25 @@
+Copyright (c) 2006-2022 by the respective authors (see AUTHORS file).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/licenses.dart
+++ b/lib/licenses.dart
@@ -16,6 +16,16 @@ Stream<LicenseEntry> additionalLicenses() async* {
     ['Noto Color Emoji'],
     await rootBundle.loadString('assets/Noto_Color_Emoji/LICENSE'));
   yield LicenseEntryWithLineBreaks(
+    ['Pygments'],
+    await () async {
+      final [licenseFileText, authorsFileText] = await Future.wait([
+        rootBundle.loadString('assets/Pygments/LICENSE.txt'),
+        rootBundle.loadString('assets/Pygments/AUTHORS.txt'),
+      ]);
+
+      return '$licenseFileText\n\nAUTHORS file follows:\n\n$authorsFileText';
+    }());
+  yield LicenseEntryWithLineBreaks(
     ['Source Code Pro'],
     await rootBundle.loadString('assets/Source_Code_Pro/LICENSE.md'));
   yield LicenseEntryWithLineBreaks(

--- a/lib/licenses.dart
+++ b/lib/licenses.dart
@@ -10,13 +10,17 @@ import 'package:flutter/services.dart';
 // remember to include the file in the asset bundle by listing its path
 // under `assets` in pubspec.yaml.
 Stream<LicenseEntry> additionalLicenses() async* {
+  // Alphabetic by path.
+
+  yield LicenseEntryWithLineBreaks(
+    ['Noto Color Emoji'],
+    await rootBundle.loadString('assets/Noto_Color_Emoji/LICENSE'));
   yield LicenseEntryWithLineBreaks(
     ['Source Code Pro'],
     await rootBundle.loadString('assets/Source_Code_Pro/LICENSE.md'));
   yield LicenseEntryWithLineBreaks(
     ['Source Sans 3'],
     await rootBundle.loadString('assets/Source_Sans_3/LICENSE.md'));
-  yield LicenseEntryWithLineBreaks(
-    ['Noto Color Emoji'],
-    await rootBundle.loadString('assets/Noto_Color_Emoji/LICENSE'));
+
+  // Alphabetic by path.
 }

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -9,7 +9,7 @@ import 'text.dart';
 /// Use [forSpan] for syntax highlighting.
 // TODO(#749) follow web for dark-theme colors
 class CodeBlockTextStyles {
-  factory CodeBlockTextStyles(BuildContext context) {
+  factory CodeBlockTextStyles.light(BuildContext context) {
     final bold = weightVariableTextStyle(context, wght: 700);
     return CodeBlockTextStyles._(
       plain: kMonospaceTextStyle

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -7,7 +7,6 @@ import 'text.dart';
 /// [TextStyle]s used to render code blocks.
 ///
 /// Use [forSpan] for syntax highlighting.
-// TODO(#749) follow web for dark-theme colors
 class CodeBlockTextStyles {
   // TODO(#754) update these styles
   factory CodeBlockTextStyles.light(BuildContext context) {
@@ -242,6 +241,260 @@ class CodeBlockTextStyles {
 
       // .il { color: hsl(0deg 0% 40%); }
       il: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor())
+    );
+  }
+
+  // Pygments Monokai, following web in web/styles/pygments.css.
+  // The CSS in comments is quoted from that file.
+  // The styles ultimately come from here:
+  //   https://github.com/pygments/pygments/blob/f64833d9d/pygments/styles/monokai.py
+  factory CodeBlockTextStyles.dark(BuildContext context) {
+    final bold = weightVariableTextStyle(context, wght: 700);
+    return CodeBlockTextStyles._(
+      plain: kMonospaceTextStyle
+        .merge(TextStyle(
+          // --color-markdown-code-text in web
+          color: const HSLColor.fromAHSL(0.85, 0, 0, 1).toColor(),
+          fontSize: 0.825 * kBaseFontSize,
+          height: 1.4))
+        .merge(weightVariableTextStyle(context)),
+
+      // .hll { background-color: #49483e; }
+      hll: const TextStyle(backgroundColor: Color(0xff49483e)),
+
+      // .c { color: #959077; }
+      c: const TextStyle(color: Color(0xff959077)),
+
+      // .err { color: #ed007e; background-color: #1e0010; }
+      err: const TextStyle(color: Color(0xffed007e), backgroundColor: Color(0xff1e0010)),
+
+      // .esc { color: #f8f8f2; }
+      esc: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .g { color: #f8f8f2; }
+      g: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .k { color: #66d9ef; }
+      k: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .l { color: #ae81ff; }
+      l: const TextStyle(color: Color(0xffae81ff)),
+
+      // .n { color: #f8f8f2; }
+      n: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .o { color: #ff4689; }
+      o: const TextStyle(color: Color(0xffff4689)),
+
+      // .x { color: #f8f8f2; }
+      x: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .p { color: #f8f8f2; }
+      p: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .ch { color: #959077; }
+      ch: const TextStyle(color: Color(0xff959077)),
+
+      // .cm { color: #959077; }
+      cm: const TextStyle(color: Color(0xff959077)),
+
+      // .cp { color: #959077; }
+      cp: const TextStyle(color: Color(0xff959077)),
+
+      // .cpf { color: #959077; }
+      cpf: const TextStyle(color: Color(0xff959077)),
+
+      // .c1 { color: #959077; }
+      c1: const TextStyle(color: Color(0xff959077)),
+
+      // .cs { color: #959077; }
+      cs: const TextStyle(color: Color(0xff959077)),
+
+      // .gd { color: #ff4689; }
+      gd: const TextStyle(color: Color(0xffff4689)),
+
+      // .ge { color: #f8f8f2; font-style: italic; }
+      ge: const TextStyle(color: Color(0xfff8f8f2), fontStyle: FontStyle.italic),
+
+      // .ges { color: #f8f8f2; font-weight: bold; font-style: italic; }
+      ges: const TextStyle(color: Color(0xfff8f8f2), fontStyle: FontStyle.italic).merge(bold),
+
+      // .gr { color: #f8f8f2; }
+      gr: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .gh { color: #f8f8f2; }
+      gh: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .gi { color: #a6e22e; }
+      gi: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .go { color: #66d9ef; }
+      go: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .gp { color: #ff4689; font-weight: bold; }
+      gp: const TextStyle(color: Color(0xffff4689)).merge(bold),
+
+      // .gs { color: #f8f8f2; font-weight: bold; }
+      gs: const TextStyle(color: Color(0xfff8f8f2)).merge(bold),
+
+      // .gu { color: #959077; }
+      gu: const TextStyle(color: Color(0xff959077)),
+
+      // .gt { color: #f8f8f2; }
+      gt: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .kc { color: #66d9ef; }
+      kc: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .kd { color: #66d9ef; }
+      kd: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .kn { color: #ff4689; }
+      kn: const TextStyle(color: Color(0xffff4689)),
+
+      // .kp { color: #66d9ef; }
+      kp: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .kr { color: #66d9ef; }
+      kr: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .kt { color: #66d9ef; }
+      kt: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .ld { color: #e6db74; }
+      ld: const TextStyle(color: Color(0xffe6db74)),
+
+      // .m { color: #ae81ff; }
+      m: const TextStyle(color: Color(0xffae81ff)),
+
+      // .s { color: #e6db74; }
+      s: const TextStyle(color: Color(0xffe6db74)),
+
+      // .na { color: #a6e22e; }
+      na: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .nb { color: #f8f8f2; }
+      nb: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .nc { color: #a6e22e; }
+      nc: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .no { color: #66d9ef; }
+      no: const TextStyle(color: Color(0xff66d9ef)),
+
+      // .nd { color: #a6e22e; }
+      nd: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .ni { color: #f8f8f2; }
+      ni: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .ne { color: #a6e22e; }
+      ne: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .nf { color: #a6e22e; }
+      nf: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .nl { color: #f8f8f2; }
+      nl: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .nn { color: #f8f8f2; }
+      nn: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .nx { color: #a6e22e; }
+      nx: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .py { color: #f8f8f2; }
+      py: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .nt { color: #ff4689; }
+      nt: const TextStyle(color: Color(0xffff4689)),
+
+      // .nv { color: #f8f8f2; }
+      nv: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .ow { color: #ff4689; }
+      ow: const TextStyle(color: Color(0xffff4689)),
+
+      // .pm { color: #f8f8f2; }
+      pm: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .w { color: #f8f8f2; }
+      w: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .mb { color: #ae81ff; }
+      mb: const TextStyle(color: Color(0xffae81ff)),
+
+      // .mf { color: #ae81ff; }
+      mf: const TextStyle(color: Color(0xffae81ff)),
+
+      // .mh { color: #ae81ff; }
+      mh: const TextStyle(color: Color(0xffae81ff)),
+
+      // .mi { color: #ae81ff; }
+      mi: const TextStyle(color: Color(0xffae81ff)),
+
+      // .mo { color: #ae81ff; }
+      mo: const TextStyle(color: Color(0xffae81ff)),
+
+      // .sa { color: #e6db74; }
+      sa: const TextStyle(color: Color(0xffe6db74)),
+
+      // .sb { color: #e6db74; }
+      sb: const TextStyle(color: Color(0xffe6db74)),
+
+      // .sc { color: #e6db74; }
+      sc: const TextStyle(color: Color(0xffe6db74)),
+
+      // .dl { color: #e6db74; }
+      dl: const TextStyle(color: Color(0xffe6db74)),
+
+      // .sd { color: #e6db74; }
+      sd: const TextStyle(color: Color(0xffe6db74)),
+
+      // .s2 { color: #e6db74; }
+      s2: const TextStyle(color: Color(0xffe6db74)),
+
+      // .se { color: #ae81ff; }
+      se: const TextStyle(color: Color(0xffae81ff)),
+
+      // .sh { color: #e6db74; }
+      sh: const TextStyle(color: Color(0xffe6db74)),
+
+      // .si { color: #e6db74; }
+      si: const TextStyle(color: Color(0xffe6db74)),
+
+      // .sx { color: #e6db74; }
+      sx: const TextStyle(color: Color(0xffe6db74)),
+
+      // .sr { color: #e6db74; }
+      sr: const TextStyle(color: Color(0xffe6db74)),
+
+      // .s1 { color: #e6db74; }
+      s1: const TextStyle(color: Color(0xffe6db74)),
+
+      // .ss { color: #e6db74; }
+      ss: const TextStyle(color: Color(0xffe6db74)),
+
+      // .bp { color: #f8f8f2; }
+      bp: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .fm { color: #a6e22e; }
+      fm: const TextStyle(color: Color(0xffa6e22e)),
+
+      // .vc { color: #f8f8f2; }
+      vc: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .vg { color: #f8f8f2; }
+      vg: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .vi { color: #f8f8f2; }
+      vi: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .vm { color: #f8f8f2; }
+      vm: const TextStyle(color: Color(0xfff8f8f2)),
+
+      // .il { color: #ae81ff; }
+      il: const TextStyle(color: Color(0xffae81ff)),
     );
   }
 

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -14,6 +14,7 @@ class CodeBlockTextStyles {
     return CodeBlockTextStyles._(
       plain: kMonospaceTextStyle
         .merge(const TextStyle(
+          color: Colors.black, // --color-markdown-code-text in web
           fontSize: 0.825 * kBaseFontSize,
           height: 1.4))
         .merge(weightVariableTextStyle(context)),

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -9,6 +9,7 @@ import 'text.dart';
 /// Use [forSpan] for syntax highlighting.
 // TODO(#749) follow web for dark-theme colors
 class CodeBlockTextStyles {
+  // TODO(#754) update these styles
   factory CodeBlockTextStyles.light(BuildContext context) {
     final bold = weightVariableTextStyle(context, wght: 700);
     return CodeBlockTextStyles._(
@@ -31,17 +32,33 @@ class CodeBlockTextStyles {
       // .err { border: 1px solid hsl(0deg 100% 50%); }
       err: const TextStyle(backgroundColor: Color(0xffe2706e)),
 
+      esc: null,
+
+      g: null,
+
       // .k { color: hsl(332deg 70% 38%); }
       k: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.7, 0.38).toColor()),
 
+      l: null,
+
+      n: null,
+
       // .o { color: hsl(332deg 70% 38%); }
       o: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.7, 0.38).toColor()),
+
+      x: null,
+
+      p: null,
+
+      ch: null,
 
       // .cm { color: hsl(180deg 33% 37%); font-style: italic; }
       cm: TextStyle(color: const HSLColor.fromAHSL(1, 180, 0.33, 0.37).toColor(), fontStyle: FontStyle.italic),
 
       // .cp { color: hsl(38deg 100% 36%); }
       cp: TextStyle(color: const HSLColor.fromAHSL(1, 38, 1, 0.36).toColor()),
+
+      cpf: null,
 
       // .c1 { color: hsl(0deg 0% 67%); font-style: italic; }
       c1: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.67).toColor(), fontStyle: FontStyle.italic),
@@ -54,6 +71,8 @@ class CodeBlockTextStyles {
 
       // .ge { font-style: italic; }
       ge: const TextStyle(fontStyle: FontStyle.italic),
+
+      ges: null,
 
       // .gr { color: hsl(0deg 100% 50%); }
       gr: TextStyle(color: const HSLColor.fromAHSL(1, 0, 1, 0.50).toColor()),
@@ -96,6 +115,8 @@ class CodeBlockTextStyles {
 
       // .kt { color: hsl(332deg 70% 38%); }
       kt: TextStyle(color: const HSLColor.fromAHSL(1, 332, 0.70, 0.38).toColor()),
+
+      ld: null,
 
       // .m { color: hsl(0deg 0% 40%); }
       m: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor()),
@@ -142,11 +163,17 @@ class CodeBlockTextStyles {
       // .nx { color: hsl(0deg 0% 26%); }
       nx: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.26).toColor()),
 
+      py: null,
+
       // .ow { color: hsl(276deg 100% 56%); font-weight: bold; }
       ow: TextStyle(color: const HSLColor.fromAHSL(1, 276, 1, 0.56).toColor()).merge(bold),
 
+      pm: null,
+
       // .w { color: hsl(0deg 0% 73%); }
       w: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.73).toColor()),
+
+      mb: null,
 
       // .mf { color: hsl(195deg 100% 35%); }
       mf: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
@@ -160,11 +187,15 @@ class CodeBlockTextStyles {
       // .mo { color: hsl(195deg 100% 35%); }
       mo: TextStyle(color: const HSLColor.fromAHSL(1, 195, 1, 0.35).toColor()),
 
+      sa: null,
+
       // .sb { color: hsl(86deg 57% 40%); }
       sb: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
 
       // .sc { color: hsl(86deg 57% 40%); }
       sc: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor()),
+
+      dl: null,
 
       // .sd { color: hsl(86deg 57% 40%); font-style: italic; }
       sd: TextStyle(color: const HSLColor.fromAHSL(1, 86, 0.57, 0.40).toColor(), fontStyle: FontStyle.italic),
@@ -196,6 +227,8 @@ class CodeBlockTextStyles {
       // .bp { color: hsl(120deg 100% 25%); }
       bp: TextStyle(color: const HSLColor.fromAHSL(1, 120, 1, 0.25).toColor()),
 
+      fm: null,
+
       // .vc { color: hsl(241deg 68% 28%); }
       vc: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
 
@@ -204,6 +237,8 @@ class CodeBlockTextStyles {
 
       // .vi { color: hsl(241deg 68% 28%); }
       vi: TextStyle(color: const HSLColor.fromAHSL(1, 241, 0.68, 0.28).toColor()),
+
+      vm: null,
 
       // .il { color: hsl(0deg 0% 40%); }
       il: TextStyle(color: const HSLColor.fromAHSL(1, 0, 0, 0.40).toColor())
@@ -215,14 +250,23 @@ class CodeBlockTextStyles {
     required TextStyle hll,
     required TextStyle c,
     required TextStyle err,
+    required TextStyle? esc,
+    required TextStyle? g,
     required TextStyle k,
+    required TextStyle? l,
+    required TextStyle? n,
     required TextStyle o,
+    required TextStyle? x,
+    required TextStyle? p,
+    required TextStyle? ch,
     required TextStyle cm,
     required TextStyle cp,
+    required TextStyle? cpf,
     required TextStyle c1,
     required TextStyle cs,
     required TextStyle gd,
     required TextStyle ge,
+    required TextStyle? ges,
     required TextStyle gr,
     required TextStyle gh,
     required TextStyle gi,
@@ -237,6 +281,7 @@ class CodeBlockTextStyles {
     required TextStyle kp,
     required TextStyle kr,
     required TextStyle kt,
+    required TextStyle? ld,
     required TextStyle m,
     required TextStyle s,
     required TextStyle na,
@@ -252,14 +297,19 @@ class CodeBlockTextStyles {
     required TextStyle nt,
     required TextStyle nv,
     required TextStyle nx,
+    required TextStyle? py,
     required TextStyle ow,
+    required TextStyle? pm,
     required TextStyle w,
+    required TextStyle? mb,
     required TextStyle mf,
     required TextStyle mh,
     required TextStyle mi,
     required TextStyle mo,
+    required TextStyle? sa,
     required TextStyle sb,
     required TextStyle sc,
+    required TextStyle? dl,
     required TextStyle sd,
     required TextStyle s2,
     required TextStyle se,
@@ -270,22 +320,33 @@ class CodeBlockTextStyles {
     required TextStyle s1,
     required TextStyle ss,
     required TextStyle bp,
+    required TextStyle? fm,
     required TextStyle vc,
     required TextStyle vg,
     required TextStyle vi,
+    required TextStyle? vm,
     required TextStyle il,
   }) :
     _hll = hll,
     _c = c,
     _err = err,
+    _esc = esc,
+    _g = g,
     _k = k,
+    _l = l,
+    _n = n,
     _o = o,
+    _x = x,
+    _p = p,
+    _ch = ch,
     _cm = cm,
     _cp = cp,
+    _cpf = cpf,
     _c1 = c1,
     _cs = cs,
     _gd = gd,
     _ge = ge,
+    _ges = ges,
     _gr = gr,
     _gh = gh,
     _gi = gi,
@@ -300,6 +361,7 @@ class CodeBlockTextStyles {
     _kp = kp,
     _kr = kr,
     _kt = kt,
+    _ld = ld,
     _m = m,
     _s = s,
     _na = na,
@@ -315,14 +377,19 @@ class CodeBlockTextStyles {
     _nt = nt,
     _nv = nv,
     _nx = nx,
+    _py = py,
     _ow = ow,
+    _pm = pm,
     _w = w,
+    _mb = mb,
     _mf = mf,
     _mh = mh,
     _mi = mi,
     _mo = mo,
+    _sa = sa,
     _sb = sb,
     _sc = sc,
+    _dl = dl,
     _sd = sd,
     _s2 = s2,
     _se = se,
@@ -333,9 +400,11 @@ class CodeBlockTextStyles {
     _s1 = s1,
     _ss = ss,
     _bp = bp,
+    _fm = fm,
     _vc = vc,
     _vg = vg,
     _vi = vi,
+    _vm = vm,
     _il = il;
 
   /// The baseline style that the [forSpan] styles get applied on top of.
@@ -344,14 +413,23 @@ class CodeBlockTextStyles {
   final TextStyle _hll;
   final TextStyle _c;
   final TextStyle _err;
+  final TextStyle? _esc;
+  final TextStyle? _g;
   final TextStyle _k;
+  final TextStyle? _l;
+  final TextStyle? _n;
   final TextStyle _o;
+  final TextStyle? _x;
+  final TextStyle? _p;
+  final TextStyle? _ch;
   final TextStyle _cm;
   final TextStyle _cp;
+  final TextStyle? _cpf;
   final TextStyle _c1;
   final TextStyle _cs;
   final TextStyle _gd;
   final TextStyle _ge;
+  final TextStyle? _ges;
   final TextStyle _gr;
   final TextStyle _gh;
   final TextStyle _gi;
@@ -366,6 +444,7 @@ class CodeBlockTextStyles {
   final TextStyle _kp;
   final TextStyle _kr;
   final TextStyle _kt;
+  final TextStyle? _ld;
   final TextStyle _m;
   final TextStyle _s;
   final TextStyle _na;
@@ -381,14 +460,19 @@ class CodeBlockTextStyles {
   final TextStyle _nt;
   final TextStyle _nv;
   final TextStyle _nx;
+  final TextStyle? _py;
   final TextStyle _ow;
+  final TextStyle? _pm;
   final TextStyle _w;
+  final TextStyle? _mb;
   final TextStyle _mf;
   final TextStyle _mh;
   final TextStyle _mi;
   final TextStyle _mo;
+  final TextStyle? _sa;
   final TextStyle _sb;
   final TextStyle _sc;
+  final TextStyle? _dl;
   final TextStyle _sd;
   final TextStyle _s2;
   final TextStyle _se;
@@ -399,9 +483,11 @@ class CodeBlockTextStyles {
   final TextStyle _s1;
   final TextStyle _ss;
   final TextStyle _bp;
+  final TextStyle? _fm;
   final TextStyle _vc;
   final TextStyle _vg;
   final TextStyle _vi;
+  final TextStyle? _vm;
   final TextStyle _il;
 
   /// The [TextStyle] for a [CodeBlockSpanType], if there is one.
@@ -415,14 +501,23 @@ class CodeBlockTextStyles {
       CodeBlockSpanType.highlightedLines => _hll,
       CodeBlockSpanType.comment => _c,
       CodeBlockSpanType.error => _err,
+      CodeBlockSpanType.escape => _esc,
+      CodeBlockSpanType.generic => _g,
       CodeBlockSpanType.keyword => _k,
+      CodeBlockSpanType.literal => _l,
+      CodeBlockSpanType.name => _n,
       CodeBlockSpanType.operator => _o,
+      CodeBlockSpanType.other => _x,
+      CodeBlockSpanType.punctuation => _p,
+      CodeBlockSpanType.commentHashbang => _ch,
       CodeBlockSpanType.commentMultiline => _cm,
       CodeBlockSpanType.commentPreproc => _cp,
+      CodeBlockSpanType.commentPreprocFile => _cpf,
       CodeBlockSpanType.commentSingle => _c1,
       CodeBlockSpanType.commentSpecial => _cs,
       CodeBlockSpanType.genericDeleted => _gd,
       CodeBlockSpanType.genericEmph => _ge,
+      CodeBlockSpanType.genericEmphStrong => _ges,
       CodeBlockSpanType.genericError => _gr,
       CodeBlockSpanType.genericHeading => _gh,
       CodeBlockSpanType.genericInserted => _gi,
@@ -437,6 +532,7 @@ class CodeBlockTextStyles {
       CodeBlockSpanType.keywordPseudo => _kp,
       CodeBlockSpanType.keywordReserved => _kr,
       CodeBlockSpanType.keywordType => _kt,
+      CodeBlockSpanType.literalDate => _ld,
       CodeBlockSpanType.number => _m,
       CodeBlockSpanType.string => _s,
       CodeBlockSpanType.nameAttribute => _na,
@@ -452,14 +548,19 @@ class CodeBlockTextStyles {
       CodeBlockSpanType.nameTag => _nt,
       CodeBlockSpanType.nameVariable => _nv,
       CodeBlockSpanType.nameOther => _nx,
+      CodeBlockSpanType.nameProperty => _py,
       CodeBlockSpanType.operatorWord => _ow,
+      CodeBlockSpanType.punctuationMarker => _pm,
       CodeBlockSpanType.whitespace => _w,
+      CodeBlockSpanType.numberBin => _mb,
       CodeBlockSpanType.numberFloat => _mf,
       CodeBlockSpanType.numberHex => _mh,
       CodeBlockSpanType.numberInteger => _mi,
       CodeBlockSpanType.numberOct => _mo,
+      CodeBlockSpanType.stringAffix => _sa,
       CodeBlockSpanType.stringBacktick => _sb,
       CodeBlockSpanType.stringChar => _sc,
+      CodeBlockSpanType.stringDelimiter => _dl,
       CodeBlockSpanType.stringDoc => _sd,
       CodeBlockSpanType.stringDouble => _s2,
       CodeBlockSpanType.stringEscape => _se,
@@ -470,11 +571,13 @@ class CodeBlockTextStyles {
       CodeBlockSpanType.stringSingle => _s1,
       CodeBlockSpanType.stringSymbol => _ss,
       CodeBlockSpanType.nameBuiltinPseudo => _bp,
+      CodeBlockSpanType.nameFunctionMagic => _fm,
       CodeBlockSpanType.nameVariableClass => _vc,
       CodeBlockSpanType.nameVariableGlobal => _vg,
       CodeBlockSpanType.nameVariableInstance => _vi,
+      CodeBlockSpanType.nameVariableMagic => _vm,
       CodeBlockSpanType.numberIntegerLong => _il,
-      _ => null, // not every token is styled
+      CodeBlockSpanType.unknown => null,
     };
   }
 
@@ -486,14 +589,23 @@ class CodeBlockTextStyles {
       hll: TextStyle.lerp(a._hll, b._hll, t)!,
       c: TextStyle.lerp(a._c, b._c, t)!,
       err: TextStyle.lerp(a._err, b._err, t)!,
+      esc: TextStyle.lerp(a._esc, b._esc, t)!,
+      g: TextStyle.lerp(a._g, b._g, t)!,
       k: TextStyle.lerp(a._k, b._k, t)!,
+      l: TextStyle.lerp(a._l, b._l, t)!,
+      n: TextStyle.lerp(a._n, b._n, t)!,
       o: TextStyle.lerp(a._o, b._o, t)!,
+      x: TextStyle.lerp(a._x, b._x, t)!,
+      p: TextStyle.lerp(a._p, b._p, t)!,
+      ch: TextStyle.lerp(a._ch, b._ch, t)!,
       cm: TextStyle.lerp(a._cm, b._cm, t)!,
       cp: TextStyle.lerp(a._cp, b._cp, t)!,
+      cpf: TextStyle.lerp(a._cpf, b._cpf, t)!,
       c1: TextStyle.lerp(a._c1, b._c1, t)!,
       cs: TextStyle.lerp(a._cs, b._cs, t)!,
       gd: TextStyle.lerp(a._gd, b._gd, t)!,
       ge: TextStyle.lerp(a._ge, b._ge, t)!,
+      ges: TextStyle.lerp(a._ges, b._ges, t)!,
       gr: TextStyle.lerp(a._gr, b._gr, t)!,
       gh: TextStyle.lerp(a._gh, b._gh, t)!,
       gi: TextStyle.lerp(a._gi, b._gi, t)!,
@@ -508,6 +620,7 @@ class CodeBlockTextStyles {
       kp: TextStyle.lerp(a._kp, b._kp, t)!,
       kr: TextStyle.lerp(a._kr, b._kr, t)!,
       kt: TextStyle.lerp(a._kt, b._kt, t)!,
+      ld: TextStyle.lerp(a._ld, b._ld, t)!,
       m: TextStyle.lerp(a._m, b._m, t)!,
       s: TextStyle.lerp(a._s, b._s, t)!,
       na: TextStyle.lerp(a._na, b._na, t)!,
@@ -523,14 +636,19 @@ class CodeBlockTextStyles {
       nt: TextStyle.lerp(a._nt, b._nt, t)!,
       nv: TextStyle.lerp(a._nv, b._nv, t)!,
       nx: TextStyle.lerp(a._nx, b._nx, t)!,
+      py: TextStyle.lerp(a._py, b._py, t)!,
       ow: TextStyle.lerp(a._ow, b._ow, t)!,
+      pm: TextStyle.lerp(a._pm, b._pm, t)!,
       w: TextStyle.lerp(a._w, b._w, t)!,
+      mb: TextStyle.lerp(a._mb, b._mb, t)!,
       mf: TextStyle.lerp(a._mf, b._mf, t)!,
       mh: TextStyle.lerp(a._mh, b._mh, t)!,
       mi: TextStyle.lerp(a._mi, b._mi, t)!,
       mo: TextStyle.lerp(a._mo, b._mo, t)!,
+      sa: TextStyle.lerp(a._sa, b._sa, t)!,
       sb: TextStyle.lerp(a._sb, b._sb, t)!,
       sc: TextStyle.lerp(a._sc, b._sc, t)!,
+      dl: TextStyle.lerp(a._dl, b._dl, t)!,
       sd: TextStyle.lerp(a._sd, b._sd, t)!,
       s2: TextStyle.lerp(a._s2, b._s2, t)!,
       se: TextStyle.lerp(a._se, b._se, t)!,
@@ -541,9 +659,11 @@ class CodeBlockTextStyles {
       s1: TextStyle.lerp(a._s1, b._s1, t)!,
       ss: TextStyle.lerp(a._ss, b._ss, t)!,
       bp: TextStyle.lerp(a._bp, b._bp, t)!,
+      fm: TextStyle.lerp(a._fm, b._fm, t)!,
       vc: TextStyle.lerp(a._vc, b._vc, t)!,
       vg: TextStyle.lerp(a._vg, b._vg, t)!,
       vi: TextStyle.lerp(a._vi, b._vi, t)!,
+      vm: TextStyle.lerp(a._vm, b._vm, t)!,
       il: TextStyle.lerp(a._il, b._il, t)!,
     );
   }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -48,7 +48,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     )
       .merge(weightVariableTextStyle(context))
       .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
-    codeBlockTextStyles = CodeBlockTextStyles(context),
+    codeBlockTextStyles = CodeBlockTextStyles.light(context),
     textStyleError = const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
       .merge(weightVariableTextStyle(context, wght: 700)),
     textStyleErrorCode = kMonospaceTextStyle

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -95,6 +95,8 @@ flutter:
 
   assets:
     - assets/Noto_Color_Emoji/LICENSE
+    - assets/Pygments/AUTHORS.txt
+    - assets/Pygments/LICENSE.txt
     - assets/Source_Code_Pro/LICENSE.md
     - assets/Source_Sans_3/LICENSE.md
 


### PR DESCRIPTION
For dark theme, web currently uses a mix of Pygments Monokai and Pygments Default. Mixing in Pygments Default seems accidental, so here we just use pure Pygments Monokai. [Discussion](https://chat.zulip.org/#narrow/stream/431-redesign-project/topic/code.20span.20colors/near/1832283).

I've included screenshots, below, of just Pygments Monokai, and of Pygments Monokai with web's adjustments. (Except for the adjustment of putting a border around `err` text; that's hard in Flutter.)

Compare with Pygments's own demonstration of Pygments Monokai here: https://pygments.org/styles/

(To make these screenshots, I plugged in dark-theme colors for the code-block background and message background. So just focus on the code blocks and disregard the jarring appearance of light-theme-styled elements elsewhere. When we implement dark theme #95, we'll do it coherently.)

| This PR (pure Pygments Monokai) | Following web (having some Pygments Default mixed in) |
| --- | --- |
| ![8F5F5901-6293-4CF6-9A16-13516A8C2813](https://github.com/zulip/zulip-flutter/assets/22248748/99cbacae-e37c-42ec-a2fe-76589b751654) | ![D497DCF5-8115-469B-BBCF-C6827DF33DEE](https://github.com/zulip/zulip-flutter/assets/22248748/9c690dd3-e705-4b24-9679-04a84457c4df) |

Fixes: #749