### PR TITLE
msglist [nfc]: Comment about typing-indicator color for light/dark

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -669,7 +669,9 @@ class _TypingStatusWidgetState extends State<TypingStatusWidget> with PerAccount
       padding: const EdgeInsetsDirectional.only(start: 16, top: 2),
       child: Text(text,
         style: const TextStyle(
-          color: HslColor(0, 0, 53), fontStyle: FontStyle.italic)));
+          // Web has the same color in light and dark mode.
+          color: HslColor(0, 0, 53),
+          fontStyle: FontStyle.italic)));
   }
 }
 


### PR DESCRIPTION
Aha, well this did turn out to be pretty quick. 🙂

Fixes: #858