### PR TITLE
msglist: Fix mark-as-read button icon color in dark mode

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -758,6 +758,7 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
                 // state is disabled, pressed, etc.  We handle those states
                 // separately, via MarkAsReadAnimation.
                 foregroundColor: const WidgetStatePropertyAll(Colors.white),
+                iconColor: const WidgetStatePropertyAll(Colors.white),
                 backgroundColor: WidgetStatePropertyAll(messageListTheme.unreadMarker),
               ),
               onPressed: _loading ? null : () => _handlePress(context),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -757,8 +757,8 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
                 // Give the buttons a constant color regardless of whether their
                 // state is disabled, pressed, etc.  We handle those states
                 // separately, via MarkAsReadAnimation.
-                foregroundColor: WidgetStateColor.resolveWith((_) => Colors.white),
-                backgroundColor: WidgetStateColor.resolveWith((_) => messageListTheme.unreadMarker),
+                foregroundColor: const WidgetStatePropertyAll(Colors.white),
+                backgroundColor: WidgetStatePropertyAll(messageListTheme.unreadMarker),
               ),
               onPressed: _loading ? null : () => _handlePress(context),
               icon: const Icon(Icons.playlist_add_check),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -745,13 +745,13 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
                   // Restate [FilledButton]'s default, which inherits from
                   // [zulipTypography]…
                   Theme.of(context).textTheme.labelLarge!
-                  // …then clobber some attributes to follow Figma:
-                  .merge(TextStyle(
-                    fontSize: 18,
-                    letterSpacing: proportionalLetterSpacing(context,
-                      kButtonTextLetterSpacingProportion, baseFontSize: 18),
-                    height: (23 / 18))
-                  .merge(weightVariableTextStyle(context, wght: 400))),
+                    // …then clobber some attributes to follow Figma:
+                    .merge(TextStyle(
+                      fontSize: 18,
+                      letterSpacing: proportionalLetterSpacing(context,
+                        kButtonTextLetterSpacingProportion, baseFontSize: 18),
+                      height: (23 / 18))
+                    .merge(weightVariableTextStyle(context, wght: 400))),
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(7)),
               ).copyWith(
                 // Give the buttons a constant color regardless of whether their


### PR DESCRIPTION
    msglist: Fix mark-as-read button icon color in dark mode
    
    After sweeping through the message-list screen to implement dark
    theme (#843), in late July, the Flutter framework merged
    flutter/flutter#143501, in early August. This made it so our
    `foregroundColor` no longer controlled the icon color, as promised
    in the dartdocs of `foregroundColor` and `iconColor`.
    
    I opened an issue for Flutter about the inconsistency with the doc:
      https://github.com/flutter/flutter/issues/154644
    and sent a PR to resolve it, by updating the doc (which the author
    of 143501 had said was the right fix):
      https://github.com/flutter/flutter/pull/154646
    
Fixes: #926
