### PR TITLE
Handle moved messages in MessageStore and message lists

### DIFF
--- a/integration_test/unreadmarker_test.dart
+++ b/integration_test/unreadmarker_test.dart
@@ -32,7 +32,7 @@ void main() {
       newestResult(foundOldest: true, messages: messages).toJson());
 
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-      child: const MessageListPage(narrow: CombinedFeedNarrow())));
+      child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
     await tester.pumpAndSettle();
     return messages;
   }

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -576,7 +576,11 @@ class StreamMessage extends Message {
   @JsonKey(includeToJson: true)
   String get type => 'stream';
 
-  final String displayRecipient;
+  // This is not nullable API-wise, but if the message moves across channels,
+  // [displayRecipient] still refers to the original channel and it has to be
+  // invalidated.
+  @JsonKey(required: true, disallowNullValue: true)
+  String? displayRecipient;
   final int streamId;
 
   StreamMessage({

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -480,7 +480,7 @@ sealed class Message {
   final int senderId;
   final String senderRealmStr;
   @JsonKey(name: 'subject')
-  final String topic;
+  String topic;
   // final List<string> submessages; // TODO handle
   final int timestamp;
   String get type;
@@ -581,7 +581,7 @@ class StreamMessage extends Message {
   // invalidated.
   @JsonKey(required: true, disallowNullValue: true)
   String? displayRecipient;
-  final int streamId;
+  int streamId;
 
   StreamMessage({
     required super.client,

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -260,55 +260,70 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'color': instance.color,
     };
 
-StreamMessage _$StreamMessageFromJson(Map<String, dynamic> json) =>
-    StreamMessage(
-      client: json['client'] as String,
-      content: json['content'] as String,
-      contentType: json['content_type'] as String,
-      editState: Message._messageEditStateFromJson(
-          MessageEditState._readFromMessage(json, 'edit_state')),
-      id: (json['id'] as num).toInt(),
-      isMeMessage: json['is_me_message'] as bool,
-      lastEditTimestamp: (json['last_edit_timestamp'] as num?)?.toInt(),
-      reactions: Message._reactionsFromJson(json['reactions']),
-      recipientId: (json['recipient_id'] as num).toInt(),
-      senderEmail: json['sender_email'] as String,
-      senderFullName: json['sender_full_name'] as String,
-      senderId: (json['sender_id'] as num).toInt(),
-      senderRealmStr: json['sender_realm_str'] as String,
-      topic: json['subject'] as String,
-      timestamp: (json['timestamp'] as num).toInt(),
-      flags: Message._flagsFromJson(json['flags']),
-      matchContent: json['match_content'] as String?,
-      matchTopic: json['match_subject'] as String?,
-      displayRecipient: json['display_recipient'] as String,
-      streamId: (json['stream_id'] as num).toInt(),
-    );
+StreamMessage _$StreamMessageFromJson(Map<String, dynamic> json) {
+  $checkKeys(
+    json,
+    requiredKeys: const ['display_recipient'],
+    disallowNullValues: const ['display_recipient'],
+  );
+  return StreamMessage(
+    client: json['client'] as String,
+    content: json['content'] as String,
+    contentType: json['content_type'] as String,
+    editState: Message._messageEditStateFromJson(
+        MessageEditState._readFromMessage(json, 'edit_state')),
+    id: (json['id'] as num).toInt(),
+    isMeMessage: json['is_me_message'] as bool,
+    lastEditTimestamp: (json['last_edit_timestamp'] as num?)?.toInt(),
+    reactions: Message._reactionsFromJson(json['reactions']),
+    recipientId: (json['recipient_id'] as num).toInt(),
+    senderEmail: json['sender_email'] as String,
+    senderFullName: json['sender_full_name'] as String,
+    senderId: (json['sender_id'] as num).toInt(),
+    senderRealmStr: json['sender_realm_str'] as String,
+    topic: json['subject'] as String,
+    timestamp: (json['timestamp'] as num).toInt(),
+    flags: Message._flagsFromJson(json['flags']),
+    matchContent: json['match_content'] as String?,
+    matchTopic: json['match_subject'] as String?,
+    displayRecipient: json['display_recipient'] as String?,
+    streamId: (json['stream_id'] as num).toInt(),
+  );
+}
 
-Map<String, dynamic> _$StreamMessageToJson(StreamMessage instance) =>
-    <String, dynamic>{
-      'client': instance.client,
-      'content': instance.content,
-      'content_type': instance.contentType,
-      'edit_state': _$MessageEditStateEnumMap[instance.editState]!,
-      'id': instance.id,
-      'is_me_message': instance.isMeMessage,
-      'last_edit_timestamp': instance.lastEditTimestamp,
-      'reactions': Message._reactionsToJson(instance.reactions),
-      'recipient_id': instance.recipientId,
-      'sender_email': instance.senderEmail,
-      'sender_full_name': instance.senderFullName,
-      'sender_id': instance.senderId,
-      'sender_realm_str': instance.senderRealmStr,
-      'subject': instance.topic,
-      'timestamp': instance.timestamp,
-      'flags': instance.flags,
-      'match_content': instance.matchContent,
-      'match_subject': instance.matchTopic,
-      'type': instance.type,
-      'display_recipient': instance.displayRecipient,
-      'stream_id': instance.streamId,
-    };
+Map<String, dynamic> _$StreamMessageToJson(StreamMessage instance) {
+  final val = <String, dynamic>{
+    'client': instance.client,
+    'content': instance.content,
+    'content_type': instance.contentType,
+    'edit_state': _$MessageEditStateEnumMap[instance.editState]!,
+    'id': instance.id,
+    'is_me_message': instance.isMeMessage,
+    'last_edit_timestamp': instance.lastEditTimestamp,
+    'reactions': Message._reactionsToJson(instance.reactions),
+    'recipient_id': instance.recipientId,
+    'sender_email': instance.senderEmail,
+    'sender_full_name': instance.senderFullName,
+    'sender_id': instance.senderId,
+    'sender_realm_str': instance.senderRealmStr,
+    'subject': instance.topic,
+    'timestamp': instance.timestamp,
+    'flags': instance.flags,
+    'match_content': instance.matchContent,
+    'match_subject': instance.matchTopic,
+    'type': instance.type,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('display_recipient', instance.displayRecipient);
+  val['stream_id'] = instance.streamId;
+  return val;
+}
 
 const _$MessageEditStateEnumMap = {
   MessageEditState.none: 'none',

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -152,6 +152,7 @@ class MessageStoreImpl with MessageStore {
     final newStreamId = event.newStreamId; // null if topic-only move
     final origTopic = event.origTopic;
     final newTopic = event.newTopic;
+    final propagateMode = event.propagateMode;
 
     if (origTopic == null) {
       // There was no move.
@@ -176,6 +177,11 @@ class MessageStoreImpl with MessageStore {
     if (origStreamId == null) {
       // The `stream_id` field (aka origStreamId) is documented to be present on moves.
       assert(debugLog('Malformed UpdateMessageEvent: move but no origStreamId')); // TODO(log)
+      return;
+    }
+    if (propagateMode == null) {
+      // The `propagate_mode` field (aka propagateMode) is documented to be present on moves.
+      assert(debugLog('Malformed UpdateMessageEvent: move but no propagateMode')); // TODO(log)
       return;
     }
 
@@ -215,6 +221,7 @@ class MessageStoreImpl with MessageStore {
         origTopic: origTopic,
         newTopic: newTopic ?? origTopic,
         messageIds: event.messageIds,
+        propagateMode: propagateMode,
       );
     }
   }

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -167,9 +167,10 @@ class MessageStoreImpl with MessageStore {
       return;
     }
 
-    if (newTopic == null) {
-      // The `subject` field (aka newTopic) is documented to be present on moves.
-      assert(debugLog('Malformed UpdateMessageEvent: move but no newTopic')); // TODO(log)
+    if (newStreamId == null && newTopic == null) {
+      // If neither the channel nor topic name changed, nothing moved.
+      // In that case `orig_subject` (aka origTopic) should have been null.
+      assert(debugLog('Malformed UpdateMessageEvent: move but no newStreamId or newTopic')); // TODO(log)
       return;
     }
     if (origStreamId == null) {
@@ -179,7 +180,7 @@ class MessageStoreImpl with MessageStore {
     }
 
     if (newStreamId == null
-        && MessageEditState.topicMoveWasResolveOrUnresolve(origTopic, newTopic)) {
+        && MessageEditState.topicMoveWasResolveOrUnresolve(origTopic, newTopic!)) {
       // The topic was only resolved/unresolved.
       // No change to the messages' editState.
       return;

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -65,6 +65,9 @@ class MessageListHistoryStartItem extends MessageListItem {
 ///
 /// This comprises much of the guts of [MessageListView].
 mixin _MessageSequence {
+  /// A sequence number for invalidating stale fetches.
+  int generation = 0;
+
   /// The messages.
   ///
   /// See also [contents] and [items].
@@ -190,6 +193,17 @@ mixin _MessageSequence {
       (message) => parseContent(message.content)));
     assert(contents.length == messages.length);
     _reprocessAll();
+  }
+
+  /// Reset all [_MessageSequence] data, and cancel any active fetches.
+  void _reset() {
+    generation += 1;
+    messages.clear();
+    _fetched = false;
+    _haveOldest = false;
+    _fetchingOlder = false;
+    contents.clear();
+    items.clear();
   }
 
   /// Redo all computations from scratch, based on [messages].
@@ -398,12 +412,14 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     assert(!fetched && !haveOldest && !fetchingOlder);
     assert(messages.isEmpty && contents.isEmpty);
     // TODO schedule all this in another isolate
+    final generation = this.generation;
     final result = await getMessages(store.connection,
       narrow: narrow.apiEncode(),
       anchor: AnchorCode.newest,
       numBefore: kMessageListFetchBatchSize,
       numAfter: 0,
     );
+    if (this.generation > generation) return;
     store.reconcileMessages(result.messages);
     store.recentSenders.handleMessages(result.messages); // TODO(#824)
     for (final message in result.messages) {
@@ -426,6 +442,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     _fetchingOlder = true;
     _updateEndMarkers();
     notifyListeners();
+    final generation = this.generation;
     try {
       final result = await getMessages(store.connection,
         narrow: narrow.apiEncode(),
@@ -434,6 +451,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         numBefore: kMessageListFetchBatchSize,
         numAfter: 0,
       );
+      if (this.generation > generation) return;
 
       if (result.messages.isNotEmpty
           && result.messages.last.id == messages[0].id) {
@@ -451,9 +469,11 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       _insertAllMessages(0, fetchedMessages);
       _haveOldest = result.foundOldest;
     } finally {
-      _fetchingOlder = false;
-      _updateEndMarkers();
-      notifyListeners();
+      if (this.generation == generation) {
+        _fetchingOlder = false;
+        _updateEndMarkers();
+        notifyListeners();
+      }
     }
   }
 
@@ -486,6 +506,73 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     final index = _findMessageWithId(messageId);
     if (index != -1) {
       _reparseContent(index);
+    }
+  }
+
+  void _messagesMovedInternally(List<int> messageIds) {
+    for (final messageId in messageIds) {
+      if (_findMessageWithId(messageId) != -1) {
+        _reprocessAll();
+        notifyListeners();
+        return;
+      }
+    }
+  }
+
+  void _messagesMovedIntoNarrow() {
+    // If there are some messages we don't have in [MessageStore], and they
+    // occur later than the messages we have here, then we just have to
+    // re-fetch from scratch.  That's always valid, so just do that always.
+    // TODO in cases where we do have data to do better, do better.
+    _reset();
+    notifyListeners();
+    fetchInitial();
+  }
+
+  void _messagesMovedFromNarrow(List<int> messageIds) {
+    if (_removeMessagesById(messageIds)) {
+      notifyListeners();
+    }
+  }
+
+  void messagesMoved({
+    required int origStreamId,
+    required int newStreamId,
+    required String origTopic,
+    required String newTopic,
+    required List<int> messageIds,
+  }) {
+    switch (narrow) {
+      case DmNarrow():
+        // DMs can't be moved (nor created by moves),
+        // so the messages weren't in this narrow and still aren't.
+        return;
+
+      case CombinedFeedNarrow():
+      case MentionsNarrow():
+        // The messages were and remain in this narrow.
+        // TODO(#421): … except they may have become muted or not.
+        //   We'll handle that at the same time as we handle muting itself changing.
+        // Recipient headers, and downstream of those, may change, though.
+        _messagesMovedInternally(messageIds);
+
+      case ChannelNarrow(:final streamId):
+        switch ((origStreamId == streamId, newStreamId == streamId)) {
+          case (false, false): return;
+          case (true,  true ): _messagesMovedInternally(messageIds);
+          case (false, true ): _messagesMovedIntoNarrow();
+          case (true,  false): _messagesMovedFromNarrow(messageIds);
+        }
+
+      case TopicNarrow(:final streamId, :final topic):
+        final oldMatch = (origStreamId == streamId && origTopic == topic);
+        final newMatch = (newStreamId == streamId && newTopic == topic);
+        switch ((oldMatch, newMatch)) {
+          case (false, false): return;
+          case (true,  true ): return; // TODO(log) no-op move
+          case (false, true ): _messagesMovedIntoNarrow();
+          case (true,  false): _messagesMovedFromNarrow(messageIds); // TODO handle propagateMode
+        }
     }
   }
 

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -272,7 +272,7 @@ class NotificationDisplayManager {
     // TODO(nav): Better interact with existing nav stack on notif open
     navigator.push(MaterialAccountWidgetRoute<void>(accountId: account.id,
       // TODO(#82): Open at specific message, not just conversation
-      page: MessageListPage(narrow: narrow)));
+      page: MessageListPage(initNarrow: narrow)));
     return;
   }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -191,12 +191,12 @@ abstract class MessageListPageState {
 }
 
 class MessageListPage extends StatefulWidget {
-  const MessageListPage({super.key, required this.narrow});
+  const MessageListPage({super.key, required this.initNarrow});
 
   static Route<void> buildRoute({int? accountId, BuildContext? context,
       required Narrow narrow}) {
     return MaterialAccountWidgetRoute(accountId: accountId, context: context,
-      page: MessageListPage(narrow: narrow));
+      page: MessageListPage(initNarrow: narrow));
   }
 
   /// The [MessageListPageState] above this context in the tree.
@@ -211,7 +211,7 @@ class MessageListPage extends StatefulWidget {
     return state!;
   }
 
-  final Narrow narrow;
+  final Narrow initNarrow;
 
   @override
   State<MessageListPage> createState() => _MessageListPageState();
@@ -219,12 +219,18 @@ class MessageListPage extends StatefulWidget {
 
 class _MessageListPageState extends State<MessageListPage> implements MessageListPageState {
   @override
-  Narrow get narrow => widget.narrow;
+  late Narrow narrow;
 
   @override
   ComposeBoxController? get composeBoxController => _composeBoxKey.currentState;
 
   final GlobalKey<ComposeBoxController> _composeBoxKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    narrow = widget.initNarrow;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -233,7 +239,7 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
 
     final Color? appBarBackgroundColor;
     bool removeAppBarBottomBorder = false;
-    switch(widget.narrow) {
+    switch(narrow) {
       case CombinedFeedNarrow():
       case MentionsNarrow():
         appBarBackgroundColor = null; // i.e., inherit
@@ -256,7 +262,7 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
     }
 
     return Scaffold(
-      appBar: AppBar(title: MessageListAppBarTitle(narrow: widget.narrow),
+      appBar: AppBar(title: MessageListAppBarTitle(narrow: narrow),
         backgroundColor: appBarBackgroundColor,
         shape: removeAppBarBottomBorder
           ? const Border()
@@ -280,11 +286,11 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
               // The compose box, when present, pads the bottom inset.
               // TODO(#311) If we have a bottom nav, it will pad the bottom
               //   inset, and this should always be true.
-              removeBottom: ComposeBox.hasComposeBox(widget.narrow),
+              removeBottom: ComposeBox.hasComposeBox(narrow),
 
               child: Expanded(
-                child: MessageList(narrow: widget.narrow))),
-            ComposeBox(controllerKey: _composeBoxKey, narrow: widget.narrow),
+                child: MessageList(narrow: narrow))),
+            ComposeBox(controllerKey: _composeBoxKey, narrow: narrow),
           ]))));
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -978,7 +978,9 @@ class StreamMessageRecipientHeader extends StatelessWidget {
       streamWidget = const SizedBox(width: 16);
     } else {
       final stream = store.streams[message.streamId];
-      final streamName = stream?.name ?? message.displayRecipient; // TODO(log) if missing
+      final streamName = stream?.name
+        ?? message.displayRecipient
+        ?? '(unknown channel)'; // TODO(log)
 
       streamWidget = GestureDetector(
         onTap: () => Navigator.push(context,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -232,6 +232,12 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
     narrow = widget.initNarrow;
   }
 
+  void _narrowChanged(Narrow newNarrow) {
+    setState(() {
+      narrow = newNarrow;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
@@ -289,7 +295,7 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
               removeBottom: ComposeBox.hasComposeBox(narrow),
 
               child: Expanded(
-                child: MessageList(narrow: narrow))),
+                child: MessageList(narrow: narrow, onNarrowChanged: _narrowChanged))),
             ComposeBox(controllerKey: _composeBoxKey, narrow: narrow),
           ]))));
   }
@@ -368,9 +374,10 @@ const _kShortMessageHeight = 80;
 const kFetchMessagesBufferPixels = (kMessageListFetchBatchSize / 2) * _kShortMessageHeight;
 
 class MessageList extends StatefulWidget {
-  const MessageList({super.key, required this.narrow});
+  const MessageList({super.key, required this.narrow, required this.onNarrowChanged});
 
   final Narrow narrow;
+  final void Function(Narrow newNarrow) onNarrowChanged;
 
   @override
   State<StatefulWidget> createState() => _MessageListState();
@@ -407,6 +414,11 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   }
 
   void _modelChanged() {
+    if (model!.narrow != widget.narrow) {
+      // A message move event occurred, where propagate mode is
+      // [PropagateMode.changeAll] or [PropagateMode.changeLater].
+      widget.onNarrowChanged(model!.narrow);
+    }
     setState(() {
       // The actual state lives in the [MessageListView] model.
       // This method was called because that just changed.

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -49,6 +49,10 @@ extension MessageChecks on Subject<Message> {
   Subject<String?> get matchTopic => has((e) => e.matchTopic, 'matchTopic');
 }
 
+extension StreamMessageChecks on Subject<StreamMessage> {
+  Subject<String?> get displayRecipient => has((e) => e.displayRecipient, 'displayRecipient');
+}
+
 extension ReactionsChecks on Subject<Reactions> {
   Subject<int> get total => has((e) => e.total, 'total');
   Subject<List<ReactionWithVotes>> get aggregated => has((e) => e.aggregated, 'aggregated');

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:checks/checks.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/model.dart';
 
@@ -147,6 +148,14 @@ void main() {
           ..['flags'] = ['read', 'something_unknown'],
       );
       check(m2).flags.deepEquals([MessageFlag.read, MessageFlag.unknown]);
+    });
+
+    test('require displayRecipient on parse', () {
+      check(() => StreamMessage.fromJson(baseStreamJson()..['display_recipient'] = null))
+        .throws<DisallowedNullValueException>();
+
+      check(() => StreamMessage.fromJson(baseStreamJson()..remove('display_recipient')))
+        .throws<MissingRequiredKeysException>();
     });
 
     // Code relevant to messageEditState is tested separately in the

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -472,6 +472,7 @@ UpdateMessageEvent _updateMessageMoveEvent(
   String? origContent,
   String? newContent,
   required List<MessageFlag> flags,
+  PropagateMode propagateMode = PropagateMode.changeOne,
 }) {
   assert(newTopic != origTopic
          || (newStreamId != null && newStreamId != origStreamId));
@@ -486,7 +487,7 @@ UpdateMessageEvent _updateMessageMoveEvent(
     editTimestamp: 1234567890, // TODO generate timestamp
     origStreamId: origStreamId,
     newStreamId: newStreamId,
-    propagateMode: null,
+    propagateMode: propagateMode,
     origTopic: origTopic,
     newTopic: newTopic,
     origContent: origContent,
@@ -503,6 +504,7 @@ UpdateMessageEvent updateMessageEventMoveFrom({
   int? newStreamId,
   String? newTopic,
   String? newContent,
+  PropagateMode propagateMode = PropagateMode.changeOne,
 }) {
   assert(origMessages.isNotEmpty);
   final origMessage = origMessages.first;
@@ -516,6 +518,7 @@ UpdateMessageEvent updateMessageEventMoveFrom({
     origContent: origContent,
     newContent: newContent,
     flags: origMessage.flags,
+    propagateMode: propagateMode,
   );
 }
 
@@ -525,6 +528,7 @@ UpdateMessageEvent updateMessageEventMoveTo({
   int? origStreamId,
   String? origTopic,
   String? origContent,
+  PropagateMode propagateMode = PropagateMode.changeOne,
 }) {
   assert(newMessages.isNotEmpty);
   final newMessage = newMessages.first;
@@ -542,6 +546,7 @@ UpdateMessageEvent updateMessageEventMoveTo({
     origContent: origContent,
     newContent: newContent,
     flags: newMessage.flags,
+    propagateMode: propagateMode,
   );
 }
 

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -60,8 +60,14 @@ extension TextChecks on Subject<Text> {
   Subject<TextStyle?> get style => has((t) => t.style, 'style');
 }
 
+extension TextEditingControllerChecks on Subject<TextEditingController> {
+  Subject<String?> get text => has((t) => t.text, 'text');
+}
+
 extension TextFieldChecks on Subject<TextField> {
   Subject<TextCapitalization?> get textCapitalization => has((t) => t.textCapitalization, 'textCapitalization');
+  Subject<InputDecoration?> get decoration => has((t) => t.decoration, 'decoration');
+  Subject<TextEditingController?> get controller => has((t) => t.controller, 'controller');
 }
 
 extension TextStyleChecks on Subject<TextStyle> {
@@ -130,4 +136,8 @@ extension MediaQueryDataChecks on Subject<MediaQueryData> {
 extension MaterialChecks on Subject<Material> {
   Subject<Color?> get color => has((x) => x.color, 'color');
   // TODO more
+}
+
+extension InputDecorationChecks on Subject<InputDecoration> {
+  Subject<String?> get hintText => has((x) => x.hintText, 'hintText');
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -16,6 +16,7 @@ import 'package:zulip/model/store.dart';
 import '../api/fake_api.dart';
 import '../api/model/model_checks.dart';
 import '../example_data.dart' as eg;
+import '../fake_async.dart';
 import '../stdlib_checks.dart';
 import 'content_checks.dart';
 import 'recent_senders_test.dart' as recent_senders_test;
@@ -462,6 +463,412 @@ void main() {
       await store.handleEvent(eg.updateMessageEditEvent(messageNotInNarrow,
         renderedContent: '${messageNotInNarrow.content}<p>edited</p'));
       checkNotNotified();
+    });
+  });
+
+  group('messagesMoved', () {
+    final stream = eg.stream(streamId: 1, name: 'test stream');
+    final otherStream = eg.stream(streamId: 2, name: 'other stream');
+
+    void checkHasMessages(Iterable<Message> messages) {
+      check(model.messages.map((e) => e.id)).deepEquals(messages.map((e) => e.id));
+    }
+
+    Future<void> prepareNarrow(Narrow narrow, List<Message>? messages) async {
+      await prepare(narrow: narrow);
+      for (final streamToAdd in [stream, otherStream]) {
+        final subscription = eg.subscription(streamToAdd);
+        await store.addStream(streamToAdd);
+        await store.addSubscription(subscription);
+      }
+      if (messages != null) {
+        await prepareMessages(foundOldest: false, messages: messages);
+      }
+      checkHasMessages(messages ?? []);
+    }
+
+    group('in combined feed narrow', () {
+      const narrow = CombinedFeedNarrow();
+      final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+      final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+
+      test('internal move between channels', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, initialMessages);
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: initialMessages,
+          newTopic: initialMessages[0].topic,
+          newStreamId: otherStream.streamId,
+        ));
+        checkHasMessages(initialMessages);
+        checkNotified(count: 2);
+      }));
+
+      test('internal move between topics', () async {
+        await prepareNarrow(narrow, initialMessages + movedMessages);
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: movedMessages,
+          newTopic: 'new',
+        ));
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotified(count: 2);
+      });
+    });
+
+    group('in channel narrow', () {
+      final narrow = ChannelNarrow(stream.streamId);
+      final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+      final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+      final otherChannelMovedMessages = List.generate(5, (i) => eg.streamMessage(stream: otherStream, topic: 'topic'));
+
+      test('channel -> channel: internal move', () async {
+        await prepareNarrow(narrow, initialMessages + movedMessages);
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: movedMessages,
+          newTopic: 'new',
+        ));
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotified(count: 2);
+      });
+
+      test('old channel -> channel: refetch', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, initialMessages);
+
+        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + movedMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveTo(
+          origTopic: 'orig topic',
+          origStreamId: otherStream.streamId,
+          newMessages: movedMessages,
+        ));
+        check(model).fetched.isFalse();
+        checkHasMessages([]);
+        checkNotifiedOnce();
+
+        async.elapse(const Duration(seconds: 2));
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotifiedOnce();
+      }));
+
+      test('channel -> new channel: remove moved messages', () async {
+        await prepareNarrow(narrow, initialMessages + movedMessages);
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: movedMessages,
+          newTopic: 'new',
+          newStreamId: otherStream.streamId,
+        ));
+        checkHasMessages(initialMessages);
+        checkNotifiedOnce();
+      });
+
+      test('unrelated channel -> new channel: unaffected', () async {
+        await prepareNarrow(narrow, initialMessages);
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: otherChannelMovedMessages,
+          newStreamId: otherStream.streamId,
+        ));
+        checkHasMessages(initialMessages);
+        checkNotNotified();
+      });
+
+      test('unrelated channel -> unrelated channel: unaffected', () async {
+        await prepareNarrow(narrow, initialMessages);
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: otherChannelMovedMessages,
+          newTopic: 'new',
+        ));
+        checkHasMessages(initialMessages);
+        checkNotNotified();
+      });
+    });
+
+    group('in topic narrow', () {
+      final narrow = TopicNarrow(stream.streamId, 'topic');
+      final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream, topic: 'topic'));
+      final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream, topic: 'topic'));
+      final otherTopicMovedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream, topic: 'other topic'));
+      final otherChannelMovedMessages = List.generate(5, (i) => eg.streamMessage(stream: otherStream, topic: 'topic'));
+
+      group('moved into narrow: should refetch messages', () {
+        final testCases = [
+          ('(old channel, topic) -> (channel, topic)',     200,   null),
+          ('(channel, old topic) -> (channel, topic)',     null, 'other'),
+          ('(old channel, old topic) -> (channel, topic)', 200,  'other'),
+        ];
+
+        for (final (description, origStreamId, origTopic) in testCases) {
+          test(description, () => awaitFakeAsync((async) async {
+            await prepareNarrow(narrow, initialMessages);
+
+            connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+              foundOldest: false,
+              messages: initialMessages + movedMessages,
+            ).toJson());
+            await store.handleEvent(eg.updateMessageEventMoveTo(
+              origStreamId: origStreamId,
+              origTopic: origTopic,
+              newMessages: movedMessages,
+            ));
+            check(model).fetched.isFalse();
+            checkHasMessages([]);
+            checkNotifiedOnce();
+
+            async.elapse(const Duration(seconds: 2));
+            checkHasMessages(initialMessages + movedMessages);
+            checkNotifiedOnce();
+          }));
+        }
+      });
+
+      group('moved from narrow: should remove moved messages', () {
+        final testCases = [
+          ('(channel, topic) -> (new channel, topic)',     200,   null),
+          ('(channel, topic) -> (channel, new topic)',     null, 'new'),
+          ('(channel, topic) -> (new channel, new topic)', 200,  'new'),
+        ];
+
+        for (final (description, newStreamId, newTopic) in testCases) {
+          test(description, () async {
+            await prepareNarrow(narrow, initialMessages + movedMessages);
+
+            await store.handleEvent(eg.updateMessageEventMoveFrom(
+              origMessages: movedMessages,
+              newStreamId: newStreamId,
+              newTopic: newTopic,
+            ));
+            checkHasMessages(initialMessages);
+            checkNotifiedOnce();
+          });
+        }
+      });
+
+      group('irrelevant moves', () {
+        test('(channel, old topic) -> (channel, unrelated topic)', () => awaitFakeAsync((async) async {
+          await prepareNarrow(narrow, initialMessages);
+
+          await store.handleEvent(eg.updateMessageEventMoveTo(
+            origTopic: 'other',
+            newMessages: otherTopicMovedMessages,
+          ));
+          check(model).fetched.isTrue();
+          checkHasMessages(initialMessages);
+          checkNotNotified();
+        }));
+
+        test('(old channel, topic) - > (unrelated channel, topic)', () => awaitFakeAsync((async) async {
+          await prepareNarrow(narrow, initialMessages);
+
+          await store.handleEvent(eg.updateMessageEventMoveTo(
+            origStreamId: 200,
+            newMessages: otherChannelMovedMessages,
+          ));
+          check(model).fetched.isTrue();
+          checkHasMessages(initialMessages);
+          checkNotNotified();
+        }));
+      });
+    });
+
+    group('fetch races', () {
+      final narrow = ChannelNarrow(stream.streamId);
+      final olderMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+      final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+      final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+
+      test('fetchOlder, _reset, fetchOlder returns, move fetch finishes', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, initialMessages);
+
+        connection.prepare(delay: const Duration(seconds: 1), json: olderResult(
+          anchor: model.messages[0].id,
+          foundOldest: true,
+          messages: olderMessages,
+        ).toJson());
+        final fetchFuture = model.fetchOlder();
+        check(model).fetchingOlder.isTrue();
+        checkHasMessages(initialMessages);
+        checkNotifiedOnce();
+
+        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + movedMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveTo(
+          origTopic: movedMessages[0].topic,
+          origStreamId: otherStream.streamId,
+          newMessages: movedMessages,
+        ));
+        check(model).fetchingOlder.isFalse();
+        checkHasMessages([]);
+        checkNotifiedOnce();
+
+        await fetchFuture;
+        checkHasMessages([]);
+        checkNotNotified();
+
+        async.elapse(const Duration(seconds: 1));
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotifiedOnce();
+      }));
+
+      test('fetchOlder, _reset, move fetch finishes, fetchOlder returns', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, initialMessages);
+
+        connection.prepare(delay: const Duration(seconds: 2), json: olderResult(
+          anchor: model.messages[0].id,
+          foundOldest: true,
+          messages: olderMessages,
+        ).toJson());
+        final fetchFuture = model.fetchOlder();
+        checkHasMessages(initialMessages);
+        check(model).fetchingOlder.isTrue();
+        checkNotifiedOnce();
+
+        connection.prepare(delay: const Duration(seconds: 1), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + movedMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveTo(
+          origTopic: movedMessages[0].topic,
+          origStreamId: otherStream.streamId,
+          newMessages: movedMessages,
+        ));
+        checkHasMessages([]);
+        check(model).fetchingOlder.isFalse();
+        checkNotifiedOnce();
+
+        async.elapse(const Duration(seconds: 1));
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotifiedOnce();
+
+        await fetchFuture;
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotNotified();
+      }));
+
+      test('fetchInitial, _reset, initial fetch finishes, move fetch finishes', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, null);
+
+        connection.prepare(delay: const Duration(seconds: 1), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages,
+        ).toJson());
+        final fetchFuture = model.fetchInitial();
+        checkHasMessages([]);
+        check(model).fetched.isFalse();
+
+        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + movedMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveTo(
+          origTopic: movedMessages[0].topic,
+          origStreamId: otherStream.streamId,
+          newMessages: movedMessages,
+        ));
+        checkHasMessages([]);
+        check(model).fetched.isFalse();
+        checkNotifiedOnce();
+
+        await fetchFuture;
+        checkHasMessages([]);
+        check(model).fetched.isFalse();
+        checkNotNotified();
+
+        async.elapse(const Duration(seconds: 1));
+        checkHasMessages(initialMessages + movedMessages);
+        checkNotifiedOnce();
+      }));
+
+      test('fetchInitial, _reset, move fetch finishes, initial fetch finishes', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, null);
+
+        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages,
+        ).toJson());
+        final fetchFuture = model.fetchInitial();
+        checkHasMessages([]);
+        check(model).fetched.isFalse();
+
+        connection.prepare(delay: const Duration(seconds: 1), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + movedMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveTo(
+          origTopic: movedMessages[0].topic,
+          origStreamId: otherStream.streamId,
+          newMessages: movedMessages,
+        ));
+        checkHasMessages([]);
+        check(model).fetched.isFalse();
+
+        async.elapse(const Duration(seconds: 1));
+        checkHasMessages(initialMessages + movedMessages);
+        check(model).fetched.isTrue();
+
+        await fetchFuture;
+        checkHasMessages(initialMessages + movedMessages);
+      }));
+
+      test('fetchOlder #1, _reset, move fetch finishes, fetchOlder #2, '
+        'fetchOlder #1 finishes, fetchOlder #2 finishes', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, initialMessages);
+
+        connection.prepare(delay: const Duration(seconds: 2), json: olderResult(
+          anchor: model.messages[0].id,
+          foundOldest: true,
+          messages: olderMessages,
+        ).toJson());
+        final fetchFuture1 = model.fetchOlder();
+        checkHasMessages(initialMessages);
+        check(model).fetchingOlder.isTrue();
+        checkNotifiedOnce();
+
+        connection.prepare(delay: const Duration(seconds: 1), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + movedMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveTo(
+          origTopic: movedMessages[0].topic,
+          origStreamId: otherStream.streamId,
+          newMessages: movedMessages,
+        ));
+        checkHasMessages([]);
+        check(model).fetchingOlder.isFalse();
+        checkNotifiedOnce();
+
+        async.elapse(const Duration(seconds: 1));
+        checkNotifiedOnce();
+
+        connection.prepare(delay: const Duration(seconds: 2), json: olderResult(
+          anchor: model.messages[0].id,
+          foundOldest: true,
+          messages: olderMessages
+        ).toJson());
+        final fetchFuture2 = model.fetchOlder();
+        checkHasMessages(initialMessages + movedMessages);
+        check(model).fetchingOlder.isTrue();
+        checkNotifiedOnce();
+
+        await fetchFuture1;
+        checkHasMessages(initialMessages + movedMessages);
+        // The older fetchOlder call should not override fetchingOlder set by
+        // the new fetchOlder call, nor should it notify the listeners.
+        check(model).fetchingOlder.isTrue();
+        checkNotNotified();
+
+        await fetchFuture2;
+        checkHasMessages(olderMessages + initialMessages + movedMessages);
+        check(model).fetchingOlder.isFalse();
+        checkNotifiedOnce();
+      }));
     });
   });
 

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -297,11 +297,15 @@ void main() {
 
       test('message topic moved update', () async {
         await prepareOrigMessages(origTopic: 'old topic');
+        final originalDisplayRecipient = origMessages[0].displayRecipient!;
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newTopic:  'new topic'));
-        checkNotifiedOnce();
-        check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
+        checkNotified(count: 2);
+        check(store).messages.values.every(((message) =>
+          message.isA<StreamMessage>()
+            ..editState.equals(MessageEditState.moved)
+            ..displayRecipient.equals(originalDisplayRecipient)));
       });
 
       test('message topic resolved update', () async {
@@ -309,7 +313,7 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newTopic:  '✔ new topic'));
-        checkNotifiedOnce();
+        checkNotified(count: 2);
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.none)));
       });
 
