### PR TITLE
api: Rename to ChannelDestination and ChannelPostPolicy from "stream"

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -320,9 +320,9 @@ class ZulipStream {
   final bool isWebPublic; // present since 2.1, according to /api/changelog
   final bool historyPublicToSubscribers;
   final int? messageRetentionDays;
-
-  final ChannelPostPolicy streamPostPolicy;
-  // final bool isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
+  @JsonKey(name: 'stream_post_policy')
+  final ChannelPostPolicy channelPostPolicy;
+  // final bool isAnnouncementOnly; // deprecated for `channelPostPolicy`; ignore
 
   // TODO(server-6): `canRemoveSubscribersGroupId` added in FL 142
   // TODO(server-8): in FL 197 renamed to `canRemoveSubscribersGroup`
@@ -348,7 +348,7 @@ class ZulipStream {
     required this.isWebPublic,
     required this.historyPublicToSubscribers,
     required this.messageRetentionDays,
-    required this.streamPostPolicy,
+    required this.channelPostPolicy,
     required this.canRemoveSubscribersGroup,
     required this.streamWeeklyTraffic,
   });
@@ -419,7 +419,7 @@ class Subscription extends ZulipStream {
     required super.isWebPublic,
     required super.historyPublicToSubscribers,
     required super.messageRetentionDays,
-    required super.streamPostPolicy,
+    required super.channelPostPolicy,
     required super.canRemoveSubscribersGroup,
     required super.streamWeeklyTraffic,
     required this.desktopNotifications,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -321,7 +321,7 @@ class ZulipStream {
   final bool historyPublicToSubscribers;
   final int? messageRetentionDays;
 
-  final StreamPostPolicy streamPostPolicy;
+  final ChannelPostPolicy streamPostPolicy;
   // final bool isAnnouncementOnly; // deprecated for `streamPostPolicy`; ignore
 
   // TODO(server-6): `canRemoveSubscribersGroupId` added in FL 142
@@ -364,14 +364,14 @@ class ZulipStream {
 /// For docs, search for "stream_post_policy"
 /// in <https://zulip.com/api/get-stream-by-id>
 @JsonEnum(valueField: 'apiValue')
-enum StreamPostPolicy {
+enum ChannelPostPolicy {
   any(apiValue: 1),
   administrators(apiValue: 2),
   fullMembers(apiValue: 3),
   moderators(apiValue: 4),
   unknown(apiValue: null);
 
-  const StreamPostPolicy({
+  const ChannelPostPolicy({
     required this.apiValue,
   });
 

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -176,7 +176,7 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
       streamPostPolicy:
-          $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
+          $enumDecode(_$ChannelPostPolicyEnumMap, json['stream_post_policy']),
       canRemoveSubscribersGroup: (ZulipStream._readCanRemoveSubscribersGroup(
               json, 'can_remove_subscribers_group') as num?)
           ?.toInt(),
@@ -200,12 +200,12 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
     };
 
-const _$StreamPostPolicyEnumMap = {
-  StreamPostPolicy.any: 1,
-  StreamPostPolicy.administrators: 2,
-  StreamPostPolicy.fullMembers: 3,
-  StreamPostPolicy.moderators: 4,
-  StreamPostPolicy.unknown: null,
+const _$ChannelPostPolicyEnumMap = {
+  ChannelPostPolicy.any: 1,
+  ChannelPostPolicy.administrators: 2,
+  ChannelPostPolicy.fullMembers: 3,
+  ChannelPostPolicy.moderators: 4,
+  ChannelPostPolicy.unknown: null,
 };
 
 Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
@@ -220,7 +220,7 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
       streamPostPolicy:
-          $enumDecode(_$StreamPostPolicyEnumMap, json['stream_post_policy']),
+          $enumDecode(_$ChannelPostPolicyEnumMap, json['stream_post_policy']),
       canRemoveSubscribersGroup: (ZulipStream._readCanRemoveSubscribersGroup(
               json, 'can_remove_subscribers_group') as num?)
           ?.toInt(),

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -175,7 +175,7 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
       isWebPublic: json['is_web_public'] as bool,
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
-      streamPostPolicy:
+      channelPostPolicy:
           $enumDecode(_$ChannelPostPolicyEnumMap, json['stream_post_policy']),
       canRemoveSubscribersGroup: (ZulipStream._readCanRemoveSubscribersGroup(
               json, 'can_remove_subscribers_group') as num?)
@@ -195,7 +195,7 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'is_web_public': instance.isWebPublic,
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
-      'stream_post_policy': instance.streamPostPolicy,
+      'stream_post_policy': instance.channelPostPolicy,
       'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
     };
@@ -219,7 +219,7 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       isWebPublic: json['is_web_public'] as bool,
       historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
       messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
-      streamPostPolicy:
+      channelPostPolicy:
           $enumDecode(_$ChannelPostPolicyEnumMap, json['stream_post_policy']),
       canRemoveSubscribersGroup: (ZulipStream._readCanRemoveSubscribersGroup(
               json, 'can_remove_subscribers_group') as num?)
@@ -247,7 +247,7 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'is_web_public': instance.isWebPublic,
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
-      'stream_post_policy': instance.streamPostPolicy,
+      'stream_post_policy': instance.channelPostPolicy,
       'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
       'desktop_notifications': instance.desktopNotifications,

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -78,7 +78,7 @@ void main() {
       'is_web_public': false,
       'history_public_to_subscribers': true,
       'message_retention_days': null,
-      'stream_post_policy': StreamPostPolicy.any.apiValue,
+      'stream_post_policy': ChannelPostPolicy.any.apiValue,
       // 'can_remove_subscribers_group': null,
       'stream_weekly_traffic': null,
     });

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -171,7 +171,7 @@ ZulipStream stream({
   bool? isWebPublic,
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
-  ChannelPostPolicy? streamPostPolicy,
+  ChannelPostPolicy? channelPostPolicy,
   int? canRemoveSubscribersGroup,
   int? streamWeeklyTraffic,
 }) {
@@ -186,7 +186,7 @@ ZulipStream stream({
     isWebPublic: isWebPublic ?? false,
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
-    streamPostPolicy: streamPostPolicy ?? ChannelPostPolicy.any,
+    channelPostPolicy: channelPostPolicy ?? ChannelPostPolicy.any,
     canRemoveSubscribersGroup: canRemoveSubscribersGroup ?? 123,
     streamWeeklyTraffic: streamWeeklyTraffic,
   );
@@ -219,7 +219,7 @@ Subscription subscription(
     isWebPublic: stream.isWebPublic,
     historyPublicToSubscribers: stream.historyPublicToSubscribers,
     messageRetentionDays: stream.messageRetentionDays,
-    streamPostPolicy: stream.streamPostPolicy,
+    channelPostPolicy: stream.channelPostPolicy,
     canRemoveSubscribersGroup: stream.canRemoveSubscribersGroup,
     streamWeeklyTraffic: stream.streamWeeklyTraffic,
     desktopNotifications: desktopNotifications ?? false,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -171,7 +171,7 @@ ZulipStream stream({
   bool? isWebPublic,
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
-  StreamPostPolicy? streamPostPolicy,
+  ChannelPostPolicy? streamPostPolicy,
   int? canRemoveSubscribersGroup,
   int? streamWeeklyTraffic,
 }) {
@@ -186,7 +186,7 @@ ZulipStream stream({
     isWebPublic: isWebPublic ?? false,
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
-    streamPostPolicy: streamPostPolicy ?? StreamPostPolicy.any,
+    streamPostPolicy: streamPostPolicy ?? ChannelPostPolicy.any,
     canRemoveSubscribersGroup: canRemoveSubscribersGroup ?? 123,
     streamWeeklyTraffic: streamWeeklyTraffic,
   );


### PR DESCRIPTION
Fixes parts of #631.

This focuses on two models:
- `ChannelDestination`
- `ChannelPostPolicy`