### PR TITLE
msglist: Support @-mentions narrow

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -472,6 +472,10 @@
   "@combinedFeedPageTitle": {
     "description": "Title for the page of combined feed."
   },
+  "mentionsPageTitle": "Mentions",
+  "@mentionsPageTitle": {
+    "description": "Title for the page of @-mentions."
+  },
   "notifGroupDmConversationLabel": "{senderFullName} to you and {numOthers, plural, =1{1 other} other{{numOthers} others}}",
   "@notifGroupDmConversationLabel": {
     "description": "Label for a group DM conversation notification.",

--- a/lib/api/model/narrow.dart
+++ b/lib/api/model/narrow.dart
@@ -115,6 +115,13 @@ class ApiNarrowPmWith extends ApiNarrowDm {
 }
 
 // TODO: generalize into ApiNarrowIs
+class ApiNarrowIsMentioned extends ApiNarrowElement {
+  @override String get operator => 'is';
+  @override String get operand => 'mentioned';
+
+  ApiNarrowIsMentioned({super.negated});
+}
+
 class ApiNarrowIsUnread extends ApiNarrowElement {
   @override String get operator => 'is';
   @override String get operand => 'unread';

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -222,6 +222,7 @@ class MentionAutocompleteView extends ChangeNotifier {
       case DmNarrow():
         break;
       case CombinedFeedNarrow():
+      case MentionsNarrow():
         assert(false, 'No compose box, thus no autocomplete is available in ${narrow.runtimeType}.');
     }
     return (userA, userB) => _compareByRelevance(userA, userB,

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -85,6 +85,8 @@ Uri narrowLink(PerAccountStore store, Narrow narrow, {int? nearMessageId}) {
         fragment.write('${element.operand.join(',')}-$suffix');
       case ApiNarrowDm():
         assert(false, 'ApiNarrowDm should have been resolved');
+      case ApiNarrowIsMentioned():
+        fragment.write(element.operand.toString());
       case ApiNarrowIsUnread():
         fragment.write(element.operand.toString());
       case ApiNarrowMessageId():

--- a/lib/model/internal_link.g.dart
+++ b/lib/model/internal_link.g.dart
@@ -12,6 +12,7 @@ const _$_NarrowOperatorEnumMap = {
   _NarrowOperator.dm: 'dm',
   _NarrowOperator.near: 'near',
   _NarrowOperator.with_: 'with',
+  _NarrowOperator.is_: 'is',
   _NarrowOperator.pmWith: 'pm-with',
   _NarrowOperator.stream: 'stream',
   _NarrowOperator.channel: 'channel',

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -370,6 +370,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
       case TopicNarrow():
       case DmNarrow():
+      case MentionsNarrow():
         return true;
     }
   }
@@ -385,6 +386,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
       case TopicNarrow():
       case DmNarrow():
+      case MentionsNarrow():
         return true;
     }
   }

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -291,17 +291,21 @@ class MentionsNarrow extends Narrow {
 
   @override
   bool containsMessage(Message message) {
-    return message.flags.any((flag) =>
+    return message.flags.any((flag) {
       switch (flag) {
-        MessageFlag.mentioned => true,
-        MessageFlag.wildcardMentioned => true,
-        MessageFlag.read => false,
-        MessageFlag.starred => false,
-        MessageFlag.collapsed => false,
-        MessageFlag.hasAlertWord => false,
-        MessageFlag.historical => false,
-        MessageFlag.unknown => false,
-      });
+        case MessageFlag.mentioned:
+        case MessageFlag.wildcardMentioned:
+          return true;
+
+        case MessageFlag.read:
+        case MessageFlag.starred:
+        case MessageFlag.collapsed:
+        case MessageFlag.hasAlertWord:
+        case MessageFlag.historical:
+        case MessageFlag.unknown:
+          return false;
+      }
+    });
   }
 
   @override

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -286,4 +286,34 @@ class DmNarrow extends Narrow implements SendableNarrow {
   int get hashCode => Object.hash('DmNarrow', _key);
 }
 
-// TODO other narrow types: starred, mentioned; searches; arbitrary
+class MentionsNarrow extends Narrow {
+  const MentionsNarrow();
+
+  @override
+  bool containsMessage(Message message) {
+    return message.flags.any((flag) =>
+      switch (flag) {
+        MessageFlag.mentioned => true,
+        MessageFlag.wildcardMentioned => true,
+        MessageFlag.read => false,
+        MessageFlag.starred => false,
+        MessageFlag.collapsed => false,
+        MessageFlag.hasAlertWord => false,
+        MessageFlag.historical => false,
+        MessageFlag.unknown => false,
+      });
+  }
+
+  @override
+  ApiNarrow apiEncode() => [ApiNarrowIsMentioned()];
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! MentionsNarrow) return false;
+    // Conceptually there's only one value of this type.
+    return true;
+  }
+
+  @override
+  int get hashCode => 'MentionsNarrow'.hashCode;
+}

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -193,6 +193,8 @@ class Unreads extends ChangeNotifier {
 
   int countInDmNarrow(DmNarrow narrow) => dms[narrow]?.length ?? 0;
 
+  int countInMentionsNarrow() => mentions.length;
+
   int countInNarrow(Narrow narrow) {
     switch (narrow) {
       case CombinedFeedNarrow():
@@ -203,6 +205,8 @@ class Unreads extends ChangeNotifier {
         return countInTopicNarrow(narrow.streamId, narrow.topic);
       case DmNarrow():
         return countInDmNarrow(narrow);
+      case MentionsNarrow():
+        return countInMentionsNarrow();
     }
   }
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -134,5 +134,12 @@ Future<void> _legacyMarkNarrowAsRead(BuildContext context, Narrow narrow) async 
         messages: unreadDms,
         op: UpdateMessageFlagsOp.add,
         flag: MessageFlag.read);
+    case MentionsNarrow():
+      final unreadMentions = store.unreads.mentions.toList();
+      if (unreadMentions.isEmpty) return;
+      await updateMessageFlags(connection,
+        messages: unreadMentions,
+        op: UpdateMessageFlagsOp.add,
+        flag: MessageFlag.read);
   }
 }

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -278,6 +278,12 @@ class HomePage extends StatelessWidget {
           const SizedBox(height: 16),
           ElevatedButton(
             onPressed: () => Navigator.push(context,
+              MessageListPage.buildRoute(context: context,
+                narrow: const MentionsNarrow())),
+            child: Text(zulipLocalizations.mentionsPageTitle)),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
               InboxPage.buildRoute(context: context)),
             child: const Text("Inbox")), // TODO(i18n)
           const SizedBox(height: 16),

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1025,13 +1025,14 @@ class ComposeBox extends StatelessWidget {
 
   static bool hasComposeBox(Narrow narrow) {
     switch (narrow) {
-      case CombinedFeedNarrow():
-        return false;
-
       case ChannelNarrow():
       case TopicNarrow():
       case DmNarrow():
         return true;
+
+      case CombinedFeedNarrow():
+      case MentionsNarrow():
+        return false;
     }
   }
 
@@ -1046,6 +1047,7 @@ class ComposeBox extends StatelessWidget {
       case DmNarrow():
         return _FixedDestinationComposeBox(key: controllerKey, narrow: narrow);
       case CombinedFeedNarrow():
+      case MentionsNarrow():
         return const SizedBox.shrink();
     }
   }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1023,6 +1023,18 @@ class ComposeBox extends StatelessWidget {
   final GlobalKey<ComposeBoxController>? controllerKey;
   final Narrow narrow;
 
+  static bool hasComposeBox(Narrow narrow) {
+    switch (narrow) {
+      case CombinedFeedNarrow():
+        return false;
+
+      case ChannelNarrow():
+      case TopicNarrow():
+      case DmNarrow():
+        return true;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final narrow = this.narrow;

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -277,11 +277,9 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
               context: context,
 
               // The compose box, when present, pads the bottom inset.
-              // TODO this copies the details of when the compose box is shown;
-              //   if those details get complicated, refactor to avoid copying.
               // TODO(#311) If we have a bottom nav, it will pad the bottom
               //   inset, and this should always be true.
-              removeBottom: widget.narrow is! CombinedFeedNarrow,
+              removeBottom: ComposeBox.hasComposeBox(widget.narrow),
 
               child: Expanded(
                 child: MessageList(narrow: widget.narrow))),
@@ -514,7 +512,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           return _buildItem(data, i);
         }));
 
