### PR TITLE
 autocomplete: Add "recent senders criterion" to user-mention autocomplete

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -250,11 +250,11 @@ class MentionAutocompleteView extends ChangeNotifier {
       if (result != 0) return result;
     }
 
-    final aMessageId = recentSenders.latestMessageIdOfSenderInStream(
-      streamId: streamId, senderId: userA.userId);
-    final bMessageId = recentSenders.latestMessageIdOfSenderInStream(
-      streamId: streamId, senderId: userB.userId);
-    return -compareRecentMessageIds(aMessageId, bMessageId);
+    return -compareRecentMessageIds(
+      recentSenders.latestMessageIdOfSenderInStream(
+        streamId: streamId, senderId: userA.userId),
+      recentSenders.latestMessageIdOfSenderInStream(
+        streamId: streamId, senderId: userB.userId));
   }
 
   /// Determines which of the two users is more recent in DM conversations.

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -187,20 +187,20 @@ class MentionAutocompleteView extends ChangeNotifier {
     required PerAccountStore store,
     required Narrow narrow,
   }) {
-    final (int?, String?) streamAndTopic;
+    int? streamId;
+    String? topic;
     switch (narrow) {
       case StreamNarrow():
-        streamAndTopic = (narrow.streamId, null);
+        streamId = narrow.streamId;
       case TopicNarrow():
-        streamAndTopic = (narrow.streamId, narrow.topic);
+        streamId = narrow.streamId;
+        topic = narrow.topic;
       case DmNarrow():
-        streamAndTopic = (null, null);
+        break;
       case CombinedFeedNarrow():
         assert(false, 'No compose box, thus no autocomplete is available in ${narrow.runtimeType}.');
-        streamAndTopic = (null, null);
     }
 
-    final (streamId, topic) = streamAndTopic;
     return store.users.values.toList()
       ..sort((userA, userB) => _compareByRelevance(userA, userB,
           streamId: streamId,

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -204,10 +204,21 @@ class MentionAutocompleteView extends ChangeNotifier {
     final aLatestMessageId = recentDms.latestMessagesByRecipient[userA.userId];
     final bLatestMessageId = recentDms.latestMessagesByRecipient[userB.userId];
 
-    return switch((aLatestMessageId, bLatestMessageId)) {
-      (int a, int b) => -a.compareTo(b),
-      (int(),     _) => -1,
-      (_,     int()) => 1,
+    return -compareRecentMessageIds(aLatestMessageId, bLatestMessageId);
+  }
+
+  /// Compares [a] to [b], with null less than all integers.
+  ///
+  /// The values should represent the most recent message ID in each of two
+  /// sets of messages, with null meaning the set is empty.
+  ///
+  /// Return values are as with [Comparable.compareTo].
+  @visibleForTesting
+  static int compareRecentMessageIds(int? a, int? b) {
+    return switch ((a, b)) {
+      (int a, int b) => a.compareTo(b),
+      (int(),     _) => 1,
+      (_,     int()) => -1,
       _              => 0,
     };
   }

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -370,7 +370,7 @@ void main() {
       await store.addMessages(messages);
     }
 
-    group('MentionAutocompleteView.compareRecentMessageIds', () {
+    group('compareRecentMessageIds', () {
       test('both a and b are non-null', () async {
         check(MentionAutocompleteView.compareRecentMessageIds(2, 5)).isLessThan(0);
         check(MentionAutocompleteView.compareRecentMessageIds(5, 2)).isGreaterThan(0);
@@ -387,7 +387,7 @@ void main() {
       });
     });
 
-    group('MentionAutocompleteView.compareByRecency', () {
+    group('compareByRecency', () {
       final userA = eg.otherUser;
       final userB = eg.thirdUser;
       final stream = eg.stream();
@@ -438,7 +438,7 @@ void main() {
       });
     });
 
-    group('MentionAutocompleteView.compareByDms', () {
+    group('compareByDms', () {
       const idA = 1;
       const idB = 2;
 

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -395,44 +395,28 @@ void main() {
       const topic2 = 'topic2';
 
       Message message(User sender, String topic) {
-        return eg.streamMessage(
-          sender: sender,
-          stream: stream,
-          topic: topic,
-        );
+        return eg.streamMessage(sender: sender, stream: stream, topic: topic);
       }
 
       int compareAB({required String? topic}) {
         return MentionAutocompleteView.compareByRecency(userA, userB,
-          streamId: stream.streamId,
-          topic: topic,
-          store: store,
-        );
+          streamId: stream.streamId, topic: topic, store: store);
       }
 
       test('prioritizes the user with more recent activity in the topic', () async {
-        await prepare(messages: [
-          message(userA, topic1),
-          message(userB, topic1),
-        ]);
+        await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
         check(compareAB(topic: topic1)).isGreaterThan(0);
       });
 
       test('no activity in topic -> prioritizes the user with more recent '
           'activity in the stream', () async {
-        await prepare(messages: [
-          message(userA, topic1),
-          message(userB, topic1),
-        ]);
+        await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
         check(compareAB(topic: topic2)).isGreaterThan(0);
       });
 
       test('no topic provided -> prioritizes the user with more recent '
           'activity in the stream', () async {
-        await prepare(messages: [
-          message(userA, topic1),
-          message(userB, topic2),
-        ]);
+        await prepare(messages: [message(userA, topic1), message(userB, topic2)]);
         check(compareAB(topic: null)).isGreaterThan(0);
       });
 

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -565,6 +565,13 @@ void main() {
           checkPrecedes(narrow, users[2], users.skip(3));
         }
       });
+
+      test('CombinedFeedNarrow gives error', () async {
+        await prepare(users: [eg.user(), eg.user()], messages: []);
+        const narrow = CombinedFeedNarrow();
+        check(() => MentionAutocompleteView.init(store: store, narrow: narrow))
+          .throws<AssertionError>();
+      });
     });
 
     group('autocomplete suggests relevant users in the intended order', () {
@@ -722,16 +729,6 @@ void main() {
 
           await checkResultsIn(dmNarrow, expected: [1, 3, 0, 2, 4]);
         });
-      });
-
-      test('CombinedFeedNarrow', () async {
-        await prepareStore();
-        // As we do not expect a compose box in [CombinedFeedNarrow], it should
-        // not proceed to show any results.
-        await check(checkResultsIn(
-          const CombinedFeedNarrow(),
-          expected: [0, 1, 2, 3, 4])
-        ).throws();
       });
     });
   });

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -583,20 +583,20 @@ void main() {
       const topic = 'topic';
       final topicNarrow = TopicNarrow(stream.streamId, topic);
 
-      final users = List.generate(5, (i) => eg.user(userId: i));
+      final users = List.generate(5, (i) => eg.user(userId: 1 + i));
 
       final dmConversations = [
-        RecentDmConversation(userIds: [3],    maxMessageId: 300),
-        RecentDmConversation(userIds: [0],    maxMessageId: 200),
-        RecentDmConversation(userIds: [0, 1], maxMessageId: 100),
+        RecentDmConversation(userIds: [4],    maxMessageId: 300),
+        RecentDmConversation(userIds: [1],    maxMessageId: 200),
+        RecentDmConversation(userIds: [1, 2], maxMessageId: 100),
       ];
 
       StreamMessage streamMessage({required int id, required int senderId, String? topic}) =>
-        eg.streamMessage(id: id, sender: users[senderId], topic: topic, stream: stream);
+        eg.streamMessage(id: id, sender: users[senderId-1], topic: topic, stream: stream);
 
       final messages = [
-        streamMessage(id: 50, senderId: 0, topic: topic),
-        streamMessage(id: 60, senderId: 4),
+        streamMessage(id: 50, senderId: 1, topic: topic),
+        streamMessage(id: 60, senderId: 5),
       ];
 
       Future<void> prepareStore() async {
@@ -629,7 +629,7 @@ void main() {
 
       await prepareStore();
       await fetchInitialMessagesIn(topicNarrow);
-      await checkResultsIn(topicNarrow, expected: [0, 4, 3, 1, 2]);
+      await checkResultsIn(topicNarrow, expected: [1, 5, 4, 2, 3]);
     });
   });
 }

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -416,6 +416,12 @@ void main() {
         check(compareAB(topic: topic1)).isGreaterThan(0);
       });
 
