### PR TITLE
compose: Include content-type in image-upload requests

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
 
 import '../log.dart';
 import '../model/binding.dart';
@@ -192,10 +193,20 @@ class ApiConnection {
   }
 
   Future<T> postFileFromStream<T>(String routeName, T Function(Map<String, dynamic>) fromJson,
-      String path, Stream<List<int>> content, int length, {String? filename}) async {
+      String path, Stream<List<int>> content, int length,
+      {String? filename, String? contentType}) async {
     final url = realmUrl.replace(path: "/api/v1/$path");
+    MediaType? parsedContentType;
+    if (contentType != null) {
+      try {
+        parsedContentType = MediaType.parse(contentType);
+      } on FormatException {
+        // TODO log
+      }
+    }
     final request = http.MultipartRequest('POST', url)
-      ..files.add(http.MultipartFile('file', content, length, filename: filename));
+      ..files.add(http.MultipartFile('file', content, length,
+        filename: filename, contentType: parsedContentType));
     return send(routeName, fromJson, request);
   }
 

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -262,9 +262,10 @@ Future<UploadFileResult> uploadFile(
   required Stream<List<int>> content,
   required int length,
   required String filename,
+  required String? contentType,
 }) {
   return connection.postFileFromStream('uploadFile', UploadFileResult.fromJson, 'user_uploads',
-    content, length, filename: filename);
+    content, length, filename: filename, contentType: contentType);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -1,4 +1,5 @@
 import 'package:device_info_plus/device_info_plus.dart' as device_info_plus;
+import 'package:file_picker/file_picker.dart' as file_picker;
 import 'package:firebase_core/firebase_core.dart' as firebase_core;
 import 'package:firebase_messaging/firebase_messaging.dart' as firebase_messaging;
 import 'package:flutter/foundation.dart';
@@ -10,6 +11,8 @@ import '../host/android_notifications.dart';
 import '../log.dart';
 import '../widgets/store.dart';
 import 'store.dart';
+
+export 'package:file_picker/file_picker.dart' show FilePickerResult, FileType, PlatformFile;
 
 /// Alias for [url_launcher.LaunchMode].
 typedef UrlLaunchMode = url_launcher.LaunchMode;
@@ -152,6 +155,15 @@ abstract class ZulipBinding {
 
   /// Wraps the [AndroidNotificationHostApi] constructor.
   AndroidNotificationHostApi get androidNotificationHost;
+
+  /// Pick files from the media library, via package:file_picker.
+  ///
+  /// This wraps [file_picker.pickFiles].
+  Future<file_picker.FilePickerResult?> pickFiles({
+    bool allowMultiple,
+    bool withReadStream,
+    file_picker.FileType type,
+  });
 }
 
 /// Like [device_info_plus.BaseDeviceInfo], but without things we don't use.
@@ -389,4 +401,17 @@ class LiveZulipBinding extends ZulipBinding {
 
   @override
   AndroidNotificationHostApi get androidNotificationHost => AndroidNotificationHostApi();
+
+  @override
+  Future<file_picker.FilePickerResult?> pickFiles({
+    bool allowMultiple = false,
+    bool withReadStream = false,
+    file_picker.FileType type = file_picker.FileType.any,
+  }) async {
+    return file_picker.FilePicker.platform.pickFiles(
+      allowMultiple: allowMultiple,
+      withReadStream: withReadStream,
+      type: type,
+    );
+  }
 }

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -4,6 +4,7 @@ import 'package:firebase_core/firebase_core.dart' as firebase_core;
 import 'package:firebase_messaging/firebase_messaging.dart' as firebase_messaging;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:image_picker/image_picker.dart' as image_picker;
 import 'package:package_info_plus/package_info_plus.dart' as package_info_plus;
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
@@ -13,6 +14,7 @@ import '../widgets/store.dart';
 import 'store.dart';
 
 export 'package:file_picker/file_picker.dart' show FilePickerResult, FileType, PlatformFile;
