### PR TITLE
Sketch removing notification when message read

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/zulip.iml" filepath="$PROJECT_DIR$/.idea/zulip.iml" />
+      <module fileurl="file://$PROJECT_DIR$/android/zulip_android.iml" filepath="$PROJECT_DIR$/android/zulip_android.iml" />
     </modules>
   </component>
 </project>

--- a/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
@@ -443,6 +443,12 @@ interface AndroidNotificationHostApi {
    *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
    */
   fun getActiveNotificationMessagingStyleByTag(tag: String): MessagingStyle?
+  /**
+   * Corresponds to `android.app.NotificationManager.cancel`.
+   *
+   * See: https://developer.android.com/reference/kotlin/android/app/NotificationManager.html#cancel
+   */
+  fun cancel(tag: String?, id: Long)
 
   companion object {
     /** The codec used by AndroidNotificationHostApi. */
@@ -526,6 +532,25 @@ interface AndroidNotificationHostApi {
             val tagArg = args[0] as String
             val wrapped: List<Any?> = try {
               listOf(api.getActiveNotificationMessagingStyleByTag(tagArg))
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.AndroidNotificationHostApi.cancel$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val tagArg = args[0] as String?
+            val idArg = args[1].let { num -> if (num is Int) num.toLong() else num as Long }
+            val wrapped: List<Any?> = try {
+              api.cancel(tagArg, idArg)
+              listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
@@ -256,6 +256,65 @@ data class MessagingStyle (
     )
   }
 }
+
+/**
+ * Corresponds to `android.app.Notification`.
+ *
+ * See: https://developer.android.com/reference/kotlin/android/app/Notification
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class Notification (
+  val group: String? = null,
+  val extras: Map<String?, Any?>
+
+) {
+  companion object {
+    @Suppress("LocalVariableName")
+    fun fromList(__pigeon_list: List<Any?>): Notification {
+      val group = __pigeon_list[0] as String?
+      val extras = __pigeon_list[1] as Map<String?, Any?>
+      return Notification(group, extras)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      group,
+      extras,
+    )
+  }
+}
+
+/**
+ * Corresponds to `android.service.notification.StatusBarNotification`.
+ *
+ * See: https://developer.android.com/reference/kotlin/android/service/notification/StatusBarNotification
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class StatusBarNotification (
+  val id: Long,
+  val notification: Notification,
+  val tag: String? = null
+
+) {
+  companion object {
+    @Suppress("LocalVariableName")
+    fun fromList(__pigeon_list: List<Any?>): StatusBarNotification {
+      val id = __pigeon_list[0].let { num -> if (num is Int) num.toLong() else num as Long }
+      val notification = __pigeon_list[1] as Notification
+      val tag = __pigeon_list[2] as String?
+      return StatusBarNotification(id, notification, tag)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      id,
+      notification,
+      tag,
+    )
+  }
+}
 private object NotificationsPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -289,6 +348,16 @@ private object NotificationsPigeonCodec : StandardMessageCodec() {
           MessagingStyle.fromList(it)
         }
       }
+      135.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          Notification.fromList(it)
+        }
+      }
+      136.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          StatusBarNotification.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -316,6 +385,14 @@ private object NotificationsPigeonCodec : StandardMessageCodec() {
       }
       is MessagingStyle -> {
         stream.write(134)
+        writeValue(stream, value.toList())
+      }
+      is Notification -> {
+        stream.write(135)
+        writeValue(stream, value.toList())
+      }
+      is StatusBarNotification -> {
+        stream.write(136)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -351,6 +428,7 @@ interface AndroidNotificationHostApi {
    *   https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder
    */
   fun notify(tag: String?, id: Long, autoCancel: Boolean?, channelId: String, color: Long?, contentIntent: PendingIntent?, contentText: String?, contentTitle: String?, extras: Map<String?, String?>?, groupKey: String?, inboxStyle: InboxStyle?, isGroupSummary: Boolean?, messagingStyle: MessagingStyle?, number: Long?, smallIconResourceName: String?)
+  fun getActiveNotifications(): List<StatusBarNotification>
   /**
    * Wraps `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
    * combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
@@ -416,6 +494,21 @@ interface AndroidNotificationHostApi {
             val wrapped: List<Any?> = try {
               api.notify(tagArg, idArg, autoCancelArg, channelIdArg, colorArg, contentIntentArg, contentTextArg, contentTitleArg, extrasArg, groupKeyArg, inboxStyleArg, isGroupSummaryArg, messagingStyleArg, numberArg, smallIconResourceNameArg)
               listOf(null)
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotifications$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              listOf(api.getActiveNotifications())
             } catch (exception: Throwable) {
               wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -166,6 +166,11 @@ private class AndroidNotificationHost(val context: Context)
         }
         return null
     }
+
+    override fun cancel(tag: String?, id: Long) {
+        val notificationManager = context.getSystemService(NotificationManager::class.java)!!
+        notificationManager.cancel(tag, id.toInt())
+    }
 }
 
 /** A Flutter plugin for the Zulip app's ad-hoc needs. */

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -12,13 +12,12 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import java.io.Serializable
 
 private const val TAG = "ZulipPlugin"
 
-private fun Bundle.asMap(): Map<String, Serializable?>  {
+private fun Bundle.stringsMap(): Map<String, CharSequence?>  {
     return keySet().associateWith {
-        try { get(it) as Serializable? }
+        try { get(it) as CharSequence? }
         catch (e: Throwable) { null }
     }
 }
@@ -138,7 +137,7 @@ private class AndroidNotificationHost(val context: Context)
                 tag = it.tag,
                 notification = Notification(
                     group = it.notification.group,
-                    extras = it.notification.extras.asMap() as Map<String?, Any?>,
+                    extras = it.notification.extras.stringsMap() as Map<String?, Any?>,
                 )
             )
         }

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -240,6 +240,69 @@ class MessagingStyle {
   }
 }
 
+/// Corresponds to `android.app.Notification`.
+///
+/// See: https://developer.android.com/reference/kotlin/android/app/Notification
+class Notification {
+  Notification({
+    this.group,
+    required this.extras,
+  });
+
+  String? group;
+
+  Map<String?, Object?> extras;
+
+  Object encode() {
+    return <Object?>[
+      group,
+      extras,
+    ];
+  }
+
+  static Notification decode(Object result) {
+    result as List<Object?>;
+    return Notification(
+      group: result[0] as String?,
+      extras: (result[1] as Map<Object?, Object?>?)!.cast<String?, Object?>(),
+    );
+  }
+}
+
+/// Corresponds to `android.service.notification.StatusBarNotification`.
+///
+/// See: https://developer.android.com/reference/kotlin/android/service/notification/StatusBarNotification
+class StatusBarNotification {
+  StatusBarNotification({
+    required this.id,
+    required this.notification,
+    this.tag,
+  });
+
+  int id;
+
+  Notification notification;
+
+  String? tag;
+
+  Object encode() {
+    return <Object?>[
+      id,
+      notification,
+      tag,
+    ];
+  }
+
+  static StatusBarNotification decode(Object result) {
+    result as List<Object?>;
+    return StatusBarNotification(
+      id: result[0]! as int,
+      notification: result[1]! as Notification,
+      tag: result[2] as String?,
+    );
+  }
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -263,6 +326,12 @@ class _PigeonCodec extends StandardMessageCodec {
     } else     if (value is MessagingStyle) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
+    } else     if (value is Notification) {
+      buffer.putUint8(135);
+      writeValue(buffer, value.encode());
+    } else     if (value is StatusBarNotification) {
+      buffer.putUint8(136);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -283,6 +352,10 @@ class _PigeonCodec extends StandardMessageCodec {
         return MessagingStyleMessage.decode(readValue(buffer)!);
       case 134: 
         return MessagingStyle.decode(readValue(buffer)!);
+      case 135: 
+        return Notification.decode(readValue(buffer)!);
+      case 136: 
+        return StatusBarNotification.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -363,6 +436,33 @@ class AndroidNotificationHostApi {
       );
     } else {
       return;
+    }
+  }
+
+  Future<List<StatusBarNotification?>> getActiveNotifications() async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotifications$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(null) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else if (__pigeon_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (__pigeon_replyList[0] as List<Object?>?)!.cast<StatusBarNotification?>();
     }
   }
 

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -498,4 +498,29 @@ class AndroidNotificationHostApi {
       return (__pigeon_replyList[0] as MessagingStyle?);
     }
   }
