### PR TITLE
deps: Upgrade `flutter_local_notifications` and `Flutter` to the latest

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -444,10 +444,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "40e6fbd2da7dcc7ed78432c5cdab1559674b4af035fddbfb2f9a8f9c2112fcef"
+      sha256: ced76d337f54de33d7d9f06092137b4ac2da5079e00cee8a11a1794ffc7c61c6
       url: "https://pub.dev"
     source: hosted
-    version: "17.1.2"
+    version: "17.2.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "340abf67df238f7f0ef58f4a26d2a83e1ab74c77ab03cd2b2d5018ac64db30b7"
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1358,5 +1358,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.5.0-308.0.dev <4.0.0"
-  flutter: ">=3.23.0-13.0.pre.363"
+  dart: ">=3.5.0-319.0.dev <4.0.0"
+  flutter: ">=3.23.0-14.0.pre.77"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,8 +47,8 @@ dependencies:
   firebase_core: ^3.1.0
   firebase_messaging: ^15.0.1
   flutter_color_models: ^1.3.3+2
-  flutter_local_notifications: ^17.0.0
-  flutter_local_notifications_platform_interface: ^7.0.0+1
+  flutter_local_notifications: ^17.2.1
+  flutter_local_notifications_platform_interface: ^7.2.0
   html: ^0.15.1
   http: ^1.0.0
   image_picker: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.5.0-308.0.dev <4.0.0'
-  flutter: '>=3.23.0-13.0.pre.363'
+  sdk: '>=3.5.0-319.0.dev <4.0.0'
+  flutter: '>=3.23.0-14.0.pre.77'
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
After the Flutter upstream commit: https://github.com/flutter/flutter/commit/f23dbc50f05c56ef5be871203bb4f167f07df845 a build error related to `flutter_local_notifications` plugin occurs when trying to run the app on Android. The upgrade to `flutter_local_notifications ^7.2.0` version in this PR resolves the issue.

More about the issue: https://github.com/MaikuB/flutter_local_notifications/issues/2329

Fixes: #771 