### PR TITLE
content [nfc]: Finish writing down dark-theme color variants for all content

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -34,6 +34,7 @@ import 'text.dart';
 class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.light(BuildContext context) {
     return ContentTheme._(
+      colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
@@ -49,6 +50,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   factory ContentTheme.dark(BuildContext context) {
     return ContentTheme._(
+      colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 1).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
@@ -63,6 +65,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }
 
   ContentTheme._({
+    required this.colorCodeBlockBackground,
     required this.colorMessageMediaContainerBackground,
     required this.colorThematicBreak,
     required this.textStylePlainParagraph,
@@ -81,6 +84,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return extension!;
   }
 
+  final Color colorCodeBlockBackground;
   final Color colorMessageMediaContainerBackground;
   final Color colorThematicBreak;
 
@@ -113,6 +117,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   @override
   ContentTheme copyWith({
+    Color? colorCodeBlockBackground,
     Color? colorMessageMediaContainerBackground,
     Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
@@ -121,6 +126,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     TextStyle? textStyleErrorCode,
   }) {
     return ContentTheme._(
+      colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
@@ -136,6 +142,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       return this;
     }
     return ContentTheme._(
+      colorCodeBlockBackground: Color.lerp(colorCodeBlockBackground, other.colorCodeBlockBackground, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
@@ -646,7 +653,7 @@ class _CodeBlockContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
+        color: ContentTheme.of(context).colorCodeBlockBackground,
         border: Border.all(
           width: 1,
           color: borderColor),

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -36,6 +36,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.2, 240, 0.7, 0.7).toColor(),
+      colorGlobalTimeBackground: const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
@@ -59,6 +60,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 1).toColor(),
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.25, 240, 0.52, 0.6).toColor(),
+      colorGlobalTimeBackground: const HSLColor.fromAHSL(0.2, 0, 0, 0).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
@@ -81,6 +83,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   ContentTheme._({
     required this.colorCodeBlockBackground,
     required this.colorDirectMentionBackground,
+    required this.colorGlobalTimeBackground,
     required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
     required this.colorThematicBreak,
@@ -104,6 +107,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   final Color colorCodeBlockBackground;
   final Color colorDirectMentionBackground;
+  final Color colorGlobalTimeBackground;
   final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
   final Color colorThematicBreak;
@@ -153,6 +157,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   ContentTheme copyWith({
     Color? colorCodeBlockBackground,
     Color? colorDirectMentionBackground,
+    Color? colorGlobalTimeBackground,
     Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
     Color? colorThematicBreak,
@@ -166,6 +171,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
       colorDirectMentionBackground: colorDirectMentionBackground ?? this.colorDirectMentionBackground,
+      colorGlobalTimeBackground: colorGlobalTimeBackground ?? this.colorGlobalTimeBackground,
       colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
@@ -186,6 +192,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: Color.lerp(colorCodeBlockBackground, other.colorCodeBlockBackground, t)!,
       colorDirectMentionBackground: Color.lerp(colorDirectMentionBackground, other.colorDirectMentionBackground, t)!,
+      colorGlobalTimeBackground: Color.lerp(colorGlobalTimeBackground, other.colorGlobalTimeBackground, t)!,
       colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
@@ -1117,7 +1124,6 @@ class GlobalTime extends StatelessWidget {
   final GlobalTimeNode node;
   final TextStyle ambientTextStyle;
 
-  static final _backgroundColor = const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor();
   static final _borderColor = const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor();
   static final _dateFormat = DateFormat('EEE, MMM d, y, h:mm a'); // TODO(intl): localize date
 
@@ -1126,11 +1132,12 @@ class GlobalTime extends StatelessWidget {
     // Design taken from css for `.rendered_markdown & time` in web,
     //   see zulip:web/styles/rendered_markdown.css .
     final text = _dateFormat.format(node.datetime.toLocal());
+    final contentTheme = ContentTheme.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 2),
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: _backgroundColor,
+          color: contentTheme.colorGlobalTimeBackground,
           border: Border.all(width: 1, color: _borderColor),
           borderRadius: BorderRadius.circular(3)),
         child: Padding(

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -34,6 +34,7 @@ import 'text.dart';
 class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.light(BuildContext context) {
     return ContentTheme._(
+      colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
         debugLabel: 'ContentTheme.textStylePlainParagraph'),
@@ -47,6 +48,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   factory ContentTheme.dark(BuildContext context) {
     return ContentTheme._(
+      colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(0.75, 0, 0, 1).toColor(),
         debugLabel: 'ContentTheme.textStylePlainParagraph'),
@@ -59,6 +61,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }
 
   ContentTheme._({
+    required this.colorThematicBreak,
     required this.textStylePlainParagraph,
     required this.codeBlockTextStyles,
     required this.textStyleError,
@@ -74,6 +77,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     assert(extension != null);
     return extension!;
   }
+
+  final Color colorThematicBreak;
 
   /// The complete [TextStyle] we use for plain, unstyled paragraphs.
   ///
@@ -104,12 +109,14 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   @override
   ContentTheme copyWith({
+    Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
     CodeBlockTextStyles? codeBlockTextStyles,
     TextStyle? textStyleError,
     TextStyle? textStyleErrorCode,
   }) {
     return ContentTheme._(
+      colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
       codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
       textStyleError: textStyleError ?? this.textStyleError,
@@ -123,6 +130,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       return this;
     }
     return ContentTheme._(
+      colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
       codeBlockTextStyles: CodeBlockTextStyles.lerp(codeBlockTextStyles, other.codeBlockTextStyles, t),
       textStyleError: TextStyle.lerp(textStyleError, other.textStyleError, t)!,
@@ -235,7 +243,7 @@ class ThematicBreak extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Divider(
-      color: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
+      color: ContentTheme.of(context).colorThematicBreak,
       thickness: htmlHeight,
       height: 2 * htmlMarginY + htmlHeight,
     );

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -34,21 +34,9 @@ import 'text.dart';
 class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.light(BuildContext context) {
     return ContentTheme._(
-      textStylePlainParagraph: TextStyle(
-        inherit: false,
-
+      textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
-        fontSize: kBaseFontSize,
-        letterSpacing: 0,
-        textBaseline: localizedTextBaseline(context),
-        height: (22 / kBaseFontSize),
-        leadingDistribution: TextLeadingDistribution.even,
-        decoration: TextDecoration.none,
-        fontFamily: kDefaultFontFamily,
-        fontFamilyFallback: defaultFontFamilyFallback,
-      )
-        .merge(weightVariableTextStyle(context))
-        .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
+        debugLabel: 'ContentTheme.textStylePlainParagraph'),
       codeBlockTextStyles: CodeBlockTextStyles.light(context),
       textStyleError: const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
         .merge(weightVariableTextStyle(context, wght: 700)),
@@ -59,21 +47,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   factory ContentTheme.dark(BuildContext context) {
     return ContentTheme._(
-      textStylePlainParagraph: TextStyle(
-        inherit: false,
-
+      textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(0.75, 0, 0, 1).toColor(),
-        fontSize: kBaseFontSize,
-        letterSpacing: 0,
-        textBaseline: localizedTextBaseline(context),
-        height: (22 / kBaseFontSize),
-        leadingDistribution: TextLeadingDistribution.even,
-        decoration: TextDecoration.none,
-        fontFamily: kDefaultFontFamily,
-        fontFamilyFallback: defaultFontFamilyFallback,
-      )
-        .merge(weightVariableTextStyle(context))
-        .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
+        debugLabel: 'ContentTheme.textStylePlainParagraph'),
       codeBlockTextStyles: CodeBlockTextStyles.dark(context),
       textStyleError: TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)
         .merge(weightVariableTextStyle(context, wght: 700)),
@@ -110,6 +86,21 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final CodeBlockTextStyles codeBlockTextStyles;
   final TextStyle textStyleError;
   final TextStyle textStyleErrorCode;
+
+  /// [ContentTheme.textStylePlainParagraph] attributes independent of theme.
+  static TextStyle _plainParagraphCommon(BuildContext context) => TextStyle(
+    inherit: false,
+
+    fontSize: kBaseFontSize,
+    letterSpacing: 0,
+    textBaseline: localizedTextBaseline(context),
+    height: (22 / kBaseFontSize),
+    leadingDistribution: TextLeadingDistribution.even,
+    decoration: TextDecoration.none,
+    fontFamily: kDefaultFontFamily,
+    fontFamilyFallback: defaultFontFamilyFallback,
+  )
+    .merge(weightVariableTextStyle(context));
 
   @override
   ContentTheme copyWith({

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1007,22 +1007,6 @@ final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(TextStyle(
     backgroundColor: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor()));
 
-// const _kInlineCodeLeftBracket = '⸤';
-// const _kInlineCodeRightBracket = '⸣';
-// Some alternatives:
-// const _kInlineCodeLeftBracket = '⸢'; // end-bracket looks a lot like comma
-// const _kInlineCodeRightBracket = '⸥';
-// const _kInlineCodeLeftBracket = '｢'; // a bit bigger
-// const _kInlineCodeRightBracket = '｣';
-// const _kInlineCodeLeftBracket = '「'; // too much space
-// const _kInlineCodeRightBracket = '」';
-// const _kInlineCodeLeftBracket = '﹝'; // neat but too much space
-// const _kInlineCodeRightBracket = '﹞';
-// const _kInlineCodeLeftBracket = '❲'; // different shape, could work
-// const _kInlineCodeRightBracket = '❳';
-// const _kInlineCodeLeftBracket = '⟨'; // probably too visually similar to paren
-// const _kInlineCodeRightBracket = '⟩';
-
 class UserMention extends StatelessWidget {
   const UserMention({
     super.key,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -37,6 +37,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.2, 240, 0.7, 0.7).toColor(),
       colorGlobalTimeBackground: const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor(),
+      colorGlobalTimeBorder: const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
@@ -61,6 +62,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 1).toColor(),
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.25, 240, 0.52, 0.6).toColor(),
       colorGlobalTimeBackground: const HSLColor.fromAHSL(0.2, 0, 0, 0).toColor(),
+      colorGlobalTimeBorder: const HSLColor.fromAHSL(0.4, 0, 0, 0).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
@@ -84,6 +86,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.colorCodeBlockBackground,
     required this.colorDirectMentionBackground,
     required this.colorGlobalTimeBackground,
+    required this.colorGlobalTimeBorder,
     required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
     required this.colorThematicBreak,
@@ -108,6 +111,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final Color colorCodeBlockBackground;
   final Color colorDirectMentionBackground;
   final Color colorGlobalTimeBackground;
+  final Color colorGlobalTimeBorder;
   final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
   final Color colorThematicBreak;
@@ -158,6 +162,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     Color? colorCodeBlockBackground,
     Color? colorDirectMentionBackground,
     Color? colorGlobalTimeBackground,
+    Color? colorGlobalTimeBorder,
     Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
     Color? colorThematicBreak,
@@ -172,6 +177,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
       colorDirectMentionBackground: colorDirectMentionBackground ?? this.colorDirectMentionBackground,
       colorGlobalTimeBackground: colorGlobalTimeBackground ?? this.colorGlobalTimeBackground,
+      colorGlobalTimeBorder: colorGlobalTimeBorder ?? this.colorGlobalTimeBorder,
       colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
@@ -193,6 +199,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorCodeBlockBackground: Color.lerp(colorCodeBlockBackground, other.colorCodeBlockBackground, t)!,
       colorDirectMentionBackground: Color.lerp(colorDirectMentionBackground, other.colorDirectMentionBackground, t)!,
       colorGlobalTimeBackground: Color.lerp(colorGlobalTimeBackground, other.colorGlobalTimeBackground, t)!,
+      colorGlobalTimeBorder: Color.lerp(colorGlobalTimeBorder, other.colorGlobalTimeBorder, t)!,
       colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
@@ -1124,7 +1131,6 @@ class GlobalTime extends StatelessWidget {
   final GlobalTimeNode node;
   final TextStyle ambientTextStyle;
 
-  static final _borderColor = const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor();
   static final _dateFormat = DateFormat('EEE, MMM d, y, h:mm a'); // TODO(intl): localize date
 
   @override
@@ -1138,7 +1144,7 @@ class GlobalTime extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: contentTheme.colorGlobalTimeBackground,
-          border: Border.all(width: 1, color: _borderColor),
+          border: Border.all(width: 1, color: contentTheme.colorGlobalTimeBorder),
           borderRadius: BorderRadius.circular(3)),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 0.2 * kBaseFontSize),

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1140,6 +1140,8 @@ class GlobalTime extends StatelessWidget {
             children: [
               Icon(
                 size: ambientTextStyle.fontSize!,
+                // (When GlobalTime appears in a link, it should be blue
+                // like the text.)
                 color: DefaultTextStyle.of(context).style.color!,
                 ZulipIcons.clock),
               // Ad-hoc spacing adjustment per feedback:

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -46,7 +46,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
         .merge(weightVariableTextStyle(context, wght: 700)),
       textStyleErrorCode: kMonospaceTextStyle
         .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red)),
-      textStyleInlineMath: _kInlineCodeStyle.merge(TextStyle(
+      textStyleInlineMath: kMonospaceTextStyle.merge(TextStyle(
         // TODO(#46) this won't be needed
         backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.93).toColor())),
     );
@@ -66,7 +66,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
         .merge(weightVariableTextStyle(context, wght: 700)),
       textStyleErrorCode: kMonospaceTextStyle
         .merge(TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)),
-      textStyleInlineMath: _kInlineCodeStyle.merge(TextStyle(
+      textStyleInlineMath: kMonospaceTextStyle.merge(TextStyle(
         // TODO(#46) this won't be needed
         backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor())),
     );

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -46,6 +46,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
         .merge(weightVariableTextStyle(context, wght: 700)),
       textStyleErrorCode: kMonospaceTextStyle
         .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red)),
+      textStyleInlineMath: _kInlineCodeStyle.merge(TextStyle(
+        // TODO(#46) this won't be needed
+        backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.93).toColor())),
     );
   }
 
@@ -63,6 +66,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
         .merge(weightVariableTextStyle(context, wght: 700)),
       textStyleErrorCode: kMonospaceTextStyle
         .merge(TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)),
+      textStyleInlineMath: _kInlineCodeStyle.merge(TextStyle(
+        // TODO(#46) this won't be needed
+        backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor())),
     );
   }
 
@@ -75,6 +81,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.codeBlockTextStyles,
     required this.textStyleError,
     required this.textStyleErrorCode,
+    required this.textStyleInlineMath,
   });
 
   /// The [ContentTheme] from the context's active theme.
@@ -104,6 +111,13 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final TextStyle textStyleError;
   final TextStyle textStyleErrorCode;
 
+  /// The [TextStyle] for inline math, excluding font-size adjustment.
+  ///
+  /// Inline math should use this and also apply [kInlineCodeFontSizeFactor]
+  /// to the font size of the surrounding text
+  /// (which might be a Paragraph, a Heading, etc.).
+  final TextStyle textStyleInlineMath;
+
   /// [ContentTheme.textStylePlainParagraph] attributes independent of theme.
   static TextStyle _plainParagraphCommon(BuildContext context) => TextStyle(
     inherit: false,
@@ -129,6 +143,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     CodeBlockTextStyles? codeBlockTextStyles,
     TextStyle? textStyleError,
     TextStyle? textStyleErrorCode,
+    TextStyle? textStyleInlineMath,
   }) {
     return ContentTheme._(
       colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
@@ -139,6 +154,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
       textStyleError: textStyleError ?? this.textStyleError,
       textStyleErrorCode: textStyleErrorCode ?? this.textStyleErrorCode,
+      textStyleInlineMath: textStyleInlineMath ?? this.textStyleInlineMath,
     );
   }
 
@@ -156,6 +172,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       codeBlockTextStyles: CodeBlockTextStyles.lerp(codeBlockTextStyles, other.codeBlockTextStyles, t),
       textStyleError: TextStyle.lerp(textStyleError, other.textStyleError, t)!,
       textStyleErrorCode: TextStyle.lerp(textStyleErrorCode, other.textStyleErrorCode, t)!,
+      textStyleInlineMath: TextStyle.lerp(textStyleInlineMath, other.textStyleInlineMath, t)!,
     );
   }
 }