@@ -318,7 +322,7 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newTopic:  'new topic'));
-        checkNotifiedOnce();
+        checkNotified(count: 2);
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.none)));
       });
 
@@ -327,7 +331,7 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newTopic:  '✔ new topic 2'));
-        checkNotifiedOnce();
+        checkNotified(count: 2);
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
@@ -336,7 +340,7 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newTopic:  'new topic 2'));
-        checkNotifiedOnce();
+        checkNotified(count: 2);
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
@@ -345,8 +349,11 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newStreamId: 20));
-        checkNotifiedOnce();
-        check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
+        checkNotified(count: 2);
+        check(store).messages.values.every(((message) =>
+          message.isA<StreamMessage>()
+            ..editState.equals(MessageEditState.moved)
+            ..displayRecipient.equals(null)));
       });
 
       test('message is both moved and updated', () async {
@@ -355,7 +362,7 @@ void main() {
           origMessages: origMessages,
           newStreamId: 20,
           newContent: 'new content'));
-        checkNotifiedOnce();
+        checkNotified(count: 2);
         check(store).messages[origMessages[0].id].editState.equals(MessageEditState.edited);
         check(store).messages[origMessages[1].id].editState.equals(MessageEditState.moved);
       });

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -345,7 +345,7 @@ void main() {
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
-      test('message stream moved update', () async {
+      test('message stream moved without topic change', () async {
         await prepareOrigMessages(origTopic: 'topic');
         await store.handleEvent(eg.updateMessageMoveEvent(
           origMessages,

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -273,75 +273,101 @@ void main() {
     });
 
     group('Handle message edit state update', () {
-      final message = eg.streamMessage();
-      final otherMessage = eg.streamMessage();
+      late List<StreamMessage> origMessages;
 
-      Future<void> sendEvent(Message message, UpdateMessageEvent event) async {
+      Future<void> prepareOrigMessages({
+        required String origTopic,
+        String? origContent,
+      }) async {
+        origMessages = List.generate(2, (i) => eg.streamMessage(
+          topic: origTopic,
+          content: origContent,
+        ));
         await prepare();
-        await prepareMessages([message, otherMessage]);
-
-        await store.handleEvent(event);
-        checkNotifiedOnce();
+        await prepareMessages(origMessages);
       }
 
       test('message not moved update', () async {
-        await sendEvent(message, eg.updateMessageEditEvent(message));
-        check(store).messages[message.id].editState.equals(MessageEditState.edited);
-        check(store).messages[otherMessage.id].editState.equals(MessageEditState.none);
+        await prepareOrigMessages(origTopic: 'origTopic');
+        await store.handleEvent(eg.updateMessageEditEvent(origMessages[0]));
+        checkNotifiedOnce();
+        check(store).messages[origMessages[0].id].editState.equals(MessageEditState.edited);
+        check(store).messages[origMessages[1].id].editState.equals(MessageEditState.none);
       });
 
       test('message topic moved update', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: 'old topic');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: 'old topic',
           newTopic:  'new topic'));
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
       test('message topic resolved update', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: 'new topic');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: 'new topic',
           newTopic:  '✔ new topic'));
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.none)));
       });
 
       test('message topic unresolved update', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: '✔ new topic');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: '✔ new topic',
           newTopic:  'new topic'));
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.none)));
       });
 
       test('message topic both resolved and edited update', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: 'new topic');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: 'new topic',
           newTopic:  '✔ new topic 2'));
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
       test('message topic both unresolved and edited update', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: '✔ new topic');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: '✔ new topic',
           newTopic:  'new topic 2'));
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
       test('message stream moved update', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: 'topic');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: 'topic',
           newTopic: 'topic',
           newStreamId:  20));
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
       test('message is both moved and updated', () async {
-        await sendEvent(message, eg.updateMessageMoveEvent([message, otherMessage],
+        await prepareOrigMessages(origTopic: 'topic', origContent: 'old content');
+        await store.handleEvent(eg.updateMessageMoveEvent(
+          origMessages,
           origTopic: 'topic',
           newTopic: 'topic',
           newStreamId:  20,
           origContent: 'old content',
           newContent: 'new content'));
-        check(store).messages[message.id].editState.equals(MessageEditState.edited);
-        check(store).messages[otherMessage.id].editState.equals(MessageEditState.moved);
+        checkNotifiedOnce();
+        check(store).messages[origMessages[0].id].editState.equals(MessageEditState.edited);
+        check(store).messages[origMessages[1].id].editState.equals(MessageEditState.moved);
       });
     });
   });

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -297,9 +297,8 @@ void main() {
 
       test('message topic moved update', () async {
         await prepareOrigMessages(origTopic: 'old topic');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: 'old topic',
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
           newTopic:  'new topic'));
         checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
@@ -307,9 +306,8 @@ void main() {
 
       test('message topic resolved update', () async {
         await prepareOrigMessages(origTopic: 'new topic');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: 'new topic',
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
           newTopic:  '✔ new topic'));
         checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.none)));
