### PR TITLE
msglist: Handle UserTopicEvent, hiding/showing messages as needed

### DIFF
--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -156,10 +156,10 @@ class ChannelStoreImpl with ChannelStore {
     switch (event) {
       case SubscriptionAddEvent():
         for (final subscription in event.subscriptions) {
-          assert(streams.containsKey(subscription.streamId)
-            && streams[subscription.streamId] is! Subscription);
-          assert(streamsByName.containsKey(subscription.name)
-            && streamsByName[subscription.name] is! Subscription);
+          assert(streams.containsKey(subscription.streamId));
+          assert(streams[subscription.streamId] is! Subscription);
+          assert(streamsByName.containsKey(subscription.name));
+          assert(streamsByName[subscription.name] is! Subscription);
           assert(!subscriptions.containsKey(subscription.streamId));
           streams[subscription.streamId] = subscription;
           streamsByName[subscription.name] = subscription;

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -82,6 +82,12 @@ class MessageStoreImpl with MessageStore {
     }
   }
 
+  void handleUserTopicEvent(UserTopicEvent event) {
+    for (final view in _messageListViews) {
+      view.handleUserTopicEvent(event);
+    }
+  }
+
   void handleMessageEvent(MessageEvent event) {
     // If the message is one we already know about (from a fetch),
     // clobber it with the one from the event system.

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -503,6 +503,8 @@ class PerAccountStore extends ChangeNotifier with ChannelStore, MessageStore {
 
       case UserTopicEvent():
         assert(debugLog("server event: user_topic"));
+        _messages.handleUserTopicEvent(event);
+        // Update _channels last, so other handlers can compare to the old value.
         _channels.handleUserTopicEvent(event);
         notifyListeners();
 

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -426,6 +426,17 @@ const _unreadMsgs = unreadMsgs;
 // Events.
 //
 
+UserTopicEvent userTopicEvent(
+    int streamId, String topic, UserTopicVisibilityPolicy visibilityPolicy) {
+  return UserTopicEvent(
+    id: 1,
+    streamId: streamId,
+    topicName: topic,
+    lastUpdated: 1234567890,
+    visibilityPolicy: visibilityPolicy,
+  );
+}
+
 DeleteMessageEvent deleteMessageEvent(List<StreamMessage> messages) {
   assert(messages.isNotEmpty);
   final streamId = messages.first.streamId;

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -183,11 +183,14 @@ ZulipStream stream({
 }) {
   _checkPositive(streamId, 'stream ID');
   _checkPositive(firstMessageId, 'message ID');
+  var effectiveStreamId = streamId ?? _nextStreamId();
+  var effectiveName = name ?? 'stream $effectiveStreamId';
+  var effectiveDescription = description ?? 'Description of $effectiveName';
   return ZulipStream(
-    streamId: streamId ?? _nextStreamId(),
-    name: name ?? 'A stream', // TODO generate example names
-    description: description ?? 'A description', // TODO generate example descriptions
-    renderedDescription: renderedDescription ?? '<p>A description</p>', // TODO generate random
+    streamId: effectiveStreamId,
+    name: effectiveName,
+    description: effectiveDescription,
+    renderedDescription: renderedDescription ?? '<p>$effectiveDescription</p>',
     dateCreated: dateCreated ?? 1686774898,
     firstMessageId: firstMessageId,
     inviteOnly: inviteOnly ?? false,

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -34,8 +34,8 @@ void main() {
     }
 
     test('initial', () {
-      final stream1 = eg.stream(streamId: 1, name: 'stream 1');
-      final stream2 = eg.stream(streamId: 2, name: 'stream 2');
+      final stream1 = eg.stream();
+      final stream2 = eg.stream();
       checkUnified(eg.store(initialSnapshot: eg.initialSnapshot(
         streams: [stream1, stream2],
         subscriptions: [eg.subscription(stream1)],
@@ -43,8 +43,8 @@ void main() {
     });
 
     test('added by events', () async {
-      final stream1 = eg.stream(streamId: 1, name: 'stream 1');
-      final stream2 = eg.stream(streamId: 2, name: 'stream 2');
+      final stream1 = eg.stream();
+      final stream2 = eg.stream();
       final store = eg.store();
       checkUnified(store);
 
@@ -106,8 +106,8 @@ void main() {
   });
 
   group('topic visibility', () {
-    final stream1 = eg.stream(streamId: 1, name: 'stream 1');
-    final stream2 = eg.stream(streamId: 2, name: 'stream 2');
+    final stream1 = eg.stream();
+    final stream2 = eg.stream();
 
     group('getter topicVisibilityPolicy', () {
       test('with nothing for stream', () {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -467,8 +467,8 @@ void main() {
   });
 
   group('messagesMoved', () {
-    final stream = eg.stream(streamId: 1, name: 'test stream');
-    final otherStream = eg.stream(streamId: 2, name: 'other stream');
+    final stream = eg.stream();
+    final otherStream = eg.stream();
 
     void checkHasMessages(Iterable<Message> messages) {
       check(model.messages.map((e) => e.id)).deepEquals(messages.map((e) => e.id));
@@ -1094,8 +1094,8 @@ void main() {
 
   group('stream/topic muting', () {
     test('in CombinedFeedNarrow', () async {
-      final stream1 = eg.stream(streamId: 1, name: 'stream 1');
-      final stream2 = eg.stream(streamId: 2, name: 'stream 2');
+      final stream1 = eg.stream();
+      final stream2 = eg.stream();
       await prepare(narrow: const CombinedFeedNarrow());
       await store.addStreams([stream1, stream2]);
       await store.addSubscription(eg.subscription(stream1));
@@ -1157,7 +1157,7 @@ void main() {
     });
 
     test('in ChannelNarrow', () async {
-      final stream = eg.stream(streamId: 1, name: 'stream 1');
+      final stream = eg.stream();
       await prepare(narrow: ChannelNarrow(stream.streamId));
       await store.addStream(stream);
       await store.addSubscription(eg.subscription(stream, isMuted: true));
@@ -1204,7 +1204,7 @@ void main() {
     });
 
     test('in TopicNarrow', () async {
-      final stream = eg.stream(streamId: 1, name: 'stream 1');
+      final stream = eg.stream();
       await prepare(narrow: TopicNarrow(stream.streamId, 'A'));
       await store.addStream(stream);
       await store.addSubscription(eg.subscription(stream, isMuted: true));
@@ -1236,7 +1236,7 @@ void main() {
     });
 
     test('in MentionsNarrow', () async {
-      final stream = eg.stream(streamId: 1, name: 'muted stream');
+      final stream = eg.stream();
       const mutedTopic = 'muted';
       await prepare(narrow: const MentionsNarrow());
       await store.addStream(stream);

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -5,6 +5,7 @@ import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/store.dart';
 
 import '../api/fake_api.dart';
+import '../example_data.dart' as eg;
 
 /// A [GlobalStore] containing data provided by callers,
 /// and that causes no database queries or network requests.
@@ -146,13 +147,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
   }
 
   Future<void> addUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy visibilityPolicy) async {
-    await handleEvent(UserTopicEvent(
-      id: 1,
-      streamId: stream.streamId,
-      topicName: topic,
-      lastUpdated: 1234567890,
-      visibilityPolicy: visibilityPolicy,
-    ));
+    await handleEvent(eg.userTopicEvent(stream.streamId, topic, visibilityPolicy));
   }
 
   Future<void> addMessage(Message message) async {

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -153,9 +153,9 @@ void main() {
 
   group('count helpers', () {
     test('countInCombinedFeedNarrow', () async {
-      final stream1 = eg.stream(streamId: 1, name: 'stream 1');
-      final stream2 = eg.stream(streamId: 2, name: 'stream 2');
-      final stream3 = eg.stream(streamId: 3, name: 'stream 3');
+      final stream1 = eg.stream();
+      final stream2 = eg.stream();
+      final stream3 = eg.stream();
       prepare();
       await channelStore.addStreams([stream1, stream2, stream3]);
       await channelStore.addSubscription(eg.subscription(stream1));

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -618,8 +618,8 @@ void main() {
 
   group('Update Narrow on message move', () {
     const topic = 'foo';
-    final channel = eg.stream(name: 'move test stream');
-    final otherChannel = eg.stream(name: 'other move test stream');
+    final channel = eg.stream();
+    final otherChannel = eg.stream();
     final narrow = TopicNarrow(channel.streamId, topic);
 
     void prepareGetMessageResponse(List<Message> messages) {

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -284,10 +284,10 @@ void main() {
       check(wght).equals(expectedWght);
     }
 
-    final unmutedStreamWithUnmutedUnreads =   eg.stream(name: 'Unmuted stream with unmuted unreads');
-    final unmutedStreamWithNoUnmutedUnreads = eg.stream(name: 'Unmuted stream with no unmuted unreads');
-    final mutedStreamWithUnmutedUnreads =     eg.stream(name: 'Muted stream with unmuted unreads');
-    final mutedStreamWithNoUnmutedUnreads =   eg.stream(name: 'Muted stream with no unmuted unreads');
+    final unmutedStreamWithUnmutedUnreads =   eg.stream();
+    final unmutedStreamWithNoUnmutedUnreads = eg.stream();
+    final mutedStreamWithUnmutedUnreads =     eg.stream();
+    final mutedStreamWithNoUnmutedUnreads =   eg.stream();
 
     await setupStreamListPage(tester,
       subscriptions: [


### PR DESCRIPTION
In particular this will allow us to start offering UI for muting
and unmuting topics, and have the message list the user is looking at
update appropriately when they do so.

Fixes: #421

---

The first two commits are taken from #787 (/cc @PIG208):
aef0ab1eb test [nfc]: Allow overriding original stream and add checks.
9c50ba57e message: Handle moved messages from UpdateMessageEvent.

So they can be ignored in reviewing this PR, and we'll plan to merge #787 before this one.
