### PR TITLE
action_sheet: Add "Mark as unread from here" button

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -51,6 +51,10 @@
   "@actionSheetOptionCopyMessageLink": {
     "description": "Label for copy message link button on action sheet."
   },
+  "actionSheetOptionMarkAsUnread": "Mark as unread from here",
+  "@actionSheetOptionMarkAsUnread":  {
+    "description": "Label for mark as unread button on action sheet."
+  },
   "actionSheetOptionShare": "Share",
   "@actionSheetOptionShare":  {
     "description": "Label for share button on action sheet."
@@ -435,6 +439,21 @@
   "errorMarkAsReadFailedTitle": "Mark as read failed",
   "@errorMarkAsReadFailedTitle": {
     "description": "Error title when mark as read action failed."
+  },
+  "markAsUnreadComplete": "Marked {num, plural, =1{1 message} other{{num} messages}} as unread.",
+  "@markAsUnreadComplete": {
+    "description": "Message when marking messages as unread has completed.",
+    "placeholders": {
+      "num": {"type": "int", "example": "4"}
+    }
+  },
+  "markAsUnreadInProgress": "Marking messages as unread...",
+  "@markAsUnreadInProgress": {
+    "description": "Progress message when marking messages as unread."
+  },
+  "errorMarkAsUnreadFailedTitle": "Mark as unread failed",
+  "@errorMarkAsUnreadFailedTitle": {
+    "description": "Error title when mark as unread action failed."
   },
   "today": "Today",
   "@today": {

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -16,14 +16,11 @@ import '../model/narrow.dart';
 import 'dialog.dart';
 import 'store.dart';
 
-Future<void> markNarrowAsRead(
-  BuildContext context,
-  Narrow narrow,
-  bool useLegacy, // TODO(server-6)
-) async {
+Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
   try {
     final store = PerAccountStoreWidget.of(context);
     final connection = store.connection;
+    final useLegacy = connection.zulipFeatureLevel! < 155; // TODO(server-6)
     if (useLegacy) {
       await _legacyMarkNarrowAsRead(context, narrow);
       return;

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -16,7 +16,8 @@ import '../model/narrow.dart';
 import 'dialog.dart';
 import 'store.dart';
 
-Future<void> markNarrowAsRead(
+/// Returns true if mark as read process is completed successfully.
+Future<bool> markNarrowAsRead(
   BuildContext context,
   Narrow narrow,
   bool useLegacy, // TODO(server-6)
@@ -24,7 +25,8 @@ Future<void> markNarrowAsRead(
   final store = PerAccountStoreWidget.of(context);
   final connection = store.connection;
   if (useLegacy) {
-    return await _legacyMarkNarrowAsRead(context, narrow);
+    await _legacyMarkNarrowAsRead(context, narrow);
+    return true;
   }
 
   // Compare web's `mark_all_as_read` in web/src/unread_ops.js
@@ -66,7 +68,7 @@ Future<void> markNarrowAsRead(
       flag: MessageFlag.read);
     if (!context.mounted) {
       scaffoldMessenger.clearSnackBars();
-      return;
+      return false;
     }
     responseCount++;
     updatedCount += result.updatedCount;
@@ -81,7 +83,7 @@ Future<void> markNarrowAsRead(
           ..showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
               content: Text(zulipLocalizations.markAsReadComplete(updatedCount))));
       }
-      return;
+      return true;
     }
 
     if (result.lastProcessedId == null) {
@@ -91,7 +93,7 @@ Future<void> markNarrowAsRead(
       await showErrorDialog(context: context,
         title: zulipLocalizations.errorMarkAsReadFailedTitle,
         message: zulipLocalizations.errorInvalidResponse);
-      return;
+      return false;
     }
     anchor = NumericAnchor(result.lastProcessedId!);
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -62,6 +62,26 @@ Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
   }
 }
 
+Future<void> markNarrowAsUnreadFromMessage(
+  BuildContext context,
+  Message message,
+  Narrow narrow,
+) async {
+  final connection = PerAccountStoreWidget.of(context).connection;
+  assert(connection.zulipFeatureLevel! >= 155); // TODO(server-6)
+  final zulipLocalizations = ZulipLocalizations.of(context);
+  await updateMessageFlagsStartingFromAnchor(
+    context: context,
+    apiNarrow: narrow.apiEncode(),
+    startingAnchor: NumericAnchor(message.id),
+    includeAnchor: true,
+    op: UpdateMessageFlagsOp.remove,
+    flag: MessageFlag.read,
+    onCompletedMessage: zulipLocalizations.markAsUnreadComplete,
+    progressMessage: zulipLocalizations.markAsUnreadInProgress,
+    onFailedTitle: zulipLocalizations.errorMarkAsUnreadFailedTitle);
+}
+
 /// Updates message flags by applying given operation `op` using given `flag`
 /// the update happens on given `apiNarrow` starting from given `startingAnchor`
 ///

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -22,97 +22,106 @@ Future<bool> markNarrowAsRead(
   Narrow narrow,
   bool useLegacy, // TODO(server-6)
 ) async {
-  final store = PerAccountStoreWidget.of(context);
-  final connection = store.connection;
-  if (useLegacy) {
-    await _legacyMarkNarrowAsRead(context, narrow);
-    return true;
-  }
-
-  // Compare web's `mark_all_as_read` in web/src/unread_ops.js
-  // and zulip-mobile's `markAsUnreadFromMessage` in src/action-sheets/index.js .
-  final zulipLocalizations = ZulipLocalizations.of(context);
-  final scaffoldMessenger = ScaffoldMessenger.of(context);
-  // Use [AnchorCode.oldest], because [AnchorCode.firstUnread]
-  // will be the oldest non-muted unread message, which would
-  // result in muted unreads older than the first unread not
-  // being processed.
-  Anchor anchor = AnchorCode.oldest;
-  int responseCount = 0;
-  int updatedCount = 0;
-
-  // Include `is:unread` in the narrow.  That has a database index, so
-  // this can be an important optimization in narrows with a lot of history.
-  // The server applies the same optimization within the (deprecated)
-  // specialized endpoints for marking messages as read; see
-  // `do_mark_stream_messages_as_read` in `zulip:zerver/actions/message_flags.py`.
-  final apiNarrow = narrow.apiEncode()..add(ApiNarrowIsUnread());
-
-  while (true) {
-    final result = await updateMessageFlagsForNarrow(connection,
-      anchor: anchor,
-      // [AnchorCode.oldest] is an anchor ID lower than any valid
-      // message ID; and follow-up requests will have already
-      // processed the anchor ID, so we just want this to be
-      // unconditionally false.
-      includeAnchor: false,
-      // There is an upper limit of 5000 messages per batch
-      // (numBefore + numAfter <= 5000) enforced on the server.
-      // See `update_message_flags_in_narrow` in zerver/views/message_flags.py .
-      // zulip-mobile uses `numAfter` of 5000, but web uses 1000
-      // for more responsive feedback. See zulip@f0d87fcf6.
-      numBefore: 0,
-      numAfter: 1000,
-      narrow: apiNarrow,
-      op: UpdateMessageFlagsOp.add,
-      flag: MessageFlag.read);
-    if (!context.mounted) {
-      scaffoldMessenger.clearSnackBars();
-      return false;
-    }
-    responseCount++;
-    updatedCount += result.updatedCount;
-
-    if (result.foundNewest) {
-      if (responseCount > 1) {
-        // We previously showed an in-progress [SnackBar], so say we're done.
-        // There may be a backlog of [SnackBar]s accumulated in the queue
-        // so be sure to clear them out here.
-        scaffoldMessenger
-          ..clearSnackBars()
-          ..showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
-              content: Text(zulipLocalizations.markAsReadComplete(updatedCount))));
-      }
+  try {
+    final store = PerAccountStoreWidget.of(context);
+    final connection = store.connection;
+    if (useLegacy) {
+      await _legacyMarkNarrowAsRead(context, narrow);
       return true;
     }
 
-    if (result.lastProcessedId == null) {
-      // No messages were in the range of the request.
-      // This should be impossible given that `foundNewest` was false
-      // (and that our `numAfter` was positive.)
-      await showErrorDialog(context: context,
-        title: zulipLocalizations.errorMarkAsReadFailedTitle,
-        message: zulipLocalizations.errorInvalidResponse);
-      return false;
-    }
-    anchor = NumericAnchor(result.lastProcessedId!);
+    // Compare web's `mark_all_as_read` in web/src/unread_ops.js
+    // and zulip-mobile's `markAsUnreadFromMessage` in src/action-sheets/index.js .
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    // Use [AnchorCode.oldest], because [AnchorCode.firstUnread]
+    // will be the oldest non-muted unread message, which would
+    // result in muted unreads older than the first unread not
+    // being processed.
+    Anchor anchor = AnchorCode.oldest;
+    int responseCount = 0;
+    int updatedCount = 0;
 
-    // The task is taking a while, so tell the user we're working on it.
-    // No need to say how many messages, as the [MarkAsUnread] widget
-    // should follow along.
-    // TODO: Ideally we'd have a progress widget here that showed up based
-    //   on actual time elapsed -- so it could appear before the first
-    //   batch returns, if that takes a while -- and that then stuck
-    //   around continuously until the task ends. For now we use a
-    //   series of [SnackBar]s, which may feel a bit janky.
-    //   There is complexity in tracking the status of each [SnackBar],
-    //   due to having no way to determine which is currently active,
-    //   or if there is an active one at all.  Resetting the [SnackBar] here
-    //   results in the same message popping in and out and the user experience
-    //   is better for now if we allow them to run their timer through
-    //   and clear the backlog later.
-    scaffoldMessenger.showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
-      content: Text(zulipLocalizations.markAsReadInProgress)));
+    // Include `is:unread` in the narrow.  That has a database index, so
+    // this can be an important optimization in narrows with a lot of history.
+    // The server applies the same optimization within the (deprecated)
+    // specialized endpoints for marking messages as read; see
+    // `do_mark_stream_messages_as_read` in `zulip:zerver/actions/message_flags.py`.
+    final apiNarrow = narrow.apiEncode()..add(ApiNarrowIsUnread());
+
+    while (true) {
+      final result = await updateMessageFlagsForNarrow(connection,
+        anchor: anchor,
+        // [AnchorCode.oldest] is an anchor ID lower than any valid
+        // message ID; and follow-up requests will have already
+        // processed the anchor ID, so we just want this to be
+        // unconditionally false.
+        includeAnchor: false,
+        // There is an upper limit of 5000 messages per batch
+        // (numBefore + numAfter <= 5000) enforced on the server.
+        // See `update_message_flags_in_narrow` in zerver/views/message_flags.py .
+        // zulip-mobile uses `numAfter` of 5000, but web uses 1000
+        // for more responsive feedback. See zulip@f0d87fcf6.
+        numBefore: 0,
+        numAfter: 1000,
+        narrow: apiNarrow,
+        op: UpdateMessageFlagsOp.add,
+        flag: MessageFlag.read);
+      if (!context.mounted) {
+        scaffoldMessenger.clearSnackBars();
+        return false;
+      }
+      responseCount++;
+      updatedCount += result.updatedCount;
+
+      if (result.foundNewest) {
+        if (responseCount > 1) {
+          // We previously showed an in-progress [SnackBar], so say we're done.
+          // There may be a backlog of [SnackBar]s accumulated in the queue
+          // so be sure to clear them out here.
+          scaffoldMessenger
+            ..clearSnackBars()
+            ..showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
+                content: Text(zulipLocalizations.markAsReadComplete(updatedCount))));
+        }
+        return true;
+      }
+
+      if (result.lastProcessedId == null) {
+        // No messages were in the range of the request.
+        // This should be impossible given that `foundNewest` was false
+        // (and that our `numAfter` was positive.)
+        showErrorDialog(context: context,
+          title: zulipLocalizations.errorMarkAsReadFailedTitle,
+          message: zulipLocalizations.errorInvalidResponse);
+        return false;
+      }
+      anchor = NumericAnchor(result.lastProcessedId!);
+
+      // The task is taking a while, so tell the user we're working on it.
+      // No need to say how many messages, as the [MarkAsUnread] widget
+      // should follow along.
+      // TODO: Ideally we'd have a progress widget here that showed up based
+      //   on actual time elapsed -- so it could appear before the first
+      //   batch returns, if that takes a while -- and that then stuck
+      //   around continuously until the task ends. For now we use a
+      //   series of [SnackBar]s, which may feel a bit janky.
+      //   There is complexity in tracking the status of each [SnackBar],
+      //   due to having no way to determine which is currently active,
+      //   or if there is an active one at all.  Resetting the [SnackBar] here
+      //   results in the same message popping in and out and the user experience
+      //   is better for now if we allow them to run their timer through
+      //   and clear the backlog later.
+      scaffoldMessenger.showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
+        content: Text(zulipLocalizations.markAsReadInProgress)));
+    }
+  } catch (e) {
+    if (!context.mounted) return false;
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    showErrorDialog(context: context,
+      title: zulipLocalizations.errorMarkAsReadFailedTitle,
+      message: e.toString()); // TODO(#741): extract user-facing message better
+    return false;
   }
 }
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -46,7 +46,7 @@ Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
     // will be the oldest non-muted unread message, which would
     // result in muted unreads older than the first unread not
     // being processed.
