### PR TITLE
deps: Upgrade Flutter to 3.24.0-1.0.pre.518

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -194,10 +194,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   color_models:
     dependency: transitive
     description:
@@ -1066,10 +1066,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   sync_http:
     dependency: transitive
     description:
@@ -1090,26 +1090,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.7"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   timezone:
     dependency: transitive
     description:
@@ -1358,5 +1358,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.5.0-319.0.dev <4.0.0"
-  flutter: ">=3.23.0-14.0.pre.77"
+  dart: ">=3.6.0-129.0.dev <4.0.0"
+  flutter: ">=3.24.0-1.0.pre.518"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.5.0-319.0.dev <4.0.0'
-  flutter: '>=3.23.0-14.0.pre.77'
+  sdk: '>=3.6.0-129.0.dev <4.0.0'
+  flutter: '>=3.24.0-1.0.pre.518'
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
And update Flutter's supporting libraries to match.

We haven't had a Flutter upgrade for over a month now; specifically, there is the [`spacing` property](https://github.com/flutter/flutter/pull/152472) available to `Column` and `Row` now, which is [helpful](https://github.com/zulip/zulip-flutter/pull/853/files#r1710247901) in #853. So I think it's a good time to have an upgrade!