### PR TITLE
autocomplete [nfc]: Cut disused CandidateT type parameters

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -187,7 +187,7 @@ class AutocompleteViewManager {
 ///  * On reassemble, call [reassemble].
 ///  * When the object will no longer be used, call [dispose] to free
 ///    resources on the [PerAccountStore].
-abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult, CandidateT> extends ChangeNotifier {
+abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult> extends ChangeNotifier {
   AutocompleteView({required this.store});
 
   final PerAccountStore store;
@@ -284,7 +284,7 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
   }
 }
 
-class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery, MentionAutocompleteResult, User> {
+class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery, MentionAutocompleteResult> {
   MentionAutocompleteView._({
     required super.store,
     required this.narrow,
@@ -589,7 +589,7 @@ class UserMentionAutocompleteResult extends MentionAutocompleteResult {
 
 // TODO(#234): // class WildcardMentionAutocompleteResult extends MentionAutocompleteResult {
 
-class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, TopicAutocompleteResult, String> {
+class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, TopicAutocompleteResult> {
   TopicAutocompleteView._({required super.store, required this.streamId});
 
   factory TopicAutocompleteView.init({required PerAccountStore store, required int streamId}) {

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -24,14 +24,14 @@ abstract class AutocompleteField<QueryT extends AutocompleteQuery, ResultT exten
 
   Widget buildItem(BuildContext context, int index, ResultT option);
 
-  AutocompleteView<QueryT, ResultT, CandidateT> initViewModel(BuildContext context);
+  AutocompleteView<QueryT, ResultT> initViewModel(BuildContext context);
 
   @override
   State<AutocompleteField<QueryT, ResultT, CandidateT>> createState() => _AutocompleteFieldState<QueryT, ResultT, CandidateT>();
 }
 
 class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult, CandidateT> extends State<AutocompleteField<QueryT, ResultT, CandidateT>> with PerAccountStoreAwareStateMixin<AutocompleteField<QueryT, ResultT, CandidateT>> {
-  AutocompleteView<QueryT, ResultT, CandidateT>? _viewModel;
+  AutocompleteView<QueryT, ResultT>? _viewModel;
 
   void _initViewModel() {
     _viewModel = widget.initViewModel(context)

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../api/model/model.dart';
 import 'content.dart';
 import 'store.dart';
 import '../model/autocomplete.dart';
@@ -8,7 +7,7 @@ import '../model/compose.dart';
 import '../model/narrow.dart';
 import 'compose_box.dart';
 
-abstract class AutocompleteField<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult, CandidateT> extends StatefulWidget {
+abstract class AutocompleteField<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult> extends StatefulWidget {
   const AutocompleteField({
     super.key,
     required this.controller,
@@ -27,10 +26,10 @@ abstract class AutocompleteField<QueryT extends AutocompleteQuery, ResultT exten
   AutocompleteView<QueryT, ResultT> initViewModel(BuildContext context);
 
   @override
-  State<AutocompleteField<QueryT, ResultT, CandidateT>> createState() => _AutocompleteFieldState<QueryT, ResultT, CandidateT>();
+  State<AutocompleteField<QueryT, ResultT>> createState() => _AutocompleteFieldState<QueryT, ResultT>();
 }
 
-class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult, CandidateT> extends State<AutocompleteField<QueryT, ResultT, CandidateT>> with PerAccountStoreAwareStateMixin<AutocompleteField<QueryT, ResultT, CandidateT>> {
+class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult> extends State<AutocompleteField<QueryT, ResultT>> with PerAccountStoreAwareStateMixin<AutocompleteField<QueryT, ResultT>> {
   AutocompleteView<QueryT, ResultT>? _viewModel;
 
   void _initViewModel() {
@@ -71,7 +70,7 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
   }
 
   @override
-  void didUpdateWidget(covariant AutocompleteField<QueryT, ResultT, CandidateT> oldWidget) {
+  void didUpdateWidget(covariant AutocompleteField<QueryT, ResultT> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller.removeListener(_handleControllerChange);
@@ -145,7 +144,7 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
   }
 }
 
-class ComposeAutocomplete extends AutocompleteField<MentionAutocompleteQuery, MentionAutocompleteResult, User> {
+class ComposeAutocomplete extends AutocompleteField<MentionAutocompleteQuery, MentionAutocompleteResult> {
   const ComposeAutocomplete({
     super.key,
     required this.narrow,
@@ -218,7 +217,7 @@ class ComposeAutocomplete extends AutocompleteField<MentionAutocompleteQuery, Me
   }
 }
 
-class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicAutocompleteResult, String> {
+class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicAutocompleteResult> {
   const TopicAutocomplete({
     super.key,
     required this.streamId,

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -106,8 +106,8 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
       optionsBuilder: (_) => _resultsToDisplay,
       optionsViewOpenDirection: OptionsViewOpenDirection.up,
       // RawAutocomplete passes these when it calls optionsViewBuilder:
-      //   AutocompleteOnSelected<CandidateT> onSelected,
-      //   Iterable<CandidateT> options,
+      //   AutocompleteOnSelected<ResultT> onSelected,
+      //   Iterable<ResultT> options,
       //
       // We ignore them:
       // - `onSelected` would cause some behavior we don't want,


### PR DESCRIPTION
This is a small followup to #896 — after making these type parameters no longer needed, I forgot to also go back and remove them.

(/cc @sm-sayedi as you'll want to rebase #889 atop this)