+
+  /// Corresponds to `android.app.NotificationManager.cancel`.
+  ///
+  /// See: https://developer.android.com/reference/kotlin/android/app/NotificationManager.html#cancel
+  Future<void> cancel({String? tag, required int id}) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.cancel$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[tag, id]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -220,7 +220,8 @@ class NotificationDisplayManager {
         ' id: ${statusBarNotification.id}, tag: ${statusBarNotification.tag},'
         ' notification: (group: ${notification.group}, extras: ${notification.extras}))'));
 
-      final rawZulipMessageId = notification.extras[_extraZulipMessageId] as String;
+      final rawZulipMessageId = notification.extras[_extraZulipMessageId];
+      if (rawZulipMessageId is! String) continue;
       final zulipMessageId = int.parse(rawZulipMessageId, radix: 10);
       if (data.zulipMessageIds.contains(zulipMessageId)) {
         // The latest Zulip message in this conversation was read.

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -84,7 +84,7 @@ class NotificationDisplayManager {
   static void onFcmMessage(FcmMessage data, Map<String, dynamic> dataJson) {
     switch (data) {
       case MessageFcmMessage(): _onMessageFcmMessage(data, dataJson);
-      case RemoveFcmMessage(): break; // TODO(#341) handle
+      case RemoveFcmMessage(): _onRemoveFcmMessage(data);
       case UnexpectedFcmMessage(): break; // TODO(log)
     }
   }
@@ -200,6 +200,14 @@ class NotificationDisplayManager {
       // TODO(android-12): cut this autoCancel workaround
       autoCancel: true,
     );
+  }
+
+  static void _onRemoveFcmMessage(RemoveFcmMessage data) async {
+    final api = AndroidNotificationHostApi();
+    final notifs = await api.getActiveNotifications();
+    print('notifs: $notifs');
+
+    // TODO implement
   }
 
   /// A notification ID, derived as a hash of the given string key.

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -205,7 +205,10 @@ class NotificationDisplayManager {
   static void _onRemoveFcmMessage(RemoveFcmMessage data) async {
     final api = AndroidNotificationHostApi();
     final notifs = await api.getActiveNotifications();
-    print('notifs: $notifs');
+    // Sadly we don't get toString on Pigeon data classes: flutter#59027
+    print('notifs: ${notifs.map((n) => n == null ? null
+      : '(id: ${n.id}, tag: ${n.tag}, notification: '
+         '(group: ${n.notification.group}, extras: ${n.notification.extras}))')}');
 
     // TODO implement
   }

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -225,7 +225,8 @@ class NotificationDisplayManager {
       if (data.zulipMessageIds.contains(zulipMessageId)) {
         // The latest Zulip message in this conversation was read.
         // That's our cue to cancel the notification for the conversation.
-        print('would cancel: tag ${statusBarNotification.tag}, id ${statusBarNotification.id}'); // TODO actually cancel
+        print('  canceling: tag ${statusBarNotification.tag}, id ${statusBarNotification.id}');
+        await api.cancel(tag: statusBarNotification.tag, id: statusBarNotification.id);
       }
     }
   }

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -211,22 +211,22 @@ class NotificationDisplayManager {
 
     final api = AndroidNotificationHostApi();
     final notifs = await api.getActiveNotifications();
-    // Sadly we don't get toString on Pigeon data classes: flutter#59027
-    print('notifs: ${notifs.map((n) => n == null ? null
-      : '(id: ${n.id}, tag: ${n.tag}, notification: '
-         '(group: ${n.notification.group}, extras: ${n.notification.extras}))')}');
-
     for (final statusBarNotification in notifs) {
-      if (statusBarNotification == null) continue;
+      if (statusBarNotification == null) continue; // TODO(pigeon) eliminate this case
       final notification = statusBarNotification.notification;
+
+      // Sadly we don't get toString on Pigeon data classes: flutter#59027
+      assert(debugLog('  existing notif'
+        ' id: ${statusBarNotification.id}, tag: ${statusBarNotification.tag},'
+        ' notification: (group: ${notification.group}, extras: ${notification.extras}))'));
 
       final rawZulipMessageId = notification.extras[_extraZulipMessageId] as String;
       final zulipMessageId = int.parse(rawZulipMessageId, radix: 10);
       if (data.zulipMessageIds.contains(zulipMessageId)) {
         // The latest Zulip message in this conversation was read.
         // That's our cue to cancel the notification for the conversation.
-        print('  canceling: tag ${statusBarNotification.tag}, id ${statusBarNotification.id}');
         await api.cancel(tag: statusBarNotification.tag, id: statusBarNotification.id);
+        assert(debugLog('  … notif cancelled.'));
       }
     }
   }

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -220,4 +220,9 @@ abstract class AndroidNotificationHostApi {
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getActiveNotifications()
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
   MessagingStyle? getActiveNotificationMessagingStyleByTag(String tag);
+
+  /// Corresponds to `android.app.NotificationManager.cancel`.
+  ///
+  /// See: https://developer.android.com/reference/kotlin/android/app/NotificationManager.html#cancel
+  void cancel({String? tag, required int id});
 }

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -122,6 +122,37 @@ class MessagingStyle {
   final bool isGroupConversation;
 }
 
