### PR TITLE
msglist: Follow web instead of Figma for message timestamp color

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1004,5 +1004,4 @@ class MessageWithPossibleSender extends StatelessWidget {
 // TODO web seems to ignore locale in formatting time, but we could do better
 final _kMessageTimestampFormat = DateFormat('h:mm aa', 'en_US');
 
-// TODO(#95) need dark-theme color (this one comes from the Figma)
-final _kMessageTimestampColor = const HSLColor.fromAHSL(1, 0, 0, 0.5).toColor();
+final _kMessageTimestampColor = const HSLColor.fromAHSL(0.8, 0, 0, 0.2).toColor();


### PR DESCRIPTION
Just because web has a dark-theme variant for this color, and the Figma doesn't yet.

(Web actually expresses this with separate `color` and `opacity` attributes. We just collapse those into a Color with the right alpha.)

| Before | After |
| --- | --- |
| ![8EDAAFA3-80E8-4573-A90F-07EF730FFD7A](https://github.com/user-attachments/assets/f9c5fa54-a649-45ab-9204-66a2900c2e60) | ![3661485E-4E12-49CD-A90E-97EEB93720ED](https://github.com/user-attachments/assets/874dbcda-4a94-4a2a-82d5-66d928fe6859) |