-    startingAnchor: AnchorCode.oldest,
+    anchor: AnchorCode.oldest,
     // [AnchorCode.oldest] is an anchor ID lower than any valid
     // message ID.
     includeAnchor: false,
@@ -73,7 +73,7 @@ Future<void> markNarrowAsUnreadFromMessage(
   await updateMessageFlagsStartingFromAnchor(
     context: context,
     apiNarrow: narrow.apiEncode(),
-    startingAnchor: NumericAnchor(message.id),
+    anchor: NumericAnchor(message.id),
     includeAnchor: true,
     op: UpdateMessageFlagsOp.remove,
     flag: MessageFlag.read,
@@ -95,7 +95,7 @@ Future<void> markNarrowAsUnreadFromMessage(
 Future<bool> updateMessageFlagsStartingFromAnchor({
   required BuildContext context,
   required List<ApiNarrowElement> apiNarrow,
-  required Anchor startingAnchor,
+  required Anchor anchor,
   required bool includeAnchor,
   required UpdateMessageFlagsOp op,
   required MessageFlag flag,
@@ -110,10 +110,8 @@ Future<bool> updateMessageFlagsStartingFromAnchor({
 
     // Compare web's `mark_all_as_read` in web/src/unread_ops.js
     // and zulip-mobile's `markAsUnreadFromMessage` in src/action-sheets/index.js .
-    Anchor anchor = startingAnchor;
     int responseCount = 0;
     int updatedCount = 0;
-
     while (true) {
       final result = await updateMessageFlagsForNarrow(connection,
         anchor: anchor,

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -117,10 +117,7 @@ Future<bool> updateMessageFlagsStartingFromAnchor({
     while (true) {
       final result = await updateMessageFlagsForNarrow(connection,
         anchor: anchor,
-        // Follow-up requests will have already processed the
-        // anchor ID, so after the first iteration, this will be
-        // unconditionally false.
-        includeAnchor: responseCount == 0 ? includeAnchor : false,
+        includeAnchor: includeAnchor,
         // There is an upper limit of 5000 messages per batch
         // (numBefore + numAfter <= 5000) enforced on the server.
         // See `update_message_flags_in_narrow` in zerver/views/message_flags.py .
@@ -162,6 +159,7 @@ Future<bool> updateMessageFlagsStartingFromAnchor({
         return false;
       }
       anchor = NumericAnchor(result.lastProcessedId!);
+      includeAnchor = false;
 
       // The task is taking a while, so tell the user we're working on it.
       // TODO: Ideally we'd have a progress widget here that showed up based

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -82,16 +82,20 @@ Future<void> markNarrowAsUnreadFromMessage(
     onFailedTitle: zulipLocalizations.errorMarkAsUnreadFailedTitle);
 }
 
-/// Updates message flags by applying given operation `op` using given `flag`
-/// the update happens on given `apiNarrow` starting from given `startingAnchor`
+/// Add or remove the given flag from the anchor to the end of the narrow,
+/// showing feedback to the user on progress or failure.
 ///
-/// This also handles interactions with the user as it shows a `Snackbar` with
-/// `progressMessage` while performing the update, shows an error dialog when
-/// update fails with the given title using `onFailedTitle` and shows
-/// a `Snackbar` with computed message using given `onCompletedMessage`.
+/// This has the semantics of [updateMessageFlagsForNarrow]
+/// (see https://zulip.com/api/update-message-flags-for-narrow)
+/// with `numBefore: 0` and infinite `numAfter`.  It operates by calling that
+/// endpoint with a finite `numAfter` as a batch size, in a loop.
 ///
-/// Returns true in case the process is completed with no exceptions
-/// otherwise shows an error dialog and returns false.
+/// If the operation requires more than one batch, the user is shown progress
+/// feedback through [SnackBar], using [progressMessage] and [onCompletedMessage].
+/// If the operation fails, the user is shown an error dialog box with title
+/// [onFailedTitle].
+///
+/// Returns true just if the operation finished successfully.
 Future<bool> updateMessageFlagsStartingFromAnchor({
   required BuildContext context,
   required List<ApiNarrowElement> apiNarrow,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -16,7 +16,6 @@ import 'actions.dart';
 import 'app_bar.dart';
 import 'compose_box.dart';
 import 'content.dart';
-import 'dialog.dart';
 import 'emoji_reaction.dart';
 import 'icons.dart';
 import 'page.dart';
@@ -714,19 +713,9 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
     final connection = store.connection;
     final useLegacy = connection.zulipFeatureLevel! < 155;
     setState(() => _loading = true);
-    bool didPass = false;
-    try {
-      didPass = await markNarrowAsRead(context, widget.narrow, useLegacy);
-    } catch (e) {
-      if (!context.mounted) return;
-      final zulipLocalizations = ZulipLocalizations.of(context);
-      showErrorDialog(context: context,
-        title: zulipLocalizations.errorMarkAsReadFailedTitle,
-        message: e.toString()); // TODO(#741): extract user-facing message better
-      return;
-    } finally {
-      setState(() => _loading = false);
-    }
+
+    final didPass = await markNarrowAsRead(context, widget.narrow, useLegacy);
+    setState(() => _loading = false);
     if (!didPass) return;
     if (!context.mounted) return;
     if (widget.narrow is CombinedFeedNarrow && !useLegacy) {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -714,9 +714,9 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
     final connection = store.connection;
     final useLegacy = connection.zulipFeatureLevel! < 155;
     setState(() => _loading = true);
-
+    bool didPass = false;
     try {
-      await markNarrowAsRead(context, widget.narrow, useLegacy);
+      didPass = await markNarrowAsRead(context, widget.narrow, useLegacy);
     } catch (e) {
       if (!context.mounted) return;
       final zulipLocalizations = ZulipLocalizations.of(context);
@@ -727,6 +727,7 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
     } finally {
       setState(() => _loading = false);
     }
+    if (!didPass) return;
     if (!context.mounted) return;
     if (widget.narrow is CombinedFeedNarrow && !useLegacy) {
       PerAccountStoreWidget.of(context).unreads.handleAllMessagesReadSuccess();

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -708,12 +708,8 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
 
   void _handlePress(BuildContext context) async {
     if (!context.mounted) return;
-
-    final store = PerAccountStoreWidget.of(context);
-    final connection = store.connection;
-    final useLegacy = connection.zulipFeatureLevel! < 155;
     setState(() => _loading = true);
-    await markNarrowAsRead(context, widget.narrow, useLegacy);
+    await markNarrowAsRead(context, widget.narrow);
     setState(() => _loading = false);
   }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -713,14 +713,8 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
     final connection = store.connection;
     final useLegacy = connection.zulipFeatureLevel! < 155;
     setState(() => _loading = true);
-
-    final didPass = await markNarrowAsRead(context, widget.narrow, useLegacy);
+    await markNarrowAsRead(context, widget.narrow, useLegacy);
     setState(() => _loading = false);
-    if (!didPass) return;
-    if (!context.mounted) return;
-    if (widget.narrow is CombinedFeedNarrow && !useLegacy) {
-      PerAccountStoreWidget.of(context).unreads.handleAllMessagesReadSuccess();
-    }
   }
 
   @override

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -290,7 +290,6 @@ void main() {
       checkErrorDialog(tester,
         expectedTitle: zulipLocalizations.errorMarkAsReadFailedTitle,
         expectedMessage: 'NetworkException: Oops (ClientException: Oops)');
-    }, skip: true, // TODO move this functionality inside markNarrowAsRead
-    );
+    });
   });
 }

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -52,7 +52,7 @@ void main() {
         processedCount: 11, updatedCount: 3,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: true).toJson());
-      markNarrowAsRead(context, narrow, false);
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       final apiNarrow = narrow.apiEncode()..add(ApiNarrowIsUnread());
       check(connection.lastRequest).isA<http.Request>()
@@ -77,7 +77,7 @@ void main() {
         processedCount: 11, updatedCount: 3,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: true).toJson());
-      markNarrowAsRead(context, narrow, false);
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -103,7 +103,7 @@ void main() {
         processedCount: 1000, updatedCount: 890,
         firstProcessedId: 1, lastProcessedId: 1989,
         foundOldest: true, foundNewest: false).toJson());
-      markNarrowAsRead(context, narrow, false);
+      markNarrowAsRead(context, narrow);
       final apiNarrow = narrow.apiEncode()..add(ApiNarrowIsUnread());
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -147,7 +147,7 @@ void main() {
         processedCount: 11, updatedCount: 3,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: true).toJson());
-      markNarrowAsRead(context, narrow, false);
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await tester.pumpAndSettle();
       check(store.unreads.oldUnreadsMissing).isFalse();
@@ -161,7 +161,7 @@ void main() {
         processedCount: 1000, updatedCount: 0,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: false).toJson());
-      markNarrowAsRead(context, narrow, false);
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       final apiNarrow = narrow.apiEncode()..add(ApiNarrowIsUnread());
       check(connection.lastRequest).isA<http.Request>()
@@ -191,7 +191,7 @@ void main() {
 
       connection.zulipFeatureLevel = 154;
       connection.prepare(json: {});
-      markNarrowAsRead(context, narrow, true); // TODO move legacy-server check inside markNarrowAsRead
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -209,7 +209,7 @@ void main() {
       await prepare(tester);
       connection.zulipFeatureLevel = 154;
       connection.prepare(json: {});
-      markNarrowAsRead(context, narrow, true); // TODO move legacy-server check inside markNarrowAsRead
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -224,7 +224,7 @@ void main() {
       await prepare(tester);
       connection.zulipFeatureLevel = 154;
       connection.prepare(json: {});
-      markNarrowAsRead(context, narrow, true); // TODO move legacy-server check inside markNarrowAsRead
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -246,7 +246,7 @@ void main() {
       connection.zulipFeatureLevel = 154;
       connection.prepare(json:
         UpdateMessageFlagsResult(messages: [message.id]).toJson());
-      markNarrowAsRead(context, narrow, true); // TODO move legacy-server check inside markNarrowAsRead
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -266,7 +266,7 @@ void main() {
       connection.zulipFeatureLevel = 154;
       connection.prepare(json:
         UpdateMessageFlagsResult(messages: [message.id]).toJson());
-      markNarrowAsRead(context, narrow, true);  // TODO move legacy-server check inside markNarrowAsRead
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
@@ -283,7 +283,7 @@ void main() {
       const narrow = CombinedFeedNarrow();
       await prepare(tester);
       connection.prepare(exception: http.ClientException('Oops'));
-      markNarrowAsRead(context, narrow, false);
+      markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await tester.pumpAndSettle();
       checkErrorDialog(tester,

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -151,8 +151,7 @@ void main() {
       await tester.pump(Duration.zero);
       await tester.pumpAndSettle();
       check(store.unreads.oldUnreadsMissing).isFalse();
-    }, skip: true, // TODO move this functionality inside markNarrowAsRead
-    );
+    });
 
     testWidgets('on invalid response', (tester) async {
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -217,7 +217,7 @@ void main() {
         op: UpdateMessageFlagsOp.add,
         flag: MessageFlag.read,
         includeAnchor: false,
-        startingAnchor: AnchorCode.oldest,
+        anchor: AnchorCode.oldest,
         onCompletedMessage: onCompletedMessage,
         onFailedTitle: onFailedTitle,
         progressMessage: progressMessage);


### PR DESCRIPTION
Fixes: #131
This adds a new button "**Mark as unread from here**" to the bottom sheet activated for read messages, when clicked all messages starting from selected one down are marked as unread.
| Before | After|
| --- | --- |
| ![image](https://github.com/user-attachments/assets/534c9d40-c5ac-46dd-8769-f24faaf25b4b)| ![image](https://github.com/user-attachments/assets/8cbce6d5-3596-40ae-80a9-e4fc2f805d47) |


https://github.com/zulip/zulip-flutter/assets/63330019/b800f93f-6b9d-47d6-a41d-07daf3da1773

