### PR TITLE
channel [nfc]: Document methods on ChannelStore; expose debugTopicVisibility directly

### DIFF
--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../api/model/events.dart';
 import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
@@ -40,6 +42,16 @@ mixin ChannelStore {
   /// For policies directly applicable in the UI, see
   /// [isTopicVisibleInStream] and [isTopicVisible].
   UserTopicVisibilityPolicy topicVisibilityPolicy(int streamId, String topic);
+
+  /// The raw data structure underlying [topicVisibilityPolicy].
+  ///
+  /// This is sometimes convenient for checks in tests.
+  /// It differs from [topicVisibilityPolicy] in on the one hand omitting
+  /// all topics where the value would be [UserTopicVisibilityPolicy.none],
+  /// and on the other hand being a concrete, finite data structure that
+  /// can be compared using `deepEquals`.
+  @visibleForTesting
+  Map<int, Map<String, UserTopicVisibilityPolicy>> get debugTopicVisibility;
 
   /// Whether this topic should appear when already focusing on its stream.
   ///
@@ -190,6 +202,9 @@ class ChannelStoreImpl with ChannelStore {
   final Map<String, ZulipStream> streamsByName;
   @override
   final Map<int, Subscription> subscriptions;
+
+  @override
+  Map<int, Map<String, UserTopicVisibilityPolicy>> get debugTopicVisibility => topicVisibility;
 
   final Map<int, Map<String, UserTopicVisibilityPolicy>> topicVisibility;
 

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -9,9 +9,36 @@ import '../api/model/model.dart';
 ///
 /// The data structures described here are implemented at [ChannelStoreImpl].
 mixin ChannelStore {
+  /// All known channels/streams, indexed by [ZulipStream.streamId].
+  ///
+  /// The same [ZulipStream] objects also appear in [streamsByName].
+  ///
+  /// For channels the self-user is subscribed to, the value is in fact
+  /// a [Subscription] object and also appears in [subscriptions].
   Map<int, ZulipStream> get streams;
+
+  /// All known channels/streams, indexed by [ZulipStream.name].
+  ///
+  /// The same [ZulipStream] objects also appear in [streams].
+  ///
+  /// For channels the self-user is subscribed to, the value is in fact
+  /// a [Subscription] object and also appears in [subscriptions].
   Map<String, ZulipStream> get streamsByName;
+
+  /// All the channels the self-user is subscribed to, indexed by
+  /// [Subscription.streamId], with subscription details.
+  ///
+  /// The same [Subscription] objects are among the values in [streams]
+  /// and [streamsByName].
   Map<int, Subscription> get subscriptions;
+
+  /// The visibility policy that the self-user has for the given topic.
+  ///
+  /// This does not incorporate the user's channel-level policy,
+  /// and is mainly used in the implementation of other [ChannelStore] methods.
+  ///
+  /// For policies directly applicable in the UI, see
+  /// [isTopicVisibleInStream] and [isTopicVisible].
   UserTopicVisibilityPolicy topicVisibilityPolicy(int streamId, String topic);
 
   /// Whether this topic should appear when already focusing on its stream.

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -355,11 +355,11 @@ class PerAccountStore extends ChangeNotifier with ChannelStore, MessageStore {
   @override
   UserTopicVisibilityPolicy topicVisibilityPolicy(int streamId, String topic) =>
     _channels.topicVisibilityPolicy(streamId, topic);
+  @override
+  Map<int, Map<String, UserTopicVisibilityPolicy>> get debugTopicVisibility =>
+    _channels.debugTopicVisibility;
 
   final ChannelStoreImpl _channels;
-
-  @visibleForTesting
-  ChannelStoreImpl get debugChannelStore => _channels;
 
   ////////////////////////////////
   // Messages, and summaries of messages.

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -295,8 +295,8 @@ void main() {
       final expectedStore = eg.store(initialSnapshot: eg.initialSnapshot(
         userTopics: expected,
       ));
-      check(store.debugChannelStore.topicVisibility)
-        .deepEquals(expectedStore.debugChannelStore.topicVisibility);
+      check(store.debugTopicVisibility)
+        .deepEquals(expectedStore.debugTopicVisibility);
     }
 
     test('data structure', () {
@@ -308,7 +308,7 @@ void main() {
           eg.userTopicItem(stream2, 'topic 3', UserTopicVisibilityPolicy.unknown),
           eg.userTopicItem(stream2, 'topic 4', UserTopicVisibilityPolicy.followed),
         ]));
-      check(store.debugChannelStore.topicVisibility).deepEquals({
+      check(store.debugTopicVisibility).deepEquals({
         stream1.streamId: {
           'topic 1': UserTopicVisibilityPolicy.muted,
           'topic 2': UserTopicVisibilityPolicy.unmuted,


### PR DESCRIPTION
These members didn't have docs. They have some nontrivial invariants, so can especially benefit from docs.

Then this arrangement of debugTopicVisibility
follows the pattern we generally use for other members of
ChannelStore and MessageStore, and lets us eliminate the getter
returning a ChannelStoreImpl.

This pattern -- exposing all the data as members directly on the
overall PerAccountStore, delegating to the underlying channel store
and message store as needed -- is convenient because it means that
code consuming the store doesn't have to worry about which sub-area
of the store we've organized a given piece of data into: it's all
just methods on the store.

Noticed this was here while reviewing a PR that included a new
similar deviation from this pattern (/cc @PIG208):
  https://github.com/zulip/zulip-flutter/pull/909#discussion_r1747875935


