### PR TITLE
test: Use color checks that tolerate floating-point errors

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1360,5 +1360,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.6.0-217.0.dev <4.0.0"
-  flutter: ">=3.25.0-1.0.pre.296"
+  dart: ">=3.6.0-263.0.dev <4.0.0"
+  flutter: ">=3.26.0-1.0.pre.155"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,6 +420,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_checks:
+    dependency: "direct main"
+    description:
+      name: flutter_checks
+      sha256: b0a40b15d38436b7c08b83353e74b0569c1ec687bd81c9556091fbb8807c1b99
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   flutter_color_models:
     dependency: "direct main"
     description:
@@ -683,6 +691,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  legacy_checks:
+    dependency: "direct main"
+    description:
+      name: legacy_checks
+      sha256: b22e5b1ff55a14e8bd91acafbabff909e14829b73ca492dcdaf0fbbb70476079
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,8 @@ dependencies:
   video_player: ^2.8.3
   zulip_plugin:
     path: ./packages/zulip_plugin
+  flutter_checks: ^0.1.1
+  legacy_checks: ^0.1.0
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.6.0-217.0.dev <4.0.0'
-  flutter: '>=3.25.0-1.0.pre.296'
+  sdk: '>=3.6.0-263.0.dev <4.0.0'
+  flutter: '>=3.26.0-1.0.pre.155'
 
 # To update dependencies, see instructions in README.md.
 dependencies:

--- a/test/widgets/channel_colors_test.dart
+++ b/test/widgets/channel_colors_test.dart
@@ -1,9 +1,11 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/channel_colors.dart';
 
 import 'channel_colors_checks.dart';