@@ -317,9 +315,8 @@ void main() {
 
       test('message topic unresolved update', () async {
         await prepareOrigMessages(origTopic: '✔ new topic');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: '✔ new topic',
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
           newTopic:  'new topic'));
         checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.none)));
@@ -327,9 +324,8 @@ void main() {
 
       test('message topic both resolved and edited update', () async {
         await prepareOrigMessages(origTopic: 'new topic');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: 'new topic',
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
           newTopic:  '✔ new topic 2'));
         checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
@@ -337,9 +333,8 @@ void main() {
 
       test('message topic both unresolved and edited update', () async {
         await prepareOrigMessages(origTopic: '✔ new topic');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: '✔ new topic',
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
           newTopic:  'new topic 2'));
         checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
@@ -347,23 +342,18 @@ void main() {
 
       test('message stream moved without topic change', () async {
         await prepareOrigMessages(origTopic: 'topic');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: 'topic',
-          newTopic: 'topic',
-          newStreamId:  20));
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
+          newStreamId: 20));
         checkNotifiedOnce();
         check(store).messages.values.every(((message) => message.editState.equals(MessageEditState.moved)));
       });
 
       test('message is both moved and updated', () async {
         await prepareOrigMessages(origTopic: 'topic', origContent: 'old content');
-        await store.handleEvent(eg.updateMessageMoveEvent(
-          origMessages,
-          origTopic: 'topic',
-          newTopic: 'topic',
-          newStreamId:  20,
-          origContent: 'old content',
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: origMessages,
+          newStreamId: 20,
           newContent: 'new content'));
         checkNotifiedOnce();
         check(store).messages[origMessages[0].id].editState.equals(MessageEditState.edited);

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -546,7 +546,7 @@ void main() {
       route.isA<MaterialAccountWidgetRoute>()
         ..accountId.equals(account.id)
         ..page.isA<MessageListPage>()
-          .narrow.equals(SendableNarrow.ofMessage(message,
+          .initNarrow.equals(SendableNarrow.ofMessage(message,
             selfUserId: account.userId));
     }
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -59,7 +59,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   ).toJson());
 
   await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-    child: MessageListPage(narrow: narrow)));
