### PR TITLE
ios: Add workaround for package:firebase_messaging when building with Xcode 16

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+#include "Zulip.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+#include "Zulip.xcconfig"

--- a/ios/Flutter/Zulip.xcconfig
+++ b/ios/Flutter/Zulip.xcconfig
@@ -1,0 +1,10 @@
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// TODO(firebase/flutterfire#13323): remove this flag
+//
+// This flag is added to work around the iOS build failing
+// on Xcode 16.  Remove it when `package:firebase_messaging`
+// is patched with a fix to build successfully on Xcode 16:
+//   https://github.com/firebase/flutterfire/issues/13323
+CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES=YES

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B3AF53A72CA20BD10039801D /* Zulip.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Zulip.xcconfig; path = Flutter/Zulip.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +79,7 @@
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
+				B3AF53A72CA20BD10039801D /* Zulip.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
 			);
 			name = Flutter;


### PR DESCRIPTION
Without this workaround iOS build currently fails with the following error:
```
Lexical or Preprocessor Issue (Xcode): Include of non-modular header inside framework module 'firebase_messaging FLTFirebaseMessagingPlugin':
'/Users/rajveer/Projects/zulip-flutter/ios/Pods/Headers/Public/Firebase/Firebase.h'
/Users/rajveer/.pub-cache/hosted/pub.dev/firebase_messaging-15.0.4/ios/Classes/FLTFirebaseMessagingPlugin.h:11:8
```
Upstream issue and the workaround comment:
  https://github.com/firebase/flutterfire/issues/13323
  https://github.com/firebase/flutterfire/issues/13323#issuecomment-2355013360

Docs: https://developer.apple.com/documentation/xcode/build-settings-reference#Allow-Non-modular-Includes-In-Framework-Modules

The documentation states that enabling this setting may result in issues later on, which is why this workaround should only be temporary until firebase_messaging is patched with the correct fix.