### PR TITLE
deps: Add some overrides to unblock Flutter Color API changes for wide-gamut

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -199,12 +199,13 @@ packages:
     source: hosted
     version: "1.19.0"
   color_models:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: color_models
-      sha256: "3683f0a461570161ca22b7d3e1765b2ce2bce3534db14e00d5ee458d0287abac"
-      url: "https://pub.dev"
-    source: hosted
+      path: color_models
+      ref: wide-gamut
+      resolved-ref: "27298bc2cbfc9f1da08503be68da472076bcb61c"
+      url: "https://github.com/gaaclarke/color_models.git"
+    source: git
     version: "1.3.3"
   convert:
     dependency: "direct main"
@@ -422,11 +423,12 @@ packages:
   flutter_color_models:
     dependency: "direct main"
     description:
-      name: flutter_color_models
-      sha256: "8454198ba9a82e533452d0764f1df3d6c3ccc2b33e18eb1f2fedc7ae4a5c43be"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.3+2"
+      path: flutter_color_models
+      ref: wide-gamut
+      resolved-ref: "27298bc2cbfc9f1da08503be68da472076bcb61c"
+      url: "https://github.com/gaaclarke/color_models.git"
+    source: git
+    version: "1.4.0"
   flutter_driver:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,22 @@ dependencies:
     path: ./packages/zulip_plugin
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 
+dependency_overrides:
+  # TODO(#918) remove this and `flutter_color_models` when `flutter_color_models` accommodates
+  #   wide-gamut adjustments to Flutter's `Color`. A PR to `flutter_color_models` is already open:
+  #     https://github.com/james-alex/color_models/pull/10
+  color_models:
+    git:
+      url: https://github.com/gaaclarke/color_models.git
+      ref: wide-gamut
+      path: color_models
+  flutter_color_models:
+    git:
+      url: https://github.com/gaaclarke/color_models.git
+      ref: wide-gamut
+      path: flutter_color_models
+
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter


### PR DESCRIPTION
This commit follows the request in
  https://github.com/flutter/flutter/issues/154123
by pointing to a Flutter maintainer's fork of `flutter_color_model` and `color_model` while we wait for their PR from that fork to be settled.

To validate this change, I checked out the roll from engine-flutter-autoroll that failed on our tests:
  https://github.com/flutter/flutter/pull/153985
and confirmed that our tests (the ones that run with `tools/check test --all`) failed with same-looking errors before this change and passed after this change.

I did run all of `tools/check --all`, not just the `test` suite. There was "info"-level output from the analyzer telling us about things we've been using that will be deprecated with the proposed Color API change (`Color.value` and `Color.withOpacity`). We'll want to respond promptly to these deprecation notices -- and in fact our CI treats this "info"-level output as an error -- but I think we can leave that out of scope for the customer-tests fix, because we've set it so "info"-level analyzer output isn't fatal there:
  https://github.com/flutter/tests/commit/54cc35f9f#diff-d2bef7bb93d58c3db877456685dad3e25d1546c1fc318e9d6c560e91c457eaa7R10