### PR TITLE
login: Show `visiblePassword` type keyboard only when password is unobscured

### DIFF
--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -584,7 +584,7 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
       key: _passwordKey,
       autofillHints: const [AutofillHints.password],
       obscureText: _obscurePassword,
-      keyboardType: TextInputType.visiblePassword,
+      keyboardType: _obscurePassword ? null : TextInputType.visiblePassword,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       validator: (value) {
         if (value == null || value.isEmpty) {


### PR DESCRIPTION
`keyboardType: TextInputType.visiblePassword` contradicts with `obscureText: true`, resulting in Gboard not obscuring the clipboard preview.

| `obscureText: true` | `obscureText: false` |
|-|-|
| <img width="412" alt="Screenshot 2024-07-08 at 04 09 14" src="https://github.com/zulip/zulip-flutter/assets/36819268/a9396b67-4210-4852-ac8c-907af021ce71"> | <img width="412" alt="Screenshot 2024-07-08 at 04 08 46" src="https://github.com/zulip/zulip-flutter/assets/36819268/4aa0f51f-900c-4b7d-a693-d355bf3c8bb0"> |

Fixes: #743

(This PR was result of pair-programming session with @sm-sayedi)