### PR TITLE
Intl: Rename stream to channel in translation labels

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -211,11 +211,11 @@
   "@composeBoxSelfDmContentHint": {
     "description": "Hint text for content input when sending a message to yourself."
   },
-  "composeBoxStreamContentHint": "Message #{stream} > {topic}",
-  "@composeBoxStreamContentHint": {
+  "composeBoxChannelContentHint": "Message #{channel} > {topic}",
+  "@composeBoxChannelContentHint": {
     "description": "Hint text for content input when sending a message to a channel",
     "placeholders": {
-      "stream": {"type": "String", "example": "channel name"},
+      "channel": {"type": "String", "example": "channel name"},
       "topic": {"type": "String", "example": "topic name"}
     }
   },
@@ -223,8 +223,8 @@
   "@composeBoxSendTooltip":  {
     "description": "Tooltip for send button in compose box."
   },
-  "composeBoxUnknownStreamName": "(unknown channel)",
-  "@composeBoxUnknownStreamName": {
+  "composeBoxUnknownChannelName": "(unknown channel)",
+  "@composeBoxUnknownChannelName": {
     "description": "Replacement name for channel when it cannot be found in the store."
   },
   "composeBoxTopicHintText": "Topic",
@@ -352,8 +352,8 @@
   "@topicValidationErrorMandatoryButEmpty": {
     "description": "Topic validation error when topic is required but was empty."
   },
-  "subscribedToNStreams": "Subscribed to {num, plural, =0{no channels} =1{1 channel} other{{num} channels}}",
-  "@subscribedToNStreams": {
+  "subscribedToNChannels": "Subscribed to {num, plural, =0{no channels} =1{1 channel} other{{num} channels}}",
+  "@subscribedToNChannels": {
     "description": "Test page label showing number of channels user is subscribed to.",
     "placeholders": {
       "num": {"type": "int", "example": "4"}

--- a/assets/l10n/app_ja.arb
+++ b/assets/l10n/app_ja.arb
@@ -5,7 +5,7 @@
   "cameraAccessDeniedTitle": "権限が必要です",
   "cameraAccessDeniedMessage": "画像をアップロードするには、「設定」で Zulip に追加の権限を許可してください。",
   "cameraAccessDeniedButtonText": "設定を開く",
-  "subscribedToNStreams": "{num, plural, other{{num}つのチャンネルをフォローしています}}",
+  "subscribedToNChannels": "{num, plural, other{{num}つのチャンネルをフォローしています}}",
   "userRoleOwner": "オーナー",
   "userRoleAdministrator": "管理者",
   "userRoleModerator": "モデレータ",

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -81,7 +81,7 @@ the generated Dart binding for it will instead be a function,
 taking arguments corresponding to the placeholders.
 
 For example:
-`zulipLocalizations.subscribedToNStreams(store.subscriptions.length)`.
+`zulipLocalizations.subscribedToNChannels(store.subscriptions.length)`.
 
 
 ## Hack to enforce locale (for testing, etc.)

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -267,7 +267,7 @@ class HomePage extends StatelessWidget {
               Text.rich(TextSpan(
                 text: 'Zulip server version: ',
                 children: [bold(store.zulipVersion)])),
-              Text(zulipLocalizations.subscribedToNStreams(store.subscriptions.length)),
+              Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
             ])),
           const SizedBox(height: 16),
           ElevatedButton(

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -363,12 +363,12 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
     final streamName = store.streams[widget.narrow.streamId]?.name
-      ?? zulipLocalizations.composeBoxUnknownStreamName;
+      ?? zulipLocalizations.composeBoxUnknownChannelName;
     return _ContentInput(
       narrow: widget.narrow,
       controller: widget.controller,
       focusNode: widget.focusNode,
-      hintText: zulipLocalizations.composeBoxStreamContentHint(streamName, _topicTextNormalized));
+      hintText: zulipLocalizations.composeBoxChannelContentHint(streamName, _topicTextNormalized));
   }
 }
 
@@ -389,8 +389,8 @@ class _FixedDestinationContentInput extends StatelessWidget {
       case TopicNarrow(:final streamId, :final topic):
         final store = PerAccountStoreWidget.of(context);
         final streamName = store.streams[streamId]?.name
-          ?? zulipLocalizations.composeBoxUnknownStreamName;
-        return zulipLocalizations.composeBoxStreamContentHint(streamName, topic);
+          ?? zulipLocalizations.composeBoxUnknownChannelName;
+        return zulipLocalizations.composeBoxChannelContentHint(streamName, topic);
 
       case DmNarrow(otherRecipientIds: []): // The self-1:1 thread.
         return zulipLocalizations.composeBoxSelfDmContentHint;


### PR DESCRIPTION
This is the first one of a series of PRs that target #631.

Fixes parts of #631 