### PR TITLE
Handle the case when a code block has no grandchildren

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -990,7 +990,7 @@ class _ZulipContentParser {
       if (child is! dom.Element) return null;
       if (child.localName != 'pre') return null;
 
-      if (child.nodes.length > 2) return null;
+      if (child.nodes.length > 2 || child.nodes.isEmpty) return null;
       if (child.nodes.length == 2) {
         final first = child.nodes[0];
         if (first is! dom.Element

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -986,7 +986,7 @@ class _ZulipContentParser {
           && divElement.className == "codehilite");
 
       if (divElement.nodes.length != 1) return null;
-      final child = divElement.nodes[0];
+      final child = divElement.nodes.single;
       if (child is! dom.Element) return null;
       if (child.localName != 'pre') return null;
 
@@ -997,7 +997,7 @@ class _ZulipContentParser {
             || first.localName != 'span'
             || first.nodes.isNotEmpty) return null;
       }
-      final grandchild = child.nodes[child.nodes.length - 1];
+      final grandchild = child.nodes.last;
       if (grandchild is! dom.Element) return null;
       if (grandchild.localName != 'code') return null;
 

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -344,6 +344,17 @@ class ContentExample {
       ]),
     ]);
 
+  // Current servers no longer produce this, but it can be found in ancient
+  // messages.  For example:
+  //   https://chat.zulip.org/#narrow/stream/2-general/topic/Error.20in.20dev.20server/near/18765
+  static final codeBlockWithEmptyBody = ContentExample(
+      'code block, with an empty body',
+      '```',
+      '<div class="codehilite"><pre></pre></div>', [
+      blockUnimplemented(
+          '<div class="codehilite"><pre></pre></div>'),
+  ]);
+
   static final codeBlockWithHighlightedLines = ContentExample(
     'code block, with syntax highlighting and highlighted lines',
     '```\n::markdown hl_lines="2 4"\n# he\n## llo\n### world\n```',
@@ -1149,6 +1160,7 @@ void main() {
   testParseExample(ContentExample.codeBlockPlain);
   testParseExample(ContentExample.codeBlockHighlightedShort);
   testParseExample(ContentExample.codeBlockHighlightedMultiline);
+  testParseExample(ContentExample.codeBlockWithEmptyBody);
   testParseExample(ContentExample.codeBlockWithHighlightedLines);
   testParseExample(ContentExample.codeBlockWithUnknownSpanType);
   testParseExample(ContentExample.codeBlockFollowedByMultipleLineBreaks);


### PR DESCRIPTION
For some very old messages (e.g.: [this](https://chat.zulip.org/#narrow/stream/2-general/topic/Error.20in.20dev.20server/near/18765)), a code block might contain no grandchildren, or equivalently, the `<pre></pre>` block within the `<div class="codehilite"></div>` element is empty.

While these messages might be present on CZO only due to some ancient server bugs, the client should not crash when it does encounter them.

```
Crashes:
- RangeError (length): Invalid value: Valid value range is empty: -1
  Oldest message: 5020; newest message: 29855
```