### PR TITLE
compose_box: Replace compose box with a banner in DMs with deactivated users

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -180,6 +180,10 @@
   "@successMessageLinkCopied": {
     "description": "Message when link of a message was copied to the user's system clipboard."
   },
+  "errorBannerDeactivatedDmLabel": "You cannot send messages to deactivated users.",
+  "@errorBannerDeactivatedDmLabel": {
+    "description": "Label text for error banner when sending a message to one or multiple deactivated users."
+  },
   "composeBoxAttachFilesTooltip": "Attach files",
   "@composeBoxAttachFilesTooltip": {
     "description": "Tooltip for compose box icon to attach a file to the message."

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -286,6 +286,7 @@ class RealmUserUpdateEvent extends RealmUserEvent {
 
   @JsonKey(readValue: _readFromPerson) final RealmUserUpdateCustomProfileField? customProfileField;
   @JsonKey(readValue: _readFromPerson) final String? newEmail;
+  @JsonKey(readValue: _readFromPerson) final bool? isActive;
 
   static Object? _readFromPerson(Map<dynamic, dynamic> json, String key) {
     return (json['person'] as Map<String, dynamic>)[key];
@@ -319,6 +320,7 @@ class RealmUserUpdateEvent extends RealmUserEvent {
     this.deliveryEmail,
     this.customProfileField,
     this.newEmail,
+    this.isActive,
   });
 
   factory RealmUserUpdateEvent.fromJson(Map<String, dynamic> json) =>

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -151,6 +151,8 @@ RealmUserUpdateEvent _$RealmUserUpdateEventFromJson(
                   as Map<String, dynamic>),
       newEmail:
           RealmUserUpdateEvent._readFromPerson(json, 'new_email') as String?,
+      isActive:
+          RealmUserUpdateEvent._readFromPerson(json, 'is_active') as bool?,
     );
 
 Map<String, dynamic> _$RealmUserUpdateEventToJson(
@@ -172,6 +174,7 @@ Map<String, dynamic> _$RealmUserUpdateEventToJson(
               const NullableStringJsonConverter().toJson),
       'custom_profile_field': instance.customProfileField,
       'new_email': instance.newEmail,
+      'is_active': instance.isActive,
     };
 
 const _$UserRoleEnumMap = {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -461,6 +461,7 @@ class PerAccountStore extends ChangeNotifier with ChannelStore, MessageStore {
         if (event.isBillingAdmin != null) user.isBillingAdmin = event.isBillingAdmin!;
         if (event.deliveryEmail != null)  user.deliveryEmail  = event.deliveryEmail!.value;
         if (event.newEmail != null)       user.email          = event.newEmail!;
+        if (event.isActive != null)       user.isActive       = event.isActive!;
         if (event.customProfileField != null) {
           final profileData = (user.profileData ??= {});
           final update = event.customProfileField!;

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -141,6 +141,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       channelColorSwatches: ChannelColorSwatches.light,
       atMentionMarker: const HSLColor.fromAHSL(0.5, 0, 0, 0.2).toColor(),
       dmHeaderBg: const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor(),
+      errorBannerBackground: const HSLColor.fromAHSL(1, 4, 0.33, 0.90).toColor(),
+      errorBannerBorder: const HSLColor.fromAHSL(0.4, 3, 0.57, 0.33).toColor(),
+      errorBannerLabel: const HSLColor.fromAHSL(1, 4, 0.58, 0.33).toColor(),
       loginOrDivider: const Color(0xffdedede),
       loginOrDividerText: const Color(0xff575757),
       sectionCollapseIcon: const Color(0x7f1e2e48),
@@ -163,6 +166,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       // TODO(#95) need proper dark-theme color (this is ad hoc)
       atMentionMarker: const HSLColor.fromAHSL(0.4, 0, 0, 1).toColor(),
       dmHeaderBg: const HSLColor.fromAHSL(1, 46, 0.15, 0.2).toColor(),
+      errorBannerBackground: const HSLColor.fromAHSL(1, 0, 0.61, 0.19).toColor(),
+      errorBannerBorder: const HSLColor.fromAHSL(0.4, 3, 0.73, 0.74).toColor(),
+      errorBannerLabel: const HSLColor.fromAHSL(1, 2, 0.73, 0.80).toColor(),
       loginOrDivider: const Color(0xff424242),
       loginOrDividerText: const Color(0xffa8a8a8),
       // TODO(#95) need proper dark-theme color (this is ad hoc)
@@ -185,6 +191,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.channelColorSwatches,
     required this.atMentionMarker,
     required this.dmHeaderBg,
+    required this.errorBannerBackground,
+    required this.errorBannerBorder,
+    required this.errorBannerLabel,
     required this.loginOrDivider,
     required this.loginOrDividerText,
     required this.sectionCollapseIcon,
@@ -218,6 +227,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   // Not named variables in Figma; taken from older Figma drafts, or elsewhere.
   final Color atMentionMarker;
   final Color dmHeaderBg;
+  final Color errorBannerBackground;
+  final Color errorBannerBorder;
+  final Color errorBannerLabel;
   final Color loginOrDivider; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color loginOrDividerText; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color sectionCollapseIcon;
@@ -238,6 +250,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     ChannelColorSwatches? channelColorSwatches,
     Color? atMentionMarker,
     Color? dmHeaderBg,
+    Color? errorBannerBackground,
+    Color? errorBannerBorder,
+    Color? errorBannerLabel,
     Color? loginOrDivider,
     Color? loginOrDividerText,
     Color? sectionCollapseIcon,
@@ -257,6 +272,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       channelColorSwatches: channelColorSwatches ?? this.channelColorSwatches,
       atMentionMarker: atMentionMarker ?? this.atMentionMarker,
       dmHeaderBg: dmHeaderBg ?? this.dmHeaderBg,
+      errorBannerBackground: errorBannerBackground ?? this.errorBannerBackground,
+      errorBannerBorder: errorBannerBorder ?? this.errorBannerBorder,
+      errorBannerLabel: errorBannerLabel ?? this.errorBannerLabel,
       loginOrDivider: loginOrDivider ?? this.loginOrDivider,
       loginOrDividerText: loginOrDividerText ?? this.loginOrDividerText,
       sectionCollapseIcon: sectionCollapseIcon ?? this.sectionCollapseIcon,
@@ -283,6 +301,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       channelColorSwatches: ChannelColorSwatches.lerp(channelColorSwatches, other.channelColorSwatches, t),
       atMentionMarker: Color.lerp(atMentionMarker, other.atMentionMarker, t)!,
       dmHeaderBg: Color.lerp(dmHeaderBg, other.dmHeaderBg, t)!,
+      errorBannerBackground: Color.lerp(errorBannerBackground, other.errorBannerBackground, t)!,
+      errorBannerBorder: Color.lerp(errorBannerBorder, other.errorBannerBorder, t)!,
+      errorBannerLabel: Color.lerp(errorBannerLabel, other.errorBannerLabel, t)!,
       loginOrDivider: Color.lerp(loginOrDivider, other.loginOrDivider, t)!,
       loginOrDividerText: Color.lerp(loginOrDividerText, other.loginOrDividerText, t)!,
       sectionCollapseIcon: Color.lerp(sectionCollapseIcon, other.sectionCollapseIcon, t)!,


### PR DESCRIPTION
When DMs have one or multiple deactivated users, all parts of the compose box are replaced with a banner, saying: _You cannot send messages to deactivated users_.

<table>
    <tr>
        <td><b>DMs with active user</b></td>
        <td><b>DMs with deactivated user</b></td>
        <td><b>DMs with deactivated user - Dark</b></td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/f0724c2d-2a06-498c-b752-188a42535b79" width="300"/></td>
        <td><img src="https://github.com/user-attachments/assets/6096c014-9473-4f39-a4e0-fd0db6fc78b0" width="300"/></td>
<td><img src="https://github.com/user-attachments/assets/997577f5-1a7c-4377-b75c-8ae671e37f00" width="300"/></td>
    </tr>
</table>


https://github.com/user-attachments/assets/f219ef6f-3f65-44d8-a5d8-93b7883eb348

**Note:** This work is the result of a productive pair programming session with @rajveermalviya.

Fixes: #675

