### PR TITLE
lint: Enable always_declare_return_types; fix existing places they're missing

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,6 +21,7 @@ linter:
   # For a list of all available lints, with docs, see:
   #   https://dart-lang.github.io/linter/lints/index.html.
   rules:
+    always_declare_return_types: true
     no_literal_bool_comparisons: true
     prefer_relative_imports: true
     unnecessary_statements: true

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -39,7 +39,7 @@ import 'package:flutter/material.dart';
 Typography zulipTypography(BuildContext context) {
   final typography = Theme.of(context).typography;
 
-  convertGeometry(TextTheme inputTextTheme) {
+  TextTheme convertGeometry(TextTheme inputTextTheme) {
     TextTheme result = _weightVariableTextTheme(context, inputTextTheme);
 
     result = _convertTextTheme(result, (maybeInputStyle, _) =>

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -73,7 +73,7 @@ Typography zulipTypography(BuildContext context) {
     // Set [TextStyle.debugLabel] for all styles, like:
     //   "zulipTypography black titleMedium"
 
-    mkAddLabel(String debugTextThemeLabel)
+    TextStyleConverter mkAddLabel(String debugTextThemeLabel)
       => (TextStyle? maybeInputStyle, String debugStyleLabel)
       => maybeInputStyle?.copyWith(debugLabel: '$debugTextThemeLabel $debugStyleLabel');
 
@@ -119,9 +119,11 @@ TextTheme _weightVariableTextTheme(BuildContext context, TextTheme input) {
   return _convertTextTheme(input, convert);
 }
 
+typedef TextStyleConverter = TextStyle? Function(TextStyle?, String debugStyleLabel);
+
 TextTheme _convertTextTheme(
   TextTheme input,
-  TextStyle? Function(TextStyle?, String debugStyleLabel) converter,
+  TextStyleConverter converter,
 ) => TextTheme(
   displayLarge:   converter(input.displayLarge,   'displayLarge'),
   displayMedium:  converter(input.displayMedium,  'displayMedium'),

--- a/test/api/model/reaction_test.dart
+++ b/test/api/model/reaction_test.dart
@@ -7,7 +7,7 @@ import 'model_checks.dart';
 void main() {
   group('Reactions', () {
     // helper to cut out "it()..isA<ReactionWithVotes>()" goo for callers
-    matchesReactions(List<Reaction> reactions) {
+    Condition<Object?> matchesReactions(List<Reaction> reactions) {
       return (Subject<Object?> it) => it.isA<ReactionWithVotes>().matchesReactions(reactions);
     }
 

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -16,9 +16,11 @@ import '../example_data.dart' as eg;
 import 'test_store.dart';
 import 'autocomplete_checks.dart';
 
+typedef MarkedTextParse = ({int? expectedSyntaxStart, TextEditingValue value});
+
 void main() {
   group('ComposeContentController.autocompleteIntent', () {
-    parseMarkedText(String markedText) {
+    MarkedTextParse parseMarkedText(String markedText) {
       final TextSelection selection;
       int? expectedSyntaxStart;
       final textBuffer = StringBuffer();

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -66,7 +66,7 @@ void main() {
     ///
     /// For example, "~@chris^" means the text is "@chris", the selection is
     /// collapsed at index 6, and we expect the syntax to start at index 0.
-    doTest(String markedText, MentionAutocompleteQuery? expectedQuery) {
+    void doTest(String markedText, MentionAutocompleteQuery? expectedQuery) {
       final description = expectedQuery != null
         ? 'in ${jsonEncode(markedText)}, query ${jsonEncode(expectedQuery.raw)}'
         : 'no query in ${jsonEncode(markedText)}';
@@ -311,7 +311,7 @@ void main() {
   });
 
   group('MentionAutocompleteQuery.testUser', () {
-    doCheck(String rawQuery, User user, bool expected) {
+    void doCheck(String rawQuery, User user, bool expected) {
       final result = MentionAutocompleteQuery(rawQuery)
         .testUser(user, AutocompleteDataCache());
       expected ? check(result).isTrue() : check(result).isFalse();

--- a/test/model/recent_dm_conversations_test.dart
+++ b/test/model/recent_dm_conversations_test.dart
@@ -41,7 +41,7 @@ void main() {
     });
 
     group('message event (new message)', () {
-      setupView() {
+      RecentDmConversationsView setupView() {
         return RecentDmConversationsView(selfUserId: eg.selfUser.userId,
           initial: [
             RecentDmConversation(userIds: [1],    maxMessageId: 200),

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -827,7 +827,7 @@ void main() {
     });
 
     group('mark as unread', () {
-      mkEvent(Iterable<Message> messages) =>
+      UpdateMessageFlagsEvent mkEvent(Iterable<Message> messages) =>
         eg.updateMessageFlagsRemoveEvent(MessageFlag.read, messages);
 
       test('usual cases', () {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -45,7 +45,7 @@ void main() {
     group('insertPadded', () {
       // Like `parseMarkedText` in test/model/autocomplete_test.dart,
       //   but a bit different -- could maybe deduplicate some.
-      parseMarkedText(String markedText) {
+      TextEditingValue parseMarkedText(String markedText) {
         final textBuffer = StringBuffer();
         int? insertionPoint;
         int i = 0;
@@ -70,7 +70,7 @@ void main() {
       ///
       /// In valueBefore, represent the insertion point as "^".
       /// In expectedValue, represent the collapsed selection as "^".
-      testInsertPadded(String description, String valueBefore, String textToInsert, String expectedValue) {
+      void testInsertPadded(String description, String valueBefore, String textToInsert, String expectedValue) {
         test(description, () {
           final controller = ComposeContentController();
           controller.value = parseMarkedText(valueBefore);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -79,6 +79,10 @@ TextStyle? mergedStyleOfSubstring(InlineSpan rootSpan, Pattern substringPattern)
     });
 }
 
+/// A callback that finds some target subspan within the given span,
+/// and reports the target's font size.
+typedef TargetFontSizeFinder = double Function(InlineSpan rootSpan);
+
 void main() {
   // For testing a new content feature:
   //
@@ -495,9 +499,9 @@ void main() {
 
   testContentSmoke(ContentExample.mathBlock);
 
-  /// Make a [targetFontSizeFinder] for [checkFontSizeRatio],
+  /// Make a [TargetFontSizeFinder] to pass to [checkFontSizeRatio],
   /// from a target [Pattern] (such as a string).
-  mkTargetFontSizeFinderFromPattern(Pattern targetPattern)
+  TargetFontSizeFinder mkTargetFontSizeFinderFromPattern(Pattern targetPattern)
     => (InlineSpan rootSpan)
     => mergedStyleOfSubstring(rootSpan, targetPattern)!.fontSize!;
 
@@ -512,7 +516,7 @@ void main() {
   /// in [GlobalTime].)
   Future<void> checkFontSizeRatio(WidgetTester tester, {
     required String targetHtml,
-    required double Function(InlineSpan rootSpan) targetFontSizeFinder,
+    required TargetFontSizeFinder targetFontSizeFinder,
   }) async {
     await prepareContent(tester, plainContent(
       '<h1>header-plain $targetHtml</h1>\n'

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -27,7 +27,7 @@ void main() {
   group('ServerUrlTextEditingController.tryParse', () {
     final controller = ServerUrlTextEditingController();
 
-    expectUrlFromText(String text, String expectedUrl) {
+    void expectUrlFromText(String text, String expectedUrl) {
       test('text "$text" gives URL "$expectedUrl"', () {
         controller.text = text;
         final result = controller.tryParse();
@@ -36,7 +36,7 @@ void main() {
       });
     }
 
-    expectErrorFromText(String text, ServerUrlValidationError expectedError) {
+    void expectErrorFromText(String text, ServerUrlValidationError expectedError) {
       test('text "$text" gives error "$expectedError"', () {
         controller.text = text;
         final result = controller.tryParse();

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -33,11 +33,11 @@ void main() {
       return result;
     }
 
-    matchesFontFamilies(Subject<TextStyle> it) => it
+    void matchesFontFamilies(Subject<TextStyle> it) => it
       ..fontFamily.equals(kDefaultFontFamily)
       ..fontFamilyFallback.isNotNull().deepEquals(defaultFontFamilyFallback);
 
-    matchesWeight(FontWeight weight) => (Subject<TextStyle> it) => it
+    Condition<TextStyle> matchesWeight(FontWeight weight) => (Subject<TextStyle> it) => it
       ..fontWeight.equals(weight)
       ..fontVariations.isNotNull().contains(
           FontVariation('wght', wghtFromFontWeight(weight)));

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -307,7 +307,7 @@ void main() {
   });
 
   test('wghtFromTextStyle', () {
-    doCheck(TextStyle style, double? expected) {
+    void doCheck(TextStyle style, double? expected) {
       check(wghtFromTextStyle(style)).equals(expected);
     }
 


### PR DESCRIPTION
When the return type is omitted, the syntax for a function declaration looks a lot like that for a function call.

Some of these also get clearer because the type is nontrivial and a typedef for it is helpful for describing another function's signature too.

Prompted by
https://github.com/zulip/zulip-flutter/pull/813#discussion_r1696064086
and previously
https://github.com/zulip/zulip-flutter/pull/790#discussion_r1692330545
… and previously [several other occasions](https://chat.zulip.org/#narrow/stream/494-mobile-github/search/explicit.20return.20type), going back to:
https://github.com/zulip/zulip-flutter/pull/305#discussion_r1355788136