### PR TITLE
poll: Support read-only poll widget UI.

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -545,5 +545,13 @@
   "messageIsMovedLabel": "MOVED",
   "@messageIsMovedLabel": {
     "description": "Label for a moved message. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)"
+  },
+  "pollWidgetQuestionMissing": "No question.",
+  "@pollWidgetQuestionMissing": {
+    "description": "Text to display for a poll when the question is missing"
+  },
+  "pollWidgetOptionsMissing": "This poll has no options yet.",
+  "@pollWidgetOptionsMissing": {
+    "description": "Text to display for a poll when it has no options"
   }
 }

--- a/lib/api/model/submessage.dart
+++ b/lib/api/model/submessage.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import '../../log.dart';
@@ -354,7 +355,7 @@ class UnknownPollEventSubmessage extends PollEventSubmessage {
 /// See also:
 /// - https://zulip.com/help/create-a-poll
 /// - https://github.com/zulip/zulip/blob/304d948416465c1a085122af5d752f03d6797003/web/shared/src/poll_data.ts
-class Poll {
+class Poll extends ChangeNotifier {
   /// Construct a poll from submessages.
   ///
   /// For a poll Zulip widget, the first submessage's content contains a
@@ -412,6 +413,7 @@ class Poll {
       return;
     }
     _applyEvent(event.senderId, pollEventSubmessage);
+    notifyListeners();
   }
 
   void _applyEvent(int senderId, PollEventSubmessage event) {

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -4,6 +4,7 @@ import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart';
 
 import '../api/model/model.dart';
+import '../api/model/submessage.dart';
 import 'code_block.dart';
 
 /// A node in a parse tree for Zulip message-style content.
@@ -75,6 +76,16 @@ mixin UnimplementedNode on ContentNode {
 
 /// A parsed, ready-to-render representation of Zulip message content.
 sealed class ZulipMessageContent {}
+
+/// A wrapper around a mutable representation of a Zulip poll message.
+///
+/// Consumers are expected to listen for [Poll]'s changes to receive
+/// live-updates.
+class PollContent implements ZulipMessageContent {
+  const PollContent(this.poll);
+
+  final Poll poll;
+}
 
 /// A complete parse tree for a Zulip message's content,
 /// or other complete piece of Zulip HTML content.

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -73,13 +73,16 @@ mixin UnimplementedNode on ContentNode {
   }
 }
 
+/// A parsed, ready-to-render representation of Zulip message content.
+sealed class ZulipMessageContent {}
+
 /// A complete parse tree for a Zulip message's content,
 /// or other complete piece of Zulip HTML content.
 ///
 /// This is a parsed representation for an entire value of [Message.content],
 /// [Stream.renderedDescription], or other text from a Zulip server that comes
 /// in the same Zulip HTML format.
-class ZulipContent extends ContentNode {
+class ZulipContent extends ContentNode implements ZulipMessageContent {
   const ZulipContent({super.debugHtmlNode, required this.nodes});
 
   final List<BlockContentNode> nodes;

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -331,10 +331,8 @@ class MessageStoreImpl with MessageStore {
       return;
     }
 
+    // Live-updates for polls should not rebuild the message lists.
+    // [Poll] is responsible for notifying the affected listeners.
     poll.handleSubmessageEvent(event);
-
-    for (final view in _messageListViews) {
-      view.notifyListenersIfMessagePresent(event.messageId);
-    }
   }
 }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -35,7 +35,7 @@ class MessageListDateSeparatorItem extends MessageListItem {
 /// A message to show in the message list.
 class MessageListMessageItem extends MessageListItem {
   final Message message;
-  ZulipContent content;
+  ZulipMessageContent content;
   bool showSender;
   bool isLastInBlock;
 
@@ -98,7 +98,7 @@ mixin _MessageSequence {
   ///
   /// This information is completely derived from [messages].
   /// It exists as an optimization, to memoize the work of parsing.
-  final List<ZulipContent> contents = [];
+  final List<ZulipMessageContent> contents = [];
 
   /// The messages and their siblings in the UI, in order.
   ///
@@ -134,10 +134,14 @@ mixin _MessageSequence {
     }
   }
 
+  ZulipMessageContent _parseMessageContent(Message message) {
+    return parseContent(message.content);
+  }
+
   /// Update data derived from the content of the index-th message.
   void _reparseContent(int index) {
     final message = messages[index];
-    final content = parseContent(message.content);
+    final content = _parseMessageContent(message);
     contents[index] = content;
 
     final itemIndex = findItemWithMessageId(message.id);
@@ -154,7 +158,7 @@ mixin _MessageSequence {
   void _addMessage(Message message) {
     assert(contents.length == messages.length);
     messages.add(message);
-    contents.add(parseContent(message.content));
+    contents.add(_parseMessageContent(message));
     assert(contents.length == messages.length);
     _processMessage(messages.length - 1);
   }
@@ -197,7 +201,7 @@ mixin _MessageSequence {
   /// If none of [messageIds] are found, this is a no-op.
   bool _removeMessagesById(Iterable<int> messageIds) {
     final messagesToRemoveById = <int>{};
-    final contentToRemove = Set<ZulipContent>.identity();
+    final contentToRemove = Set<ZulipMessageContent>.identity();
     for (final messageId in messageIds) {
       final index = _findMessageWithId(messageId);
       if (index == -1) continue;
@@ -223,7 +227,7 @@ mixin _MessageSequence {
     assert(contents.length == messages.length);
     messages.insertAll(index, toInsert);
     contents.insertAll(index, toInsert.map(
-      (message) => parseContent(message.content)));
+      (message) => _parseMessageContent(message)));
     assert(contents.length == messages.length);
     _reprocessAll();
   }
@@ -243,7 +247,7 @@ mixin _MessageSequence {
   void _recompute() {
     assert(contents.length == messages.length);
     contents.clear();
-    contents.addAll(messages.map((message) => parseContent(message.content)));
+    contents.addAll(messages.map((message) => _parseMessageContent(message)));
     assert(contents.length == messages.length);
     _reprocessAll();
   }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -135,6 +135,8 @@ mixin _MessageSequence {
   }
 
   ZulipMessageContent _parseMessageContent(Message message) {
+    final poll = message.poll;
+    if (poll != null) return PollContent(poll);
     return parseContent(message.content);
   }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -18,6 +18,7 @@ import 'dialog.dart';
 import 'icons.dart';
 import 'lightbox.dart';
 import 'message_list.dart';
+import 'poll.dart';
 import 'store.dart';
 import 'text.dart';
 
@@ -263,6 +264,7 @@ class MessageContent extends StatelessWidget {
         style: ContentTheme.of(context).textStylePlainParagraph,
         child: switch (content) {
           ZulipContent() => BlockContentList(nodes: content.nodes),
+          PollContent()  => PollWidget(poll: content.poll),
         }));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -41,6 +41,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorGlobalTimeBorder: const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
+      colorPollNames: const HSLColor.fromAHSL(1, 0, 0, .45).toColor(),
+      colorPollVoteCountBackground: const HSLColor.fromAHSL(1, 0, 0, 1).toColor(),
+      colorPollVoteCountBorder: const HSLColor.fromAHSL(1, 156, 0.28, 0.7).toColor(),
+      colorPollVoteCountText: const HSLColor.fromAHSL(1, 156, 0.41, 0.4).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
@@ -66,6 +70,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorGlobalTimeBorder: const HSLColor.fromAHSL(0.4, 0, 0, 0).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
+      colorPollNames: const HSLColor.fromAHSL(1, 236, .15, .7).toColor(),
+      colorPollVoteCountBackground: const HSLColor.fromAHSL(0.2, 0, 0, 0).toColor(),
+      colorPollVoteCountBorder: const HSLColor.fromAHSL(1, 185, 0.35, 0.35).toColor(),
+      colorPollVoteCountText: const HSLColor.fromAHSL(1, 185, 0.35, 0.65).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withValues(alpha: 0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.85).toColor(),
@@ -90,6 +98,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.colorGlobalTimeBorder,
     required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
+    required this.colorPollNames,
+    required this.colorPollVoteCountBackground,
+    required this.colorPollVoteCountBorder,
+    required this.colorPollVoteCountText,
     required this.colorThematicBreak,
     required this.textStylePlainParagraph,
     required this.codeBlockTextStyles,
@@ -115,6 +127,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final Color colorGlobalTimeBorder;
   final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
+  final Color colorPollNames;
+  final Color colorPollVoteCountBackground;
+  final Color colorPollVoteCountBorder;
+  final Color colorPollVoteCountText;
   final Color colorThematicBreak;
 
   /// The complete [TextStyle] we use for plain, unstyled paragraphs.
@@ -166,6 +182,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     Color? colorGlobalTimeBorder,
     Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
+    Color? colorPollNames,
+    Color? colorPollVoteCountBackground,
+    Color? colorPollVoteCountBorder,
+    Color? colorPollVoteCountText,
     Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
     CodeBlockTextStyles? codeBlockTextStyles,
@@ -181,6 +201,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorGlobalTimeBorder: colorGlobalTimeBorder ?? this.colorGlobalTimeBorder,
       colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
+      colorPollNames: colorPollNames ?? this.colorPollNames,
+      colorPollVoteCountBackground: colorPollVoteCountBackground ?? this.colorPollVoteCountBackground,
+      colorPollVoteCountBorder: colorPollVoteCountBorder ?? this.colorPollVoteCountBorder,
+      colorPollVoteCountText: colorPollVoteCountText ?? this.colorPollVoteCountText,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
       codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
@@ -203,6 +227,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorGlobalTimeBorder: Color.lerp(colorGlobalTimeBorder, other.colorGlobalTimeBorder, t)!,
       colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
+      colorPollNames: Color.lerp(colorPollNames, other.colorPollNames, t)!,
+      colorPollVoteCountBackground: Color.lerp(colorPollVoteCountBackground, other.colorPollVoteCountBackground, t)!,
+      colorPollVoteCountBorder: Color.lerp(colorPollVoteCountBorder, other.colorPollVoteCountBorder, t)!,
+      colorPollVoteCountText: Color.lerp(colorPollVoteCountText, other.colorPollVoteCountText, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
       codeBlockTextStyles: CodeBlockTextStyles.lerp(codeBlockTextStyles, other.codeBlockTextStyles, t),

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -225,14 +225,17 @@ class MessageContent extends StatelessWidget {
   const MessageContent({super.key, required this.message, required this.content});
 
   final Message message;
-  final ZulipContent content;
+  final ZulipMessageContent content;
 
   @override
   Widget build(BuildContext context) {
+    final content = this.content;
     return InheritedMessage(message: message,
       child: DefaultTextStyle(
         style: ContentTheme.of(context).textStylePlainParagraph,
-        child: BlockContentList(nodes: content.nodes)));
+        child: switch (content) {
+          ZulipContent() => BlockContentList(nodes: content.nodes),
+        }));
   }
 }
 

--- a/lib/widgets/poll.dart
+++ b/lib/widgets/poll.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
+
+import '../api/model/submessage.dart';
+import 'content.dart';
+import 'store.dart';
+import 'text.dart';
+
+class PollWidget extends StatefulWidget {
+  const PollWidget({super.key, required this.poll});
+
+  final Poll poll;
+
+  @override
+  State<PollWidget> createState() => _PollWidgetState();
+}
+
+class _PollWidgetState extends State<PollWidget> {
+  @override
+  void initState() {
+    super.initState();
+    widget.poll.addListener(_modelChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant PollWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.poll != oldWidget.poll) {
+      oldWidget.poll.removeListener(_modelChanged);
+      widget.poll.addListener(_modelChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.poll.removeListener(_modelChanged);
+    super.dispose();
+  }
+
+  void _modelChanged() {
+    setState(() {
+      // The actual state lives in the [Poll] model.
+      // This method was called because that just changed.
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final theme = ContentTheme.of(context);
+    final store = PerAccountStoreWidget.of(context);
+
+    final textStyleBold = const TextStyle(fontSize: 18)
+      .merge(weightVariableTextStyle(context, wght: 600));
+    final textStyleVoterNames = TextStyle(
+      fontSize: 16, color: theme.colorPollNames);
+
+    Text question = (widget.poll.question.isNotEmpty)
+      ? Text(widget.poll.question, style: textStyleBold)
+      : Text(zulipLocalizations.pollWidgetQuestionMissing,
+          style: textStyleBold.copyWith(fontStyle: FontStyle.italic));
+
+    Widget buildOptionItem(PollOption option) {
+      // TODO(i18n): List formatting, like you can do in JavaScript:
+      //   new Intl.ListFormat('ja').format(['Chris', 'Greg', 'Alya', 'Zixuan'])
+      //   // 'Chris、Greg、Alya、Zixuan'
+      final voterNames = option.voters
+        .map((userId) =>
+          store.users[userId]?.fullName ?? zulipLocalizations.unknownUserName)
+        .join(', ');
+
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 5),
+        child: Row(
+          spacing: 5,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: localizedTextBaseline(context),
+          children: [
+            ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 25),
+              child: Container(
+                height: 25,
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                decoration: BoxDecoration(
+                  color: theme.colorPollVoteCountBackground,
+                  border: Border.all(color: theme.colorPollVoteCountBorder),
+                  borderRadius: BorderRadius.circular(3)),
+                child: Center(
+                  child: Text(option.voters.length.toString(),
+                    textAlign: TextAlign.center,
+                    style: textStyleBold.copyWith(
+                      color: theme.colorPollVoteCountText, fontSize: 13))))),
+            Expanded(
+              child: Wrap(
+                spacing: 5,
+                children: [
+                  Text(option.text, style: textStyleBold.copyWith(fontSize: 16)),
+                  if (option.voters.isNotEmpty)
+                    // TODO(i18n): Localize parenthesis characters.
+                    Text('($voterNames)', style: textStyleVoterNames),
+                ])),
+          ]));
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(padding: const EdgeInsets.only(bottom: 6), child: question),
+        if (widget.poll.options.isEmpty)
+          Text(zulipLocalizations.pollWidgetOptionsMissing,
+            style: textStyleVoterNames.copyWith(fontStyle: FontStyle.italic)),
+        for (final option in widget.poll.options)
+          buildOptionItem(option),
+      ]);
+  }
+}

--- a/test/model/content_checks.dart
+++ b/test/model/content_checks.dart
@@ -1,5 +1,7 @@
+import 'package:checks/checks.dart';
 import 'package:checks/context.dart';
 import 'package:flutter/foundation.dart';
+import 'package:zulip/api/model/submessage.dart';
 import 'package:zulip/model/content.dart';
 
 extension ContentNodeChecks on Subject<ContentNode> {
@@ -114,4 +116,8 @@ Iterable<LinkNode> _findLinkNodes(Iterable<InlineContentNode> nodes) {
     }
     return _findLinkNodes(node.nodes);
   });
+}
+
+extension PollContentChecks on Subject<PollContent> {
+  Subject<Poll> get poll => has((x) => x.poll, 'poll');
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1257,12 +1257,13 @@ void main() {
     model.contents[0] = const ZulipContent(nodes: [
       ParagraphNode(links: null, nodes: [TextNode('something outdated')])
     ]);
-    check(model.contents[0]).not((it) => it.equalsNode(correctContent));
+    check(model.contents[0]).isA<ZulipContent>()
+      .not((it) => it.equalsNode(correctContent));
 
     model.reassemble();
     checkNotifiedOnce();
     check(model).messages.length.equals(31);
-    check(model.contents[0]).equalsNode(correctContent);
+    check(model.contents[0]).isA<ZulipContent>().equalsNode(correctContent);
   });
 
   group('stream/topic muting', () {
@@ -1740,7 +1741,7 @@ void checkInvariants(MessageListView model) {
 
   check(model).contents.length.equals(model.messages.length);
   for (int i = 0; i < model.contents.length; i++) {
-    check(model.contents[i])
+    check(model.contents[i]).isA<ZulipContent>()
       .equalsNode(parseContent(model.messages[i].content));
   }
 
@@ -1790,7 +1791,7 @@ extension MessageListDateSeparatorItemChecks on Subject<MessageListDateSeparator
 
 extension MessageListMessageItemChecks on Subject<MessageListMessageItem> {
   Subject<Message> get message => has((x) => x.message, 'message');
-  Subject<ZulipContent> get content => has((x) => x.content, 'content');
+  Subject<ZulipMessageContent> get content => has((x) => x.content, 'content');
   Subject<bool> get showSender => has((x) => x.showSender, 'showSender');
   Subject<bool> get isLastInBlock => has((x) => x.isLastInBlock, 'isLastInBlock');
 }
@@ -1799,7 +1800,7 @@ extension MessageListViewChecks on Subject<MessageListView> {
   Subject<PerAccountStore> get store => has((x) => x.store, 'store');
   Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
   Subject<List<Message>> get messages => has((x) => x.messages, 'messages');
-  Subject<List<ZulipContent>> get contents => has((x) => x.contents, 'contents');
+  Subject<List<ZulipMessageContent>> get contents => has((x) => x.contents, 'contents');
   Subject<List<MessageListItem>> get items => has((x) => x.items, 'items');
   Subject<bool> get fetched => has((x) => x.fetched, 'fetched');
   Subject<bool> get haveOldest => has((x) => x.haveOldest, 'haveOldest');

--- a/test/widgets/poll_test.dart
+++ b/test/widgets/poll_test.dart
@@ -1,0 +1,109 @@
+import 'package:checks/checks.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_checks/flutter_checks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/model/events.dart';
+import 'package:zulip/api/model/model.dart';
+import 'package:zulip/api/model/submessage.dart';
+import 'package:zulip/model/store.dart';
+import 'package:zulip/widgets/poll.dart';
+
+import '../example_data.dart' as eg;
+import '../model/binding.dart';
+import '../model/test_store.dart';
+import 'test_app.dart';
+
+void main() {
+  TestZulipBinding.ensureInitialized();
+
+  late PerAccountStore store;
+
+  Future<void> preparePollWidget(
+    WidgetTester tester,
+    SubmessageData? submessageContent, {
+    Iterable<User>? users,
+    Iterable<(User, int)> voterIdxPairs = const [],
+  }) async {
+    addTearDown(testBinding.reset);
+    await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+    store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+    await store.addUsers(users ?? [eg.selfUser, eg.otherUser]);
+
+    Message message = eg.streamMessage(
+      sender: eg.selfUser,
+      submessages: [eg.submessage(content: submessageContent)]);
+    await store.handleEvent(MessageEvent(id: 0, message: message));
+    await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+      child: PollWidget(poll: message.poll!)));
+    await tester.pump();
+
+    for (final (voter, idx) in voterIdxPairs) {
+      await store.handleEvent(eg.submessageEvent(message.id, voter.userId,
+        content: PollVoteEventSubmessage(
+          key: PollEventSubmessage.optionKey(senderId: null, idx: idx),
+          op: PollVoteOp.add)));
+    }
+    await tester.pump();
+  }
+
+  Finder findInPoll(Finder matching) =>
+    find.descendant(of: find.byType(PollWidget), matching: matching);
+
+  Finder findTextAtRow(String text, {required int index}) =>
+    find.descendant(
+      of: findInPoll(find.byType(Row)).at(index), matching: find.text(text));
+
+  testWidgets('smoke', (tester) async {
+    await preparePollWidget(tester,
+      eg.pollWidgetData(question: 'favorite letter', options: ['A', 'B', 'C']),
+      voterIdxPairs: [
+        (eg.selfUser, 0),
+        (eg.selfUser, 1),
+        (eg.otherUser, 1),
+      ]);
+
+    check(findInPoll(find.text('favorite letter'))).findsOne();
+
+    check(findTextAtRow('A', index: 0)).findsOne();
+    check(findTextAtRow('1', index: 0)).findsOne();
+    check(findTextAtRow('(${eg.selfUser.fullName})', index: 0)).findsOne();
+
+    check(findTextAtRow('B', index: 1)).findsOne();
+    check(findTextAtRow('2', index: 1)).findsOne();
+    check(findTextAtRow(
+      '(${eg.selfUser.fullName}, ${eg.otherUser.fullName})', index: 1)).findsOne();
+
+    check(findTextAtRow('C', index: 2)).findsOne();
+    check(findTextAtRow('0', index: 2)).findsOne();
+  });
+
+  final pollWidgetData = eg.pollWidgetData(question: 'poll', options: ['A', 'B']);
+
+  testWidgets('a lot of voters', (tester) async {
+    final users = List.generate(100, (i) => eg.user(fullName: 'user#$i'));
+    await preparePollWidget(tester, pollWidgetData,
+      users: users, voterIdxPairs: users.map((user) => (user, 0)));
+
+    final allUserNames = '(${users.map((user) => user.fullName).join(', ')})';
+    check(findTextAtRow(allUserNames, index: 0)).findsOne();
+    check(findTextAtRow('100', index: 0)).findsOne();
+  });
+
+  testWidgets('show unknown voter', (tester) async {
+    await preparePollWidget(tester, pollWidgetData,
+      users: [eg.selfUser], voterIdxPairs: [(eg.thirdUser, 1)]);
+    check(findInPoll(find.text('((unknown user))'))).findsOne();
+  });
+
+  testWidgets('poll title missing', (tester) async {
+    await preparePollWidget(tester, eg.pollWidgetData(
+      question: '', options: ['A']));
+    check(findInPoll(find.text('No question.'))).findsOne();
+  });
+
+  testWidgets('poll options missing', (tester) async {
+    await preparePollWidget(tester, eg.pollWidgetData(
+      question: 'title', options: []));
+    check(findInPoll(find.text('This poll has no options yet.'))).findsOne();
+  });
+}


### PR DESCRIPTION
The UI follows the webapp until we get a new design.

The dark theme colors were tentatively picked. The `TextStyle`s are the same for both light and dark theme. All the styling are based on values taken from the webapp.

References:

  - light theme:

    https://github.com/zulip/zulip/blob/2011e0df760cea52c31914e7b77d9b4e38e9ee74/web/styles/widgets.css#L138-L185 https://github.com/zulip/zulip/blob/2011e0df760cea52c31914e7b77d9b4e38e9ee74/web/styles/dark_theme.css#L358

  - dark theme:

    https://github.com/zulip/zulip/blob/2011e0df760cea52c31914e7b77d9b4e38e9ee74/web/styles/dark_theme.css#L966-L987

Fixes #165.