### PR TITLE
unread_count_badge: Clear out all `TODO(#95)`s

### DIFF
--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -138,6 +138,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDivider: const Color(0xffdedede),
       loginOrDividerText: const Color(0xff575757),
       star: const HSLColor.fromAHSL(0.5, 47, 1, 0.41).toColor(),
+      unreadCountBadgeTextForChannel: Colors.black.withOpacity(0.9),
     );
 
   DesignVariables.dark() :
@@ -152,6 +153,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: const Color(0xffa8a8a8),
       // TODO(#95) unchanged in dark theme?
       star: const HSLColor.fromAHSL(0.5, 47, 1, 0.41).toColor(),
+      unreadCountBadgeTextForChannel: Colors.white.withOpacity(0.9),
     );
 
   DesignVariables._({
@@ -164,6 +166,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.loginOrDivider,
     required this.loginOrDividerText,
     required this.star,
+    required this.unreadCountBadgeTextForChannel,
   });
 
   /// The [DesignVariables] from the context's active theme.
@@ -189,6 +192,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color loginOrDivider; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color loginOrDividerText; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color star;
+  final Color unreadCountBadgeTextForChannel;
 
   @override
   DesignVariables copyWith({
@@ -201,6 +205,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? loginOrDivider,
     Color? loginOrDividerText,
     Color? star,
+    Color? unreadCountBadgeTextForChannel,
   }) {
     return DesignVariables._(
       bgTopBar: bgTopBar ?? this.bgTopBar,
@@ -212,6 +217,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDivider: loginOrDivider ?? this.loginOrDivider,
       loginOrDividerText: loginOrDividerText ?? this.loginOrDividerText,
       star: star ?? this.star,
+      unreadCountBadgeTextForChannel: unreadCountBadgeTextForChannel ?? this.unreadCountBadgeTextForChannel,
     );
   }
 
@@ -230,6 +236,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDivider: Color.lerp(loginOrDivider, other.loginOrDivider, t)!,
       loginOrDividerText: Color.lerp(loginOrDividerText, other.loginOrDividerText, t)!,
       star: Color.lerp(star, other.star, t)!,
