### PR TITLE
Implement workable dark theme for "Channels" and "Direct messages" screens, pending design

### DIFF
--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -9,6 +9,7 @@ import 'icons.dart';
 import 'message_list.dart';
 import 'page.dart';
 import 'store.dart';
+import 'theme.dart';
 import 'unread_count_badge.dart';
 
 class RecentDmConversationsPage extends StatefulWidget {
@@ -91,6 +92,8 @@ class RecentDmConversationsItem extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final selfUser = store.users[store.selfUserId]!;
 
+    final designVariables = DesignVariables.of(context);
+
     final String title;
     final Widget avatar;
     switch (narrow.otherRecipientIds) { // TODO dedupe with DM items in [InboxPage]
@@ -109,16 +112,14 @@ class RecentDmConversationsItem extends StatelessWidget {
         //   new Intl.ListFormat('ja').format(['Chris', 'Greg', 'Alya'])
         //   // 'Chris、Greg、Alya'
         title = narrow.otherRecipientIds.map((id) => store.users[id]?.fullName ?? '(unknown user)').join(', ');
-        // TODO(#95) need dark-theme color
-        avatar = ColoredBox(color: const Color(0x33808080),
+        avatar = ColoredBox(color: designVariables.groupDmConversationIconBg,
           child: Center(
-            // TODO(#95) need dark-theme color
-            child: Icon(ZulipIcons.group_dm, color: Colors.black.withOpacity(0.5))));
+            child: Icon(color: designVariables.groupDmConversationIcon,
+              ZulipIcons.group_dm)));
     }
 
     return Material(
-      // TODO(#95) need dark-theme color
-      color: Colors.white,
+      color: designVariables.background, // TODO(design) check if this is the right variable
       child: InkWell(
         onTap: () {
           Navigator.push(context,
@@ -132,11 +133,11 @@ class RecentDmConversationsItem extends StatelessWidget {
             Expanded(child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
               child: Text(
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 17,
                   height: (20 / 17),
-                  // TODO(#95) need dark-theme color
-                  color: Color(0xFF222222),
+                  // TODO(design) check if this is the right variable
+                  color: designVariables.labelMenuButton,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -120,14 +120,15 @@ class _NoSubscriptionsItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
     return SliverToBoxAdapter(
       child: Padding(
         padding: const EdgeInsets.all(10),
         child: Text("No channels found",
           textAlign: TextAlign.center,
           style: TextStyle(
-            // TODO(#95) need dark-theme color
-            color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
+            color: designVariables.subscriptionListHeaderText,
             fontSize: 18,
             height: (20 / 18),
           ))));
@@ -139,34 +140,34 @@ class _SubscriptionListHeader extends StatelessWidget {
 
   final String label;
 
-  static final _line = Expanded(child: Divider(
-    // TODO(#95) need dark-theme color
-    color: const HSLColor.fromAHSL(0.2, 240, 0.1, 0.5).toColor()));
-
   @override
   Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    final line = Expanded(child: Divider(
+      color: designVariables.subscriptionListHeaderLine));
+
     return SliverToBoxAdapter(
       child: ColoredBox(
-        // TODO(#95) need dark-theme color
-        color: Colors.white,
+        // TODO(design) check if this is the right variable
+        color: designVariables.background,
         child: Row(crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             const SizedBox(width: 16),
-            _line,
+            line,
             const SizedBox(width: 8),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 7),
               child: Text(label,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  // TODO(#95) need dark-theme color
-                  color: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
+                  color: designVariables.subscriptionListHeaderText,
                   fontSize: 14,
                   letterSpacing: proportionalLetterSpacing(context, 0.04, baseFontSize: 14),
                   height: (16 / 14),
                 ))),
             const SizedBox(width: 8),
-            _line,
+            line,
             const SizedBox(width: 16),
           ])));
   }
@@ -207,12 +208,14 @@ class SubscriptionItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
     final swatch = colorSwatchFor(context, subscription);
     final hasUnreads = (unreadCount > 0);
     final opacity = subscription.isMuted ? 0.55 : 1.0;
     return Material(
-      // TODO(#95) need dark-theme color
-      color: Colors.white,
+      // TODO(design) check if this is the right variable
+      color: designVariables.background,
       child: InkWell(
         onTap: () {
           Navigator.push(context,
@@ -237,19 +240,11 @@ class SubscriptionItem extends StatelessWidget {
               child: Opacity(
                 opacity: opacity,
                 child: Text(
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 18,
                     height: (20 / 18),
-                    // The old, soon-to-be-outdated Figma has #262626:
-                    //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=171-12359&t=OgFPAdLiXz9OEzCF-0
-                    // That might be accidental, though. The same page has
-                    // #222222 for the topics. The "Inbox" page in that Figma
-                    // has #222222 for the "Private messages" header, but yeah,
-                    // #262626 for the channel headers. Hmm...on our "Inbox",
-                    // looks like we just took #222222 for both those headers.
-                    // Anyway, eager to have the updated Figma to work from.
-                    // TODO(#95) need dark-theme color
-                    color: Color(0xff222222),
+                    // TODO(design) check if this is the right variable
+                    color: designVariables.labelMenuButton,
                   ).merge(weightVariableTextStyle(context,
                       wght: hasUnreads ? 600 : null)),
                   maxLines: 1,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -240,8 +240,16 @@ class SubscriptionItem extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 18,
                     height: (20 / 18),
+                    // The old, soon-to-be-outdated Figma has #262626:
+                    //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=171-12359&t=OgFPAdLiXz9OEzCF-0
+                    // That might be accidental, though. The same page has
+                    // #222222 for the topics. The "Inbox" page in that Figma
+                    // has #222222 for the "Private messages" header, but yeah,
+                    // #262626 for the channel headers. Hmm...on our "Inbox",
+                    // looks like we just took #222222 for both those headers.
+                    // Anyway, eager to have the updated Figma to work from.
                     // TODO(#95) need dark-theme color
-                    color: Color(0xFF262626),
+                    color: Color(0xff222222),
                   ).merge(weightVariableTextStyle(context,
                       wght: hasUnreads ? 600 : null)),
                   maxLines: 1,

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -144,6 +144,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       errorBannerBackground: const HSLColor.fromAHSL(1, 4, 0.33, 0.90).toColor(),
       errorBannerBorder: const HSLColor.fromAHSL(0.4, 3, 0.57, 0.33).toColor(),
       errorBannerLabel: const HSLColor.fromAHSL(1, 4, 0.58, 0.33).toColor(),
+      groupDmConversationIcon: Colors.black.withOpacity(0.5),
+      groupDmConversationIconBg: const Color(0x33808080),
       loginOrDivider: const Color(0xffdedede),
       loginOrDividerText: const Color(0xff575757),
       sectionCollapseIcon: const Color(0x7f1e2e48),
@@ -169,6 +171,10 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       errorBannerBackground: const HSLColor.fromAHSL(1, 0, 0.61, 0.19).toColor(),
       errorBannerBorder: const HSLColor.fromAHSL(0.4, 3, 0.73, 0.74).toColor(),
       errorBannerLabel: const HSLColor.fromAHSL(1, 2, 0.73, 0.80).toColor(),
+      // TODO(#95) need proper dark-theme color (this is ad hoc)
+      groupDmConversationIcon: Colors.white.withOpacity(0.5),
+      // TODO(#95) need proper dark-theme color (this is ad hoc)
+      groupDmConversationIconBg: const Color(0x33cccccc),
       loginOrDivider: const Color(0xff424242),
       loginOrDividerText: const Color(0xffa8a8a8),
       // TODO(#95) need proper dark-theme color (this is ad hoc)
@@ -194,6 +200,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.errorBannerBackground,
     required this.errorBannerBorder,
     required this.errorBannerLabel,
+    required this.groupDmConversationIcon,
+    required this.groupDmConversationIconBg,
     required this.loginOrDivider,
     required this.loginOrDividerText,
     required this.sectionCollapseIcon,
@@ -230,6 +238,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color errorBannerBackground;
   final Color errorBannerBorder;
   final Color errorBannerLabel;
+  final Color groupDmConversationIcon;
+  final Color groupDmConversationIconBg;
   final Color loginOrDivider; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color loginOrDividerText; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color sectionCollapseIcon;
@@ -253,6 +263,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? errorBannerBackground,
     Color? errorBannerBorder,
     Color? errorBannerLabel,
+    Color? groupDmConversationIcon,
+    Color? groupDmConversationIconBg,
     Color? loginOrDivider,
     Color? loginOrDividerText,
     Color? sectionCollapseIcon,
@@ -275,6 +287,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       errorBannerBackground: errorBannerBackground ?? this.errorBannerBackground,
       errorBannerBorder: errorBannerBorder ?? this.errorBannerBorder,
       errorBannerLabel: errorBannerLabel ?? this.errorBannerLabel,
+      groupDmConversationIcon: groupDmConversationIcon ?? this.groupDmConversationIcon,
+      groupDmConversationIconBg: groupDmConversationIconBg ?? this.groupDmConversationIconBg,
       loginOrDivider: loginOrDivider ?? this.loginOrDivider,
       loginOrDividerText: loginOrDividerText ?? this.loginOrDividerText,
       sectionCollapseIcon: sectionCollapseIcon ?? this.sectionCollapseIcon,
@@ -304,6 +318,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       errorBannerBackground: Color.lerp(errorBannerBackground, other.errorBannerBackground, t)!,
       errorBannerBorder: Color.lerp(errorBannerBorder, other.errorBannerBorder, t)!,
       errorBannerLabel: Color.lerp(errorBannerLabel, other.errorBannerLabel, t)!,
+      groupDmConversationIcon: Color.lerp(groupDmConversationIcon, other.groupDmConversationIcon, t)!,
+      groupDmConversationIconBg: Color.lerp(groupDmConversationIconBg, other.groupDmConversationIconBg, t)!,
       loginOrDivider: Color.lerp(loginOrDivider, other.loginOrDivider, t)!,
       loginOrDividerText: Color.lerp(loginOrDividerText, other.loginOrDividerText, t)!,
       sectionCollapseIcon: Color.lerp(sectionCollapseIcon, other.sectionCollapseIcon, t)!,

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -150,6 +150,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: const Color(0xff575757),
       sectionCollapseIcon: const Color(0x7f1e2e48),
       star: const HSLColor.fromAHSL(0.5, 47, 1, 0.41).toColor(),
+      subscriptionListHeaderLine: const HSLColor.fromAHSL(0.2, 240, 0.1, 0.5).toColor(),
+      subscriptionListHeaderText: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.5).toColor(),
       unreadCountBadgeTextForChannel: Colors.black.withOpacity(0.9),
     );
 
@@ -181,6 +183,10 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       sectionCollapseIcon: const Color(0x7fb6c8e2),
       // TODO(#95) unchanged in dark theme?
       star: const HSLColor.fromAHSL(0.5, 47, 1, 0.41).toColor(),
+      // TODO(#95) need proper dark-theme color (this is ad hoc)
+      subscriptionListHeaderLine: const HSLColor.fromAHSL(0.4, 240, 0.1, 0.75).toColor(),
+      // TODO(#95) need proper dark-theme color (this is ad hoc)
+      subscriptionListHeaderText: const HSLColor.fromAHSL(1.0, 240, 0.1, 0.75).toColor(),
       unreadCountBadgeTextForChannel: Colors.white.withOpacity(0.9),
     );
 
@@ -206,6 +212,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.loginOrDividerText,
     required this.sectionCollapseIcon,
     required this.star,
+    required this.subscriptionListHeaderLine,
+    required this.subscriptionListHeaderText,
     required this.unreadCountBadgeTextForChannel,
   });
 
@@ -244,6 +252,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color loginOrDividerText; // TODO(#95) need proper dark-theme color (this is ad hoc)
   final Color sectionCollapseIcon;
   final Color star;
+  final Color subscriptionListHeaderLine;
+  final Color subscriptionListHeaderText;
   final Color unreadCountBadgeTextForChannel;
 
   @override
@@ -269,6 +279,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? loginOrDividerText,
     Color? sectionCollapseIcon,
     Color? star,
+    Color? subscriptionListHeaderLine,
+    Color? subscriptionListHeaderText,
     Color? unreadCountBadgeTextForChannel,
   }) {
     return DesignVariables._(
@@ -293,6 +305,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: loginOrDividerText ?? this.loginOrDividerText,
       sectionCollapseIcon: sectionCollapseIcon ?? this.sectionCollapseIcon,
       star: star ?? this.star,
+      subscriptionListHeaderLine: subscriptionListHeaderLine ?? this.subscriptionListHeaderLine,
+      subscriptionListHeaderText: subscriptionListHeaderText ?? this.subscriptionListHeaderText,
       unreadCountBadgeTextForChannel: unreadCountBadgeTextForChannel ?? this.unreadCountBadgeTextForChannel,
     );
   }
@@ -324,6 +338,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: Color.lerp(loginOrDividerText, other.loginOrDividerText, t)!,
       sectionCollapseIcon: Color.lerp(sectionCollapseIcon, other.sectionCollapseIcon, t)!,
       star: Color.lerp(star, other.star, t)!,
+      subscriptionListHeaderLine: Color.lerp(subscriptionListHeaderLine, other.subscriptionListHeaderLine, t)!,
+      subscriptionListHeaderText: Color.lerp(subscriptionListHeaderText, other.subscriptionListHeaderText, t)!,
       unreadCountBadgeTextForChannel: Color.lerp(unreadCountBadgeTextForChannel, other.unreadCountBadgeTextForChannel, t)!,
     );
   }


### PR DESCRIPTION
Along the way, this makes a non-NFC change in light mode on the "Channels" screen. The channel names are now somewhat darker (`#222222`, replacing `#262626`):

| Before | After |
| --- | --- |
| ![944D113F-3BBA-4104-A314-3910B906549D](https://github.com/user-attachments/assets/6c74b761-357f-4e3e-9e71-cee2e1f8b100) | ![D2D5B77B-CF03-41FB-9438-D26D21807A1F](https://github.com/user-attachments/assets/ebdcac9e-cdcf-46ca-a23e-1de5e18b5444) |