+import 'colors_checks.dart';
 
 void main() {
   group('ChannelColorSwatches', () {
@@ -12,12 +14,12 @@ void main() {
 
       const base1 = 0xff76ce90;
       final swatch1 = instance.forBaseColor(base1);
-      check(swatch1).equals(ChannelColorSwatch.light(base1));
+      check(swatch1).isSameColorSwatchAs(ChannelColorSwatch.light(base1));
       check(instance.forBaseColor(base1)).identicalTo(swatch1);
 
       const base2 = 0xfffae589;
       final swatch2 = instance.forBaseColor(base2);
-      check(swatch2).equals(ChannelColorSwatch.light(base2));
+      check(swatch2).isSameColorSwatchAs(ChannelColorSwatch.light(base2));
       check(instance.forBaseColor(base2)).identicalTo(swatch2);
       check(instance.forBaseColor(base1)).identicalTo(swatch1);
     });
@@ -28,12 +30,12 @@ void main() {
 
       const base1 = 0xff76ce90;
       final swatch1 = instance.forBaseColor(base1);
-      check(swatch1).equals(ChannelColorSwatch.dark(base1));
+      check(swatch1).isSameColorSwatchAs(ChannelColorSwatch.dark(base1));
       check(instance.forBaseColor(base1)).identicalTo(swatch1);
 
       const base2 = 0xfffae589;
       final swatch2 = instance.forBaseColor(base2);
-      check(swatch2).equals(ChannelColorSwatch.dark(base2));
+      check(swatch2).isSameColorSwatchAs(ChannelColorSwatch.dark(base2));
       check(instance.forBaseColor(base2)).identicalTo(swatch2);
       check(instance.forBaseColor(base1)).identicalTo(swatch1);
     });
@@ -53,13 +55,13 @@ void main() {
 
         const base1 = 0xff76ce90;
         final swatch1 = instance.forBaseColor(base1);
-        check(swatch1).equals(ChannelColorSwatch.lerp(
+        check(swatch1).isSameColorSwatchAs(ChannelColorSwatch.lerp(
           ChannelColorSwatch.light(base1), ChannelColorSwatch.dark(base1), 0.4)!);
         check(instance.forBaseColor(base1)).identicalTo(swatch1);
 
         const base2 = 0xfffae589;
         final swatch2 = instance.forBaseColor(base2);
-        check(swatch2).equals(ChannelColorSwatch.lerp(
+        check(swatch2).isSameColorSwatchAs(ChannelColorSwatch.lerp(
           ChannelColorSwatch.light(base2), ChannelColorSwatch.dark(base2), 0.4)!);
         check(instance.forBaseColor(base2)).identicalTo(swatch2);
         check(instance.forBaseColor(base1)).identicalTo(swatch1);
@@ -70,12 +72,14 @@ void main() {
   group('ChannelColorSwatch', () {
     group('light', () {
       test('base', () {
-        check(ChannelColorSwatch.light(0xffffffff)).base.equals(const Color(0xffffffff));
+        check(ChannelColorSwatch.light(0xffffffff))
+          .base.isSameColorAs(const Color(0xffffffff));
       });
 
       test('unreadCountBadgeBackground', () {
         void runCheck(int base, Color expected) {
-          check(ChannelColorSwatch.light(base)).unreadCountBadgeBackground.equals(expected);
+          check(ChannelColorSwatch.light(base))
+            .unreadCountBadgeBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS and EXTREME_COLORS
@@ -137,7 +141,8 @@ void main() {
 
       test('iconOnPlainBackground', () {
         void runCheck(int base, Color expected) {
-          check(ChannelColorSwatch.light(base)).iconOnPlainBackground.equals(expected);
+          check(ChannelColorSwatch.light(base))
+            .iconOnPlainBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -178,7 +183,8 @@ void main() {
 
       test('iconOnBarBackground', () {
         void runCheck(int base, Color expected) {
-          check(ChannelColorSwatch.light(base)).iconOnBarBackground.equals(expected);
+          check(ChannelColorSwatch.light(base))
+            .iconOnBarBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -219,7 +225,8 @@ void main() {
 
       test('barBackground', () {
         void runCheck(int base, Color expected) {
-          check(ChannelColorSwatch.light(base)).barBackground.equals(expected);
+          check(ChannelColorSwatch.light(base))
+            .barBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -262,13 +269,13 @@ void main() {
     group('dark', () {
       test('base', () {
         check(ChannelColorSwatch.dark(0xffffffff))
-          .base.equals(const Color(0xffffffff));
+          .base.isSameColorAs(const Color(0xffffffff));
       });
 
       test('unreadCountBadgeBackground', () {
         void runCheck(int base, Color expected) {
           check(ChannelColorSwatch.dark(base))
-            .unreadCountBadgeBackground.equals(expected);
+            .unreadCountBadgeBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS and EXTREME_COLORS
@@ -331,7 +338,7 @@ void main() {
       test('iconOnPlainBackground', () {
         void runCheck(int base, Color expected) {
           check(ChannelColorSwatch.dark(base))
-            .iconOnPlainBackground.equals(expected);
+            .iconOnPlainBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -373,7 +380,7 @@ void main() {
       test('iconOnBarBackground', () {
         void runCheck(int base, Color expected) {
           check(ChannelColorSwatch.dark(base))
-            .iconOnBarBackground.equals(expected);
+            .iconOnBarBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -415,7 +422,7 @@ void main() {
       test('barBackground', () {
         void runCheck(int base, Color expected) {
           check(ChannelColorSwatch.dark(base))
-            .barBackground.equals(expected);
+            .barBackground.isSameColorAs(expected);
         }
 
         // Check against everything in ZULIP_ASSIGNMENT_COLORS
@@ -473,7 +480,7 @@ void main() {
             ChannelColorVariant.barBackground => (check(result).barBackground,
               Color.lerp(swatchA.barBackground, swatchB.barBackground, t)!),
           };
-          subject.equals(expected);
+          subject.isSameColorAs(expected);
         }
       }
     });
@@ -484,7 +491,7 @@ void main() {
       final swatch = ChannelColorSwatch.light(0xff76ce90);
       check(ChannelColorSwatch.lerp(swatch, swatch, 0.5)).isNotNull()
         ..identicalTo(swatch)
-        ..base.equals(const Color(0xff76ce90));
+        ..base.isSameColorAs(const Color(0xff76ce90));
     });
   });
 }

--- a/test/widgets/colors_checks.dart
+++ b/test/widgets/colors_checks.dart
@@ -1,0 +1,11 @@
+import 'package:checks/checks.dart';
+import 'package:flutter_test/flutter_test.dart' as flutter_matcher;
+import 'package:flutter/painting.dart';
+import 'package:legacy_checks/legacy_checks.dart';
+
+extension ColorSwatchChecks<T> on Subject<ColorSwatch<T>> {
+  /// package:checks-style wrapper for [flutter_matcher.isSameColorSwatchAs].
+  void isSameColorSwatchAs(ColorSwatch<T> colorSwatch) {
+    legacyMatcher(flutter_matcher.isSameColorSwatchAs(colorSwatch));
+  }
+}

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:checks/checks.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -258,7 +259,7 @@ void main() {
       final expectedForegroundColor = expected
         ? colorScheme.onSurface.withValues(alpha: 0.38)
         : colorScheme.onPrimary;
-      check(sendButtonWidget.color).equals(expectedForegroundColor);
+      check(sendButtonWidget.color).isNotNull().isSameColorAs(expectedForegroundColor);
     }
 
     group('attach from media library', () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:zulip/api/core.dart';
@@ -880,7 +881,7 @@ void main() {
         final textColor = mergedStyleOfSubstring(textSpan, renderedTextRegexp)!.color;
         check(textColor).isNotNull();
 
-        check(icon).color.equals(textColor!);
+        check(icon).color.isNotNull().isSameColorAs(textColor!);
       });
     }
 

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -5,6 +5,7 @@ import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/events.dart';
@@ -238,20 +239,26 @@ void main() {
       return material.color;
     }
 
-    check(backgroundColor('smile')).equals(EmojiReactionTheme.light().bgSelected);
-    check(backgroundColor('tada')).equals(EmojiReactionTheme.light().bgUnselected);
+    check(backgroundColor('smile')).isNotNull()
+      .isSameColorAs(EmojiReactionTheme.light().bgSelected);
+    check(backgroundColor('tada')).isNotNull()
+      .isSameColorAs(EmojiReactionTheme.light().bgUnselected);
 
     tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     await tester.pump();
 
     await tester.pump(kThemeAnimationDuration * 0.4);
     final expectedLerped = EmojiReactionTheme.light().lerp(EmojiReactionTheme.dark(), 0.4);
-    check(backgroundColor('smile')).equals(expectedLerped.bgSelected);
-    check(backgroundColor('tada')).equals(expectedLerped.bgUnselected);
+    check(backgroundColor('smile')).isNotNull()
+      .isSameColorAs(expectedLerped.bgSelected);
+    check(backgroundColor('tada')).isNotNull()
+      .isSameColorAs(expectedLerped.bgUnselected);
 
     await tester.pump(kThemeAnimationDuration * 0.6);
-    check(backgroundColor('smile')).equals(EmojiReactionTheme.dark().bgSelected);
-    check(backgroundColor('tada')).equals(EmojiReactionTheme.dark().bgUnselected);
+    check(backgroundColor('smile')).isNotNull()
+      .isSameColorAs(EmojiReactionTheme.dark().bgSelected);
+    check(backgroundColor('tada')).isNotNull()
+      .isSameColorAs(EmojiReactionTheme.dark().bgUnselected);
   });
 
   // TODO more tests:

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
@@ -332,7 +333,7 @@ void main() {
           final icon = findHeaderCollapseIcon(tester, headerRow!);
           check(icon).icon.equals(ZulipIcons.arrow_down);
           check(allDmsHeaderBackgroundColor(tester))
-            .isNotNull().equals(const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor());
+            .isNotNull().isSameColorAs(const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor());
           check(tester.widgetList(findSectionContent)).isNotEmpty();
         }
 
@@ -350,7 +351,7 @@ void main() {
           final icon = findHeaderCollapseIcon(tester, headerRow!);
           check(icon).icon.equals(ZulipIcons.arrow_right);
           check(allDmsHeaderBackgroundColor(tester))
-            .isNotNull().equals(Colors.white);
+            .isNotNull().isSameColorAs(Colors.white);
           check(tester.widgetList(findSectionContent)).isEmpty();
         }
 
@@ -425,10 +426,10 @@ void main() {
           final collapseIcon = findHeaderCollapseIcon(tester, headerRow!);
           check(collapseIcon).icon.equals(ZulipIcons.arrow_down);
           final streamIcon = findStreamHeaderIcon(tester, streamId);
-          check(streamIcon).color.equals(
+          check(streamIcon).color.isNotNull().isSameColorAs(
             ChannelColorSwatch.light(subscription.color).iconOnBarBackground);
           check(streamHeaderBackgroundColor(tester, streamId))
-            .isNotNull().equals(ChannelColorSwatch.light(subscription.color).barBackground);
+            .isNotNull().isSameColorAs(ChannelColorSwatch.light(subscription.color).barBackground);
           check(tester.widgetList(findSectionContent)).isNotEmpty();
         }
 
@@ -448,10 +449,10 @@ void main() {
           final collapseIcon = findHeaderCollapseIcon(tester, headerRow!);
           check(collapseIcon).icon.equals(ZulipIcons.arrow_right);
           final streamIcon = findStreamHeaderIcon(tester, streamId);
-          check(streamIcon).color.equals(
+          check(streamIcon).color.isNotNull().isSameColorAs(
             ChannelColorSwatch.light(subscription.color).iconOnPlainBackground);
           check(streamHeaderBackgroundColor(tester, streamId))
-            .isNotNull().equals(Colors.white);
+            .isNotNull().isSameColorAs(Colors.white);
           check(tester.widgetList(findSectionContent)).isEmpty();
         }
 
@@ -482,7 +483,7 @@ void main() {
           checkAppearsUncollapsed(tester, stream.streamId, find.text('specific topic'));
 
           check(streamHeaderBackgroundColor(tester, 1))
-            .equals(ChannelColorSwatch.light(initialColor).barBackground);
+            .isNotNull().isSameColorAs(ChannelColorSwatch.light(initialColor).barBackground);
 
           final newColor = Colors.orange.argbInt;
           store.handleEvent(SubscriptionUpdateEvent(id: 1, streamId: 1,
@@ -490,7 +491,7 @@ void main() {
           await tester.pump();
 
           check(streamHeaderBackgroundColor(tester, 1))
-            .equals(ChannelColorSwatch.light(newColor).barBackground);
+            .isNotNull().isSameColorAs(ChannelColorSwatch.light(newColor).barBackground);
         });
 
         testWidgets('collapse stream section when partially offscreen: '

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -4,6 +4,7 @@ import 'package:checks/checks.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:zulip/api/model/events.dart';
@@ -158,17 +159,17 @@ void main() {
       return widget.color;
     }
 
-    check(backgroundColor()).equals(MessageListTheme.light().streamMessageBgDefault);
+    check(backgroundColor()).isSameColorAs(MessageListTheme.light().streamMessageBgDefault);
 
     tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     await tester.pump();
 
     await tester.pump(kThemeAnimationDuration * 0.4);
     final expectedLerped = MessageListTheme.light().lerp(MessageListTheme.dark(), 0.4);
-    check(backgroundColor()).equals(expectedLerped.streamMessageBgDefault);
+    check(backgroundColor()).isSameColorAs(expectedLerped.streamMessageBgDefault);
 
     await tester.pump(kThemeAnimationDuration * 0.6);
-    check(backgroundColor()).equals(MessageListTheme.dark().streamMessageBgDefault);
+    check(backgroundColor()).isSameColorAs(MessageListTheme.dark().streamMessageBgDefault);
   });
 
   group('fetch older messages on scroll', () {
@@ -765,7 +766,7 @@ void main() {
           find.descendant(
             of: find.byType(StreamMessageRecipientHeader),
             matching: find.byType(ColoredBox),
-        ))).color.equals(swatch.barBackground);
+        ))).color.isNotNull().isSameColorAs(swatch.barBackground);
       });
 
       testWidgets('color of stream icon', (tester) async {
@@ -777,7 +778,7 @@ void main() {
           subscriptions: [subscription]);
         await tester.pump();
         check(tester.widget<Icon>(find.byIcon(ZulipIcons.globe)))
-          .color.equals(swatch.iconOnBarBackground);
+          .color.isNotNull().isSameColorAs(swatch.iconOnBarBackground);
       });
 
       testWidgets('normal streams show hash icon', (tester) async {
@@ -893,7 +894,7 @@ void main() {
           zulipLocalizations.messageListGroupYouAndOthers(
             zulipLocalizations.unknownUserName))).text;
         final icon = tester.widget<Icon>(find.byIcon(ZulipIcons.user));
-        check(textSpan).style.isNotNull().color.equals(icon.color);
+        check(textSpan).style.isNotNull().color.isNotNull().isSameColorAs(icon.color!);
       });
     });
 

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
@@ -240,9 +241,9 @@ void main() {
     ], unreadMsgs: unreadMsgs);
     check(getItemCount()).equals(1);
     check(tester.widget<Icon>(find.byIcon(iconDataForStream(stream))).color)
-      .equals(swatch.iconOnPlainBackground);
+      .isNotNull().isSameColorAs(swatch.iconOnPlainBackground);
     check(tester.widget<UnreadCountBadge>(find.byType(UnreadCountBadge)).backgroundColor)
-      .equals(swatch);
+      .isNotNull().isSameColorAs(swatch);
   });
 
   testWidgets('muted streams are displayed as faded', (tester) async {

--- a/test/widgets/theme_test.dart
+++ b/test/widgets/theme_test.dart
@@ -9,6 +9,7 @@ import 'package:zulip/widgets/theme.dart';
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
+import 'colors_checks.dart';
 import 'test_app.dart';
 
 void main() {
@@ -115,21 +116,21 @@ void main() {
       final element = tester.element(find.byType(Placeholder));
       // Compares all the swatch's members; see [ColorSwatch]'s `operator ==`.
       check(colorSwatchFor(element, subscription))
-        .equals(ChannelColorSwatch.light(baseColor));
+        .isSameColorSwatchAs(ChannelColorSwatch.light(baseColor));
 
       tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
       await tester.pump();
 
       await tester.pump(kThemeAnimationDuration * 0.4);
       check(colorSwatchFor(element, subscription))
-        .equals(ChannelColorSwatch.lerp(
+        .isSameColorSwatchAs(ChannelColorSwatch.lerp(
           ChannelColorSwatch.light(baseColor),
           ChannelColorSwatch.dark(baseColor),
           0.4)!);
 
       await tester.pump(kThemeAnimationDuration * 0.6);
       check(colorSwatchFor(element, subscription))
-        .equals(ChannelColorSwatch.dark(baseColor));
+        .isSameColorSwatchAs(ChannelColorSwatch.dark(baseColor));
     });
   });
 }

--- a/test/widgets/unread_count_badge_test.dart
+++ b/test/widgets/unread_count_badge_test.dart
@@ -1,4 +1,5 @@
 import 'package:checks/checks.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -36,18 +37,18 @@ void main() {
 
       testWidgets('default color', (tester) async {
         await prepare(tester, null);
-        check(findBackgroundColor(tester)).equals(const Color(0x26666699));
+        check(findBackgroundColor(tester)).isNotNull().isSameColorAs(const Color(0x26666699));
       });
 
       testWidgets('specified color', (tester) async {
         await prepare(tester, Colors.pink);
-        check(findBackgroundColor(tester)).equals(Colors.pink);
+        check(findBackgroundColor(tester)).isNotNull().isSameColorAs(Colors.pink);
       });
 
       testWidgets('stream color', (tester) async {
         final swatch = ChannelColorSwatch.light(0xff76ce90);
         await prepare(tester, swatch);
-        check(findBackgroundColor(tester)).equals(swatch.unreadCountBadgeBackground);
+        check(findBackgroundColor(tester)).isNotNull().isSameColorAs(swatch.unreadCountBadgeBackground);
       });
     });
   });


### PR DESCRIPTION
Done to follow a draft migration guide:
  https://github.com/flutter/website/blob/997c893ccec5fb15dd085a4d23fe8c43870c631b/src/content/release/breaking-changes/wide-gamut-framework.md
for the proposed breaking change that raised
  https://github.com/flutter/flutter/issues/155113

Some other work was needed outside what's described in that draft;
see:
  https://github.com/flutter/flutter/issues/155113#issuecomment-2347374468
  https://github.com/flutter/flutter/issues/155113#issuecomment-2356356254
