### PR TITLE
msglist: Display typing indicators on typing.

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -483,5 +483,24 @@
   "notifSelfUser": "You",
   "@notifSelfUser": {
     "description": "Display name for the user themself, to show after replying in an Android notification"
+  },
+  "onePersonTyping": "{typist} is typing…",
+  "@onePersonTyping": {
+    "description": "Text to display when there is one user typing.",
+    "placeholders": {
+      "typist": {"type": "String", "example": "Alice"}
+    }
+  },
+  "twoPeopleTyping": "{typist} and {otherTypist} are typing…",
+  "@twoPeopleTyping": {
+    "description": "Text to display when there are two users typing.",
+    "placeholders": {
+      "typist": {"type": "String", "example": "Alice"},
+      "otherTypist": {"type": "String", "example": "Bob"}
+    }
+  },
+  "manyPeopleTyping": "Several people are typing…",
+  "@manyPeopleTyping": {
+    "description": "Text to display when there are multiple users typing."
   }
 }

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import '../../model/algorithms.dart';
 import 'json.dart';
 import 'model.dart';
 
@@ -900,7 +901,7 @@ class TypingEvent extends Event {
     required this.recipientIds,
     required this.streamId,
     required this.topic,
-  });
+  }) : assert(isSortedWithoutDuplicates(recipientIds ?? []));
 
   static Object? _readSenderId(Map<Object?, Object?> json, String key) {
     return (json['sender'] as Map<String, dynamic>)['user_id'];
@@ -909,7 +910,7 @@ class TypingEvent extends Event {
   static List<int>? _recipientIdsFromJson(Object? json) {
     if (json == null) return null;
     return (json as List<Object?>).map(
-      (item) => (item as Map<String, Object?>)['user_id'] as int).toList();
+      (item) => (item as Map<String, Object?>)['user_id'] as int).toList()..sort();
   }
 
   factory TypingEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -901,7 +901,7 @@ class TypingEvent extends Event {
     required this.recipientIds,
     required this.streamId,
     required this.topic,
-  }) : assert(isSortedWithoutDuplicates(recipientIds ?? []));
+  }) : assert(recipientIds == null || isSortedWithoutDuplicates(recipientIds));
 
   static Object? _readSenderId(Map<Object?, Object?> json, String key) {
     return (json['sender'] as Map<String, dynamic>)['user_id'];

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -16,7 +16,7 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection) {
       'notification_settings_null': true,
       'bulk_message_deletion': true,
       'user_avatar_url_field_optional': false, // TODO(#254): turn on
-      'stream_typing_notifications': false, // TODO implement
+      'stream_typing_notifications': true,
       'user_settings_object': true,
     },
   });

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -64,7 +64,7 @@ class TypingStatus extends ChangeNotifier {
   void handleTypingEvent(TypingEvent event) {
     SendableNarrow narrow = switch (event.messageType) {
       MessageType.direct => DmNarrow(
-        allRecipientIds: event.recipientIds!..sort(), selfUserId: selfUserId),
+        allRecipientIds: event.recipientIds!, selfUserId: selfUserId),
       MessageType.stream => TopicNarrow(event.streamId!, event.topic!),
     };
 

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../api/model/events.dart';
+import '../log.dart';
 import 'narrow.dart';
 
 /// The model for tracking the typing status organized by narrows.
@@ -38,6 +39,10 @@ class TypingStatus extends ChangeNotifier {
   }
 
   bool _addTypist(SendableNarrow narrow, int typistUserId) {
+    if (typistUserId == selfUserId) {
+      assert(debugLog('typing status: adding self as typist'));
+      return false;
+    }
     final narrowTimerMap = _timerMapsByNarrow[narrow] ??= {};
     final typistTimer = narrowTimerMap[typistUserId];
     final isNewTypist = typistTimer == null;

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -241,5 +241,12 @@ void main() {
       check(() => TypingEvent.fromJson({
         ...baseJson, 'message_type': 'stream', 'stream_id': 123})).throws<void>();
     });
+
+    test('direct type sort recipient ids', () {
+      check(TypingEvent.fromJson({
+        ...directMessageJson,
+        'recipients': [4, 10, 8, 2, 1].map((e) => {'user_id': e, 'email': '$e@example.com'}).toList(),
+      })).recipientIds.isNotNull().deepEquals([1, 2, 4, 8, 10]);
+    });
   });
 }

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -97,23 +97,6 @@ void main() {
       checkTypists({groupNarrow: [eg.otherUser, eg.thirdUser]});
       checkNotifiedOnce();
     });
-
-    test('sort dm recipients', () {
-      prepareModel(selfUserId: 5);
-      final recipientIds = [5, 4, 10, 8, 2, 1];
-
-      final eventUnsorted = TypingEvent(id: 1, op: TypingOp.start,
-        senderId: 1,
-        messageType: MessageType.direct,
-        recipientIds: recipientIds,
-        streamId: null, topic: null);
-      // DmNarrow's constructor expects the recipient IDs to be sorted,
-      // and [model.handleTypingEvent] should handle that.
-      model.handleTypingEvent(eventUnsorted);
-      check(model.typistIdsInNarrow(
-        DmNarrow(allRecipientIds: recipientIds..sort(), selfUserId: 5),
-      )).single.equals(1);
-    });
   });
 
   group('handle typing stop events', () {

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -97,6 +97,15 @@ void main() {
       checkTypists({groupNarrow: [eg.otherUser, eg.thirdUser]});
       checkNotifiedOnce();
     });
+
+    test('ignore adding self as typist', () {
+      prepareModel();
+
+      model.handleTypingEvent(
+        eg.typingEvent(groupNarrow, TypingOp.start, eg.selfUser.userId));
+      checkTypists({});
+      checkNotNotified();
+    });
   });
 
   group('handle typing stop events', () {


### PR DESCRIPTION
Display a typing indicator when there are people typing in a `SendableNarrow` such as `DmNarrow` and `TopicNarrow`, in a fashion similar to the web app.

This is stacked on top of #783 and fixes #665.