@@ -896,8 +913,8 @@ class _InlineContentBuilder {
     } else if (node is MathInlineNode) {
       return TextSpan(
         style: widget.style
-          .merge(_kInlineMathStyle)
-          .apply(fontSizeFactor: _kInlineCodeFontSizeFactor),
+          .merge(ContentTheme.of(_context!).textStyleInlineMath)
+          .apply(fontSizeFactor: kInlineCodeFontSizeFactor),
         children: [TextSpan(text: node.texSource)]);
     } else if (node is GlobalTimeNode) {
       return WidgetSpan(alignment: PlaceholderAlignment.middle,
@@ -957,7 +974,7 @@ class _InlineContentBuilder {
     return _buildNodes(
       style: widget.style
         .merge(_kInlineCodeStyle)
-        .apply(fontSizeFactor: _kInlineCodeFontSizeFactor),
+        .apply(fontSizeFactor: kInlineCodeFontSizeFactor),
       node.nodes,
     );
 
@@ -979,19 +996,11 @@ class _InlineContentBuilder {
   }
 }
 
-/// The [TextStyle] for inline math, excluding font-size adjustment.
-///
-/// Inline math should use this and also apply [_kInlineCodeFontSizeFactor]
-/// to the font size of the surrounding text
-/// (which might be a Paragraph, a Heading, etc.).
-final _kInlineMathStyle = _kInlineCodeStyle.merge(TextStyle(
-  backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.93).toColor()));
-
-const _kInlineCodeFontSizeFactor = 0.825;
+const kInlineCodeFontSizeFactor = 0.825;
 
 /// The [TextStyle] for inline code, excluding font-size adjustment.
 ///
-/// Inline code should use this and also apply [_kInlineCodeFontSizeFactor]
+/// Inline code should use this and also apply [kInlineCodeFontSizeFactor]
 /// to the font size of the surrounding text
 /// (which might be a Paragraph, a Heading, etc.).
 final _kInlineCodeStyle = kMonospaceTextStyle

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -34,6 +34,7 @@ import 'text.dart';
 class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.light(BuildContext context) {
     return ContentTheme._(
+      colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
@@ -48,6 +49,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   factory ContentTheme.dark(BuildContext context) {
     return ContentTheme._(
+      colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(0.75, 0, 0, 1).toColor(),
@@ -61,6 +63,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }
 
   ContentTheme._({
+    required this.colorMessageMediaContainerBackground,
     required this.colorThematicBreak,
     required this.textStylePlainParagraph,
     required this.codeBlockTextStyles,
@@ -78,6 +81,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return extension!;
   }
 
+  final Color colorMessageMediaContainerBackground;
   final Color colorThematicBreak;
 
   /// The complete [TextStyle] we use for plain, unstyled paragraphs.
@@ -109,6 +113,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   @override
   ContentTheme copyWith({
+    Color? colorMessageMediaContainerBackground,
     Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
     CodeBlockTextStyles? codeBlockTextStyles,
@@ -116,6 +121,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     TextStyle? textStyleErrorCode,
   }) {
     return ContentTheme._(
+      colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
       codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
@@ -130,6 +136,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       return this;
     }
     return ContentTheme._(
+      colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
       codeBlockTextStyles: CodeBlockTextStyles.lerp(codeBlockTextStyles, other.codeBlockTextStyles, t),
@@ -601,7 +608,7 @@ class MessageMediaContainer extends StatelessWidget {
           //   in particular, avoid adding loose whitespace at end of message.
           padding: const EdgeInsets.only(right: 5, bottom: 5),
           child: ColoredBox(
-            color: const Color.fromRGBO(0, 0, 0, 0.03),
+            color: ContentTheme.of(context).colorMessageMediaContainerBackground,
             child: Padding(
               padding: const EdgeInsets.all(1),
               child: SizedBox(

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -35,6 +35,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.light(BuildContext context) {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
+      colorDirectMentionBackground: const HSLColor.fromAHSL(0.2, 240, 0.7, 0.7).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
@@ -57,6 +58,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.dark(BuildContext context) {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 1).toColor(),
+      colorDirectMentionBackground: const HSLColor.fromAHSL(0.25, 240, 0.52, 0.6).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
@@ -78,6 +80,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   ContentTheme._({
     required this.colorCodeBlockBackground,
+    required this.colorDirectMentionBackground,
     required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
     required this.colorThematicBreak,
@@ -100,6 +103,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }
 
   final Color colorCodeBlockBackground;
+  final Color colorDirectMentionBackground;
   final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
   final Color colorThematicBreak;
@@ -148,6 +152,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   @override
   ContentTheme copyWith({
     Color? colorCodeBlockBackground,
+    Color? colorDirectMentionBackground,
     Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
     Color? colorThematicBreak,
@@ -160,6 +165,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }) {
     return ContentTheme._(
       colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
+      colorDirectMentionBackground: colorDirectMentionBackground ?? this.colorDirectMentionBackground,
       colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
@@ -179,6 +185,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     }
     return ContentTheme._(
       colorCodeBlockBackground: Color.lerp(colorCodeBlockBackground, other.colorCodeBlockBackground, t)!,
+      colorDirectMentionBackground: Color.lerp(colorDirectMentionBackground, other.colorDirectMentionBackground, t)!,
       colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
@@ -1025,10 +1032,11 @@ class UserMention extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final contentTheme = ContentTheme.of(context);
     return Container(
       decoration: BoxDecoration(
-        // TODO(#646) different background between direct and wildcard mentions
-        color: const HSLColor.fromAHSL(0.2, 240, 0.7, 0.7).toColor(),
+        // TODO(#646) different for wildcard mentions
+        color: contentTheme.colorDirectMentionBackground,
         borderRadius: const BorderRadius.all(Radius.circular(3))),
       padding: const EdgeInsets.symmetric(horizontal: 0.2 * kBaseFontSize),
       child: InlineContent(

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -57,6 +57,31 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     );
   }
 
+  factory ContentTheme.dark(BuildContext context) {
+    return ContentTheme._(
+      textStylePlainParagraph: TextStyle(
+        inherit: false,
+
+        color: const HSLColor.fromAHSL(0.75, 0, 0, 1).toColor(),
+        fontSize: kBaseFontSize,
+        letterSpacing: 0,
+        textBaseline: localizedTextBaseline(context),
+        height: (22 / kBaseFontSize),
+        leadingDistribution: TextLeadingDistribution.even,
+        decoration: TextDecoration.none,
+        fontFamily: kDefaultFontFamily,
+        fontFamilyFallback: defaultFontFamilyFallback,
+      )
+        .merge(weightVariableTextStyle(context))
+        .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
+      codeBlockTextStyles: CodeBlockTextStyles.dark(context),
+      textStyleError: TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)
+        .merge(weightVariableTextStyle(context, wght: 700)),
+      textStyleErrorCode: kMonospaceTextStyle
+        .merge(TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)),
+    );
+  }
+
   ContentTheme._({
     required this.textStylePlainParagraph,
     required this.codeBlockTextStyles,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1005,7 +1005,7 @@ const kInlineCodeFontSizeFactor = 0.825;
 /// (which might be a Paragraph, a Heading, etc.).
 final _kInlineCodeStyle = kMonospaceTextStyle
   .merge(TextStyle(
-    backgroundColor: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor()));
+    backgroundColor: const HSLColor.fromAHSL(0.06, 0, 0, 0).toColor()));
 
 class UserMention extends StatelessWidget {
   const UserMention({

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -46,6 +46,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
         .merge(weightVariableTextStyle(context, wght: 700)),
       textStyleErrorCode: kMonospaceTextStyle
         .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red)),
+      textStyleInlineCode: kMonospaceTextStyle.merge(TextStyle(
+        backgroundColor: const HSLColor.fromAHSL(0.06, 0, 0, 0).toColor())),
       textStyleInlineMath: kMonospaceTextStyle.merge(TextStyle(
         // TODO(#46) this won't be needed
         backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.93).toColor())),
@@ -66,6 +68,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
         .merge(weightVariableTextStyle(context, wght: 700)),
       textStyleErrorCode: kMonospaceTextStyle
         .merge(TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)),
+      textStyleInlineCode: kMonospaceTextStyle.merge(TextStyle(
+        backgroundColor: const HSLColor.fromAHSL(0.08, 0, 0, 1).toColor())),
       textStyleInlineMath: kMonospaceTextStyle.merge(TextStyle(
         // TODO(#46) this won't be needed
         backgroundColor: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor())),
@@ -81,6 +85,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.codeBlockTextStyles,
     required this.textStyleError,
     required this.textStyleErrorCode,
+    required this.textStyleInlineCode,
     required this.textStyleInlineMath,
   });
 
@@ -110,6 +115,13 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final CodeBlockTextStyles codeBlockTextStyles;
   final TextStyle textStyleError;
   final TextStyle textStyleErrorCode;
+
+  /// The [TextStyle] for inline code, excluding font-size adjustment.
+  ///
+  /// Inline code should use this and also apply [kInlineCodeFontSizeFactor]
+  /// to the font size of the surrounding text
+  /// (which might be a Paragraph, a Heading, etc.).
+  final TextStyle textStyleInlineCode;
 
   /// The [TextStyle] for inline math, excluding font-size adjustment.
   ///
@@ -143,6 +155,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     CodeBlockTextStyles? codeBlockTextStyles,
     TextStyle? textStyleError,
     TextStyle? textStyleErrorCode,
+    TextStyle? textStyleInlineCode,
     TextStyle? textStyleInlineMath,
   }) {
     return ContentTheme._(
@@ -154,6 +167,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
       textStyleError: textStyleError ?? this.textStyleError,
       textStyleErrorCode: textStyleErrorCode ?? this.textStyleErrorCode,
+      textStyleInlineCode: textStyleInlineCode ?? this.textStyleInlineCode,
       textStyleInlineMath: textStyleInlineMath ?? this.textStyleInlineMath,
     );
   }
@@ -172,6 +186,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       codeBlockTextStyles: CodeBlockTextStyles.lerp(codeBlockTextStyles, other.codeBlockTextStyles, t),
       textStyleError: TextStyle.lerp(textStyleError, other.textStyleError, t)!,
       textStyleErrorCode: TextStyle.lerp(textStyleErrorCode, other.textStyleErrorCode, t)!,
+      textStyleInlineCode: TextStyle.lerp(textStyleInlineCode, other.textStyleInlineCode, t)!,
       textStyleInlineMath: TextStyle.lerp(textStyleInlineMath, other.textStyleInlineMath, t)!,
     );
   }
@@ -973,7 +988,7 @@ class _InlineContentBuilder {
 
     return _buildNodes(
       style: widget.style
-        .merge(_kInlineCodeStyle)
+        .merge(ContentTheme.of(_context!).textStyleInlineCode)
         .apply(fontSizeFactor: kInlineCodeFontSizeFactor),
       node.nodes,
     );
@@ -997,15 +1012,6 @@ class _InlineContentBuilder {
 }
 
 const kInlineCodeFontSizeFactor = 0.825;
-
-/// The [TextStyle] for inline code, excluding font-size adjustment.
-///
-/// Inline code should use this and also apply [kInlineCodeFontSizeFactor]
-/// to the font size of the surrounding text
-/// (which might be a Paragraph, a Heading, etc.).
-final _kInlineCodeStyle = kMonospaceTextStyle
-  .merge(TextStyle(
-    backgroundColor: const HSLColor.fromAHSL(0.06, 0, 0, 0).toColor()));
 
 class UserMention extends StatelessWidget {
   const UserMention({

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -35,6 +35,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.light(BuildContext context) {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
+      colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
@@ -51,6 +52,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   factory ContentTheme.dark(BuildContext context) {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 1).toColor(),
+      colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withOpacity(0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
@@ -66,6 +68,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   ContentTheme._({
     required this.colorCodeBlockBackground,
+    required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
     required this.colorThematicBreak,
     required this.textStylePlainParagraph,
@@ -85,6 +88,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }
 
   final Color colorCodeBlockBackground;
+  final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
   final Color colorThematicBreak;
 
@@ -118,6 +122,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   @override
   ContentTheme copyWith({
     Color? colorCodeBlockBackground,
+    Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
     Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
@@ -127,6 +132,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   }) {
     return ContentTheme._(
       colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
+      colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
@@ -143,6 +149,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     }
     return ContentTheme._(
       colorCodeBlockBackground: Color.lerp(colorCodeBlockBackground, other.colorCodeBlockBackground, t)!,
+      colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
@@ -698,12 +705,10 @@ class MathBlock extends StatelessWidget {
 
   final MathBlockNode node;
 
-  static final _borderColor = const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor();
-
   @override
   Widget build(BuildContext context) {
     return _CodeBlockContainer(
-      borderColor: _borderColor,
+      borderColor: ContentTheme.of(context).colorMathBlockBorder,
       child: Text.rich(TextSpan(
         style: ContentTheme.of(context).codeBlockTextStyles.plain,
         children: [TextSpan(text: node.texSource)])));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -32,27 +32,30 @@ import 'text.dart';
 /// background. For what this is in the message list, see
 /// widgets/message_list.dart.
 class ContentTheme extends ThemeExtension<ContentTheme> {
-  ContentTheme(BuildContext context) :
-    textStylePlainParagraph = TextStyle(
-      inherit: false,
+  factory ContentTheme.light(BuildContext context) {
+    return ContentTheme._(
+      textStylePlainParagraph: TextStyle(
+        inherit: false,
 
-      color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
-      fontSize: kBaseFontSize,
-      letterSpacing: 0,
-      textBaseline: localizedTextBaseline(context),
-      height: (22 / kBaseFontSize),
-      leadingDistribution: TextLeadingDistribution.even,
-      decoration: TextDecoration.none,
-      fontFamily: kDefaultFontFamily,
-      fontFamilyFallback: defaultFontFamilyFallback,
-    )
-      .merge(weightVariableTextStyle(context))
-      .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
-    codeBlockTextStyles = CodeBlockTextStyles.light(context),
-    textStyleError = const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
-      .merge(weightVariableTextStyle(context, wght: 700)),
-    textStyleErrorCode = kMonospaceTextStyle
-      .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red));
+        color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
+        fontSize: kBaseFontSize,
+        letterSpacing: 0,
+        textBaseline: localizedTextBaseline(context),
+        height: (22 / kBaseFontSize),
+        leadingDistribution: TextLeadingDistribution.even,
+        decoration: TextDecoration.none,
+        fontFamily: kDefaultFontFamily,
+        fontFamilyFallback: defaultFontFamilyFallback,
+      )
+        .merge(weightVariableTextStyle(context))
+        .copyWith(debugLabel: 'ContentTheme.textStylePlainParagraph'),
+      codeBlockTextStyles: CodeBlockTextStyles.light(context),
+      textStyleError: const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
+        .merge(weightVariableTextStyle(context, wght: 700)),
+      textStyleErrorCode: kMonospaceTextStyle
+        .merge(const TextStyle(fontSize: kBaseFontSize, color: Colors.red)),
+    );
+  }
 
   ContentTheme._({
     required this.textStylePlainParagraph,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -327,6 +327,7 @@ class Quotation extends StatelessWidget {
           border: Border(
             left: BorderSide(
               width: 5,
+              // Web has the same color in light and dark mode.
               color: const HSLColor.fromAHSL(1, 0, 0, 0.87).toColor()))),
         child: BlockContentList(nodes: node.nodes)));
   }
@@ -432,6 +433,7 @@ class _SpoilerState extends State<Spoiler> with TickerProviderStateMixin {
       padding: const EdgeInsets.fromLTRB(0, 5, 0, 15),
       child: DecoratedBox(
         decoration: BoxDecoration(
+          // Web has the same color in light and dark mode.
           border: Border.all(color: const Color(0xff808080)),
           borderRadius: BorderRadius.circular(10),
         ),
@@ -451,6 +453,7 @@ class _SpoilerState extends State<Spoiler> with TickerProviderStateMixin {
                           nodes: effectiveHeader))),
                     RotationTransition(
                       turns: _animation.drive(Tween(begin: 0, end: 0.5)),
+                      // Web has the same color in light and dark mode.
                       child: const Icon(color: Color(0xffd4d4d4), size: 25,
                         Icons.expand_more)),
                   ]))),
@@ -460,6 +463,7 @@ class _SpoilerState extends State<Spoiler> with TickerProviderStateMixin {
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       border: Border(
+                        // Web has the same color in light and dark mode.
                         bottom: BorderSide(width: 1, color: Color(0xff808080))))))),
               SizeTransition(
                 sizeFactor: _animation,
@@ -537,13 +541,13 @@ class MessageInlineVideo extends StatelessWidget {
           mediaType: MediaType.video));
       },
       child: Container(
-        color: Colors.black,
+        color: Colors.black, // Web has the same color in light and dark mode.
         alignment: Alignment.center,
         // To avoid potentially confusing UX, do not show play icon as
         // we also disable onTap above.
         child: resolvedSrc == null ? null : const Icon( // TODO(log)
           Icons.play_arrow_rounded,
-          color: Colors.white,
+          color: Colors.white, // Web has the same color in light and dark mode.
           size: 32)));
   }
 }
@@ -571,7 +575,7 @@ class MessageEmbedVideo extends StatelessWidget {
           // the action uses hrefUrl, which might still work.
           const Icon(
             Icons.play_arrow_rounded,
-            color: Colors.white,
+            color: Colors.white, // Web has the same color in light and dark mode.
             size: 32),
         ]));
   }
@@ -902,6 +906,7 @@ class _InlineContentBuilder {
     assert(recognizer != null);
     _pushRecognizer(recognizer);
     final result = _buildNodes(node.nodes,
+      // Web has the same color in light and dark mode.
       style: TextStyle(color: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor()));
     _popRecognizer();
     return result;

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -9,7 +9,7 @@ ThemeData zulipThemeData(BuildContext context) {
   final designVariables = DesignVariables();
   return ThemeData(
     typography: zulipTypography(context),
-    extensions: [ContentTheme(context), designVariables],
+    extensions: [ContentTheme.light(context), designVariables],
     appBarTheme: AppBarTheme(
       // Set these two fields to prevent a color change in [AppBar]s when
       // there is something scrolled under it. If an app bar hasn't been

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -843,22 +843,27 @@ void main() {
       tester.widget(find.textContaining(renderedTextRegexp));
     });
 
-    testWidgets('clock icon and text are the same color', (tester) async {
-      await prepareContent(tester, plainContent('<p>$timeSpanHtml</p>'));
+    void testIconAndTextSameColor(String description, String html) {
+      testWidgets('clock icon and text are the same color: $description', (tester) async {
+        await prepareContent(tester, plainContent(html));
 
-      final icon = tester.widget<Icon>(
-        find.descendant(of: find.byType(GlobalTime),
-          matching: find.byIcon(ZulipIcons.clock)));
+        final icon = tester.widget<Icon>(
+          find.descendant(of: find.byType(GlobalTime),
+            matching: find.byIcon(ZulipIcons.clock)));
 
-      final textSpan = tester.renderObject<RenderParagraph>(
-        find.descendant(of: find.byType(GlobalTime),
-          matching: find.textContaining(renderedTextRegexp)
-      )).text;
-      final textColor = mergedStyleOfSubstring(textSpan, renderedTextRegexp)!.color;
-      check(textColor).isNotNull();
+        final textSpan = tester.renderObject<RenderParagraph>(
+          find.descendant(of: find.byType(GlobalTime),
+            matching: find.textContaining(renderedTextRegexp)
+        )).text;
+        final textColor = mergedStyleOfSubstring(textSpan, renderedTextRegexp)!.color;
+        check(textColor).isNotNull();
 
-      check(icon).color.equals(textColor!);
-    });
+        check(icon).color.equals(textColor!);
+      });
+    }
+
+    testIconAndTextSameColor('common case', '<p>$timeSpanHtml</p>');
+    testIconAndTextSameColor('inside link', '<p><a href="https://example/">$timeSpanHtml</a></p>');
 
     group('maintains font-size ratio with surrounding text', () {
       Future<void> doCheck(WidgetTester tester, double Function(GlobalTime widget) sizeFromWidget) async {


### PR DESCRIPTION
Following #756 (dark-theme variant for code-block syntax highlighting), this completes the sweep through message-content colors for #95 dark theme. By the end of the branch, all colors are defined either in `ContentTheme` with light/dark variants, or still inline but with a comment explaining that they don't need light/dark variants.

A dev-only commit at the end makes it handy to see the results, but we shouldn't merge it because it just hard-codes dark theme in message content and nowhere else. 🙂 I recommend scrolling through "Combined feed" to see if anything stands out.

There's a tiny color change in light theme—

```
content: Adjust inline-code background color to match web
```

—as it seems either f452053dc was wrong or the web app changed since then. I can make screenshots if that would be helpful.