+      unreadCountBadgeTextForChannel: Color.lerp(unreadCountBadgeTextForChannel, other.unreadCountBadgeTextForChannel, t)!,
     );
   }
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -129,9 +129,11 @@ const kZulipBrandColor = Color.fromRGBO(0x64, 0x92, 0xfe, 1);
 class DesignVariables extends ThemeExtension<DesignVariables> {
   DesignVariables.light() :
     this._(
+      bgCounterUnread: const Color(0xff666699).withOpacity(0.15),
       bgTopBar: const Color(0xfff5f5f5),
       borderBar: const Color(0x33000000),
       icon: const Color(0xff666699),
+      labelCounterUnread: const Color(0xff222222),
       mainBackground: const Color(0xfff0f0f0),
       title: const Color(0xff1a1a1a),
       channelColorSwatches: ChannelColorSwatches.light,
@@ -143,9 +145,11 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
 
   DesignVariables.dark() :
     this._(
+      bgCounterUnread: const Color(0xff666699).withOpacity(0.37),
       bgTopBar: const Color(0xff242424),
       borderBar: Colors.black.withOpacity(0.41),
       icon: const Color(0xff7070c2),
+      labelCounterUnread: const Color(0xffffffff).withOpacity(0.7),
       mainBackground: const Color(0xff1d1d1d),
       title: const Color(0xffffffff),
       channelColorSwatches: ChannelColorSwatches.dark,
@@ -157,9 +161,11 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     );
 
   DesignVariables._({
+    required this.bgCounterUnread,
     required this.bgTopBar,
     required this.borderBar,
     required this.icon,
+    required this.labelCounterUnread,
     required this.mainBackground,
     required this.title,
     required this.channelColorSwatches,
@@ -179,9 +185,11 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     return extension!;
   }
 
+  final Color bgCounterUnread;
   final Color bgTopBar;
   final Color borderBar;
   final Color icon;
+  final Color labelCounterUnread;
   final Color mainBackground;
   final Color title;
 
@@ -196,9 +204,11 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
 
   @override
   DesignVariables copyWith({
+    Color? bgCounterUnread,
     Color? bgTopBar,
     Color? borderBar,
     Color? icon,
+    Color? labelCounterUnread,
     Color? mainBackground,
     Color? title,
     ChannelColorSwatches? channelColorSwatches,
@@ -208,9 +218,11 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? unreadCountBadgeTextForChannel,
   }) {
     return DesignVariables._(
+      bgCounterUnread: bgCounterUnread ?? this.bgCounterUnread,
       bgTopBar: bgTopBar ?? this.bgTopBar,
       borderBar: borderBar ?? this.borderBar,
       icon: icon ?? this.icon,
+      labelCounterUnread: labelCounterUnread ?? this.labelCounterUnread,
       mainBackground: mainBackground ?? this.mainBackground,
       title: title ?? this.title,
       channelColorSwatches: channelColorSwatches ?? this.channelColorSwatches,
@@ -227,9 +239,11 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       return this;
     }
     return DesignVariables._(
+      bgCounterUnread: Color.lerp(bgCounterUnread, other.bgCounterUnread, t)!,
       bgTopBar: Color.lerp(bgTopBar, other.bgTopBar, t)!,
       borderBar: Color.lerp(borderBar, other.borderBar, t)!,
       icon: Color.lerp(icon, other.icon, t)!,
+      labelCounterUnread: Color.lerp(labelCounterUnread, other.labelCounterUnread, t)!,
       mainBackground: Color.lerp(mainBackground, other.mainBackground, t)!,
       title: Color.lerp(title, other.title, t)!,
       channelColorSwatches: ChannelColorSwatches.lerp(channelColorSwatches, other.channelColorSwatches, t),

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -1,8 +1,8 @@
-
 import 'package:flutter/widgets.dart';
 
 import 'channel_colors.dart';
 import 'text.dart';
+import 'theme.dart';
 
 /// A widget to display a given number of unreads in a conversation.
 ///
@@ -29,6 +29,8 @@ class UnreadCountBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
     final effectiveBackgroundColor = switch (backgroundColor) {
       ChannelColorSwatch(unreadCountBadgeBackground: var color) => color,
       Color() => backgroundColor,
@@ -44,22 +46,17 @@ class UnreadCountBadge extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.fromLTRB(4, 0, 4, 1),
         child: Text(
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
             height: (18 / 16),
-            fontFeatures: [FontFeature.enable('smcp')], // small caps
+            fontFeatures: const [FontFeature.enable('smcp')], // small caps
 
             // From the Figma:
             //   https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?type=design&node-id=171-12359&mode=design&t=JKrw76SGUF51nSJG-0
-            // TODO or, when background is stream-colored, follow Vlad's replit?
-            //     https://replit.com/@VladKorobov/zulip-sidebar#script.js
-            //   which would mean:
-            //   - in light mode use `Color.fromRGBO(0, 0, 0, 0.9)`
-            //   - in dark mode use `Color.fromRGBO(255, 255, 255, 0.9)`
-            //   The web app doesn't (yet?) use stream-colored unread markers
-            //   so we can't take direction from there.
             // TODO(#95) need dark-theme color
-            color: Color(0xFF222222),
+            color: backgroundColor is ChannelColorSwatch
+              ? designVariables.unreadCountBadgeTextForChannel
+              : const Color(0xFF222222),
           ).merge(weightVariableTextStyle(context,
               wght: bold ? 600 : null)),
           count.toString())));

--- a/lib/widgets/unread_count_badge.dart
+++ b/lib/widgets/unread_count_badge.dart
@@ -34,8 +34,7 @@ class UnreadCountBadge extends StatelessWidget {
     final effectiveBackgroundColor = switch (backgroundColor) {
       ChannelColorSwatch(unreadCountBadgeBackground: var color) => color,
       Color() => backgroundColor,
-      // TODO(#95) need dark-theme color
-      null => const Color.fromRGBO(102, 102, 153, 0.15),
+      null => designVariables.bgCounterUnread,
     };
 
     return DecoratedBox(
@@ -50,13 +49,9 @@ class UnreadCountBadge extends StatelessWidget {
             fontSize: 16,
             height: (18 / 16),
             fontFeatures: const [FontFeature.enable('smcp')], // small caps
-
-            // From the Figma:
-            //   https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?type=design&node-id=171-12359&mode=design&t=JKrw76SGUF51nSJG-0
-            // TODO(#95) need dark-theme color
             color: backgroundColor is ChannelColorSwatch
               ? designVariables.unreadCountBadgeTextForChannel
-              : const Color(0xFF222222),
+              : designVariables.labelCounterUnread,
           ).merge(weightVariableTextStyle(context,
               wght: bold ? 600 : null)),
           count.toString())));

--- a/test/widgets/unread_count_badge_test.dart
+++ b/test/widgets/unread_count_badge_test.dart
@@ -5,20 +5,27 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/channel_colors.dart';
 import 'package:zulip/widgets/unread_count_badge.dart';
 
+import '../model/binding.dart';
+import 'test_app.dart';
+
 void main() {
+  TestZulipBinding.ensureInitialized();
+
   group('UnreadCountBadge', () {
     testWidgets('smoke test; no crash', (tester) async {
-      await tester.pumpWidget(
-        const Directionality(textDirection: TextDirection.ltr,
-          child: UnreadCountBadge(count: 1, backgroundColor: null)));
+      addTearDown(testBinding.reset);
+      await tester.pumpWidget(const TestZulipApp(
+        child: UnreadCountBadge(count: 1, backgroundColor: null)));
+      await tester.pump();
       tester.widget(find.text("1"));
     });
 
     group('background', () {
       Future<void> prepare(WidgetTester tester, Color? backgroundColor) async {
-        await tester.pumpWidget(
-          Directionality(textDirection: TextDirection.ltr,
-            child: UnreadCountBadge(count: 1, backgroundColor: backgroundColor)));
+        addTearDown(testBinding.reset);
+        await tester.pumpWidget(TestZulipApp(
+          child: UnreadCountBadge(count: 1, backgroundColor: backgroundColor)));
+        await tester.pump();
       }
 
       Color? findBackgroundColor(WidgetTester tester) {


### PR DESCRIPTION
For the user-facing change in this commit:

```
unread_count_badge: Clear out a TODO by following Vlad's design
```

The difference (in the text color of the unread-count badges on the streams/topics) really is tiny. I used Mac's Digital Color Meter to see that there was in fact a difference, though.

| Before | After |
| --- | --- |
| ![BDA772E1-FEA1-4AE7-80E0-4A26BB09866B](https://github.com/user-attachments/assets/099208fc-66a4-474a-80e8-1e9a9b303d63) | ![2DF3752E-B708-4676-848E-B2932EEB6119](https://github.com/user-attachments/assets/a7ca276c-176e-4e82-b1db-ec64fad2c133) |

