### PR TITLE
widgets [nfc]: Strength-reduce flutter/material and flutter/cupertino imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import 'licenses.dart';
 import 'log.dart';

--- a/lib/widgets/edit_state_marker.dart
+++ b/lib/widgets/edit_state_marker.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import '../api/model/model.dart';
 import 'icons.dart';

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// A space to use for [InputDecoration.helperText] so the layout doesn't jump.
 ///

--- a/lib/widgets/stream_colors.dart
+++ b/lib/widgets/stream_colors.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_color_models/flutter_color_models.dart';
 
 import '../api/model/model.dart';

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -1,5 +1,5 @@
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import 'stream_colors.dart';
 import 'text.dart';

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 
 import 'package:checks/checks.dart';
 import 'package:fake_async/fake_async.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -5,7 +5,7 @@ import 'package:checks/checks.dart';
 import 'package:collection/collection.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart' hide Message, Person;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/model.dart';

--- a/test/notifications/receive_test.dart
+++ b/test/notifications/receive_test.dart
@@ -1,5 +1,5 @@
 import 'package:checks/checks.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/notifications/receive.dart';
 

--- a/test/widgets/code_block_test.dart
+++ b/test/widgets/code_block_test.dart
@@ -1,5 +1,5 @@
 import 'package:checks/checks.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/code_block.dart';
 

--- a/test/widgets/stream_colors_test.dart
+++ b/test/widgets/stream_colors_test.dart
@@ -1,5 +1,5 @@
 import 'package:checks/checks.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/stream_colors.dart';
 


### PR DESCRIPTION
I noticed this in lib/main.dart, which is short and clearly doesn't
have anything that should require the Material library.  Then just
did a sweep with the command:

  $ perl -i -0pe 's,package:flutter/\Kmaterial,widgets,' \
      -- $(git grep -l package:flutter/material)

followed by `git checkout @` on all the files where the analyzer
complained.

Then similarly for flutter/cupertino.
