### PR TITLE
check: Fix closed-pipe `git` error that could defeat build_runner suite

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -124,6 +124,15 @@ if_verbose() {
   fi
 }
 
+# usage: grep_quiet_hungry GREP_ARGUMENTS...
+#
+# Just like `grep --quiet` aka `grep -q`, except this consumes the
+# whole input.  Useful when consuming a pipeline from a command that
+# isn't robust to having its stdout pipe broken.
+grep_quiet_hungry() {
+    grep --quiet "$@" && cat >/dev/null
+}
+
 # usage: files_check [GIT_PATHSPECS...]
 #
 # True just if $opt_files includes any files matching GIT_PATHSPECS.
@@ -222,7 +231,7 @@ should_run_build_runner() {
     # (And at this point we must have a meaningful $files_base_commit.)
     if git_changed_files "${files_base_commit}" \
             | xargs -r git grep -l '^part .*g\.dart.;$' \
-            | grep -q .; then
+            | grep_quiet_hungry .; then
         return 0
     fi
 


### PR DESCRIPTION
Sometimes `tools/check build_runner` would exit with just an error message about "signal 13":

    Running build_runner...
    xargs: git: terminated with signal 13; aborting
    Running drift...

Signal 13 is SIGPIPE: it means that `git` command under `xargs` was trying to write to a pipe, presumably its own standard output, and the other end of the pipe had been closed, presumably by the next command having already exited.

The reason the other end had been closed is that `grep -q` has an optimization where it exits as soon as it knows its answer. Handy in general, but some programs (like `git grep -l`, apparently) are fragile like this to having their output pipe closed. So, undo that behavior here.

The overall effect of this bug was that the tools/check script would report success in this case, but the build_runner suite wouldn't have run, even if there were relevant input files modified.  This didn't affect runs using `--all-files`, including in CI.

See chat thread:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/build_runner.20unexpected.20output/near/1929739

Reported-by: Chris Bobbe <cbobbe@zulip.com>
Fixes: #905