### PR TITLE
lightbox: Replace onDismiss with `await showErrorDialog`

### DIFF
--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -15,26 +15,23 @@ Widget _dialogActionText(String text) {
   );
 }
 
+/// Displays an [AlertDialog] with a dismiss button.
+///
+/// Returns a [Future] that resolves when the dialog is closed.
 Future<void> showErrorDialog({
   required BuildContext context,
   required String title,
   String? message,
-  VoidCallback? onDismiss,
 }) {
   final zulipLocalizations = ZulipLocalizations.of(context);
   return showDialog(
     context: context,
-    // `showDialog` doesn't take an `onDismiss`, so dismissing via the barrier
-    // always causes the default dismiss behavior of popping just this route.
-    // When we want a non-default `onDismiss`, disable that.
-    // TODO(upstream): add onDismiss to showDialog, passing through to [ModalBarrier.onDismiss]
-    barrierDismissible: onDismiss == null,
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),
       content: message != null ? SingleChildScrollView(child: Text(message)) : null,
       actions: [
         TextButton(
-          onPressed: onDismiss ?? () => Navigator.pop(context),
+          onPressed: () => Navigator.pop(context),
           child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
       ]));
 }

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -474,17 +474,15 @@ class _VideoLightboxPageState extends State<VideoLightboxPage> with PerAccountSt
       await _controller!.play();
     } catch (error) { // TODO(log)
       assert(debugLog("VideoPlayerController.initialize failed: $error"));
-      if (mounted) {
-        final zulipLocalizations = ZulipLocalizations.of(context);
-        await showErrorDialog(
-          context: context,
-          title: zulipLocalizations.errorDialogTitle,
-          message: zulipLocalizations.errorVideoPlayerFailed,
-          onDismiss: () {
-            Navigator.pop(context); // Pops the dialog
-            Navigator.pop(context); // Pops the lightbox
-          });
-      }
+      if (!mounted) return;
+      final zulipLocalizations = ZulipLocalizations.of(context);
+      // Wait until the dialog is closed
+      await showErrorDialog(
+        context: context,
+        title: zulipLocalizations.errorDialogTitle,
+        message: zulipLocalizations.errorVideoPlayerFailed);
+      if (!mounted) return;
+      Navigator.pop(context); // Pops the lightbox
     }
   }
 


### PR DESCRIPTION
`showDialog` returns a `Future` that resolves when the dialog is dismissed.

This refactors `showErrorDialog` to stop overriding `onPressed` and `barrierIsDismissable`, and make the caller call Navigator.pop one more time once the dialog is closed.

Note that we check for `mounted` again because there has been an asynchronous gap.

See also:
  https://github.com/zulip/zulip-flutter/pull/587#discussion_r1585845428