### PR TITLE
dialog [nfc]: Wrap showErrorDialog's return value

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -120,7 +120,7 @@ class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
         default:
       }
 
-      await showErrorDialog(context: context,
+      showErrorDialog(context: context,
         title: 'Adding reaction failed', message: errorMessage);
     }
   }
@@ -165,7 +165,7 @@ class StarButton extends MessageActionSheetMenuItemButton {
         default:
       }
 
-      await showErrorDialog(context: messageListContext,
+      showErrorDialog(context: messageListContext,
         title: switch(op) {
           UpdateMessageFlagsOp.remove => zulipLocalizations.errorUnstarMessageFailedTitle,
           UpdateMessageFlagsOp.add    => zulipLocalizations.errorStarMessageFailedTitle,
@@ -215,7 +215,7 @@ Future<String?> fetchRawContentWithFeedback({
       // TODO(?) give no feedback on error conditions we expect to
       //   flag centrally in event polling, like invalid auth,
       //   user/realm deactivated. (Support with reusable code.)
-      await showErrorDialog(context: context,
+      showErrorDialog(context: context,
         title: errorDialogTitle, message: errorMessage);
     }
 
@@ -423,7 +423,7 @@ class ShareButton extends MessageActionSheetMenuItemButton {
       // Until we learn otherwise, assume something wrong happened.
       case ShareResultStatus.unavailable:
         if (!messageListContext.mounted) return;
-        await showErrorDialog(context: messageListContext,
+        showErrorDialog(context: messageListContext,
           title: zulipLocalizations.errorSharingFailed);
       case ShareResultStatus.success:
       case ShareResultStatus.dismissed:

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -27,7 +27,7 @@ Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
       return;
     } catch (e) {
       if (!context.mounted) return;
-      await showErrorDialog(context: context,
+      showErrorDialog(context: context,
         title: zulipLocalizations.errorMarkAsReadFailedTitle,
         message: e.toString()); // TODO(#741): extract user-facing message better
       return;

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1195,7 +1195,7 @@ class GlobalTime extends StatelessWidget {
 }
 
 void _launchUrl(BuildContext context, String urlString) async {
-  DialogStatusController showError(BuildContext context, String? message) {
+  DialogStatus showError(BuildContext context, String? message) {
     return showErrorDialog(context: context,
       title: 'Unable to open link',
       message: [

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1195,7 +1195,7 @@ class GlobalTime extends StatelessWidget {
 }
 
 void _launchUrl(BuildContext context, String urlString) async {
-  Future<void> showError(BuildContext context, String? message) {
+  DialogStatusController showError(BuildContext context, String? message) {
     return showErrorDialog(context: context,
       title: 'Unable to open link',
       message: [
@@ -1207,7 +1207,7 @@ void _launchUrl(BuildContext context, String urlString) async {
   final store = PerAccountStoreWidget.of(context);
   final url = store.tryResolveUrl(urlString);
   if (url == null) { // TODO(log)
-    await showError(context, null);
+    showError(context, null);
     return;
   }
 
@@ -1236,7 +1236,7 @@ void _launchUrl(BuildContext context, String urlString) async {
   }
   if (!launched) { // TODO(log)
     if (!context.mounted) return;
-    await showError(context, errorMessage);
+    showError(context, errorMessage);
   }
 }
 

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -15,16 +15,33 @@ Widget _dialogActionText(String text) {
   );
 }
 
+/// A wrapper providing access to the status of an [AlertDialog].
+///
+/// See also:
+///  * [showDialog], whose return value this class is intended to wrap.
+class DialogStatusController {
+  const DialogStatusController(this._closed);
+
+  /// Resolves when the dialog is closed.
+  Future<void> get closed => _closed;
+  final Future<void> _closed;
+}
+
 /// Displays an [AlertDialog] with a dismiss button.
 ///
-/// Returns a [Future] that resolves when the dialog is closed.
-Future<void> showErrorDialog({
+/// Returns a [DialogStatusController]. Useful for checking if the dialog has
+/// been closed.
+// This API is inspired by [ScaffoldManager.showSnackBar].  We wrap
+// [showDialog]'s return value, a [Future], inside [DialogStatusController]
+// whose documentation can be accessed.  This helps avoid confusion when
+// intepreting the meaning of the [Future].
+DialogStatusController showErrorDialog({
   required BuildContext context,
   required String title,
   String? message,
 }) {
   final zulipLocalizations = ZulipLocalizations.of(context);
-  return showDialog(
+  final future = showDialog<void>(
     context: context,
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),
@@ -34,6 +51,7 @@ Future<void> showErrorDialog({
           onPressed: () => Navigator.pop(context),
           child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
       ]));
+  return DialogStatusController(future);
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -15,27 +15,26 @@ Widget _dialogActionText(String text) {
   );
 }
 
-/// A wrapper providing access to the status of an [AlertDialog].
+/// Tracks the status of a dialog, in being still open or already closed.
 ///
 /// See also:
 ///  * [showDialog], whose return value this class is intended to wrap.
-class DialogStatusController {
-  const DialogStatusController(this._closed);
+class DialogStatus {
+  const DialogStatus(this.closed);
 
   /// Resolves when the dialog is closed.
-  Future<void> get closed => _closed;
-  final Future<void> _closed;
+  final Future<void> closed;
 }
 
 /// Displays an [AlertDialog] with a dismiss button.
 ///
-/// Returns a [DialogStatusController]. Useful for checking if the dialog has
-/// been closed.
+/// The [DialogStatus.closed] field of the return value can be used
+/// for waiting for the dialog to be closed.
 // This API is inspired by [ScaffoldManager.showSnackBar].  We wrap
-// [showDialog]'s return value, a [Future], inside [DialogStatusController]
+// [showDialog]'s return value, a [Future], inside [DialogStatus]
 // whose documentation can be accessed.  This helps avoid confusion when
 // intepreting the meaning of the [Future].
-DialogStatusController showErrorDialog({
+DialogStatus showErrorDialog({
   required BuildContext context,
   required String title,
   String? message,
@@ -51,7 +50,7 @@ DialogStatusController showErrorDialog({
           onPressed: () => Navigator.pop(context),
           child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
       ]));
-  return DialogStatusController(future);
+  return DialogStatus(future);
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -476,11 +476,11 @@ class _VideoLightboxPageState extends State<VideoLightboxPage> with PerAccountSt
       assert(debugLog("VideoPlayerController.initialize failed: $error"));
       if (!mounted) return;
       final zulipLocalizations = ZulipLocalizations.of(context);
-      // Wait until the dialog is closed
-      await showErrorDialog(
+      final dialog = showErrorDialog(
         context: context,
         title: zulipLocalizations.errorDialogTitle,
         message: zulipLocalizations.errorVideoPlayerFailed);
+      await dialog.closed;
       if (!mounted) return;
       Navigator.pop(context); // Pops the lightbox
     }

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -307,7 +307,7 @@ class _LoginPageState extends State<LoginPage> {
       if (e is PlatformException && e.message != null) {
         message = e.message!;
       }
-      await showErrorDialog(context: context,
+      showErrorDialog(context: context,
         title: zulipLocalizations.errorWebAuthOperationalErrorTitle,
         message: message);
     } finally {
@@ -351,7 +351,7 @@ class _LoginPageState extends State<LoginPage> {
       if (e is PlatformException && e.message != null) {
         message = e.message!;
       }
-      await showErrorDialog(context: context,
+      showErrorDialog(context: context,
         title: zulipLocalizations.errorWebAuthOperationalErrorTitle,
         message: message);
     }


### PR DESCRIPTION
As a result, showErrorDialog no longer returns a Future that can be mistakenly awaited.  The wrapped return value offers clarity on how the Future is supposed to be used.

There is no user visible change because existing callers (other than lightbox's) that wait for its return value are all asynchronous handlers for UI elements like buttons, and waits unnecessarily.

See also discussion
  https://github.com/zulip/zulip-flutter/pull/937#discussion_r1774377096.