+/// Corresponds to `android.app.Notification`.
+///
+/// See: https://developer.android.com/reference/kotlin/android/app/Notification
+class Notification {
+  Notification({required this.group, required this.extras});
+
+  final String? group;
+  final Map<String?, Object?> extras;
+  // Various other properties too; add them if needed.
+}
+
+/// Corresponds to `android.service.notification.StatusBarNotification`.
+///
+/// See: https://developer.android.com/reference/kotlin/android/service/notification/StatusBarNotification
+class StatusBarNotification {
+  StatusBarNotification({required this.id, required this.notification, required this.tag});
+
+  final int id;
+  final Notification notification;
+  final String? tag;
+
+  // Ignore `groupKey` and `key`.  While the `.groupKey` contains the
+  // `.notification.group`, and the `.key` contains the `.id` and `.tag`,
+  // they also have more stuff added on (and their structure doesn't seem to
+  // be documented.)
+  // final String? groupKey;
+  // final String? key;
+
+  // Various other properties too; add them if needed.
+}
+
 @HostApi()
 abstract class AndroidNotificationHostApi {
   /// Corresponds to `androidx.core.app.NotificationManagerCompat.createNotificationChannel`.
@@ -170,6 +201,12 @@ abstract class AndroidNotificationHostApi {
     // NotificationCompat.Builder has lots more methods; add as needed.
     // Keep them alphabetized, for easy comparison with that class's docs.
   });
