### PR TITLE
ui: Distinguish bot users in more places

### DIFF
--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -7,6 +7,7 @@ import '../api/model/model.dart';
 import '../model/content.dart';
 import '../model/narrow.dart';
 import 'content.dart';
+import 'icons.dart';
 import 'message_list.dart';
 import 'page.dart';
 import 'store.dart';
@@ -46,10 +47,23 @@ class ProfilePage extends StatelessWidget {
       Center(
         child: Avatar(userId: userId, size: 200, borderRadius: 200 / 8)),
       const SizedBox(height: 16),
-      Text(user.fullName,
-        textAlign: TextAlign.center,
-        style: _TextStyles.primaryFieldText
-          .merge(weightVariableTextStyle(context, wght: 700))),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (user.isBot) ...[
+            const Icon(
+              ZulipIcons.bot,
+              size: 22,
+              color: Color.fromARGB(255, 159, 173, 173),
+            ),
+            const SizedBox(width: 10),
+          ],
+          Flexible(child: Text(user.fullName,
+            textAlign: TextAlign.center,
+            style: _TextStyles.primaryFieldText
+              .merge(weightVariableTextStyle(context, wght: 700)))),
+        ],
+      ),
       // TODO(#291) render email field
       Text(roleToLabel(user.role, zulipLocalizations),
         textAlign: TextAlign.center,

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -139,7 +139,8 @@ void main() {
         // TODO(#232): syntax like `check(find(…), findsOneWidget)`
         final widget = tester.widget(find.descendant(
           of: find.byType(RecentDmConversationsItem),
-          matching: find.text(expectedText),
+          matching: find.byWidgetPredicate((widget) => widget is Text
+            && (widget.textSpan?.toPlainText(includePlaceholders: false) ?? '') == expectedText),
         ));
         if (expectedLines != null) {
           final renderObject = tester.renderObject<RenderParagraph>(find.byWidget(widget));


### PR DESCRIPTION
Now that #605 is merged already, bot icons are shown with the name of bot users in `MessageListPage`. Additional places where users appear are covered in this PR:

- `ProfilePage`
- `RecentDmConversationsPage`

### ProfilePage
<table>
    <tr>
        <td><b>Before</b></td>
        <td><b>After</b></td>
        <td><b>After (with long name)</b></td>
    </tr>
    <tr>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/f5829994-d96e-4c49-bcc4-6209cd6865c2" width="300"/></td>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/a8af9502-3009-4552-9b9a-7862290877bd" width="300"/></td>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/e7df0572-5ee9-4814-8ede-d94670011e0f" width="300"/></td>
    </tr>
</table>

### RecentDmConversationsPage
<table>
    <tr>
        <td><b>Before</b></td>
        <td><b>After</b></td>
        <td><b>After (with long name)</b></td>
    </tr>
    <tr>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/fb69bebc-3489-4716-945c-b615b5b09978" width="300"/></td>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/e66b20f5-32ef-44ce-8f1b-39f179181a59" width="300"/></td>
        <td><img src="https://github.com/zulip/zulip-flutter/assets/59946442/fd220702-ee7b-4674-b2e7-b8c9664e2d3a" width="300"/></td>
    </tr>
</table>


~**Note:** In `RecentDmConversationsPage` I wasn't sure whether to add (and where to add) the bot icon to a group dm where there may be one or multiple bot recipients.~

Fixes: #636