### PR TITLE
autocomplete [nfc]: Give subclasses control of computeResults

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -201,7 +201,7 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
   set query(QueryT? query) {
     _query = query;
     if (query != null) {
-      _startSearch(query);
+      _startSearch();
     }
   }
 
@@ -210,15 +210,15 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
   /// This will redo the search from scratch for the current query, if any.
   void reassemble() {
     if (_query != null) {
-      _startSearch(_query!);
+      _startSearch();
     }
   }
 
   Iterable<ResultT> get results => _results;
   List<ResultT> _results = [];
 
-  Future<void> _startSearch(QueryT query) async {
-    final newResults = await _computeResults(query);
+  Future<void> _startSearch() async {
+    final newResults = await _computeResults();
     if (newResults == null) {
       // Query was old; new search is in progress. Or, no listeners to notify.
       return;
@@ -228,7 +228,9 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
     notifyListeners();
   }
 
-  Future<List<ResultT>?> _computeResults(QueryT query) async {
+  Future<List<ResultT>?> _computeResults() async {
+    assert(_query != null);
+    final query = _query!;
     final List<ResultT> results = [];
     final Iterable<CandidateT> data = getSortedItemsToTest();
 
@@ -582,7 +584,7 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
     final result = await getStreamTopics(store.connection, streamId: streamId);
     _topics = result.topics.map((e) => e.name);
     _isFetching = false;
-    if (_query != null) _startSearch(_query!);
+    if (_query != null) _startSearch();
   }
 
   @override

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -256,17 +256,13 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
     final Iterable<CandidateT> data = getSortedItemsToTest();
 
     final iterator = data.iterator;
-    bool isDone = false;
-    while (!isDone) {
+    outer: while (true) {
       assert(_query == query);
       if (await shouldStop()) return null;
       assert(_query == query);
 
       for (int i = 0; i < 1000; i++) {
-        if (!iterator.moveNext()) {
-          isDone = true;
-          break;
-        }
+        if (!iterator.moveNext()) break outer;
         final CandidateT item = iterator.current;
         final result = testItem(query, item);
         if (result != null) results.add(result);

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -192,7 +192,7 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
 
   final PerAccountStore store;
 
-  Iterable<CandidateT> getSortedItemsToTest(QueryT query);
+  Iterable<CandidateT> getSortedItemsToTest();
 
   ResultT? testItem(QueryT query, CandidateT item);
 
@@ -230,7 +230,7 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
 
   Future<List<ResultT>?> _computeResults(QueryT query) async {
     final List<ResultT> results = [];
-    final Iterable<CandidateT> data = getSortedItemsToTest(query);
+    final Iterable<CandidateT> data = getSortedItemsToTest();
 
     final iterator = data.iterator;
     bool isDone = false;
@@ -386,7 +386,7 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   }
 
   @override
-  Iterable<User> getSortedItemsToTest(MentionAutocompleteQuery query) {
+  Iterable<User> getSortedItemsToTest() {
     return sortedUsers;
   }
 
@@ -586,7 +586,7 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
   }
 
   @override
-  Iterable<String> getSortedItemsToTest(TopicAutocompleteQuery query) => _topics;
+  Iterable<String> getSortedItemsToTest() => _topics;
 
   @override
   TopicAutocompleteResult? testItem(TopicAutocompleteQuery query, String item) {

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -311,6 +311,19 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   final Narrow narrow;
   final List<User> sortedUsers;
 
+  @override
+  Iterable<User> getSortedItemsToTest() {
+    return sortedUsers;
+  }
+
+  @override
+  MentionAutocompleteResult? testItem(MentionAutocompleteQuery query, User item) {
+    if (query.testUser(item, store.autocompleteViewManager.autocompleteDataCache)) {
+      return UserMentionAutocompleteResult(userId: item.userId);
+    }
+    return null;
+  }
+
   static List<User> _usersByRelevance({
     required PerAccountStore store,
     required Narrow narrow,
@@ -415,19 +428,6 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
         streamId: streamId, senderId: userA.userId),
       recentSenders.latestMessageIdOfSenderInStream(
         streamId: streamId, senderId: userB.userId));
-  }
-
-  @override
-  Iterable<User> getSortedItemsToTest() {
-    return sortedUsers;
-  }
-
-  @override
-  MentionAutocompleteResult? testItem(MentionAutocompleteQuery query, User item) {
-    if (query.testUser(item, store.autocompleteViewManager.autocompleteDataCache)) {
-      return UserMentionAutocompleteResult(userId: item.userId);
-    }
-    return null;
   }
 
   /// Determines which of the two users is more recent in DM conversations.


### PR DESCRIPTION
This gives AutocompleteView subclasses the flexibility to have an implementation that's more than a single loop through candidates.

That will be useful for #234 / #889, /cc @sm-sayedi.

To keep the tricky aspects of the main search loop encapsulated, we move them into a helper function `filterCandidates` which those `computeResults` implementations can call.
