### PR TITLE
test [nfc]: Ensure user IDs, message IDs, etc. are positive

### DIFF
--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -119,6 +119,7 @@ Account account({
   String? zulipMergeBase,
   String? ackedPushToken,
 }) {
+  _checkPositive(id, 'account ID');
   return Account(
     id: id ?? 1000, // TODO generate example IDs
     realmUrl: realmUrl ?? _realmUrl,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -10,6 +10,10 @@ import 'package:zulip/model/store.dart';
 import 'model/test_store.dart';
 import 'stdlib_checks.dart';
 
+void _checkPositive(int? value, String description) {
+  assert(value == null || value > 0, '$description should be positive');
+}
+
 ////////////////////////////////////////////////////////////////
 // Realm-wide (or server-wide) metadata.
 //
@@ -81,6 +85,7 @@ User user({
   Map<int, ProfileFieldUserData>? profileData,
 }) {
   var effectiveDeliveryEmail = deliveryEmail ?? 'name@example.com'; // TODO generate example emails
+  _checkPositive(userId, 'user ID');
   return User(
     userId: userId ?? _nextUserId(),
     deliveryEmail: effectiveDeliveryEmail,
@@ -555,6 +560,7 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
   Iterable<Message> messages, {
   int? selfUserId,
 }) {
+  _checkPositive(selfUserId, 'user ID');
   return UpdateMessageFlagsRemoveEvent(
     id: 0,
     flag: flag,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -180,6 +180,8 @@ ZulipStream stream({
   int? canRemoveSubscribersGroup,
   int? streamWeeklyTraffic,
 }) {
+  _checkPositive(streamId, 'stream ID');
+  _checkPositive(firstMessageId, 'message ID');
   return ZulipStream(
     streamId: streamId ?? _nextStreamId(),
     name: name ?? 'A stream', // TODO generate example names
@@ -334,6 +336,7 @@ StreamMessage streamMessage({
   int? timestamp,
   List<MessageFlag>? flags,
 }) {
+  _checkPositive(id, 'message ID');
   final effectiveStream = stream ?? _stream(streamId: defaultStreamMessageStreamId);
   // The use of JSON here is convenient in order to delegate parts of the data
   // to helper functions.  The main downside is that it loses static typing
@@ -376,6 +379,7 @@ DmMessage dmMessage({
   int? timestamp,
   List<MessageFlag>? flags,
 }) {
+  _checkPositive(id, 'message ID');
   assert(!to.any((user) => user.userId == from.userId));
   return DmMessage.fromJson(deepToJson({
     ..._messagePropertiesBase,
@@ -446,6 +450,7 @@ UpdateMessageEvent updateMessageEditEvent(
   String? renderedContent,
   bool isMeMessage = false,
 }) {
+  _checkPositive(messageId, 'message ID');
   messageId ??= origMessage.id;
   return UpdateMessageEvent(
     id: 0,
@@ -479,6 +484,8 @@ UpdateMessageEvent _updateMessageMoveEvent(
   required List<MessageFlag> flags,
   PropagateMode propagateMode = PropagateMode.changeOne,
 }) {
+  _checkPositive(origStreamId, 'stream ID');
+  _checkPositive(newStreamId, 'stream ID');
   assert(newTopic != origTopic
          || (newStreamId != null && newStreamId != origStreamId));
   assert(messageIds.isNotEmpty);
@@ -511,6 +518,7 @@ UpdateMessageEvent updateMessageEventMoveFrom({
   String? newContent,
   PropagateMode propagateMode = PropagateMode.changeOne,
 }) {
+  _checkPositive(newStreamId, 'stream ID');
   assert(origMessages.isNotEmpty);
   final origMessage = origMessages.first;
   // Only present on content change.
@@ -535,6 +543,7 @@ UpdateMessageEvent updateMessageEventMoveTo({
   String? origContent,
   PropagateMode propagateMode = PropagateMode.changeOne,
 }) {
+  _checkPositive(origStreamId, 'stream ID');
   assert(newMessages.isNotEmpty);
   final newMessage = newMessages.first;
   // Only present on topic move.

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -604,13 +604,13 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
 TypingEvent typingEvent(SendableNarrow narrow, TypingOp op, int senderId) {
   switch (narrow) {
     case TopicNarrow():
-      return TypingEvent(id: 1, op: op, senderId: senderId,
+      return TypingEvent(id: 0, op: op, senderId: senderId,
         messageType: MessageType.stream,
         streamId: narrow.streamId,
         topic: narrow.topic,
         recipientIds: null);
     case DmNarrow():
-      return TypingEvent(id: 1, op: op, senderId: senderId,
+      return TypingEvent(id: 0, op: op, senderId: senderId,
         messageType: MessageType.direct,
         recipientIds: narrow.allRecipientIds,
         streamId: null,
@@ -620,7 +620,7 @@ TypingEvent typingEvent(SendableNarrow narrow, TypingOp op, int senderId) {
 
 ReactionEvent reactionEvent(Reaction reaction, ReactionOp op, int messageId) {
   return ReactionEvent(
-    id: 1,
+    id: 0,
     op: op,
     emojiName: reaction.emojiName,
     emojiCode: reaction.emojiCode,
@@ -665,7 +665,7 @@ InitialSnapshot initialSnapshot({
 }) {
   return InitialSnapshot(
     queueId: queueId ?? '1:2345',
-    lastEventId: lastEventId ?? 1,
+    lastEventId: lastEventId ?? -1,
     zulipFeatureLevel: zulipFeatureLevel ?? recentZulipFeatureLevel,
     zulipVersion: zulipVersion ?? recentZulipVersion,
     zulipMergeBase: zulipMergeBase ?? recentZulipVersion,

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -224,7 +224,7 @@ void main() {
   test('MentionAutocompleteView yield between batches of 1000', () async {
     const narrow = ChannelNarrow(1);
     final store = eg.store();
-    for (int i = 0; i < 2500; i++) {
+    for (int i = 1; i <= 2500; i++) {
       await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);
@@ -247,7 +247,7 @@ void main() {
   test('MentionAutocompleteView new query during computation replaces old', () async {
     const narrow = ChannelNarrow(1);
     final store = eg.store();
-    for (int i = 0; i < 1500; i++) {
+    for (int i = 1; i <= 1500; i++) {
       await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);
@@ -258,7 +258,7 @@ void main() {
 
     await Future(() {});
     check(done).isFalse();
-    view.query = MentionAutocompleteQuery('User 0');
+    view.query = MentionAutocompleteQuery('User 234');
 
     // …new query goes through all batches
     await Future(() {});
@@ -267,14 +267,14 @@ void main() {
     check(done).isTrue(); // new result is set
     check(view.results).single
       .isA<UserMentionAutocompleteResult>()
-      .userId.equals(0);
+      .userId.equals(234);
 
     // new result sticks; it isn't clobbered with old query's result
     for (int i = 0; i < 10; i++) { // for good measure
       await Future(() {});
       check(view.results).single
         .isA<UserMentionAutocompleteResult>()
-        .userId.equals(0);
+        .userId.equals(234);
     }
   });
 
@@ -282,7 +282,7 @@ void main() {
       'prevent query from finishing', () async {
     const narrow = ChannelNarrow(1);
     final store = eg.store();
-    for (int i = 0; i < 2500; i++) {
+    for (int i = 1; i <= 2500; i++) {
       await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
     final view = MentionAutocompleteView.init(store: store, narrow: narrow);

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -74,11 +74,14 @@ void main() {
     }
 
     List<Account> generateAccounts(int count) {
-      return List.generate(count, (i) => eg.account(
-        id: i,
-        user: eg.user(fullName: 'User $i', email: 'user$i@example'),
-        apiKey: 'user${i}apikey',
-      ));
+      return List.generate(count, (i) {
+        final id = i+1;
+        return eg.account(
+          id: id,
+          user: eg.user(fullName: 'User $id', email: 'user$id@example'),
+          apiKey: 'user${id}apikey',
+        );
+      });
     }
 
     Finder findAccount(Account account) => find.text(account.email).hitTestable();

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -84,7 +84,7 @@ void main() {
     testWidgets('fling to scroll down', (WidgetTester tester) async {
       final List<User> users = [];
       final List<DmMessage> messages = [];
-      for (int i = 0; i < 30; i++) {
+      for (int i = 1; i <= 30; i++) {
         final user = eg.user(userId: i, fullName: 'User ${i.toString()}');
         users.add(user);
         messages.add(eg.dmMessage(from: eg.selfUser, to: [user]));
@@ -247,7 +247,7 @@ void main() {
       group('group', () {
         List<User> usersList(int count) {
           final result = <User>[];
-          for (int i = 0; i < count; i++) {
+          for (int i = 1; i <= count; i++) {
             result.add(eg.user(userId: i, fullName: 'User ${i.toString()}'));
           }
           return result;


### PR DESCRIPTION
Zulip user IDs, message IDs, and stream/channel IDs (and anything else that's an ID of a row in the server database) are positive integers. So are our account IDs. To help keep test data realistic, enforce those in the example-data functions.

This follows up on 739fa8491 (in #828; /cc @sm-sayedi), which made a similar fix for one test case.
