### PR TITLE
i18n: Consistently use … in favor of ...

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -239,7 +239,7 @@
   "@composeBoxTopicHintText":  {
     "description": "Hint text for topic input widget in compose box."
   },
-  "composeBoxUploadingFilename": "Uploading {filename}...",
+  "composeBoxUploadingFilename": "Uploading {filename}…",
   "@composeBoxUploadingFilename": {
     "description": "Placeholder in compose box showing the specified file is currently uploading.",
     "placeholders": {
@@ -432,7 +432,7 @@
       "num": {"type": "int", "example": "4"}
     }
   },
-  "markAsReadInProgress": "Marking messages as read...",
+  "markAsReadInProgress": "Marking messages as read…",
   "@markAsReadInProgress": {
     "description": "Progress message when marking messages as read."
   },
@@ -447,7 +447,7 @@
       "num": {"type": "int", "example": "4"}
     }
   },
-  "markAsUnreadInProgress": "Marking messages as unread...",
+  "markAsUnreadInProgress": "Marking messages as unread…",
   "@markAsUnreadInProgress": {
     "description": "Progress message when marking messages as unread."
   },

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -294,7 +294,7 @@ void main() {
         check(errorDialogs).isEmpty();
 
         check(composeBoxController.contentController.text)
-          .equals('see image: [Uploading image.jpg...]()\n\n');
+          .equals('see image: [Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -350,7 +350,7 @@ void main() {
         check(errorDialogs).isEmpty();
 
         check(composeBoxController.contentController.text)
-          .equals('see image: [Uploading image.jpg...]()\n\n');
+          .equals('see image: [Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')


### PR DESCRIPTION
We generally prefer … elsewhere in our codebase.

Motivated by https://github.com/zulip/zulip-flutter/pull/868#discussion_r1728101455