### PR TITLE
msglist: Follow web's change making dark mode's --color-text-default opaque

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -68,7 +68,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withValues(alpha: 0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
-        color: const HSLColor.fromAHSL(0.75, 0, 0, 1).toColor(),
+        color: const HSLColor.fromAHSL(1, 0, 0, 0.85).toColor(),
         debugLabel: 'ContentTheme.textStylePlainParagraph'),
       codeBlockTextStyles: CodeBlockTextStyles.dark(context),
       textStyleError: TextStyle(fontSize: kBaseFontSize, color: Colors.red.shade900)

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -58,7 +58,7 @@ class MessageListTheme extends ThemeExtension<MessageListTheme> {
       dateSeparator: Colors.white,
       dateSeparatorText: const HSLColor.fromAHSL(0.75, 0, 0, 1).toColor(),
       dmRecipientHeaderBg: const HSLColor.fromAHSL(1, 46, 0.15, 0.2).toColor(),
-      messageTimestamp: const HSLColor.fromAHSL(0.6, 0, 0, 1).toColor(),
+      messageTimestamp: const HSLColor.fromAHSL(0.8, 0, 0, 0.85).toColor(),
       recipientHeaderText: const HSLColor.fromAHSL(0.8, 0, 0, 1).toColor(),
       senderBotIcon: const HSLColor.fromAHSL(1, 180, 0.05, 0.5).toColor(),
       senderName: const HSLColor.fromAHSL(0.85, 0, 0, 1).toColor(),


### PR DESCRIPTION
Fixes: #953

| Before | After |
| --- | --- |
| <img width="675" alt="image" src="https://github.com/user-attachments/assets/13a3464f-5e87-44d2-806b-085860cc8655"> | <img width="675" alt="image" src="https://github.com/user-attachments/assets/bff27f14-d6c2-4ec3-aef3-50f159f8ac04"> |