+      test('favor most recent in topic ahead of most recent in stream', () async {
+        await prepare(messages: [
+          message(userA, topic1), message(userB, topic1), message(userA, topic2)]);
+        check(compareAB(topic: topic1)).isGreaterThan(0);
+      });
+
       test('no activity in topic -> favor user most recent in stream', () async {
         await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
         check(compareAB(topic: topic2)).isGreaterThan(0);

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -411,24 +411,22 @@ void main() {
         return resultAB;
       }
 
-      test('prioritizes the user with more recent activity in the topic', () async {
+      test('favor user most recent in topic', () async {
         await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
         check(compareAB(topic: topic1)).isGreaterThan(0);
       });
 
-      test('no activity in topic -> prioritizes the user with more recent '
-          'activity in the stream', () async {
+      test('no activity in topic -> favor user most recent in stream', () async {
         await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
         check(compareAB(topic: topic2)).isGreaterThan(0);
       });
 
-      test('no topic provided -> prioritizes the user with more recent '
-          'activity in the stream', () async {
+      test('no topic provided -> favor user most recent in stream', () async {
         await prepare(messages: [message(userA, topic1), message(userB, topic2)]);
         check(compareAB(topic: null)).isGreaterThan(0);
       });
 
-      test('no activity in topic/stream -> prioritizes none', () async {
+      test('no activity in topic/stream -> favor none', () async {
         await prepare(messages: []);
         check(compareAB(topic: null)).equals(0);
       });

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -8,14 +8,11 @@ import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/autocomplete.dart';
-import 'package:zulip/model/message_list.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/compose_box.dart';
 
-import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
-import 'message_list_test.dart';
 import 'test_store.dart';
 import 'autocomplete_checks.dart';
 
@@ -575,16 +572,6 @@ void main() {
     });
 
     test('final results end-to-end', () async {
-      Future<void> fetchInitialMessagesIn(Narrow narrow, List<Message> messages) async {
-        final connection = store.connection as FakeApiConnection;
-        connection.prepare(json: newestResult(
-          foundOldest: false,
-          messages: messages,
-        ).toJson());
-        final messageList = MessageListView.init(store: store, narrow: narrow);
-        await messageList.fetchInitial();
-      }
-
       Future<Iterable<int>> getResults(
           Narrow narrow, MentionAutocompleteQuery query) async {
         bool done = false;
@@ -611,18 +598,14 @@ void main() {
         eg.user(userId: 5, fullName: 'User Five'),
       ];
 
-      final messages = [
+      await prepare(users: users, messages: [
         eg.streamMessage(id: 50, sender: users[1-1], stream: stream, topic: topic),
         eg.streamMessage(id: 60, sender: users[5-1], stream: stream),
-      ];
-
-      await prepare(users: users, messages: messages, dmConversations: [
+      ], dmConversations: [
         RecentDmConversation(userIds: [4],    maxMessageId: 300),
         RecentDmConversation(userIds: [1],    maxMessageId: 200),
         RecentDmConversation(userIds: [1, 2], maxMessageId: 100),
       ]);
-      await fetchInitialMessagesIn(topicNarrow,
-        messages.where((m) => m.topic == topic).toList());
 
       // Check the ranking of the full list of users.
       // The order should be:

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -399,8 +399,16 @@ void main() {
       }
 
       int compareAB({required String? topic}) {
-        return MentionAutocompleteView.compareByRecency(userA, userB,
+        final resultAB = MentionAutocompleteView.compareByRecency(userA, userB,
           streamId: stream.streamId, topic: topic, store: store);
+        final resultBA = MentionAutocompleteView.compareByRecency(userB, userA,
+          streamId: stream.streamId, topic: topic, store: store);
+        switch (resultAB) {
+          case <0: check(resultBA).isGreaterThan(0);
+          case >0: check(resultBA).isLessThan(0);
+          default: check(resultBA).equals(0);
+        }
+        return resultAB;
       }
 
       test('prioritizes the user with more recent activity in the topic', () async {

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -600,7 +600,7 @@ void main() {
 
       await prepare(users: users, messages: [
         eg.streamMessage(id: 50, sender: users[1-1], stream: stream, topic: topic),
-        eg.streamMessage(id: 60, sender: users[5-1], stream: stream),
+        eg.streamMessage(id: 60, sender: users[5-1], stream: stream, topic: 'other $topic'),
       ], dmConversations: [
         RecentDmConversation(userIds: [4],    maxMessageId: 300),
         RecentDmConversation(userIds: [1],    maxMessageId: 200),

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -614,22 +614,24 @@ void main() {
         await messageList.fetchInitial();
       }
 
-      Future<void> checkResultsIn(Narrow narrow, {required List<int> expected}) async {
-        final view = MentionAutocompleteView.init(store: store, narrow: narrow);
-
+      Future<Iterable<int>> getResults(
+          Narrow narrow, MentionAutocompleteQuery query) async {
         bool done = false;
+        final view = MentionAutocompleteView.init(store: store, narrow: narrow);
         view.addListener(() { done = true; });
-        view.query = MentionAutocompleteQuery('');
+        view.query = query;
         await Future(() {});
         check(done).isTrue();
         final results = view.results
           .map((e) => (e as UserMentionAutocompleteResult).userId);
-        check(results).deepEquals(expected);
+        view.dispose();
+        return results;
       }
 
       await prepareStore();
       await fetchInitialMessagesIn(topicNarrow);
-      await checkResultsIn(topicNarrow, expected: [1, 5, 4, 2, 3]);
+      check(await getResults(topicNarrow, MentionAutocompleteQuery('')))
+        .deepEquals([1, 5, 4, 2, 3]);
     });
   });
 }

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -365,6 +365,23 @@ void main() {
       await store.addUsers(users);
     }
 
+    group('MentionAutocompleteView.compareRecentMessageIds', () {
+      test('both a and b are non-null', () async {
+        check(MentionAutocompleteView.compareRecentMessageIds(2, 5)).isLessThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(5, 2)).isGreaterThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(5, 5)).equals(0);
+      });
+
+      test('one of a and b is null', () async {
+        check(MentionAutocompleteView.compareRecentMessageIds(null, 5)).isLessThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(5, null)).isGreaterThan(0);
+      });
+
+      test('both of a and b are null', () async {
+        check(MentionAutocompleteView.compareRecentMessageIds(null, null)).equals(0);
+      });
+    });
+
     group('MentionAutocompleteView.compareByDms', () {
       const idA = 1;
       const idB = 2;

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -583,7 +583,13 @@ void main() {
       const topic = 'topic';
       final topicNarrow = TopicNarrow(stream.streamId, topic);
 
-      final users = List.generate(5, (i) => eg.user(userId: 1 + i));
+      final users = [
+        eg.user(userId: 1, fullName: 'User One'),
+        eg.user(userId: 2, fullName: 'User Two'),
+        eg.user(userId: 3, fullName: 'User Three'),
+        eg.user(userId: 4, fullName: 'User Four'),
+        eg.user(userId: 5, fullName: 'User Five'),
+      ];
 
       final dmConversations = [
         RecentDmConversation(userIds: [4],    maxMessageId: 300),
@@ -630,8 +636,14 @@ void main() {
 
       await prepareStore();
       await fetchInitialMessagesIn(topicNarrow);
+      // Check the ranking of the full list of users.
       check(await getResults(topicNarrow, MentionAutocompleteQuery('')))
         .deepEquals([1, 5, 4, 2, 3]);
+      // Check the ranking applies also to results filtered by a query.
+      check(await getResults(topicNarrow, MentionAutocompleteQuery('t')))
+        .deepEquals([2, 3]);
+      check(await getResults(topicNarrow, MentionAutocompleteQuery('f')))
+        .deepEquals([5, 4]);
     });
   });
 }


### PR DESCRIPTION
Besides recent activity in DMs, activity in the current topic/stream is also considered (as the first criterion) when suggesting users in @-mention autocomplete.

_**Note**: This is the third PR in the series of PRs #608 is divided into, coming after #692_.

Fixes part of: #228
