### PR TITLE
gitignore: Add a few lines following an upstream change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related


### PR DESCRIPTION
This change has been getting applied by `flutter run`, and Greg identified this upstream commit as the cause:
  https://github.com/flutter/flutter/commit/29f332c82

Discussion:
  https://github.com/zulip/zulip-flutter/pull/873#issuecomment-2285235234