### PR TITLE
deps: Upgrade Flutter to 3.25.0-1.0.pre.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,6 @@ To update the version bounds:
 * Use `flutter upgrade` to upgrade your local Flutter and Dart.
 * Run `tools/upgrade flutter-local`, which makes a commit updating
   `pubspec.yaml` and `pubspec.lock` to match your local Flutter.
-* Make a quick check that things work: `tools/check`,
-  and do a quick smoke-test of the app.
 * Send the changes as a PR.
 
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1258,10 +1258,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -1358,5 +1358,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.6.0-129.0.dev <4.0.0"
-  flutter: ">=3.24.0-1.0.pre.518"
+  dart: ">=3.6.0-149.3.beta <4.0.0"
+  flutter: ">=3.25.0-1.0.pre.41"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,8 @@ environment:
   # that by the time we want to release, these will have become stable.
   # TODO: Before general release, switch to stable Flutter and Dart versions,
   #   or pin exact versions: https://github.com/zulip/zulip-flutter/issues/15
-  sdk: '>=3.6.0-129.0.dev <4.0.0'
-  flutter: '>=3.24.0-1.0.pre.518'
+  sdk: '>=3.6.0-149.3.beta <4.0.0'
+  flutter: '>=3.25.0-1.0.pre.41'
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
And update Flutter's supporting libraries to match.

Also removed a piece of documentation on upgrading Flutter on running `tools/checks`.