### PR TITLE
internal_links: Add "/" before fragment identifier

### DIFF
--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -96,7 +96,11 @@ Uri narrowLink(PerAccountStore store, Narrow narrow, {int? nearMessageId}) {
     fragment.write('/near/$nearMessageId');
   }
 
-  return store.realmUrl.replace(fragment: fragment.toString());
+  final realmUrlWithSlash = store.realmUrl.path.isNotEmpty
+      ? store.realmUrl
+      : store.realmUrl.replace(path: '${store.realmUrl.path}/');
+
+  return realmUrlWithSlash.replace(fragment: fragment.toString());
 }
 
 /// A [Narrow] from a given URL, on `store`'s realm.


### PR DESCRIPTION
Fixes: #845 

This adds a **'/ '**  after hostname. when this Url is posted in Zulip message it gets linkified.
![Screenshot_20240809-213108 1](https://github.com/user-attachments/assets/7ec8d6df-3f66-4397-a714-5399293003ef)
