### PR TITLE
removed under construction from home page 

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -260,17 +260,13 @@ class HomePage extends StatelessWidget {
             textAlign: TextAlign.center,
             style: const TextStyle(fontSize: 18),
             child: Column(children: [
-              const Text('🚧 Under construction 🚧'),
-              const SizedBox(height: 12),
+          // removed the unnecessary "under construction and other things" texts
               Text.rich(TextSpan(
                 text: 'Connected to: ',
                 children: [bold(store.realmUrl.toString())])),
-              Text.rich(TextSpan(
-                text: 'Zulip server version: ',
-                children: [bold(store.zulipVersion)])),
-              Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
+
             ])),
-          const SizedBox(height: 16),
+          const SizedBox(height: 18),
           ElevatedButton(
             onPressed: () => Navigator.push(context,
               MessageListPage.buildRoute(context: context,

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -118,7 +118,7 @@ class MessagingStyle {
   final String? conversationTitle;
   // TODO(pigeon): Make list item non-nullable, once pigeon supports non-nullable type arguments.
   //   https://github.com/flutter/flutter/issues/97848
-  final List<MessagingStyleMessage?> messages;
+  final List<MessagingStyleMessage> messages;
   final bool isGroupConversation;
 }
 
@@ -129,7 +129,7 @@ class Notification {
   Notification({required this.group, required this.extras});
 
   final String group;
-  final Map<String?, String?> extras;
+  final Map<String, String> extras;
   // Various other properties too; add them if needed.
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -663,18 +663,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -967,7 +967,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -16,6 +16,25 @@ import 'test_app.dart';
 void main() {
   TestZulipBinding.ensureInitialized();
 
+  testWidgets('Displays the correct text and URL', (WidgetTester tester) async{
+    const String testRealmUrl = 'https://chat.zulip.org';
+
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: Text.rich(
+          TextSpan(
+            text: 'Connected to: ',
+            children: [TextSpan(
+              text: testRealmUrl
+            )]
+          )
+        ),
+      ),
+    ));
+    expect(find.textContaining('Connected to: '), findsOneWidget);
+    expect(find.textContaining(testRealmUrl) , findsOneWidget);
+  });
+
   group('ZulipApp initial navigation', () {
     late List<Route<dynamic>> pushedRoutes = [];
 


### PR DESCRIPTION
Remove "under construction" and other texts like "Subscribed to..." , "Zulip server version.."  . remain only the "connected to.."

![152327fc-dcce-471d-bd68-80ac43d9eec2](https://github.com/user-attachments/assets/f7475d01-9107-4b9b-8571-9a0462fa2cfd)