-    if (widget.narrow is CombinedFeedNarrow) {
+    if (!ComposeBox.hasComposeBox(widget.narrow)) {
       // TODO(#311) If we have a bottom nav, it will pad the bottom
       //   inset, and this shouldn't be necessary
       sliver = SliverSafeArea(sliver: sliver);

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -235,6 +235,7 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
     bool removeAppBarBottomBorder = false;
     switch(widget.narrow) {
       case CombinedFeedNarrow():
+      case MentionsNarrow():
         appBarBackgroundColor = null; // i.e., inherit
 
       case ChannelNarrow(:final streamId):
@@ -319,6 +320,9 @@ class MessageListAppBarTitle extends StatelessWidget {
     switch (narrow) {
       case CombinedFeedNarrow():
         return Text(zulipLocalizations.combinedFeedPageTitle);
+
+      case MentionsNarrow():
+        return Text(zulipLocalizations.mentionsPageTitle);
 
       case ChannelNarrow(:var streamId):
         final store = PerAccountStoreWidget.of(context);
@@ -808,6 +812,7 @@ class RecipientHeader extends StatelessWidget {
   static bool _containsDifferentChannels(Narrow narrow) {
     switch (narrow) {
       case CombinedFeedNarrow():
+      case MentionsNarrow():
         return true;
 
       case ChannelNarrow():

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -807,12 +807,24 @@ class RecipientHeader extends StatelessWidget {
   final Message message;
   final Narrow narrow;
 
+  static bool _containsDifferentChannels(Narrow narrow) {
+    switch (narrow) {
+      case CombinedFeedNarrow():
+        return true;
+
+      case ChannelNarrow():
+      case TopicNarrow():
+      case DmNarrow():
+        return false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final message = this.message;
     return switch (message) {
       StreamMessage() => StreamMessageRecipientHeader(message: message,
-        showStream: narrow is CombinedFeedNarrow),
+        showStream: _containsDifferentChannels(narrow)),
       DmMessage() => DmRecipientHeader(message: message),
     };
   }

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -188,6 +188,9 @@ void main() {
         {'operator': 'stream', 'operand': 12},
         {'operator': 'topic', 'operand': 'stuff'},
       ]));
+      checkNarrow(const MentionsNarrow().apiEncode(), jsonEncode([
+        {'operator': 'is', 'operand': 'mentioned'},
+      ]));
 
       checkNarrow([ApiNarrowDm([123, 234])], jsonEncode([
         {'operator': 'dm', 'operand': [123, 234]},

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -571,6 +571,13 @@ void main() {
         check(() => MentionAutocompleteView.init(store: store, narrow: narrow))
           .throws<AssertionError>();
       });
+
+      test('MentionsNarrow gives error', () async {
+        await prepare(users: [eg.user(), eg.user()], messages: []);
+        const narrow = MentionsNarrow();
+        check(() => MentionAutocompleteView.init(store: store, narrow: narrow))
+          .throws<AssertionError>();
+      });
     });
 
     test('final results end-to-end', () async {

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -231,6 +231,14 @@ hello
         .equals(store.realmUrl.resolve('#narrow/near/1'));
     });
 
+    test('MentionsNarrow', () {
+      final store = eg.store();
+      check(narrowLink(store, const MentionsNarrow()))
+        .equals(store.realmUrl.resolve('#narrow/is/mentioned'));
+      check(narrowLink(store, const MentionsNarrow(), nearMessageId: 1))
+        .equals(store.realmUrl.resolve('#narrow/is/mentioned/near/1'));
+    });
+
     test('ChannelNarrow / TopicNarrow', () {
       void checkNarrow(String expectedFragment, {
         required int streamId,
@@ -298,9 +306,6 @@ hello
         '#narrow/dm/1,2-dm/near/12345',
         '#narrow/pm-with/1,2-pm/near/12345');
     });
-
-    // TODO other Narrow subclasses as we add them:
-    //   starred, mentioned; searches; arbitrary
   });
 
   group('mention', () {

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -221,6 +221,20 @@ void main() {
       testExpectedNarrows(testCases, streams: streams);
     });
 
+    group('"/#narrow/is/mentioned returns expected MentionsNarrow', () {
+      final testCases = [
+        ('/#narrow/is/mentioned',                                     const MentionsNarrow()),
+        ('/#narrow/is/mentioned/near/1',                              const MentionsNarrow()),
+        ('/#narrow/is/mentioned/with/2',                              const MentionsNarrow()),
+        ('/#narrow/channel/7-test-here/is/mentioned',                 null),
+        ('/#narrow/channel/check/topic/test/is/mentioned',            null),
+        ('/#narrow/topic/test/is/mentioned',                          null),
+        ('/#narrow/dm/17327-Chris-Bobbe-(Test-Account)/is/mentioned', null),
+        ('/#narrow/-is/mentioned',                                    null),
+      ];
+      testExpectedNarrows(testCases, streams: streams);
+    });
+
     group('unexpected link shapes are rejected', () {
       final testCases = [
         ('/#narrow/stream/name/topic/',           null), // missing operand

--- a/test/model/narrow_test.dart
+++ b/test/model/narrow_test.dart
@@ -149,4 +149,17 @@ void main() {
       check(narrow123.containsMessage(dm(user3, [user1, user2]))).isTrue();
     });
   });
+
+  group('MentionsNarrow', () {
+    test('containsMessage', () {
+      const narrow = MentionsNarrow();
+
+      check(narrow.containsMessage(
+        eg.streamMessage(flags: []))).isFalse();
+      check(narrow.containsMessage(
+        eg.streamMessage(flags:[MessageFlag.mentioned]))).isTrue();
+      check(narrow.containsMessage(
+        eg.streamMessage(flags: [MessageFlag.wildcardMentioned]))).isTrue();
+    });
+  });
 }

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -215,6 +215,18 @@ void main() {
         eg.otherUser.userId, selfUserId: eg.selfUser.userId);
       check(model.countInDmNarrow(narrow)).equals(5);
     });
+
+    test('countInMentionsNarrow', () async {
+      final stream = eg.stream();
+      prepare();
+      await channelStore.addStream(stream);
+      fillWithMessages([
+        eg.streamMessage(stream: stream, flags: []),
+        eg.streamMessage(stream: stream, flags: [MessageFlag.mentioned]),
+        eg.streamMessage(stream: stream, flags: [MessageFlag.wildcardMentioned]),
+      ]);
+      check(model.countInMentionsNarrow()).equals(2);
+    });
   });
 
   group('handleMessageEvent', () {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -377,6 +377,12 @@ void main() {
       await setupToMessageActionSheet(tester, message: message, narrow: const CombinedFeedNarrow());
       check(findQuoteAndReplyButton(tester)).isNull();
     });
+
+    testWidgets('not offered in MentionsNarrow (composing to reply is not yet supported)', (WidgetTester tester) async {
+      final message = eg.streamMessage();
+      await setupToMessageActionSheet(tester, message: message, narrow: const MentionsNarrow());
+      check(findQuoteAndReplyButton(tester)).isNull();
+    });
   });
 
   group('CopyMessageTextButton', () {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -135,6 +135,19 @@ void main() {
       final padding = MediaQuery.of(element).padding;
       check(padding).equals(EdgeInsets.zero);
     });
+
+    testWidgets('content in MentionsNarrow not asked to consume insets (including bottom)', (tester) async {
+      const fakePadding = FakeViewPadding(left: 10, top: 10, right: 10, bottom: 10);
+      tester.view.viewInsets = fakePadding;
+      tester.view.padding = fakePadding;
+
+      await setupMessageListPage(tester, narrow: const MentionsNarrow(),
+        messages: [eg.streamMessage(content: ContentExample.codeBlockPlain.html, flags: [MessageFlag.mentioned])]);
+
+      final element = tester.element(find.byType(CodeBlock));
+      final padding = MediaQuery.of(element).padding;
+      check(padding).equals(EdgeInsets.zero);
+    });
   });
 
   testWidgets('smoke test for light/dark/lerped', (tester) async {
@@ -628,7 +641,16 @@ void main() {
         check(findInMessageList('topic name')).length.equals(1);
       });
 
-      testWidgets('do not show stream name in ChannelNarrow', (tester) async {
+      testWidgets('show channel name in MentionsNarrow', (tester) async {
+        await setupMessageListPage(tester,
+          narrow: const MentionsNarrow(),
+          messages: [message], subscriptions: [eg.subscription(stream)]);
+        await tester.pump();
+        check(findInMessageList('stream name')).length.equals(1);
+        check(findInMessageList('topic name')).length.equals(1);
+      });
+
+      testWidgets('do not show channel name in ChannelNarrow', (tester) async {
         await setupMessageListPage(tester,
           narrow: ChannelNarrow(stream.streamId),
           messages: [message], streams: [stream]);


### PR DESCRIPTION
Early prototype to support @-mentions narrow.

TODO:

- [x] Organize the commits
- [x] <del>Evaluate ways to support `wildcardMetnioned`, `channelWildcardMentioned` and `topicWildcardMentioned` with backwards/forward compatibility.</del> Deferred to #817
- [x] Test cases

Fixes #250 