### PR TITLE
autocomplete: Add "human vs. bot user" and "Alphabetical order" criteria

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -245,7 +245,10 @@ class MentionAutocompleteView extends ChangeNotifier {
     final dmsResult = compareByDms(userA, userB, store: store);
     if (dmsResult != 0) return dmsResult;
 
-    return compareByBotStatus(userA, userB);
+    final botStatusResult = compareByBotStatus(userA, userB);
+    if (botStatusResult != 0) return botStatusResult;
+
+    return compareByAlphabeticalOrder(userA, userB, store: store);
   }
 
   /// Determines which of the two users has more recent activity (messages sent
@@ -325,6 +328,21 @@ class MentionAutocompleteView extends ChangeNotifier {
       (true, false) => 1,
       _             => 0,
     };
+  }
+
+  /// Compares the two users by [User.fullName] case-insensitively.
+  ///
+  /// Returns a negative number if `userA`'s `fullName` comes first alphabetically,
+  /// returns a positive number if `userB`'s `fullName` comes first alphabetically,
+  /// and returns `0` if both users have identical `fullName`.
+  @visibleForTesting
+  static int compareByAlphabeticalOrder(User userA, User userB,
+      {required PerAccountStore store}) {
+    final userAName = store.autocompleteViewManager.autocompleteDataCache
+      .normalizedNameForUser(userA);
+    final userBName = store.autocompleteViewManager.autocompleteDataCache
+      .normalizedNameForUser(userB);
+    return userAName.compareTo(userBName); // TODO(i18n): add locale-aware sorting
   }
 
   @override

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -320,11 +320,7 @@ class MentionAutocompleteView extends ChangeNotifier {
     };
   }
 
-  /// Compares the bot status of two users and returns an integer indicating their order.
-  ///
-  /// Returns `-1` if `userA` is human and `userB` is bot, returns `1` if `userA`
-  /// is bot and `userB` is human, and returns `0` if both users have the same
-  /// bot status.
+  /// Comparator that puts non-bots before bots.
   @visibleForTesting
   static int compareByBotStatus(User userA, User userB) {
     return switch ((userA.isBot, userB.isBot)) {
@@ -334,11 +330,7 @@ class MentionAutocompleteView extends ChangeNotifier {
     };
   }
 
-  /// Compares the two users by [User.fullName] case-insensitively.
-  ///
-  /// Returns a negative number if `userA`'s `fullName` comes first alphabetically,
-  /// returns a positive number if `userB`'s `fullName` comes first alphabetically,
-  /// and returns `0` if both users have identical `fullName`.
+  /// Comparator that orders alphabetically by [User.fullName].
   @visibleForTesting
   static int compareByAlphabeticalOrder(User userA, User userB,
       {required PerAccountStore store}) {

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -236,13 +236,16 @@ class MentionAutocompleteView extends ChangeNotifier {
     required PerAccountStore store,
   }) {
     if (streamId != null) {
-      final result = compareByRecency(userA, userB,
+      final recencyResult = compareByRecency(userA, userB,
         streamId: streamId,
         topic: topic,
         store: store);
-      if (result != 0) return result;
+      if (recencyResult != 0) return recencyResult;
     }
-    return compareByDms(userA, userB, store: store);
+    final dmsResult = compareByDms(userA, userB, store: store);
+    if (dmsResult != 0) return dmsResult;
+
+    return compareByBotStatus(userA, userB);
   }
 
   /// Determines which of the two users has more recent activity (messages sent
@@ -307,6 +310,20 @@ class MentionAutocompleteView extends ChangeNotifier {
       (int(),     _) => 1,
       (_,     int()) => -1,
       _              => 0,
+    };
+  }
+
+  /// Compares the bot status of two users and returns an integer indicating their order.
+  ///
+  /// Returns `-1` if `userA` is human and `userB` is bot, returns `1` if `userA`
+  /// is bot and `userB` is human, and returns `0` if both users have the same
+  /// bot status.
+  @visibleForTesting
+  static int compareByBotStatus(User userA, User userB) {
+    return switch ((userA.isBot, userB.isBot)) {
+      (false, true) => -1,
+      (true, false) => 1,
+      _             => 0,
     };
   }
 

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -456,13 +456,21 @@ class MentionAutocompleteQuery {
 }
 
 class AutocompleteDataCache {
+  final Map<int, String> _normalizedNamesByUser = {};
+
+  /// The lowercase `fullName` of [user].
+  String normalizedNameForUser(User user) {
+    return _normalizedNamesByUser[user.userId] ??= user.fullName.toLowerCase();
+  }
+
   final Map<int, List<String>> _nameWordsByUser = {};
 
   List<String> nameWordsForUser(User user) {
-    return _nameWordsByUser[user.userId] ??= user.fullName.toLowerCase().split(' ');
+    return _nameWordsByUser[user.userId] ??= normalizedNameForUser(user).split(' ');
   }
 
   void invalidateUser(int userId) {
+    _normalizedNamesByUser.remove(userId);
     _nameWordsByUser.remove(userId);
   }
 }

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -235,6 +235,10 @@ class MentionAutocompleteView extends ChangeNotifier {
     required String? topic,
     required PerAccountStore store,
   }) {
+    // TODO(#234): give preference to "all", "everyone" or "stream"
+
+    // TODO(#618): give preference to subscribed users first
+
     if (streamId != null) {
       final recencyResult = compareByRecency(userA, userB,
         streamId: streamId,

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -705,8 +705,6 @@ void main() {
         eg.user(userId: 5, fullName: 'User Five'),
         eg.user(userId: 6, fullName: 'User Six', isBot: true),
         eg.user(userId: 7, fullName: 'User Seven'),
-        eg.user(userId: 8, fullName: 'User Xy', isBot: true),
-        eg.user(userId: 9, fullName: 'User Xz', isBot: true),
       ];
 
       await prepare(users: users, messages: [
@@ -723,19 +721,15 @@ void main() {
       // 1. Users most recent in the current topic/stream.
       // 2. Users most recent in the DM conversations.
       // 3. Human vs. Bot users (human users come first).
-      // 4. Alphabetical order.
+      // 4. Alphabetical order by name.
       check(await getResults(topicNarrow, MentionAutocompleteQuery('')))
-        .deepEquals([1, 5, 4, 2, 7, 3, 6, 8, 9]);
+        .deepEquals([1, 5, 4, 2, 7, 3, 6]);
 
       // Check the ranking applies also to results filtered by a query.
       check(await getResults(topicNarrow, MentionAutocompleteQuery('t')))
         .deepEquals([2, 3]);
       check(await getResults(topicNarrow, MentionAutocompleteQuery('f')))
         .deepEquals([5, 4]);
-      check(await getResults(topicNarrow, MentionAutocompleteQuery('s')))
-        .deepEquals([7, 6]);
-      check(await getResults(topicNarrow, MentionAutocompleteQuery('user x')))
-        .deepEquals([8, 9]);
     });
   });
 }


### PR DESCRIPTION
In @-mention autocomplete, users are suggested based on:
1. Recent activity in the current topic/stream.
2. Recent DM conversations.
3. **Human vs. Bot users (human users come first).**
4. **Alphabetical order.**

_**Note**: This is the fourth (last) PR in the series of PRs #608 is divided into, coming after #828._

Fixes: #228 