### PR TITLE
macos: Take in automatic override of `applicationSupportsSecureRestorableState`

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -6,4 +6,8 @@ class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+    return true
+  }
 }


### PR DESCRIPTION
This change was made automatically by `flutter run`, along with the following warning:

```
  macos/Runner/AppDelegate.swift does not override applicationSupportsSecureRestorableState. Updating.
```

See upstream commit that introduced this override: https://github.com/flutter/flutter/commit/68f375fe3871a28dd58017d145d24712e087f4e0