+export 'package:image_picker/image_picker.dart' show ImageSource, XFile;
 
 /// Alias for [url_launcher.LaunchMode].
 typedef UrlLaunchMode = url_launcher.LaunchMode;
@@ -163,6 +165,14 @@ abstract class ZulipBinding {
     bool allowMultiple,
     bool withReadStream,
     file_picker.FileType type,
+  });
+
+  /// Pick files from the camera or media library, via package:image_picker.
+  ///
+  /// This wraps [image_picker.pickImage].
+  Future<image_picker.XFile?> pickImage({
+    required image_picker.ImageSource source,
+    bool requestFullMetadata,
   });
 }
 
@@ -413,5 +423,14 @@ class LiveZulipBinding extends ZulipBinding {
       withReadStream: withReadStream,
       type: type,
     );
+  }
+
+  @override
+  Future<image_picker.XFile?> pickImage({
+    required image_picker.ImageSource source,
+    bool requestFullMetadata = true,
+  }) async {
+    return image_picker.ImagePicker()
+      .pickImage(source: source, requestFullMetadata: requestFullMetadata);
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -476,7 +476,11 @@ Future<void> _uploadFiles({
     Uri? url;
     try {
       final result = await uploadFile(store.connection,
-        content: content, length: length, filename: filename);
+        content: content,
+        length: length,
+        filename: filename,
+        contentType: null, // TODO(#829)
+      );
       url = Uri.parse(result.uri);
     } catch (e) {
       if (!context.mounted) return;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -2,7 +2,6 @@ import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
-import 'package:image_picker/image_picker.dart';
 
 import '../api/exception.dart';
 import '../api/model/model.dart';
@@ -624,7 +623,6 @@ class _AttachFromCameraButton extends _AttachUploadsButton {
   @override
   Future<Iterable<_File>> getFiles(BuildContext context) async {
     final zulipLocalizations = ZulipLocalizations.of(context);
-    final picker = ImagePicker();
     final XFile? result;
     try {
       // Ideally we'd open a platform interface that lets you choose between
@@ -632,7 +630,8 @@ class _AttachFromCameraButton extends _AttachUploadsButton {
       // option: https://github.com/flutter/flutter/issues/89159
       // so just stick with images for now. We could add another button for
       // videos, but we don't want too many buttons.
-      result = await picker.pickImage(source: ImageSource.camera, requestFullMetadata: false);
+      result = await ZulipBinding.instance.pickImage(
+        source: ImageSource.camera, requestFullMetadata: false);
     } catch (e) {
       if (!context.mounted) return [];
       if (e is PlatformException && e.code == 'camera_access_denied') {

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1,5 +1,4 @@
 import 'package:app_settings/app_settings.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
@@ -8,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
+import '../model/binding.dart';
 import '../model/compose.dart';
 import '../model/narrow.dart';
 import '../model/store.dart';
@@ -542,7 +542,7 @@ abstract class _AttachUploadsButton extends StatelessWidget {
 Future<Iterable<_File>> _getFilePickerFiles(BuildContext context, FileType type) async {
   FilePickerResult? result;
   try {
-    result = await FilePicker.platform
+    result = await ZulipBinding.instance
       .pickFiles(allowMultiple: true, withReadStream: true, type: type);
   } catch (e) {
     if (!context.mounted) return [];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -730,7 +730,7 @@ packages:
     source: hosted
     version: "1.15.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -541,7 +541,7 @@ packages:
     source: hosted
     version: "3.2.1"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   http_parser: ^4.0.2
   image_picker: ^1.0.0
   json_annotation: ^4.8.1
+  mime: ^1.0.5
   package_info_plus: ^8.0.0
   path: ^1.8.3
   path_provider: ^2.0.13

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   flutter_local_notifications_platform_interface: ^7.2.0
   html: ^0.15.1
   http: ^1.0.0
+  http_parser: ^4.0.2
   image_picker: ^1.0.0
   json_annotation: ^4.8.1
   package_info_plus: ^8.0.0

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -81,7 +81,7 @@ void main() {
   });
 
   test('ApiConnection.postFileFromStream', () async {
-    Future<void> checkRequest(List<List<int>> content, int length, String? filename) {
+    Future<void> checkRequest(List<List<int>> content, int length, {String? filename}) {
       return FakeApiConnection.with_(account: eg.selfAccount, (connection) async {
         connection.prepare(json: {});
         await connection.postFileFromStream(
@@ -105,14 +105,14 @@ void main() {
       });
     }
 
-    checkRequest([], 0, null);
-    checkRequest(['asdf'.codeUnits], 4, null);
-    checkRequest(['asd'.codeUnits, 'f'.codeUnits], 4, null);
+    checkRequest([], 0, filename: null);
+    checkRequest(['asdf'.codeUnits], 4, filename: null);
+    checkRequest(['asd'.codeUnits, 'f'.codeUnits], 4, filename: null);
 
-    checkRequest(['asdf'.codeUnits], 4, 'info.txt');
+    checkRequest(['asdf'.codeUnits], 4, filename: 'info.txt');
 
-    checkRequest(['asdf'.codeUnits], 1, null); // nothing on client side catches a wrong length
-    checkRequest(['asdf'.codeUnits], 100, null);
+    checkRequest(['asdf'.codeUnits], 1, filename: null); // nothing on client side catches a wrong length
+    checkRequest(['asdf'.codeUnits], 100, filename: null);
   });
 
   test('ApiConnection.delete', () async {

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -74,6 +74,7 @@ class TestZulipBinding extends ZulipBinding {
     _resetFirebase();
     _resetNotifications();
     _resetPickFiles();
+    _resetPickImage();
   }
 
   /// The current global store offered to a [GlobalStoreWidget].
@@ -327,6 +328,45 @@ class TestZulipBinding extends ZulipBinding {
   }) async {
     (_pickFilesCalls ??= []).add((allowMultiple: allowMultiple, withReadStream: withReadStream, type: type));
     return pickFilesResult;
+  }
+
+  /// The value that `ZulipBinding.instance.pickImage()` should return.
+  ///
+  /// See also [takePickImageCalls].
+  XFile? pickImageResult;
+
+  void _resetPickImage() {
+    pickImageResult = null;
+    _pickImageCalls = null;
+  }
+
+  /// Consume the log of calls made to `ZulipBinding.instance.pickImage()`.
+  ///
+  /// This returns a list of the arguments to all calls made
+  /// to `ZulipBinding.instance.pickImage()` since the last call to
+  /// either this method or [reset].
+  ///
+  /// See also [pickImageResult].
+  List<({
+    ImageSource source,
+    bool requestFullMetadata,
+  })> takePickImageCalls() {
+    final result = _pickImageCalls;
+    _pickImageCalls = null;
+    return result ?? [];
+  }
+  List<({
+    ImageSource source,
+    bool requestFullMetadata,
+  })>? _pickImageCalls;
+
+  @override
+  Future<XFile?> pickImage({
+    required ImageSource source,
+    bool requestFullMetadata = true,
+  }) async {
+    (_pickImageCalls ??= []).add((source: source, requestFullMetadata: requestFullMetadata));
+    return pickImageResult;
   }
 }
 

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -73,6 +73,7 @@ class TestZulipBinding extends ZulipBinding {
     _resetPackageInfo();
     _resetFirebase();
     _resetNotifications();
+    _resetPickFiles();
   }
 
   /// The current global store offered to a [GlobalStoreWidget].
@@ -284,6 +285,48 @@ class TestZulipBinding extends ZulipBinding {
   @override
   FakeAndroidNotificationHostApi get androidNotificationHost {
     return (_androidNotificationHostApi ??= FakeAndroidNotificationHostApi());
+  }
+
+  /// The value that `ZulipBinding.instance.pickFiles()` should return.
+  ///
+  /// See also [takePickFilesCalls].
+  FilePickerResult? pickFilesResult;
+
+  void _resetPickFiles() {
+    pickFilesResult = null;
+    _pickFilesCalls = null;
+  }
+
+  /// Consume the log of calls made to `ZulipBinding.instance.pickFiles()`.
+  ///
+  /// This returns a list of the arguments to all calls made
+  /// to `ZulipBinding.instance.pickFiles()` since the last call to
+  /// either this method or [reset].
+  ///
+  /// See also [pickFilesResult].
+  List<({
+    bool? allowMultiple,
+    bool? withReadStream,
+    FileType? type,
+  })> takePickFilesCalls() {
+    final result = _pickFilesCalls;
+    _pickFilesCalls = null;
+    return result ?? [];
+  }
+  List<({
+    bool? allowMultiple,
+    bool? withReadStream,
+    FileType? type,
+  })>? _pickFilesCalls;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    bool? allowMultiple,
+    bool? withReadStream,
+    FileType? type,
+  }) async {
+    (_pickFilesCalls ??= []).add((allowMultiple: allowMultiple, withReadStream: withReadStream, type: type));
+    return pickFilesResult;
   }
 }
 

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 
 import 'package:checks/checks.dart';
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
 
 extension ListChecks<T> on Subject<List<T>> {
   Subject<T> operator [](int index) => has((l) => l[index], '[$index]');
@@ -136,6 +137,10 @@ extension HttpMultipartFileChecks on Subject<http.MultipartFile> {
   Subject<String> get field => has((f) => f.field, 'field');
   Subject<int> get length => has((f) => f.length, 'length');
   Subject<String?> get filename => has((f) => f.filename, 'filename');
-  // TODO Subject<MediaType> get contentType => has((f) => f.contentType, 'contentType');
+  Subject<MediaType> get contentType => has((f) => f.contentType, 'contentType');
   Subject<bool> get isFinalized => has((f) => f.isFinalized, 'isFinalized');
+}
+
+extension MediaTypeChecks on Subject<MediaType> {
+  Subject<String> get asString => has((x) => x.toString(), 'toString'); // TODO(checks): what's a good convention for this?
 }

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -270,6 +270,8 @@ void main() {
 
         testBinding.pickFilesResult = FilePickerResult([PlatformFile(
           readStream: Stream.fromIterable(['asdf'.codeUnits]),
+          // TODO test inference of MIME type from initial bytes, when
+          //   it can't be inferred from path
           path: '/private/var/mobile/Containers/Data/Application/foo/tmp/image.jpg',
           name: 'image.jpg',
           size: 12345,
@@ -295,6 +297,7 @@ void main() {
             ..field.equals('file')
             ..length.equals(12345)
             ..filename.equals('image.jpg')
+            ..contentType.asString.equals('image/jpeg')
             ..has<Future<List<int>>>((f) => f.finalize().toBytes(), 'contents')
               .completes((it) => it.deepEquals(['asdf'.codeUnits].expand((l) => l)))
           );
@@ -322,6 +325,8 @@ void main() {
         checkAppearsLoading(tester, false);
 
         testBinding.pickImageResult = XFile.fromData(
+          // TODO test inference of MIME type when it's missing here
+          mimeType: 'image/jpeg',
           utf8.encode('asdf'),
           name: 'image.jpg',
           length: 12345,
@@ -348,6 +353,7 @@ void main() {
             ..field.equals('file')
             ..length.equals(12345)
             ..filename.equals('image.jpg')
+            ..contentType.asString.equals('image/jpeg')
             ..has<Future<List<int>>>((f) => f.finalize().toBytes(), 'contents')
               .completes((it) => it.deepEquals(['asdf'.codeUnits].expand((l) => l)))
           );


### PR DESCRIPTION
While working on this I realized we didn't have any widget tests for the image-upload flows! So I added some. There's still more to test there, and there might be some helpful deduplication in the tests.

But anyway, manual testing on my iPhone showed that the user-visible symptom of #829 on CZO is resolved:

> The symptom is that images don't get displayed in the message at all.

Fixes: #829