### PR TITLE
deps: Upgrade video_player_android to 2.7.3

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1244,10 +1244,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "4de50df9ee786f5891d3281e1e633d7b142ef1acf47392592eb91cba5d355849"
+      sha256: "38d8fe136c427abdce68b5e8c3c08ea29d7a794b453c7a51b12ecfad4aad9437"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.3"
   video_player_avfoundation:
     dependency: transitive
     description:


### PR DESCRIPTION
Changelog:
  https://pub.dev/packages/video_player_android/changelog

This update migrates the plugin to use newer API recommended
to support Impeller:
  https://docs.flutter.dev/release/breaking-changes/android-surface-plugins

Without this migration, the videos do play but they look
pixelated, resulting in a bad UX.

| before | after |
| - | - |
| ![before](https://github.com/user-attachments/assets/7114920d-ee49-48e3-8cc8-f6d39a552ae8) | ![after](https://github.com/user-attachments/assets/23b65c79-4046-47c1-8894-3baf9d02b13e) |

Additionally, it updates the underlying Media3-ExoPlayer
library to version 1.4.1:
  https://developer.android.com/jetpack/androidx/releases/media3#1.4.1