+
+  /// Corresponds to `android.app.NotificationManager.getActiveNotifications`.
+  ///
+  /// See: https://developer.android.com/reference/kotlin/android/app/NotificationManager.html#getactivenotifications
+  // TODO accept a list of extras to care about
+  List<StatusBarNotification> getActiveNotifications();
 
   /// Wraps `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
   /// combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.


### PR DESCRIPTION
Fixes #341.

This is a draft that isn't meant to be merged. But in my manual testing, it does work!

I originally wrote this in March, as described at https://github.com/zulip/zulip-flutter/issues/341#issuecomment-2014183497 , and it became the impetus to start work on #351 converting to use Pigeon. So the bulk of that draft branch turned into #592.

This draft PR is the result of me taking the rest of the material from that draft branch and rebasing it. Some of it may be a bit rough because it was part of our first experiment with Pigeon. The commit structure is rough because I left it mostly as it was in the draft branch, only squashing a couple of fixup commits.

Things this needs before we can ship it:
* Use the binding instead of the host API directly, so tests are possible.
* Write a few tests.
* Clean up the commits. A good structure might look like: add one Pigeon method, add the other, then make the `lib/notifications/display.dart` changes.

  To do that, probably just squash everything together and then split into new commits.
* Maybe handle the TODO on `getActiveNotifications` to accept a list of extras to care about, so that we don't take a whole bunch of irrelevant extras and try to serialize them back to Dart.

So @rajveermalviya please take it from here for #341.
