### PR TITLE
message: Handle message deletion event.

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -175,7 +175,12 @@ class MessageStoreImpl with MessageStore {
   }
 
   void handleDeleteMessageEvent(DeleteMessageEvent event) {
-    // TODO handle DeleteMessageEvent, particularly in MessageListView
+    for (final messageId in event.messageIds) {
+      messages.remove(messageId);
+    }
+    for (final view in _messageListViews) {
+      view.handleDeleteMessageEvent(event);
+    }
   }
 
   void handleUpdateMessageFlagsEvent(UpdateMessageFlagsEvent event) {

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -388,6 +388,21 @@ const _unreadMsgs = unreadMsgs;
 // Events.
 //
 
+DeleteMessageEvent deleteMessageEvent(List<StreamMessage> messages) {
+  assert(messages.isNotEmpty);
+  final streamId = messages.first.streamId;
+  final topic = messages.first.topic;
+  assert(messages.every((m) => m.streamId == streamId));
+  assert(messages.every((m) => m.topic == topic));
+  return DeleteMessageEvent(
+    id: 0,
+    messageIds: messages.map((message) => message.id).toList(),
+    messageType: MessageType.stream,
+    streamId: messages[0].streamId,
+    topic: messages[0].topic,
+  );
+}
+
 UpdateMessageEvent updateMessageEditEvent(
   Message origMessage, {
   int? userId = -1, // null means null; default is [selfUser.userId]

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -269,6 +269,67 @@ void main() {
     check(model).fetched.isFalse();
   });
 
+  group('DeleteMessageEvent', () {
+    final stream = eg.stream();
+    final messages = List.generate(30, (i) => eg.streamMessage(stream: stream));
+
+    test('in narrow', () async {
+      await prepare(narrow: StreamNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: messages);
+
+      check(model).messages.length.equals(30);
+      await store.handleEvent(eg.deleteMessageEvent(messages.sublist(0, 10)));
+      checkNotifiedOnce();
+      check(model).messages.length.equals(20);
+    });
+
+    test('not all in narrow', () async {
+      await prepare(narrow: StreamNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: messages.sublist(5));
+
+      check(model).messages.length.equals(25);
+      await store.handleEvent(eg.deleteMessageEvent(messages.sublist(0, 10)));
+      checkNotifiedOnce();
+      check(model).messages.length.equals(20);
+    });
+
+    test('not in narrow', () async {
+      await prepare(narrow: StreamNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: messages.sublist(5));
+
+      check(model).messages.length.equals(25);
+      await store.handleEvent(eg.deleteMessageEvent(messages.sublist(0, 5)));
+      checkNotNotified();
+      check(model).messages.length.equals(25);
+    });
+
+    test('complete message deletion', () async {
+      await prepare(narrow: StreamNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: messages.sublist(0, 25));
+
+      check(model).messages.length.equals(25);
+      await store.handleEvent(eg.deleteMessageEvent(messages));
+      checkNotifiedOnce();
+      check(model).messages.length.equals(0);
+    });
+
+    test('non-consecutive message deletion', () async {
+      await prepare(narrow: StreamNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: messages);
+      final messagesToDelete = messages.sublist(2, 5) + messages.sublist(10, 15);
+
+      check(model).messages.length.equals(30);
+      await store.handleEvent(eg.deleteMessageEvent(messagesToDelete));
+      checkNotifiedOnce();
+      final expected = [
+        ...messages.sublist(0, 2),
+        ...messages.sublist(5, 10),
+        ...messages.sublist(15)].map((message) => message.id);
+      check(model).messages.length.equals(expected.length);
+      check(model.messages.map((message) => message.id)).deepEquals(expected);
+    });
+  });
+
   group('notifyListenersIfMessagePresent', () {
     test('message present', () async {
       await prepare(narrow: const CombinedFeedNarrow());

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -321,12 +321,11 @@ void main() {
       check(model).messages.length.equals(30);
       await store.handleEvent(eg.deleteMessageEvent(messagesToDelete));
       checkNotifiedOnce();
-      final expected = [
+      check(model.messages.map((message) => message.id)).deepEquals([
         ...messages.sublist(0, 2),
         ...messages.sublist(5, 10),
-        ...messages.sublist(15)].map((message) => message.id);
-      check(model).messages.length.equals(expected.length);
-      check(model.messages.map((message) => message.id)).deepEquals(expected);
+        ...messages.sublist(15),
+      ].map((message) => message.id));
     });
   });
 

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -375,6 +375,39 @@ void main() {
     });
   });
 
+  group('handleDeleteMessageEvent', () {
+    test('delete an unknown message', () async {
+      final message1 = eg.streamMessage();
+      final message2 = eg.streamMessage();
+      await prepare();
+      await prepareMessages([message1]);
+      await store.handleEvent(eg.deleteMessageEvent([message2]));
+      checkNotNotified();
+      check(store).messages.values.single.id.equals(message1.id);
+    });
+
+    test('delete messages', () async {
+      final message1 = eg.streamMessage();
+      final message2 = eg.streamMessage();
+      await prepare();
+      await prepareMessages([message1, message2]);
+      await store.handleEvent(eg.deleteMessageEvent([message1, message2]));
+      checkNotifiedOnce();
+      check(store).messages.isEmpty();
+    });
+
+    test('delete an unknown message with a known message', () async {
+      final message1 = eg.streamMessage();
+      final message2 = eg.streamMessage();
+      final message3 = eg.streamMessage();
+      await prepare();
+      await prepareMessages([message1, message2]);
+      await store.handleEvent(eg.deleteMessageEvent([message2, message3]));
+      checkNotifiedOnce();
+      check(store).messages.values.single.id.equals(message1.id);
+    });
+  });
+
   group('handleReactionEvent', () {
     test('add reaction', () async {
       final originalMessage = eg.streamMessage(reactions: []);


### PR DESCRIPTION
When handling a message deletion event, we just simply remove the messages from the per account store and wipe them from the message list view if they are present.

Because message deletion can affect what items are to be seen (date separator, recipient header, etc.), if the view has any message deleted, a `_reprocessAll` call is triggered. It would be ideal to just removed the affected items for better performance.