+    child: MessageListPage(initNarrow: narrow)));
 
   // global store, per-account store, and message list get loaded
   await tester.pumpAndSettle();

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -48,7 +48,7 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
   prepareBoringImageHttpClient();
 
   await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-    child: MessageListPage(narrow: DmNarrow(
+    child: MessageListPage(initNarrow: DmNarrow(
       allRecipientIds: [eg.selfUser.userId, eg.otherUser.userId],
       selfUserId: eg.selfUser.userId))));
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -815,7 +815,7 @@ void main() {
       await tapText(tester, find.text('stream'));
       check(testBinding.takeLaunchUrlCalls()).isEmpty();
       check(pushedRoutes).single.isA<WidgetRoute>()
-        .page.isA<MessageListPage>().narrow.equals(const ChannelNarrow(1));
+        .page.isA<MessageListPage>().initNarrow.equals(const ChannelNarrow(1));
     });
 
     testWidgets('invalid internal links are opened in browser', (tester) async {

--- a/test/widgets/message_list_checks.dart
+++ b/test/widgets/message_list_checks.dart
@@ -3,5 +3,5 @@ import 'package:zulip/model/narrow.dart';
 import 'package:zulip/widgets/message_list.dart';
 
 extension MessageListPageChecks on Subject<MessageListPage> {
-  Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
+  Subject<Narrow> get initNarrow => has((x) => x.initNarrow, 'initNarrow');
 }

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1019,20 +1019,25 @@ void main() {
 
     testWidgets('edit state updates do not affect layout', (WidgetTester tester) async {
       final messages = [
-        eg.streamMessage(),
+        eg.streamMessage(topic: 'orig'),
         eg.streamMessage(
+          topic: 'orig',
           reactions: [eg.unicodeEmojiReaction, eg.realmEmojiReaction],
           flags: [MessageFlag.starred]),
-        eg.streamMessage(),
+        eg.streamMessage(topic: 'orig'),
       ];
       final StreamMessage messageWithMarker = messages[1];
       await setupMessageListPage(tester, messages: messages);
       final rectsBefore = captureMessageRects(tester, messages, messageWithMarker);
       checkMarkersCount(edited: 0, moved: 0);
 
-      // TODO(#150): [messageWithMarker]'s topic in store is inconsistent with the event. This will be fixed soon.
-      await store.handleEvent(eg.updateMessageEventMoveTo(
-        origTopic: 'old', newMessages: [messageWithMarker]));
+      await store.handleEvent(eg.updateMessageEventMoveFrom(
+        origMessages: [store.messages[messageWithMarker.id] as StreamMessage],
+        newTopic: 'new'));
+      await tester.pump();
+      await store.handleEvent(eg.updateMessageEventMoveFrom(
+        origMessages: [store.messages[messageWithMarker.id] as StreamMessage],
+        newTopic: 'orig'));
       await tester.pump();
       check(captureMessageRects(tester, messages, messageWithMarker))
         .deepEquals(rectsBefore);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -69,7 +69,7 @@ void main() {
       newestResult(foundOldest: foundOldest, messages: messages).toJson());
 
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-      child: MessageListPage(narrow: narrow)));
+      child: MessageListPage(initNarrow: narrow)));
 
     // global store, per-account store, and message list get loaded
     await tester.pumpAndSettle();

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -965,8 +965,8 @@ void main() {
     });
 
     testWidgets('edited and moved messages from events', (WidgetTester tester) async {
-      final message = eg.streamMessage();
-      final message2 = eg.streamMessage();
+      final message = eg.streamMessage(topic: 'old');
+      final message2 = eg.streamMessage(topic: 'old');
       await setupMessageListPage(tester, messages: [message, message2]);
       checkMarkersCount(edited: 0, moved: 0);
 
@@ -974,8 +974,8 @@ void main() {
       await tester.pump();
       checkMarkersCount(edited: 1, moved: 0);
 
-      await store.handleEvent(eg.updateMessageMoveEvent(
-        [message, message2], origTopic: 'old', newTopic: 'new'));
+      await store.handleEvent(eg.updateMessageEventMoveFrom(
+        origMessages: [message, message2], newTopic: 'new'));
       await tester.pump();
       checkMarkersCount(edited: 1, moved: 1);
 
@@ -1030,8 +1030,9 @@ void main() {
       final rectsBefore = captureMessageRects(tester, messages, messageWithMarker);
       checkMarkersCount(edited: 0, moved: 0);
 
-      await store.handleEvent(eg.updateMessageMoveEvent(
-        [messageWithMarker], origTopic: 'old', newTopic: messageWithMarker.topic));
+      // TODO(#150): [messageWithMarker]'s topic in store is inconsistent with the event. This will be fixed soon.
+      await store.handleEvent(eg.updateMessageEventMoveTo(
+        origTopic: 'old', newMessages: [messageWithMarker]));
       await tester.pump();
       check(captureMessageRects(tester, messages, messageWithMarker))
         .deepEquals(rectsBefore);

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -253,7 +253,7 @@ void main() {
       await tester.tap(targetWidget);
       check(pushedRoutes).last.isA<WidgetRoute>().page
         .isA<MessageListPage>()
-        .narrow.equals(DmNarrow.withUser(1, selfUserId: eg.selfUser.userId));
+        .initNarrow.equals(DmNarrow.withUser(1, selfUserId: eg.selfUser.userId));
     });
 
     testWidgets('page builds; user links render multiple avatars', (WidgetTester tester) async {

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -322,7 +322,7 @@ void main() {
 
         check(pushedRoutes).last.isA<WidgetRoute>().page
           .isA<MessageListPage>()
-          .narrow.equals(expectedNarrow);
+          .initNarrow.equals(expectedNarrow);
       }
 
       testWidgets('1:1', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes most of #150. (After this lands we should do a quick scan to identify anything else that needs updating on message moves — there are several new data structures in the store that we've merged in recent weeks.)

A couple of months ago I spent a few hours writing part of an implementation of #150. It's mostly complete, apart from the lack of tests… and any bugs it has that will be found by writing those tests.

@PIG208 since you're picking up #150 shortly, I spent a small amount of time just now cleaning up that draft branch and rebasing atop the changes from #750, and writing down what remains to be done to finish it. So please start from this, which will let you avoid duplicating that work.

I believe there are three remaining things this needs:

* Tests. As usual, these should go in the same commit that makes the changes.

  There's a variety of kinds of test cases this needs,
  but here's one in particular that may not be apparent:

  If the `generation += 1` line is commented out, the message list
  has a race bug where a fetchOlder starts; we reset (because
  messages were moved into the narrow); and then the fetch returns
  and appends in the wrong spot.  Also a related race bug where it's
  fetchInitial, and it lacks the moved messages.  So there should be
  test cases exercising each of those situations, which would fail if
  that line gets commented out.


* Update StreamMessage.displayRecipient.  This goes in a followup commit.

    If we wanted, we could update it by looking up the new stream's
    name.  To enable MessageStoreImpl to do that, we'd pass it a
    StreamStore, the same way we do with Unreads.

    But in fact the only time displayRecipient is useful is when we
    don't have data on that stream.  So there's not much point in
    looking it up here.  Instead, make the field nullable, and just
    set it to null when the message is moved between streams.

* Handle UpdateMessageEvent.propagateMode.  This also goes in a followup commit. If it gets complex (or if the rest of the branch before it gets complex), let's split it out as a followup PR.

    This probably means
    _MessageListPageState having its own notion of the current narrow,
    which is initialized with `widget.narrow` but can change.
    Then `_MessageListState._modelChanged` can check if the model's
    narrow has changed, and if so tell the page state to update.

    For comparison, see zulip-mobile's `src/events/doEventActionSideEffects.js`,
    or web.


