### PR TITLE
content: Parse code block `data-code-language` attribute

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -287,9 +287,20 @@ class SpoilerNode extends BlockContentNode {
 }
 
 class CodeBlockNode extends BlockContentNode {
-  const CodeBlockNode(this.spans, {super.debugHtmlNode});
+  const CodeBlockNode(
+    this.spans, {
+    this.codeLanguage,
+    super.debugHtmlNode,
+  });
 
   final List<CodeBlockSpanNode> spans;
+  final String? codeLanguage;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('codeLanguage', codeLanguage));
+  }
 
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
@@ -943,9 +954,11 @@ class _ZulipContentParser {
 
   BlockContentNode parseCodeBlock(dom.Element divElement) {
     assert(_debugParserContext == _ParserContext.block);
+    String? codeLanguage;
     final mainElement = () {
       assert(divElement.localName == 'div'
           && divElement.className == "codehilite");
+      codeLanguage = divElement.attributes['data-code-language'];
 
       if (divElement.nodes.length != 1) return null;
       final child = divElement.nodes[0];
@@ -1009,7 +1022,7 @@ class _ZulipContentParser {
       spans.add(span);
     }
 
-    return CodeBlockNode(spans, debugHtmlNode: debugHtmlNode);
+    return CodeBlockNode(spans, codeLanguage: codeLanguage, debugHtmlNode: debugHtmlNode);
   }
 
   BlockContentNode parseImageNode(dom.Element divElement) {

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -281,7 +281,7 @@ class ContentExample {
     "```\nverb\natim\n```",
     expectedText: 'verb\natim',
     '<div class="codehilite"><pre><span></span><code>verb\natim\n</code></pre></div>', [
-      CodeBlockNode([
+      CodeBlockNode(codeLanguage: null, [
         CodeBlockSpanNode(text: 'verb\natim', type: CodeBlockSpanType.text),
       ]),
     ]);
@@ -294,7 +294,7 @@ class ContentExample {
         '<span></span><code><span class="kd">class</span><span class="w"> </span>'
         '<span class="nc">A</span><span class="w"> </span><span class="p">{}</span>'
         '\n</code></pre></div>', [
-      CodeBlockNode([
+      CodeBlockNode(codeLanguage: 'Dart', [
         CodeBlockSpanNode(text: 'class', type: CodeBlockSpanType.keywordDeclaration),
         CodeBlockSpanNode(text: ' ', type: CodeBlockSpanType.whitespace),
         CodeBlockSpanNode(text: 'A', type: CodeBlockSpanType.nameClass),
@@ -316,7 +316,7 @@ class ContentExample {
         '<span class="s">"world!</span><span class="se">\\n</span><span class="s">"</span>'
         '<span class="p">);</span>\n<span class="p">}</span>\n'
         '</code></pre></div>', [
-      CodeBlockNode([
+      CodeBlockNode(codeLanguage: 'Rust', [
         CodeBlockSpanNode(text: 'fn', type: CodeBlockSpanType.keyword),
         CodeBlockSpanNode(text: ' ', type: CodeBlockSpanType.text),
         CodeBlockSpanNode(text: 'main', type: CodeBlockSpanType.nameFunction),
@@ -378,7 +378,8 @@ class ContentExample {
     '<div class="codehilite">'
       '<pre><span></span><code>code block.\n</code></pre></div>\n\n'
     '<p>some content</p>', [
-      CodeBlockNode([CodeBlockSpanNode(text: "code block.", type: CodeBlockSpanType.text)]),
+      CodeBlockNode(codeLanguage: null,
+        [CodeBlockSpanNode(text: "code block.", type: CodeBlockSpanType.text)]),
       ParagraphNode(links: null, nodes: [TextNode("some content")]),
     ]);
 
@@ -1062,7 +1063,7 @@ void main() {
             ParagraphNode(wasImplicit: true, links: null, nodes: [TextNode('three')]),
           ]]),
         ]),
-        CodeBlockNode([
+        CodeBlockNode(codeLanguage: null, [
           CodeBlockSpanNode(text: 'four', type: CodeBlockSpanType.text),
         ]),
         ParagraphNode(wasImplicit: true, links: null, nodes: [TextNode('\n\n')]), // TODO avoid this; it renders wrong


### PR DESCRIPTION
We don't currently need this -- I wrote it when I thought proper styling depended on knowing whether the code block was declared with a language or not -- but it took some thinking-through to get just right, so might as well do it now in case we want it later (e.g., to include the language attribute in Flutter Semantics for code blocks).