### PR TITLE
Prepare for curly_braces lint rule change

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -995,7 +995,9 @@ class _ZulipContentParser {
         final first = child.nodes[0];
         if (first is! dom.Element
             || first.localName != 'span'
-            || first.nodes.isNotEmpty) return null;
+            || first.nodes.isNotEmpty) {
+          return null;
+        }
       }
       final grandchild = child.nodes.last;
       if (grandchild is! dom.Element) return null;


### PR DESCRIPTION
To fix https://github.com/dart-lang/linter/issues/4870, the analyzer is now reporting if-statement bodies without curly braces when the if-statement condition spans multiple lines.

This change prepares zulip-flutter for this lint rule change.