### PR TITLE
test [nfc]: Remove WidgetTester type annotation from testWidgets tests.

### DIFF
--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -102,7 +102,7 @@ void main() {
       await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
     }
 
-    testWidgets('success', (WidgetTester tester) async {
+    testWidgets('success', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -122,7 +122,7 @@ void main() {
           });
     });
 
-    testWidgets('request has an error', (WidgetTester tester) async {
+    testWidgets('request has an error', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -156,7 +156,7 @@ void main() {
       await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
     }
 
-    testWidgets('star success', (WidgetTester tester) async {
+    testWidgets('star success', (tester) async {
       final message = eg.streamMessage(flags: []);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -176,7 +176,7 @@ void main() {
         });
     });
 
-    testWidgets('unstar success', (WidgetTester tester) async {
+    testWidgets('unstar success', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.starred]);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -196,7 +196,7 @@ void main() {
         });
     });
 
-    testWidgets('star request has an error', (WidgetTester tester) async {
+    testWidgets('star request has an error', (tester) async {
       final message = eg.streamMessage(flags: []);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -217,7 +217,7 @@ void main() {
         expectedMessage: 'Invalid message(s)')));
     });
 
-    testWidgets('unstar request has an error', (WidgetTester tester) async {
+    testWidgets('unstar request has an error', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.starred]);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -288,7 +288,7 @@ void main() {
       check(contentController).not((it) => it.validationErrors.contains(ContentValidationError.quoteAndReplyInProgress));
     }
 
-    testWidgets('in channel narrow', (WidgetTester tester) async {
+    testWidgets('in channel narrow', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: ChannelNarrow(message.streamId));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -306,7 +306,7 @@ void main() {
         valueBefore: valueBefore, message: message, rawContent: 'Hello world');
     });
 
-    testWidgets('in topic narrow', (WidgetTester tester) async {
+    testWidgets('in topic narrow', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -324,7 +324,7 @@ void main() {
         valueBefore: valueBefore, message: message, rawContent: 'Hello world');
     });
 
-    testWidgets('in DM narrow', (WidgetTester tester) async {
+    testWidgets('in DM narrow', (tester) async {
       final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
       await setupToMessageActionSheet(tester,
         message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
@@ -343,7 +343,7 @@ void main() {
         valueBefore: valueBefore, message: message, rawContent: 'Hello world');
     });
 
-    testWidgets('request has an error', (WidgetTester tester) async {
+    testWidgets('request has an error', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -372,13 +372,13 @@ void main() {
       ));
     });
 
-    testWidgets('not offered in CombinedFeedNarrow (composing to reply is not yet supported)', (WidgetTester tester) async {
+    testWidgets('not offered in CombinedFeedNarrow (composing to reply is not yet supported)', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: const CombinedFeedNarrow());
       check(findQuoteAndReplyButton(tester)).isNull();
     });
 
-    testWidgets('not offered in MentionsNarrow (composing to reply is not yet supported)', (WidgetTester tester) async {
+    testWidgets('not offered in MentionsNarrow (composing to reply is not yet supported)', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: const MentionsNarrow());
       check(findQuoteAndReplyButton(tester)).isNull();
@@ -399,7 +399,7 @@ void main() {
       await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
     }
 
-    testWidgets('success', (WidgetTester tester) async {
+    testWidgets('success', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -435,7 +435,7 @@ void main() {
         matching: find.text(zulipLocalizations.successMessageTextCopied)));
     });
 
-    testWidgets('request has an error', (WidgetTester tester) async {
+    testWidgets('request has an error', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -496,7 +496,7 @@ void main() {
       await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
     }
 
-    testWidgets('request succeeds; sharing succeeds', (WidgetTester tester) async {
+    testWidgets('request succeeds; sharing succeeds', (tester) async {
       final mockSharePlus = setupMockSharePlus();
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
@@ -508,7 +508,7 @@ void main() {
       check(mockSharePlus.sharedString).equals('Hello world');
     });
 
-    testWidgets('request succeeds; sharing fails', (WidgetTester tester) async {
+    testWidgets('request succeeds; sharing fails', (tester) async {
       final mockSharePlus = setupMockSharePlus();
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
@@ -524,7 +524,7 @@ void main() {
         expectedTitle: 'Sharing failed')));
     });
 
-    testWidgets('request has an error', (WidgetTester tester) async {
+    testWidgets('request has an error', (tester) async {
       final mockSharePlus = setupMockSharePlus();
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -70,7 +70,7 @@ void main() {
     });
 
 
-    testWidgets('use is:unread optimization', (WidgetTester tester) async {
+    testWidgets('use is:unread optimization', (tester) async {
       const narrow = CombinedFeedNarrow();
       await prepare(tester);
       connection.prepare(json: UpdateMessageFlagsForNarrowResult(
@@ -93,7 +93,7 @@ void main() {
           });
     });
 
-    testWidgets('pagination', (WidgetTester tester) async {
+    testWidgets('pagination', (tester) async {
       // Check that `lastProcessedId` returned from an initial
       // response is used as `anchorId` for the subsequent request.
       final narrow = TopicNarrow.ofMessage(eg.streamMessage());
@@ -154,7 +154,7 @@ void main() {
     }, skip: true, // TODO move this functionality inside markNarrowAsRead
     );
 
-    testWidgets('on invalid response', (WidgetTester tester) async {
+    testWidgets('on invalid response', (tester) async {
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       final narrow = TopicNarrow.ofMessage(eg.streamMessage());
       await prepare(tester);
@@ -184,7 +184,7 @@ void main() {
         expectedMessage: zulipLocalizations.errorInvalidResponse);
     });
 
-    testWidgets('CombinedFeedNarrow on legacy server', (WidgetTester tester) async {
+    testWidgets('CombinedFeedNarrow on legacy server', (tester) async {
       const narrow = CombinedFeedNarrow();
       await prepare(tester);
       // Might as well test with oldUnreadsMissing: true.
@@ -204,7 +204,7 @@ void main() {
       check(store.unreads).oldUnreadsMissing.isTrue();
     });
 
-    testWidgets('ChannelNarrow on legacy server', (WidgetTester tester) async {
+    testWidgets('ChannelNarrow on legacy server', (tester) async {
       final stream = eg.stream();
       final narrow = ChannelNarrow(stream.streamId);
       await prepare(tester);
@@ -220,7 +220,7 @@ void main() {
           });
     });
 
-    testWidgets('TopicNarrow on legacy server', (WidgetTester tester) async {
+    testWidgets('TopicNarrow on legacy server', (tester) async {
       final narrow = TopicNarrow.ofMessage(eg.streamMessage());
       await prepare(tester);
       connection.zulipFeatureLevel = 154;
@@ -236,7 +236,7 @@ void main() {
           });
     });
 
-    testWidgets('DmNarrow on legacy server', (WidgetTester tester) async {
+    testWidgets('DmNarrow on legacy server', (tester) async {
       final message = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
       final narrow = DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId);
       final unreadMsgs = eg.unreadMsgs(dms: [
@@ -259,7 +259,7 @@ void main() {
           });
     });
 
-    testWidgets('MentionsNarrow on legacy server', (WidgetTester tester) async {
+    testWidgets('MentionsNarrow on legacy server', (tester) async {
       const narrow = MentionsNarrow();
       final message = eg.streamMessage(flags: [MessageFlag.mentioned]);
       final unreadMsgs = eg.unreadMsgs(mentions: [message.id]);
@@ -279,7 +279,7 @@ void main() {
           });
     });
 
-    testWidgets('catch-all api errors', (WidgetTester tester) async {
+    testWidgets('catch-all api errors', (tester) async {
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       const narrow = CombinedFeedNarrow();
       await prepare(tester);

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -81,7 +81,7 @@ void main() {
       check(avatarFinder.evaluate().length).equals(expected ? 1 : 0);
     }
 
-    testWidgets('options appear, disappear, and change correctly', (WidgetTester tester) async {
+    testWidgets('options appear, disappear, and change correctly', (tester) async {
       final user1 = eg.user(userId: 1, fullName: 'User One', avatarUrl: 'user1.png');
       final user2 = eg.user(userId: 2, fullName: 'User Two', avatarUrl: 'user2.png');
       final user3 = eg.user(userId: 3, fullName: 'User Three', avatarUrl: 'user3.png');

--- a/test/widgets/clipboard_test.dart
+++ b/test/widgets/clipboard_test.dart
@@ -57,21 +57,21 @@ void main() {
       check(await Clipboard.getData('text/plain')).isNotNull().text.equals(expected);
     }
 
-    testWidgets('iOS', (WidgetTester tester) async {
+    testWidgets('iOS', (tester) async {
       testBinding.deviceInfoResult = const IosDeviceInfo(systemVersion: '16.0');
       await call(tester, text: 'asdf');
       await checkClipboardText('asdf');
       await checkSnackBar(tester, expected: true);
     });
 
-    testWidgets('Android', (WidgetTester tester) async {
+    testWidgets('Android', (tester) async {
       testBinding.deviceInfoResult = const AndroidDeviceInfo(sdkInt: 33, release: '13');
       await call(tester, text: 'asdf');
       await checkClipboardText('asdf');
       await checkSnackBar(tester, expected: false);
     });
 
-    testWidgets('Android <13', (WidgetTester tester) async {
+    testWidgets('Android <13', (tester) async {
       testBinding.deviceInfoResult = const AndroidDeviceInfo(sdkInt: 32, release: '12');
       await call(tester, text: 'asdf');
       await checkClipboardText('asdf');

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -483,7 +483,7 @@ void main() {
     testFontWeight('syntax highlighting: non-bold span',
       expectedWght: 400,
       content: plainContent(ContentExample.codeBlockHighlightedShort.html),
-      styleFinder: (WidgetTester tester) {
+      styleFinder: (tester) {
         final root = tester.renderObject<RenderParagraph>(find.textContaining('class')).text;
         return mergedStyleOfSubstring(root, 'class')!;
       });
@@ -491,7 +491,7 @@ void main() {
     testFontWeight('syntax highlighting: bold span',
       expectedWght: 700,
       content: plainContent(ContentExample.codeBlockHighlightedShort.html),
-      styleFinder: (WidgetTester tester) {
+      styleFinder: (tester) {
         final root = tester.renderObject<RenderParagraph>(find.textContaining('A')).text;
         return mergedStyleOfSubstring(root, 'A')!;
       });
@@ -986,7 +986,7 @@ void main() {
       debugNetworkImageHttpClientProvider = null;
     });
 
-    testWidgets('throws if no `PerAccountStoreWidget` ancestor', (WidgetTester tester) async {
+    testWidgets('throws if no `PerAccountStoreWidget` ancestor', (tester) async {
       await tester.pumpWidget(
         RealmContentNetworkImage(Uri.parse('https://zulip.invalid/path/to/image.png'), filterQuality: FilterQuality.medium));
       check(tester.takeException()).isA<AssertionError>();

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -271,7 +271,7 @@ void main() {
         matching: find.byTooltip("Scroll to bottom")));
     }
 
-    testWidgets('scrolling changes visibility', (WidgetTester tester) async {
+    testWidgets('scrolling changes visibility', (tester) async {
       await setupMessageListPage(tester, messageCount: 10);
 
       final scrollController = findMessageListScrollController(tester)!;
@@ -288,7 +288,7 @@ void main() {
       check(isButtonVisible(tester)).equals(false);
     });
 
-    testWidgets('dimension updates changes visibility', (WidgetTester tester) async {
+    testWidgets('dimension updates changes visibility', (tester) async {
       await setupMessageListPage(tester, messageCount: 100);
 
       final scrollController = findMessageListScrollController(tester)!;
@@ -310,7 +310,7 @@ void main() {
       check(isButtonVisible(tester)).equals(false);
     });
 
-    testWidgets('button functionality', (WidgetTester tester) async {
+    testWidgets('button functionality', (tester) async {
       await setupMessageListPage(tester, messageCount: 10);
 
       final scrollController = findMessageListScrollController(tester)!;
@@ -401,7 +401,7 @@ void main() {
       return finder.evaluate().isNotEmpty;
     }
 
-    testWidgets('from read to unread', (WidgetTester tester) async {
+    testWidgets('from read to unread', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.read]);
       await setupMessageListPage(tester, messages: [message]);
       check(isMarkAsReadButtonVisible(tester)).isFalse();
@@ -412,7 +412,7 @@ void main() {
       check(isMarkAsReadButtonVisible(tester)).isTrue();
     });
 
-    testWidgets('from unread to read', (WidgetTester tester) async {
+    testWidgets('from unread to read', (tester) async {
       final message = eg.streamMessage(flags: []);
       final unreadMsgs = eg.unreadMsgs(channels:[
         UnreadChannelSnapshot(topic: message.topic, streamId: message.streamId, unreadMessageIds: [message.id])
@@ -430,7 +430,7 @@ void main() {
       check(isMarkAsReadButtonVisible(tester)).isFalse();
     });
 
-    testWidgets("messages don't shift position", (WidgetTester tester) async {
+    testWidgets("messages don't shift position", (tester) async {
       final message = eg.streamMessage(flags: []);
       final unreadMsgs = eg.unreadMsgs(channels:[
         UnreadChannelSnapshot(topic: message.topic, streamId: message.streamId,
@@ -479,7 +479,7 @@ void main() {
           check(opacity.opacity).equals(expected ? 0.5 : 1.0);
         }
 
-        testWidgets('loading is changed correctly', (WidgetTester tester) async {
+        testWidgets('loading is changed correctly', (tester) async {
           final narrow = TopicNarrow.ofMessage(message);
           await setupMessageListPage(tester,
             narrow: narrow, messages: [message], unreadMsgs: unreadMsgs);
@@ -502,7 +502,7 @@ void main() {
           checkAppearsLoading(tester, false);
         });
 
-        testWidgets('loading is changed correctly if request fails', (WidgetTester tester) async {
+        testWidgets('loading is changed correctly if request fails', (tester) async {
           final narrow = TopicNarrow.ofMessage(message);
           await setupMessageListPage(tester,
             narrow: narrow, messages: [message], unreadMsgs: unreadMsgs);
@@ -525,7 +525,7 @@ void main() {
         });
       });
 
-      testWidgets('smoke test on modern server', (WidgetTester tester) async {
+      testWidgets('smoke test on modern server', (tester) async {
         final narrow = TopicNarrow.ofMessage(message);
         await setupMessageListPage(tester,
           narrow: narrow, messages: [message], unreadMsgs: unreadMsgs);
@@ -553,7 +553,7 @@ void main() {
         await tester.pumpAndSettle(); // process pending timers
       });
 
-      testWidgets('pagination', (WidgetTester tester) async {
+      testWidgets('pagination', (tester) async {
         // Check that `lastProcessedId` returned from an initial
         // response is used as `anchorId` for the subsequent request.
         final narrow = TopicNarrow.ofMessage(message);
@@ -599,7 +599,7 @@ void main() {
         check(store.unreads.oldUnreadsMissing).isFalse();
       });
 
-      testWidgets('catch-all api errors', (WidgetTester tester) async {
+      testWidgets('catch-all api errors', (tester) async {
         final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
         const narrow = CombinedFeedNarrow();
         await setupMessageListPage(tester,
@@ -635,7 +635,7 @@ void main() {
         propagateMode: PropagateMode.changeAll));
     }
 
-    testWidgets('compose box send message after move', (WidgetTester tester) async {
+    testWidgets('compose box send message after move', (tester) async {
       final message = eg.streamMessage(stream: channel, topic: topic, content: 'Message to move');
       await setupMessageListPage(tester, narrow: narrow, messages: [message], streams: [channel, otherChannel]);
 
@@ -670,7 +670,7 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('Move to narrow with existing messages', (WidgetTester tester) async {
+    testWidgets('Move to narrow with existing messages', (tester) async {
       final message = eg.streamMessage(stream: channel, topic: topic, content: 'Message to move');
       await setupMessageListPage(tester, narrow: narrow, messages: [message], streams: [channel]);
       check(find.textContaining('Existing message').evaluate()).length.equals(0);
@@ -1024,13 +1024,13 @@ void main() {
   });
 
   group('Starred messages', () {
-    testWidgets('unstarred message', (WidgetTester tester) async {
+    testWidgets('unstarred message', (tester) async {
       final message = eg.streamMessage(flags: []);
       await setupMessageListPage(tester, messages: [message]);
       check(find.byIcon(ZulipIcons.star_filled).evaluate()).isEmpty();
     });
 
-    testWidgets('starred message', (WidgetTester tester) async {
+    testWidgets('starred message', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.starred]);
       await setupMessageListPage(tester, messages: [message]);
       check(find.byIcon(ZulipIcons.star_filled).evaluate()).length.equals(1);
@@ -1043,13 +1043,13 @@ void main() {
       check(find.byIcon(ZulipIcons.message_moved).evaluate()).length.equals(moved);
     }
 
-    testWidgets('no edited or moved messages', (WidgetTester tester) async {
+    testWidgets('no edited or moved messages', (tester) async {
       final message = eg.streamMessage();
       await setupMessageListPage(tester, messages: [message]);
       checkMarkersCount(edited: 0, moved: 0);
     });
 
-    testWidgets('edited and moved messages from events', (WidgetTester tester) async {
+    testWidgets('edited and moved messages from events', (tester) async {
       final message = eg.streamMessage(topic: 'old');
       final message2 = eg.streamMessage(topic: 'old');
       await setupMessageListPage(tester, messages: [message, message2]);
@@ -1102,7 +1102,7 @@ void main() {
       return result;
     }
 
-    testWidgets('edit state updates do not affect layout', (WidgetTester tester) async {
+    testWidgets('edit state updates do not affect layout', (tester) async {
       final messages = [
         eg.streamMessage(topic: 'orig'),
         eg.streamMessage(
@@ -1147,7 +1147,7 @@ void main() {
       return widget.opacity;
     }
 
-    testWidgets('from read to unread', (WidgetTester tester) async {
+    testWidgets('from read to unread', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.read]);
       await setupMessageListPage(tester, messages: [message]);
       check(getAnimation(tester, message.id))
@@ -1167,7 +1167,7 @@ void main() {
         ..status.equals(AnimationStatus.completed);
     });
 
-    testWidgets('from unread to read', (WidgetTester tester) async {
+    testWidgets('from unread to read', (tester) async {
       final message = eg.streamMessage(flags: []);
       await setupMessageListPage(tester, messages: [message]);
       check(getAnimation(tester, message.id))
@@ -1191,7 +1191,7 @@ void main() {
         ..status.equals(AnimationStatus.completed);
     });
 
-    testWidgets('animation state persistence', (WidgetTester tester) async {
+    testWidgets('animation state persistence', (tester) async {
       // Check that _UnreadMarker maintains its in-progress animation
       // as the number of items changes in MessageList. See
       // `findChildIndexCallback` passed into [SliverStickyHeaderList]

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -70,7 +70,7 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   group('ProfilePage', () {
-    testWidgets('page builds; profile page renders', (WidgetTester tester) async {
+    testWidgets('page builds; profile page renders', (tester) async {
       final user = eg.user(userId: 1, fullName: 'test user',
         deliveryEmail: 'testuser@example.com');
 
@@ -81,7 +81,7 @@ void main() {
       check(because: 'find user delivery email', find.text('testuser@example.com').evaluate()).isNotEmpty();
     });
 
-    testWidgets('page builds; profile page renders with profileData', (WidgetTester tester) async {
+    testWidgets('page builds; profile page renders with profileData', (tester) async {
       await setupPage(tester,
         users: [
           eg.user(userId: 1, profileData: {
@@ -143,13 +143,13 @@ void main() {
         .deepEquals([1, 2]);
     });
 
-    testWidgets('page builds; error page shows up if data is missing', (WidgetTester tester) async {
+    testWidgets('page builds; error page shows up if data is missing', (tester) async {
       await setupPage(tester, pageUserId: eg.selfUser.userId + 1989);
       check(because: 'find no user avatar', find.byType(Avatar).evaluate()).isEmpty();
       check(because: 'find error icon', find.byIcon(Icons.error).evaluate()).isNotEmpty();
     });
 
-    testWidgets('page builds; link type will navigate', (WidgetTester tester) async {
+    testWidgets('page builds; link type will navigate', (tester) async {
       const testUrl = 'http://example/url';
       final user = eg.user(userId: 1, profileData: {
         0: ProfileFieldUserData(value: testUrl),
@@ -168,7 +168,7 @@ void main() {
       ));
     });
 
-    testWidgets('page builds; external link type navigates away', (WidgetTester tester) async {
+    testWidgets('page builds; external link type navigates away', (tester) async {
       final user = eg.user(userId: 1, profileData: {
         0: ProfileFieldUserData(value: 'externalValue'),
       });
@@ -195,7 +195,7 @@ void main() {
       ));
     });
 
-    testWidgets('page builds; user links to profile', (WidgetTester tester) async {
+    testWidgets('page builds; user links to profile', (tester) async {
       final users = [
         eg.user(userId: 1, profileData: {
           0: ProfileFieldUserData(value: '[2]'),
@@ -221,7 +221,7 @@ void main() {
       check(pushedRoutes).last.isA<WidgetRoute>().page.isA<ProfilePage>().userId.equals(2);
     });
 
-    testWidgets('page builds; user field with unknown user', (WidgetTester tester) async {
+    testWidgets('page builds; user field with unknown user', (tester) async {
       final users = [
         eg.user(userId: 1, profileData: {
           0: ProfileFieldUserData(value: '[2]'),
@@ -237,7 +237,7 @@ void main() {
       check(textFinder.evaluate()).length.equals(1);
     });
 
-    testWidgets('page builds; dm links to correct narrow', (WidgetTester tester) async {
+    testWidgets('page builds; dm links to correct narrow', (tester) async {
       final pushedRoutes = <Route<dynamic>>[];
       final testNavObserver = TestNavigatorObserver()
         ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
@@ -256,7 +256,7 @@ void main() {
         .initNarrow.equals(DmNarrow.withUser(1, selfUserId: eg.selfUser.userId));
     });
 
-    testWidgets('page builds; user links render multiple avatars', (WidgetTester tester) async {
+    testWidgets('page builds; user links render multiple avatars', (tester) async {
       final users = [
         eg.user(userId: 1, profileData: {
           0: ProfileFieldUserData(value: '[2,3]'),
@@ -276,14 +276,14 @@ void main() {
         .deepEquals([1, 2, 3]);
     });
 
-    testWidgets('page builds; ensure long name does not overflow', (WidgetTester tester) async {
+    testWidgets('page builds; ensure long name does not overflow', (tester) async {
       final longString = 'X' * 400;
       final user = eg.user(userId: 1, fullName: longString);
       await setupPage(tester, users: [user], pageUserId: user.userId);
       check(find.text(longString).evaluate()).isNotEmpty();
     });
 
-    testWidgets('page builds; ensure long customProfileFields do not overflow', (WidgetTester tester) async {
+    testWidgets('page builds; ensure long customProfileFields do not overflow', (tester) async {
       final longString = 'X' * 400;
       final user = eg.user(userId: 1, fullName: 'fullName', profileData: {
         0: ProfileFieldUserData(value: longString),

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -63,7 +63,7 @@ void main() {
       (widget) => widget is RecentDmConversationsItem && widget.narrow == narrow,
     );
 
-    testWidgets('page builds; conversations appear in order', (WidgetTester tester) async {
+    testWidgets('page builds; conversations appear in order', (tester) async {
       final user1 = eg.user(userId: 1);
       final user2 = eg.user(userId: 2);
 
@@ -81,7 +81,7 @@ void main() {
       check(items[2].narrow).equals(DmNarrow.ofMessage(message1, selfUserId: eg.selfUser.userId));
     });
 
-    testWidgets('fling to scroll down', (WidgetTester tester) async {
+    testWidgets('fling to scroll down', (tester) async {
       final List<User> users = [];
       final List<DmMessage> messages = [];
       for (int i = 0; i < 30; i++) {
@@ -164,7 +164,7 @@ void main() {
       }
 
       group('self-1:1', () {
-        testWidgets('has right title/avatar', (WidgetTester tester) async {
+        testWidgets('has right title/avatar', (tester) async {
           final message = eg.dmMessage(from: eg.selfUser, to: []);
           await setupPage(tester, users: [], dmMessages: [message]);
 
@@ -172,7 +172,7 @@ void main() {
           checkTitle(tester, eg.selfUser.fullName);
         });
 
-        testWidgets('short name takes one line', (WidgetTester tester) async {
+        testWidgets('short name takes one line', (tester) async {
           final message = eg.dmMessage(from: eg.selfUser, to: []);
           const name = 'Short name';
           await setupPage(tester, users: [], dmMessages: [message],
@@ -180,7 +180,7 @@ void main() {
           checkTitle(tester, name, 1);
         });
 
-        testWidgets('very long name takes two lines (must be ellipsized)', (WidgetTester tester) async {
+        testWidgets('very long name takes two lines (must be ellipsized)', (tester) async {
           final message = eg.dmMessage(from: eg.selfUser, to: []);
           const name = 'Long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name';
           await setupPage(tester, users: [], dmMessages: [message],
@@ -188,7 +188,7 @@ void main() {
           checkTitle(tester, name, 2);
         });
 
-        testWidgets('unread counts', (WidgetTester tester) async {
+        testWidgets('unread counts', (tester) async {
           final message = eg.dmMessage(from: eg.selfUser, to: []);
           await setupPage(tester, users: [], dmMessages: [message]);
 
@@ -199,7 +199,7 @@ void main() {
       });
 
       group('1:1', () {
-        testWidgets('has right title/avatar', (WidgetTester tester) async {
+        testWidgets('has right title/avatar', (tester) async {
           final user = eg.user(userId: 1);
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester, users: [user], dmMessages: [message]);
@@ -208,7 +208,7 @@ void main() {
           checkTitle(tester, user.fullName);
         });
 
-        testWidgets('no error when user somehow missing from store.users', (WidgetTester tester) async {
+        testWidgets('no error when user somehow missing from store.users', (tester) async {
           final user = eg.user(userId: 1);
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester,
@@ -220,21 +220,21 @@ void main() {
           checkTitle(tester, '(unknown user)');
         });
 
-        testWidgets('short name takes one line', (WidgetTester tester) async {
+        testWidgets('short name takes one line', (tester) async {
           final user = eg.user(userId: 1, fullName: 'Short name');
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester, users: [user], dmMessages: [message]);
           checkTitle(tester, user.fullName, 1);
         });
 
-        testWidgets('very long name takes two lines (must be ellipsized)', (WidgetTester tester) async {
+        testWidgets('very long name takes two lines (must be ellipsized)', (tester) async {
           final user = eg.user(userId: 1, fullName: 'Long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name');
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester, users: [user], dmMessages: [message]);
           checkTitle(tester, user.fullName, 2);
         });
 
-        testWidgets('unread counts', (WidgetTester tester) async {
+        testWidgets('unread counts', (tester) async {
           final message = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
           await setupPage(tester, users: [], dmMessages: [message]);
 
@@ -253,7 +253,7 @@ void main() {
           return result;
         }
 
-        testWidgets('has right title/avatar', (WidgetTester tester) async {
+        testWidgets('has right title/avatar', (tester) async {
           final users = usersList(2);
           final user0 = users[0];
           final user1 = users[1];
@@ -264,7 +264,7 @@ void main() {
           checkTitle(tester, '${user0.fullName}, ${user1.fullName}');
         });
 
-        testWidgets('no error when one user somehow missing from store.users', (WidgetTester tester) async {
+        testWidgets('no error when one user somehow missing from store.users', (tester) async {
           final users = usersList(2);
           final user0 = users[0];
           final user1 = users[1];
@@ -278,21 +278,21 @@ void main() {
           checkTitle(tester, '${user0.fullName}, (unknown user)');
         });
 
-        testWidgets('few names takes one line', (WidgetTester tester) async {
+        testWidgets('few names takes one line', (tester) async {
           final users = usersList(2);
           final message = eg.dmMessage(from: eg.selfUser, to: users);
           await setupPage(tester, users: users, dmMessages: [message]);
           checkTitle(tester, users.map((u) => u.fullName).join(', '), 1);
         });
 
-        testWidgets('very many names takes two lines (must be ellipsized)', (WidgetTester tester) async {
+        testWidgets('very many names takes two lines (must be ellipsized)', (tester) async {
           final users = usersList(40);
           final message = eg.dmMessage(from: eg.selfUser, to: users);
           await setupPage(tester, users: users, dmMessages: [message]);
           checkTitle(tester, users.map((u) => u.fullName).join(', '), 2);
         });
 
-        testWidgets('unread counts', (WidgetTester tester) async {
+        testWidgets('unread counts', (tester) async {
           final message = eg.dmMessage(from: eg.thirdUser, to: [eg.selfUser, eg.otherUser]);
           await setupPage(tester, users: [], dmMessages: [message]);
 
@@ -325,18 +325,18 @@ void main() {
           .initNarrow.equals(expectedNarrow);
       }
 
-      testWidgets('1:1', (WidgetTester tester) async {
+      testWidgets('1:1', (tester) async {
         final user = eg.user(userId: 1, fullName: 'User 1');
         await runAndCheck(tester, users: [user],
           message: eg.dmMessage(from: eg.selfUser, to: [user]));
       });
 
-      testWidgets('self-1:1', (WidgetTester tester) async {
+      testWidgets('self-1:1', (tester) async {
         await runAndCheck(tester, users: [],
           message: eg.dmMessage(from: eg.selfUser, to: []));
       });
 
-      testWidgets('group', (WidgetTester tester) async {
+      testWidgets('group', (tester) async {
         final user1 = eg.user(userId: 1, fullName: 'User 1');
         final user2 = eg.user(userId: 2, fullName: 'User 2');
         await runAndCheck(tester, users: [user1, user2],

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -48,7 +48,7 @@ extension MyWidgetWithMixinStateChecks on Subject<MyWidgetWithMixinState> {
 void main() {
   TestZulipBinding.ensureInitialized();
 
-  testWidgets('GlobalStoreWidget', (WidgetTester tester) async {
+  testWidgets('GlobalStoreWidget', (tester) async {
     addTearDown(testBinding.reset);
 
     GlobalStore? globalStore;

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -94,7 +94,7 @@ void main() {
       required List<FontVariation> expectedFontVariations,
       required FontWeight expectedFontWeight,
     }) async {
-      testWidgets(description, (WidgetTester tester) async {
+      testWidgets(description, (tester) async {
         addTearDown(testBinding.reset);
         tester.platformDispatcher.accessibilityFeaturesTestValue =
           FakeAccessibilityFeatures(boldText: platformRequestsBold);
@@ -185,7 +185,7 @@ void main() {
       required double expectedWght,
       required FontWeight expectedFontWeight,
     }) async {
-      testWidgets(description, (WidgetTester tester) async {
+      testWidgets(description, (tester) async {
         addTearDown(testBinding.reset);
         tester.platformDispatcher.accessibilityFeaturesTestValue =
           FakeAccessibilityFeatures(boldText: platformRequestsBold);
@@ -345,7 +345,7 @@ void main() {
       double? ambientTextScaleFactor,
       required double expected,
     }) async {
-      testWidgets(description, (WidgetTester tester) async {
+      testWidgets(description, (tester) async {
         addTearDown(testBinding.reset);
         if (ambientTextScaleFactor != null) {
           tester.platformDispatcher.textScaleFactorTestValue = ambientTextScaleFactor;

--- a/test/widgets/theme_test.dart
+++ b/test/widgets/theme_test.dart
@@ -22,7 +22,7 @@ void main() {
       required Widget button,
       double? ambientTextScaleFactor,
     }) async {
-      testWidgets(description, (WidgetTester tester) async {
+      testWidgets(description, (tester) async {
         addTearDown(testBinding.reset);
         if (ambientTextScaleFactor != null) {
           tester.platformDispatcher.textScaleFactorTestValue = ambientTextScaleFactor;
@@ -101,7 +101,7 @@ void main() {
   group('colorSwatchFor', () {
     const baseColor = 0xff76ce90;
 
-    testWidgets('light–dark animation', (WidgetTester tester) async {
+    testWidgets('light–dark animation', (tester) async {
       addTearDown(testBinding.reset);
 
       final subscription = eg.subscription(eg.stream(), color: baseColor);

--- a/test/widgets/unread_count_badge_test.dart
+++ b/test/widgets/unread_count_badge_test.dart
@@ -34,17 +34,17 @@ void main() {
         return decoration.color;
       }
 
-      testWidgets('default color', (WidgetTester tester) async {
+      testWidgets('default color', (tester) async {
         await prepare(tester, null);
         check(findBackgroundColor(tester)).equals(const Color(0x26666699));
       });
 
-      testWidgets('specified color', (WidgetTester tester) async {
+      testWidgets('specified color', (tester) async {
         await prepare(tester, Colors.pink);
         check(findBackgroundColor(tester)).equals(Colors.pink);
       });
 
-      testWidgets('stream color', (WidgetTester tester) async {
+      testWidgets('stream color', (tester) async {
         final swatch = ChannelColorSwatch.light(0xff76ce90);
         await prepare(tester, swatch);
         check(findBackgroundColor(tester)).equals(swatch.unreadCountBadgeBackground);


### PR DESCRIPTION
This consists of handpicked output from running the dart lint fix for code `avoid_types_on_closure_parameters`. We probably don't need to enable this linter rule because in many cases the type annotation improves readability. For the `(WidgetTester tester)` case, though, it is common and intuitive enough that the annotation shouldn't be necessary.

See also:

  https://github.com/zulip/zulip-flutter/pull/762#discussion_r1678487007