### PR TITLE
check: Use --text when potentially diffing generated files

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -189,7 +189,8 @@ files_check() {
 check_no_changes() {
     local change_description="$1"; shift
 
-    if git diff --quiet -- "$@" \
+    # To include files excluded in `.gitattributes`, --text is necessary.
+    if git diff --text --quiet -- "$@" \
             && no_untracked_files "$@"; then
         return
     fi

--- a/tools/check
+++ b/tools/check
@@ -189,8 +189,9 @@ files_check() {
 check_no_changes() {
     local change_description="$1"; shift
 
-    # To include files excluded in `.gitattributes`, --text is necessary.
-    if git diff --text --quiet -- "$@" \
+    # We use `git diff -a` in order to include all matching files,
+    # overriding our `.gitattributes` which excludes generated files.
+    if git diff -a --quiet -- "$@" \
             && no_untracked_files "$@"; then
         return
     fi


### PR DESCRIPTION
The diffs generated from running `tools/check build_runner` were not detected.  See comment: https://github.com/zulip/zulip-flutter/pull/904#discussion_r1762083210

We normally exclude diffs from generated files through our `.gitattributes` configurations.  This happens to `git --quiet -- [<path>...]` too.  -a/--text allows us to include those files regardless.