### PR TITLE
api: JsonNullable; handle absent-vs-null RealmUserUpdateEvent.deliveryEmail

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json.dart';
 import 'model.dart';
 
 part 'events.g.dart';
@@ -266,6 +267,7 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   String get op => 'update';
 
   @JsonKey(readValue: _readFromPerson) final int userId;
+
   @JsonKey(readValue: _readFromPerson) final String? fullName;
   @JsonKey(readValue: _readFromPerson) final String? avatarUrl;
   // @JsonKey(readValue: _readFromPerson) final String? avatarSource; // TODO obsolete?
@@ -275,12 +277,28 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   @JsonKey(readValue: _readFromPerson) final int? botOwnerId;
   @JsonKey(readValue: _readFromPerson, unknownEnumValue: UserRole.unknown) final UserRole? role;
   @JsonKey(readValue: _readFromPerson) final bool? isBillingAdmin;
-  @JsonKey(readValue: _readFromPerson) final String? deliveryEmail; // TODO handle JSON `null`
+
+  @JsonKey(readValue: _readNullableStringFromPerson)
+  @NullableStringJsonConverter()
+  final JsonNullable<String>? deliveryEmail;
+
   @JsonKey(readValue: _readFromPerson) final RealmUserUpdateCustomProfileField? customProfileField;
   @JsonKey(readValue: _readFromPerson) final String? newEmail;
 
   static Object? _readFromPerson(Map<dynamic, dynamic> json, String key) {
     return (json['person'] as Map<String, dynamic>)[key];
+  }
+
+  static JsonNullable<String>? _readNullableStringFromPerson(
+      Map<dynamic, dynamic> json, String key) {
+    // We can't just say `readValue: _readNullableFromPerson<String>`,
+    // because json_serializable drops the type argument in the generated code.
+    return _readNullableFromPerson<String>(json, key);
+  }
+
+  static JsonNullable<T>? _readNullableFromPerson<T extends Object>(
+      Map<dynamic, dynamic> json, String key) {
+    return JsonNullable.readFromJson(json['person'] as Map<String, dynamic>, key);
   }
 
   RealmUserUpdateEvent({

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -138,8 +138,10 @@ RealmUserUpdateEvent _$RealmUserUpdateEventFromJson(
           RealmUserUpdateEvent._readFromPerson(json, 'is_billing_admin')
               as bool?,
       deliveryEmail:
-          RealmUserUpdateEvent._readFromPerson(json, 'delivery_email')
-              as String?,
+          _$JsonConverterFromJson<JsonNullable<String>, JsonNullable<String>>(
+              RealmUserUpdateEvent._readNullableStringFromPerson(
+                  json, 'delivery_email'),
+              const NullableStringJsonConverter().fromJson),
       customProfileField: RealmUserUpdateEvent._readFromPerson(
                   json, 'custom_profile_field') ==
               null
@@ -164,7 +166,10 @@ Map<String, dynamic> _$RealmUserUpdateEventToJson(
       'bot_owner_id': instance.botOwnerId,
       'role': instance.role,
       'is_billing_admin': instance.isBillingAdmin,
-      'delivery_email': instance.deliveryEmail,
+      'delivery_email':
+          _$JsonConverterToJson<JsonNullable<String>, JsonNullable<String>>(
+              instance.deliveryEmail,
+              const NullableStringJsonConverter().toJson),
       'custom_profile_field': instance.customProfileField,
       'new_email': instance.newEmail,
     };
@@ -177,6 +182,18 @@ const _$UserRoleEnumMap = {
   UserRole.guest: 600,
   UserRole.unknown: null,
 };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
 
 StreamCreateEvent _$StreamCreateEventFromJson(Map<String, dynamic> json) =>
     StreamCreateEvent(

--- a/lib/api/model/json.dart
+++ b/lib/api/model/json.dart
@@ -1,3 +1,5 @@
+import 'package:json_annotation/json_annotation.dart';
+
 /// A value parsed from JSON as either `null` or another value.
 ///
 /// This can be used to represent JSON properties where absence, null,
@@ -28,4 +30,22 @@ class JsonNullable<T extends Object> {
 
   @override
   int get hashCode => Object.hash('JsonNullable', value);
+}
+
+class IdentityJsonConverter<T> extends JsonConverter<T, T> {
+  const IdentityJsonConverter();
+
+  @override
+  T fromJson(T json) => json;
+
+  @override
+  T toJson(T object) => object;
+}
+
+// Make similar IdentityJsonConverter<…> subclasses as needed.
+// Just writing `@IdentityJsonConverter<…>` directly as the annotation
+// doesn't work, as json_serializable gets confused.  Possibly related:
+//   https://github.com/google/json_serializable.dart/issues/1398
+class NullableStringJsonConverter extends IdentityJsonConverter<JsonNullable<String>> {
+  const NullableStringJsonConverter();
 }

--- a/lib/api/model/json.dart
+++ b/lib/api/model/json.dart
@@ -1,0 +1,31 @@
+/// A value parsed from JSON as either `null` or another value.
+///
+/// This can be used to represent JSON properties where absence, null,
+/// and some other type are distinguished.
+/// For example, with the following field definition:
+/// ```dart
+///   JsonNullable<String>? name;
+/// ```
+/// a `name` value of `null` (as a Dart value) represents
+/// the `name` property being absent in JSON;
+/// a value of `JsonNullable(null)` represents `'name': null` in JSON;
+/// and a value of `JsonNullable("foo")` represents `'name': 'foo'` in JSON.
+class JsonNullable<T extends Object> {
+  const JsonNullable(this.value);
+
+  final T? value;
+
+  static JsonNullable<T>? readFromJson<T extends Object>(
+      Map<dynamic, dynamic> map, String key) {
+    return map.containsKey(key) ? JsonNullable(map[key] as T?) : null;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! JsonNullable) return false;
+    return value == other.value;
+  }
+
+  @override
+  int get hashCode => Object.hash('JsonNullable', value);
+}

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -204,7 +204,7 @@ class User {
   @JsonKey(unknownEnumValue: UserRole.unknown)
   UserRole role;
   String timezone;
-  String? avatarUrl; // TODO distinguish null from missing https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20omitted.20vs.2E.20null.20in.20JSON/near/1551759
+  String? avatarUrl; // TODO(#255) distinguish null from missing, as a `JsonNullable<String>?`
   int avatarVersion;
 
   // null for bots, which don't have custom profile fields.

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -4,6 +4,7 @@ import 'events.dart';
 import 'initial_snapshot.dart';
 import 'reaction.dart';
 
+export 'json.dart' show JsonNullable;
 export 'reaction.dart';
 
 part 'model.g.dart';

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -189,8 +189,7 @@ enum Emojiset {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class User {
   final int userId;
-  @JsonKey(name: 'delivery_email')
-  String? deliveryEmailStaleDoNotUse; // TODO see [RealmUserUpdateEvent.deliveryEmail]
+  String? deliveryEmail;
   String email;
   String fullName;
   String dateJoined;
@@ -236,7 +235,7 @@ class User {
 
   User({
     required this.userId,
-    required this.deliveryEmailStaleDoNotUse,
+    required this.deliveryEmail,
     required this.email,
     required this.fullName,
     required this.dateJoined,

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -92,7 +92,7 @@ Map<String, dynamic> _$RealmEmojiItemToJson(RealmEmojiItem instance) =>
 
 User _$UserFromJson(Map<String, dynamic> json) => User(
       userId: (json['user_id'] as num).toInt(),
-      deliveryEmailStaleDoNotUse: json['delivery_email'] as String?,
+      deliveryEmail: json['delivery_email'] as String?,
       email: json['email'] as String,
       fullName: json['full_name'] as String,
       dateJoined: json['date_joined'] as String,
@@ -120,7 +120,7 @@ User _$UserFromJson(Map<String, dynamic> json) => User(
 
 Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
       'user_id': instance.userId,
-      'delivery_email': instance.deliveryEmailStaleDoNotUse,
+      'delivery_email': instance.deliveryEmail,
       'email': instance.email,
       'full_name': instance.fullName,
       'date_joined': instance.dateJoined,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -430,15 +430,15 @@ class PerAccountStore extends ChangeNotifier with StreamStore, MessageStore {
       if (user == null) {
         return; // TODO log
       }
-      if (event.fullName != null)       user.fullName                   = event.fullName!;
-      if (event.avatarUrl != null)      user.avatarUrl                  = event.avatarUrl!;
-      if (event.avatarVersion != null)  user.avatarVersion              = event.avatarVersion!;
-      if (event.timezone != null)       user.timezone                   = event.timezone!;
-      if (event.botOwnerId != null)     user.botOwnerId                 = event.botOwnerId!;
-      if (event.role != null)           user.role                       = event.role!;
-      if (event.isBillingAdmin != null) user.isBillingAdmin             = event.isBillingAdmin!;
-      if (event.deliveryEmail != null)  user.deliveryEmailStaleDoNotUse = event.deliveryEmail!.value;
-      if (event.newEmail != null)       user.email                      = event.newEmail!;
+      if (event.fullName != null)       user.fullName       = event.fullName!;
+      if (event.avatarUrl != null)      user.avatarUrl      = event.avatarUrl!;
+      if (event.avatarVersion != null)  user.avatarVersion  = event.avatarVersion!;
+      if (event.timezone != null)       user.timezone       = event.timezone!;
+      if (event.botOwnerId != null)     user.botOwnerId     = event.botOwnerId!;
+      if (event.role != null)           user.role           = event.role!;
+      if (event.isBillingAdmin != null) user.isBillingAdmin = event.isBillingAdmin!;
+      if (event.deliveryEmail != null)  user.deliveryEmail  = event.deliveryEmail!.value;
+      if (event.newEmail != null)       user.email          = event.newEmail!;
       if (event.customProfileField != null) {
         final profileData = (user.profileData ??= {});
         final update = event.customProfileField!;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -437,7 +437,7 @@ class PerAccountStore extends ChangeNotifier with StreamStore, MessageStore {
       if (event.botOwnerId != null)     user.botOwnerId                 = event.botOwnerId!;
       if (event.role != null)           user.role                       = event.role!;
       if (event.isBillingAdmin != null) user.isBillingAdmin             = event.isBillingAdmin!;
-      if (event.deliveryEmail != null)  user.deliveryEmailStaleDoNotUse = event.deliveryEmail!;
+      if (event.deliveryEmail != null)  user.deliveryEmailStaleDoNotUse = event.deliveryEmail!.value;
       if (event.newEmail != null)       user.email                      = event.newEmail!;
       if (event.customProfileField != null) {
         final profileData = (user.profileData ??= {});

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -15,6 +15,20 @@ extension AlertWordsEventChecks on Subject<AlertWordsEvent> {
   Subject<List<String>> get alertWords => has((e) => e.alertWords, 'alertWords');
 }
 
+extension RealmUserUpdateEventChecks on Subject<RealmUserUpdateEvent> {
+  Subject<int> get userId => has((e) => e.userId, 'userId');
+  Subject<String?> get fullName => has((e) => e.fullName, 'fullName');
+  Subject<String?> get avatarUrl => has((e) => e.avatarUrl, 'avatarUrl');
+  Subject<int?> get avatarVersion => has((e) => e.avatarVersion, 'avatarVersion');
+  Subject<String?> get timezone => has((e) => e.timezone, 'timezone');
+  Subject<int?> get botOwnerId => has((e) => e.botOwnerId, 'botOwnerId');
+  Subject<UserRole?> get role => has((e) => e.role, 'role');
+  Subject<bool?> get isBillingAdmin => has((e) => e.isBillingAdmin, 'isBillingAdmin');
+  Subject<RealmUserUpdateCustomProfileField?> get customProfileField => has((e) => e.customProfileField, 'customProfileField');
+  Subject<String?> get newEmail => has((e) => e.newEmail, 'newEmail');
+  Subject<JsonNullable<String>?> get deliveryEmail => has((e) => e.deliveryEmail, 'deliveryEmail');
+}
+
 extension SubscriptionRemoveEventChecks on Subject<SubscriptionRemoveEvent> {
   Subject<List<int>> get streamIds => has((e) => e.streamIds, 'streamIds');
 }

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -30,6 +30,28 @@ void main() {
     ).isEmpty();
   });
 
+  group('realm_user/update', () {
+    Map<String, Object?> mkJson(Map<String, Object?> data) =>
+      {'id': 1, 'type': 'realm_user', 'op': 'update',
+       'person': {'user_id': 1, ...data}};
+
+    test('delivery_email absent', () {
+      check(Event.fromJson(mkJson({})))
+        .isA<RealmUserUpdateEvent>().deliveryEmail.isNull();
+    });
+
+    test('delivery_email null', () {
+      check(Event.fromJson(mkJson({'delivery_email': null})))
+        .isA<RealmUserUpdateEvent>().deliveryEmail.equals(const JsonNullable(null));
+    });
+
+    test('delivery_email a string', () {
+      check(Event.fromJson(mkJson({'delivery_email': 'name@example.org'})))
+        .isA<RealmUserUpdateEvent>().deliveryEmail.equals(
+          const JsonNullable('name@example.org'));
+    });
+  });
+
   test('subscription/remove: deserialize stream_ids correctly', () {
     check(Event.fromJson({
       'id': 1,

--- a/test/api/model/json_test.dart
+++ b/test/api/model/json_test.dart
@@ -1,0 +1,43 @@
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/json.dart';
+
+void main() {
+  group('JsonNullable', () {
+    test('value', () {
+      check(const JsonNullable<int>(null)).value.isNull();
+      check(const JsonNullable(3)).value.equals(3);
+      check(const JsonNullable(JsonNullable(3))).value
+        ..identicalTo(const JsonNullable(3))
+        ..isNotNull().value.equals(3);
+    });
+
+    test('readFromJson', () {
+      check(JsonNullable.readFromJson({},          'a')).isNull();
+      check(JsonNullable.readFromJson({'a': null}, 'a')).equals(const JsonNullable(null));
+      check(JsonNullable.readFromJson({'a': 3},    'a')).equals(const JsonNullable(3));
+    });
+
+    test('==/hashCode', () {
+      // ignore: prefer_const_constructors
+      check(JsonNullable<int>(null)).equals(JsonNullable(null));
+      // ignore: prefer_const_constructors
+      check(JsonNullable(3)).equals(JsonNullable(3));
+      // ignore: prefer_const_constructors
+      check(JsonNullable(JsonNullable(3))).equals(JsonNullable(JsonNullable(3)));
+
+      const values = [JsonNullable<int>(null), JsonNullable(3), JsonNullable(4),
+        JsonNullable(JsonNullable<int>(null)), JsonNullable(JsonNullable(3))];
+      for (int i = 0; i < values.length; i++) {
+        for (int j = i + 1; j < values.length; j++) {
+          check(values[i]).not((it) => it.equals(values[j]));
+          check(values[i].hashCode).not((it) => it.equals(values[j].hashCode));
+        }
+      }
+    });
+  });
+}
+
+extension JsonNullableChecks<T extends Object> on Subject<JsonNullable<T>> {
+  Subject<T?> get value => has((x) => x.value, 'value');
+}

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -3,7 +3,7 @@ import 'package:zulip/api/model/model.dart';
 
 extension UserChecks on Subject<User> {
   Subject<int> get userId => has((x) => x.userId, 'userId');
-  Subject<String?> get deliveryEmailStaleDoNotUse => has((x) => x.deliveryEmailStaleDoNotUse, 'deliveryEmailStaleDoNotUse');
+  Subject<String?> get deliveryEmail => has((x) => x.deliveryEmail, 'deliveryEmail');
   Subject<String> get email => has((x) => x.email, 'email');
   Subject<String> get fullName => has((x) => x.fullName, 'fullName');
   Subject<String> get dateJoined => has((x) => x.dateJoined, 'dateJoined');

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -48,7 +48,7 @@ void main() {
     }
 
     test('delivery_email', () {
-      check(mkUser({'delivery_email': 'name@email.com'}).deliveryEmailStaleDoNotUse)
+      check(mkUser({'delivery_email': 'name@email.com'}).deliveryEmail)
         .equals('name@email.com');
     });
 

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -72,6 +72,7 @@ int _lastUserId = 1000;
 /// from the calls to [user].
 User user({
   int? userId,
+  String? deliveryEmail,
   String? email,
   String? fullName,
   bool? isActive,
@@ -79,10 +80,11 @@ User user({
   String? avatarUrl,
   Map<int, ProfileFieldUserData>? profileData,
 }) {
+  var effectiveDeliveryEmail = deliveryEmail ?? 'name@example.com'; // TODO generate example emails
   return User(
     userId: userId ?? _nextUserId(),
-    deliveryEmailStaleDoNotUse: 'name@example.com',
-    email: email ?? 'name@example.com', // TODO generate example emails
+    deliveryEmailStaleDoNotUse: effectiveDeliveryEmail,
+    email: email ?? effectiveDeliveryEmail,
     fullName: fullName ?? 'A user', // TODO generate example names
     dateJoined: '2023-04-28',
     isActive: isActive ?? true,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -83,7 +83,7 @@ User user({
   var effectiveDeliveryEmail = deliveryEmail ?? 'name@example.com'; // TODO generate example emails
   return User(
     userId: userId ?? _nextUserId(),
-    deliveryEmailStaleDoNotUse: effectiveDeliveryEmail,
+    deliveryEmail: effectiveDeliveryEmail,
     email: email ?? effectiveDeliveryEmail,
     fullName: fullName ?? 'A user', // TODO generate example names
     dateJoined: '2023-04-28',

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -179,19 +179,19 @@ void main() {
 
         store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
           deliveryEmail: null));
-        check(getUser()).deliveryEmailStaleDoNotUse.equals('a@mail.example');
+        check(getUser()).deliveryEmail.equals('a@mail.example');
 
         store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
           deliveryEmail: const JsonNullable(null)));
-        check(getUser()).deliveryEmailStaleDoNotUse.isNull();
+        check(getUser()).deliveryEmail.isNull();
 
         store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
           deliveryEmail: const JsonNullable('b@mail.example')));
-        check(getUser()).deliveryEmailStaleDoNotUse.equals('b@mail.example');
+        check(getUser()).deliveryEmail.equals('b@mail.example');
 
         store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
           deliveryEmail: const JsonNullable('c@mail.example')));
-        check(getUser()).deliveryEmailStaleDoNotUse.equals('c@mail.example');
+        check(getUser()).deliveryEmail.equals('c@mail.example');
       });
     });
   });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -162,6 +162,40 @@ void main() {
     // TODO test database gets updated correctly (an integration test with sqlite?)
   });
 
+  group('PerAccountStore.handleEvent', () {
+    // Mostly this method just dispatches to StreamStore and MessageStore etc.,
+    // and so most of the tests live in the test files for those
+    // (but they call the handleEvent method because it's the entry point).
+
+    group('RealmUserUpdateEvent', () {
+      // TODO write more tests for handling RealmUserUpdateEvent
+
+      test('deliveryEmail', () {
+        final user = eg.user(deliveryEmail: 'a@mail.example');
+        final store = eg.store(initialSnapshot: eg.initialSnapshot(
+          realmUsers: [eg.selfUser, user]));
+
+        User getUser() => store.users[user.userId]!;
+
+        store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
+          deliveryEmail: null));
+        check(getUser()).deliveryEmailStaleDoNotUse.equals('a@mail.example');
+
+        store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
+          deliveryEmail: const JsonNullable(null)));
+        check(getUser()).deliveryEmailStaleDoNotUse.isNull();
+
+        store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
+          deliveryEmail: const JsonNullable('b@mail.example')));
+        check(getUser()).deliveryEmailStaleDoNotUse.equals('b@mail.example');
+
+        store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
+          deliveryEmail: const JsonNullable('c@mail.example')));
+        check(getUser()).deliveryEmailStaleDoNotUse.equals('c@mail.example');
+      });
+    });
+  });
+
   group('PerAccountStore.sendMessage', () {
     test('smoke', () async {
       final store = eg.store();


### PR DESCRIPTION
This introduces `JsonNullable` to handle cases where the Zulip API expresses a distinction by having some property be null vs. absent entirely. It's based on the draft I wrote in a chat conversation last year:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20omitted.20vs.2E.20null.20in.20JSON/near/1551714

Then we use that for RealmUserUpdateEvent.deliveryEmail; which causes the former User.deliveryEmailStaleDoNotUse to no longer be stale, and we can call it simply `User.deliveryEmail`. That will be helpful for #291 (fyi @sm-sayedi).
