### PR TITLE
dart [nfc]: Replace else-if's with switch.

### DIFF
--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -182,16 +182,16 @@ Future<SendMessageResult> sendMessage(
   final supportsTypeDirect = connection.zulipFeatureLevel! >= 174; // TODO(server-7)
   final supportsReadBySender = connection.zulipFeatureLevel! >= 236; // TODO(server-8)
   return connection.post('sendMessage', SendMessageResult.fromJson, 'messages', {
-    if (destination is StreamDestination) ...{
-      'type': RawParameter('stream'),
-      'to': destination.streamId,
-      'topic': RawParameter(destination.topic),
-    } else if (destination is DmDestination) ...{
-      'type': supportsTypeDirect ? RawParameter('direct') : RawParameter('private'),
-      'to': destination.userIds,
-    } else ...(
-      throw Exception('impossible destination') // TODO(dart-3) show this statically
-    ),
+    ...(switch (destination) {
+      StreamDestination() => {
+        'type': RawParameter('stream'),
+        'to': destination.streamId,
+        'topic': RawParameter(destination.topic),
+      },
+      DmDestination() => {
+        'type': supportsTypeDirect ? RawParameter('direct') : RawParameter('private'),
+        'to': destination.userIds,
+      }}),
     'content': RawParameter(content),
     if (queueId != null) 'queue_id': queueId, // TODO should this use RawParameter?
     if (localId != null) 'local_id': localId, // TODO should this use RawParameter?

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -99,7 +99,7 @@ class ZulipContent extends ContentNode {
 ///   <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout/Block_and_inline_layout_in_normal_flow>
 ///
 /// Almost all nodes are either a [BlockContentNode] or an [InlineContentNode].
-abstract class BlockContentNode extends ContentNode {
+sealed class BlockContentNode extends ContentNode {
   const BlockContentNode({super.debugHtmlNode});
 }
 
@@ -134,7 +134,7 @@ class _BlockContentListNode extends DiagnosticableTree {
 /// but provides an inline layout context for its children.
 ///
 /// See also [InlineContainerNode].
-class BlockInlineContainerNode extends BlockContentNode {
+sealed class BlockInlineContainerNode extends BlockContentNode {
   const BlockInlineContainerNode({
     super.debugHtmlNode,
     required this.links,

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -487,7 +487,7 @@ class EmbedVideoNode extends BlockContentNode {
 ///   https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout/Block_and_inline_layout_in_normal_flow#elements_participating_in_an_inline_formatting_context
 ///
 /// Almost all nodes are either an [InlineContentNode] or a [BlockContentNode].
-abstract class InlineContentNode extends ContentNode {
+sealed class InlineContentNode extends ContentNode {
   const InlineContentNode({super.debugHtmlNode});
 }
 
@@ -548,7 +548,7 @@ class LineBreakInlineNode extends InlineContentNode {
 /// itself does.
 ///
 /// See also [BlockInlineContainerNode].
-abstract class InlineContainerNode extends InlineContentNode {
+sealed class InlineContainerNode extends InlineContentNode {
   const InlineContainerNode({super.debugHtmlNode, required this.nodes});
 
   final List<InlineContentNode> nodes;
@@ -614,7 +614,7 @@ class UserMentionNode extends InlineContainerNode {
   //   final bool isSilent;
 }
 
-abstract class EmojiNode extends InlineContentNode {
+sealed class EmojiNode extends InlineContentNode {
   const EmojiNode({super.debugHtmlNode});
 }
 

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -297,7 +297,7 @@ class CodeBlockNode extends BlockContentNode {
   }
 }
 
-class CodeBlockSpanNode extends InlineContentNode {
+class CodeBlockSpanNode extends ContentNode {
   const CodeBlockSpanNode({super.debugHtmlNode, required this.text, required this.type});
 
   final String text;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -979,16 +979,15 @@ class ComposeBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final narrow = this.narrow;
-    if (narrow is StreamNarrow) {
-      return _StreamComposeBox(key: controllerKey, narrow: narrow);
-    } else if (narrow is TopicNarrow) {
-      return _FixedDestinationComposeBox(key: controllerKey, narrow: narrow);
-    } else if (narrow is DmNarrow) {
-      return _FixedDestinationComposeBox(key: controllerKey, narrow: narrow);
-    } else if (narrow is CombinedFeedNarrow) {
-      return const SizedBox.shrink();
-    } else {
-      throw Exception("impossible narrow"); // TODO(dart-3): show this statically
+    switch (narrow) {
+      case StreamNarrow():
+        return _StreamComposeBox(key: controllerKey, narrow: narrow);
+      case TopicNarrow():
+        return _FixedDestinationComposeBox(key: controllerKey, narrow: narrow);
+      case DmNarrow():
+        return _FixedDestinationComposeBox(key: controllerKey, narrow: narrow);
+      case CombinedFeedNarrow():
+        return const SizedBox.shrink();
     }
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -266,44 +266,33 @@ class BlockContentList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
       ...nodes.map((node) {
-        if (node is LineBreakNode) {
-          // This goes in a Column.  So to get the effect of a newline,
-          // just use an empty Text.
-          return const Text('');
-        } else if (node is ThematicBreakNode) {
-          return const ThematicBreak();
-        } else if (node is ParagraphNode) {
-          return Paragraph(node: node);
-        } else if (node is HeadingNode) {
-          return Heading(node: node);
-        } else if (node is QuotationNode) {
-          return Quotation(node: node);
-        } else if (node is ListNode) {
-          return ListNodeWidget(node: node);
-        } else if (node is SpoilerNode) {
-          return Spoiler(node: node);
-        } else if (node is CodeBlockNode) {
-          return CodeBlock(node: node);
-        } else if (node is MathBlockNode) {
-          return MathBlock(node: node);
-        } else if (node is ImageNodeList) {
-          return MessageImageList(node: node);
-        } else if (node is ImageNode) {
-          assert(false,
-            "[ImageNode] not allowed in [BlockContentList]. "
-            "It should be wrapped in [ImageNodeList]."
-          );
-          return MessageImage(node: node);
-        } else if (node is InlineVideoNode) {
-          return MessageInlineVideo(node: node);
-        } else if (node is EmbedVideoNode) {
-          return MessageEmbedVideo(node: node);
-        } else if (node is UnimplementedBlockContentNode) {
-          return Text.rich(_errorUnimplemented(node, context: context));
-        } else {
-          // TODO(dart-3): Use a sealed class / pattern-matching to exclude this.
-          throw Exception("impossible BlockContentNode: ${node.debugHtmlText}");
-        }
+        return switch (node) {
+          LineBreakNode() =>
+            // This goes in a Column.  So to get the effect of a newline,
+            // just use an empty Text.
+            const Text(''),
+          ThematicBreakNode() => const ThematicBreak(),
+          ParagraphNode() => Paragraph(node: node),
+          HeadingNode() => Heading(node: node),
+          QuotationNode() => Quotation(node: node),
+          ListNode() => ListNodeWidget(node: node),
+          SpoilerNode() => Spoiler(node: node),
+          CodeBlockNode() => CodeBlock(node: node),
+          MathBlockNode() => MathBlock(node: node),
+          ImageNodeList() => MessageImageList(node: node),
+          ImageNode() => (){
+            assert(false,
+              "[ImageNode] not allowed in [BlockContentList]. "
+              "It should be wrapped in [ImageNodeList]."
+            );
+            return MessageImage(node: node);
+          }(),
+          InlineVideoNode() => MessageInlineVideo(node: node),
+          EmbedVideoNode() => MessageEmbedVideo(node: node),
+          UnimplementedBlockContentNode() =>
+            Text.rich(_errorUnimplemented(node, context: context)),
+        };
+
       }),
     ]);
   }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -930,44 +930,54 @@ class _InlineContentBuilder {
   }
 
   InlineSpan _buildNode(InlineContentNode node) {
-    if (node is TextNode) {
-      return TextSpan(text: node.text, recognizer: _recognizer);
-    } else if (node is LineBreakInlineNode) {
-      // Each `<br/>` is followed by a newline, which browsers apparently ignore
-      // and our parser doesn't.  So don't do anything here.
-      return const TextSpan(text: "");
-    } else if (node is StrongNode) {
-      return _buildStrong(node);
-    } else if (node is DeletedNode) {
-      return _buildDeleted(node);
-    } else if (node is EmphasisNode) {
-      return _buildEmphasis(node);
-    } else if (node is LinkNode) {
-      return _buildLink(node);
-    } else if (node is InlineCodeNode) {
-      return _buildInlineCode(node);
-    } else if (node is UserMentionNode) {
-      return WidgetSpan(alignment: PlaceholderAlignment.middle,
-        child: UserMention(ambientTextStyle: widget.style, node: node));
-    } else if (node is UnicodeEmojiNode) {
-      return TextSpan(text: node.emojiUnicode, recognizer: _recognizer);
-    } else if (node is ImageEmojiNode) {
-      return WidgetSpan(alignment: PlaceholderAlignment.middle,
-        child: MessageImageEmoji(node: node));
-    } else if (node is MathInlineNode) {
-      return TextSpan(
-        style: widget.style
-          .merge(ContentTheme.of(_context!).textStyleInlineMath)
-          .apply(fontSizeFactor: kInlineCodeFontSizeFactor),
-        children: [TextSpan(text: node.texSource)]);
-    } else if (node is GlobalTimeNode) {
-      return WidgetSpan(alignment: PlaceholderAlignment.middle,
-        child: GlobalTime(node: node, ambientTextStyle: widget.style));
-    } else if (node is UnimplementedInlineContentNode) {
-      return _errorUnimplemented(node, context: _context!);
-    } else {
-      // TODO(dart-3): Use a sealed class / pattern matching to eliminate this case.
-      throw Exception("impossible InlineContentNode: ${node.debugHtmlText}");
+    switch (node) {
+      case TextNode():
+        return TextSpan(text: node.text, recognizer: _recognizer);
+
+      case LineBreakInlineNode():
+        // Each `<br/>` is followed by a newline, which browsers apparently ignore
+        // and our parser doesn't.  So don't do anything here.
+        return const TextSpan(text: "");
+
+      case StrongNode():
+        return _buildStrong(node);
+
+      case DeletedNode():
+        return _buildDeleted(node);
+
+      case EmphasisNode():
+        return _buildEmphasis(node);
+
+      case LinkNode():
+        return _buildLink(node);
+
+      case InlineCodeNode():
+        return _buildInlineCode(node);
+
+      case UserMentionNode():
+        return WidgetSpan(alignment: PlaceholderAlignment.middle,
+          child: UserMention(ambientTextStyle: widget.style, node: node));
+
+      case UnicodeEmojiNode():
+        return TextSpan(text: node.emojiUnicode, recognizer: _recognizer);
+
+      case ImageEmojiNode():
+        return WidgetSpan(alignment: PlaceholderAlignment.middle,
+          child: MessageImageEmoji(node: node));
+
+      case MathInlineNode():
+        return TextSpan(
+          style: widget.style
+            .merge(ContentTheme.of(_context!).textStyleInlineMath)
+            .apply(fontSizeFactor: kInlineCodeFontSizeFactor),
+          children: [TextSpan(text: node.texSource)]);
+
+      case GlobalTimeNode():
+        return WidgetSpan(alignment: PlaceholderAlignment.middle,
+          child: GlobalTime(node: node, ambientTextStyle: widget.style));
+
+      case UnimplementedInlineContentNode():
+        return _errorUnimplemented(node, context: _context!);
     }
   }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -940,16 +940,26 @@ class _InlineContentBuilder {
         return const TextSpan(text: "");
 
       case StrongNode():
-        return _buildStrong(node);
+        return _buildNodes(node.nodes,
+          style: bolderWghtTextStyle(widget.style, by: 200));
 
       case DeletedNode():
-        return _buildDeleted(node);
+        return _buildNodes(node.nodes,
+          style: const TextStyle(decoration: TextDecoration.lineThrough));
 
       case EmphasisNode():
-        return _buildEmphasis(node);
+        return _buildNodes(node.nodes,
+          style: const TextStyle(fontStyle: FontStyle.italic));
 
       case LinkNode():
-        return _buildLink(node);
+        final recognizer = widget.linkRecognizers?[node];
+        assert(recognizer != null);
+        _pushRecognizer(recognizer);
+        final result = _buildNodes(node.nodes,
+          // Web has the same color in light and dark mode.
+          style: TextStyle(color: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor()));
+        _popRecognizer();
+        return result;
 
       case InlineCodeNode():
         return _buildInlineCode(node);
@@ -979,26 +989,6 @@ class _InlineContentBuilder {
       case UnimplementedInlineContentNode():
         return _errorUnimplemented(node, context: _context!);
     }
-  }
-
-  InlineSpan _buildStrong(StrongNode node) => _buildNodes(node.nodes,
-    style: bolderWghtTextStyle(widget.style, by: 200));
-
-  InlineSpan _buildDeleted(DeletedNode node) => _buildNodes(node.nodes,
-    style: const TextStyle(decoration: TextDecoration.lineThrough));
-
-  InlineSpan _buildEmphasis(EmphasisNode node) => _buildNodes(node.nodes,
-    style: const TextStyle(fontStyle: FontStyle.italic));
-
-  InlineSpan _buildLink(LinkNode node) {
-    final recognizer = widget.linkRecognizers?[node];
-    assert(recognizer != null);
-    _pushRecognizer(recognizer);
-    final result = _buildNodes(node.nodes,
-      // Web has the same color in light and dark mode.
-      style: TextStyle(color: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor()));
-    _popRecognizer();
-    return result;
   }
 
   InlineSpan _buildInlineCode(InlineCodeNode node) {


### PR DESCRIPTION
The first commit preps for later changes to add more narrows (#807). Using `switch` gives us the benefit of exhaustive match checks.

narrow is refactored to become private because otherwise `switch` is not able to promote the type of it.

https://dart.dev/tools/non-promotion-reasons#private

The remaining commits are follow-ups to sweep the remaining TODO(dart-3) items throughout the code base.