### PR TITLE
Small NFC tweaks to message-move-related code

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -474,6 +474,17 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     notifyListeners();
   }
 
+  /// Update data derived from the content of the given message.
+  ///
+  /// This does not notify listeners.
+  /// The caller should ensure that happens later.
+  void messageContentChanged(int messageId) {
+    final index = _findMessageWithId(messageId);
+    if (index != -1) {
+      _reparseContent(index);
+    }
+  }
+
   // Repeal the `@protected` annotation that applies on the base implementation,
   // so we can call this method from [MessageStoreImpl].
   @override
@@ -494,17 +505,6 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     final isAnyPresent = messageIds.any((id) => _findMessageWithId(id) != -1);
     if (isAnyPresent) {
       notifyListeners();
-    }
-  }
-
-  /// Update data derived from the content of the given message.
-  ///
-  /// This does not notify listeners.
-  /// The caller should ensure that happens later.
-  void messageContentChanged(int messageId) {
-    final index = _findMessageWithId(messageId);
-    if (index != -1) {
-      _reparseContent(index);
     }
   }
 


### PR DESCRIPTION
I'm about to send all my draft changes toward #150 as a draft PR, so that @PIG208 can build on that without duplicating the work I did on that a couple of months ago.

This PR pulls out from that draft work a couple of small prep commits that are self-contained and ready to go, so that we can merge them (to reduce future merge conflicts) without blocking on the larger work.
