### PR TITLE
test [nfc]: Cut redundant checks-extensions from compose_box_checks

### DIFF
--- a/test/widgets/compose_box_checks.dart
+++ b/test/widgets/compose_box_checks.dart
@@ -1,16 +1,6 @@
 import 'package:checks/checks.dart';
-import 'package:zulip/model/autocomplete.dart';
 import 'package:zulip/widgets/compose_box.dart';
 
 extension ComposeContentControllerChecks on Subject<ComposeContentController> {
   Subject<List<ContentValidationError>> get validationErrors => has((c) => c.validationErrors, 'validationErrors');
-}
-
-extension AutocompleteIntentChecks on Subject<AutocompleteIntent> {
-  Subject<int> get syntaxStart => has((i) => i.syntaxStart, 'syntaxStart');
-  Subject<AutocompleteQuery> get query => has((i) => i.query, 'query');
-}
-
-extension UserMentionAutocompleteResultChecks on Subject<UserMentionAutocompleteResult> {
-  Subject<int> get userId => has((r) => r.userId, 'userId');
 }


### PR DESCRIPTION
(A tiny cleanup I happened across this while writing another change.)

These types live in lib/model/autocomplete.dart, so the corresponding checks-extensions live in test/model/autocomplete_checks.dart (which indeed has them).
