### PR TITLE
notif: Support migration of Android notification channels

### DIFF
--- a/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
@@ -409,6 +409,12 @@ interface AndroidNotificationHostApi {
    */
   fun createNotificationChannel(channel: NotificationChannel)
   /**
+   * Corresponds to `androidx.core.app.NotificationManagerCompat.getNotificationChannelsCompat`.
+   *
+   * See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getNotificationChannelsCompat()
+   */
+  fun getNotificationChannels(): List<NotificationChannel>
+  /**
    * Corresponds to `android.app.NotificationManager.notify`,
    * combined with `androidx.core.app.NotificationCompat.Builder`.
    *
@@ -478,6 +484,21 @@ interface AndroidNotificationHostApi {
             val wrapped: List<Any?> = try {
               api.createNotificationChannel(channelArg)
               listOf(null)
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getNotificationChannels$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              listOf(api.getNotificationChannels())
             } catch (exception: Throwable) {
               wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
@@ -415,6 +415,12 @@ interface AndroidNotificationHostApi {
    */
   fun getNotificationChannels(): List<NotificationChannel>
   /**
+   * Corresponds to `androidx.core.app.NotificationManagerCompat.deleteNotificationChannel`
+   *
+   * See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#deleteNotificationChannel(java.lang.String)
+   */
+  fun deleteNotificationChannel(channelId: String)
+  /**
    * Corresponds to `android.app.NotificationManager.notify`,
    * combined with `androidx.core.app.NotificationCompat.Builder`.
    *
@@ -499,6 +505,24 @@ interface AndroidNotificationHostApi {
           channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
               listOf(api.getNotificationChannels())
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.AndroidNotificationHostApi.deleteNotificationChannel$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val channelIdArg = args[0] as String
+            val wrapped: List<Any?> = try {
+              api.deleteNotificationChannel(channelIdArg)
+              listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -64,6 +64,10 @@ private class AndroidNotificationHost(val context: Context)
             ) }
     }
 
+    override fun deleteNotificationChannel(channelId: String) {
+        NotificationManagerCompat.from(context).deleteNotificationChannel(channelId)
+    }
+
     @SuppressLint(
         // If permission is missing, `notify` will throw an exception.
         // Which hopefully will propagate to Dart, and then it's up to Dart code to handle it.

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -53,6 +53,17 @@ private class AndroidNotificationHost(val context: Context)
         NotificationManagerCompat.from(context).createNotificationChannel(notificationChannel)
     }
 
+    override fun getNotificationChannels(): List<NotificationChannel> {
+        return NotificationManagerCompat.from(context)
+            .notificationChannelsCompat
+            .map { NotificationChannel(
+                id = it.id,
+                importance =  it.importance.toLong(),
+                name = it.name?.toString(),
+                lightsEnabled = it.shouldShowLights()
+            ) }
+    }
+
     @SuppressLint(
         // If permission is missing, `notify` will throw an exception.
         // Which hopefully will propagate to Dart, and then it's up to Dart code to handle it.

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -400,6 +400,36 @@ class AndroidNotificationHostApi {
     }
   }
 
+  /// Corresponds to `androidx.core.app.NotificationManagerCompat.getNotificationChannelsCompat`.
+  ///
+  /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getNotificationChannelsCompat()
+  Future<List<NotificationChannel?>> getNotificationChannels() async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getNotificationChannels$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(null) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else if (__pigeon_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (__pigeon_replyList[0] as List<Object?>?)!.cast<NotificationChannel?>();
+    }
+  }
+
   /// Corresponds to `android.app.NotificationManager.notify`,
   /// combined with `androidx.core.app.NotificationCompat.Builder`.
   ///

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -430,6 +430,31 @@ class AndroidNotificationHostApi {
     }
   }
 
+  /// Corresponds to `androidx.core.app.NotificationManagerCompat.deleteNotificationChannel`
+  ///
+  /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#deleteNotificationChannel(java.lang.String)
+  Future<void> deleteNotificationChannel(String channelId) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.deleteNotificationChannel$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[channelId]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   /// Corresponds to `android.app.NotificationManager.notify`,
   /// combined with `androidx.core.app.NotificationCompat.Builder`.
   ///

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -160,6 +160,11 @@ abstract class AndroidNotificationHostApi {
   /// See: https://developer.android.com/reference/androidx/core/app/NotificationManagerCompat#createNotificationChannel(androidx.core.app.NotificationChannelCompat)
   void createNotificationChannel(NotificationChannel channel);
 
+  /// Corresponds to `androidx.core.app.NotificationManagerCompat.getNotificationChannelsCompat`.
+  ///
+  /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getNotificationChannelsCompat()
+  List<NotificationChannel> getNotificationChannels();
+
   /// Corresponds to `android.app.NotificationManager.notify`,
   /// combined with `androidx.core.app.NotificationCompat.Builder`.
   ///

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -165,6 +165,11 @@ abstract class AndroidNotificationHostApi {
   /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getNotificationChannelsCompat()
   List<NotificationChannel> getNotificationChannels();
 
+  /// Corresponds to `androidx.core.app.NotificationManagerCompat.deleteNotificationChannel`
+  ///
+  /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#deleteNotificationChannel(java.lang.String)
+  void deleteNotificationChannel(String channelId);
+
   /// Corresponds to `android.app.NotificationManager.notify`,
   /// combined with `androidx.core.app.NotificationCompat.Builder`.
   ///

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -559,6 +559,11 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
     _createdChannels.add(channel);
   }
 
+  @override
+  Future<List<NotificationChannel?>> getNotificationChannels() async {
+    return _createdChannels.toList(growable: false);
+  }
+
   /// Consume the log of calls made to [notify].
   ///
   /// This returns a list of the arguments to all calls made

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -543,6 +543,12 @@ class FakeFlutterLocalNotificationsPlugin extends Fake implements FlutterLocalNo
 }
 
 class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
+  /// Lists currently active channels, result is aggregated from calls made to
+  /// [createNotificationChannel] and [deleteNotificationChannel],
+  /// order of creation is preserved.
+  Iterable<NotificationChannel> get activeChannels => _activeChannels.values;
+  final Map<String, NotificationChannel> _activeChannels = {};
+
   /// Consume the log of calls made to [createNotificationChannel].
   ///
   /// This returns a list of the arguments to all calls made
@@ -557,11 +563,29 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
   @override
   Future<void> createNotificationChannel(NotificationChannel channel) async {
     _createdChannels.add(channel);
+    _activeChannels[channel.id] = channel;
   }
 
   @override
   Future<List<NotificationChannel?>> getNotificationChannels() async {
-    return _createdChannels.toList(growable: false);
+    return _activeChannels.values.toList(growable: false);
+  }
+
+  /// Consume the log of calls made to [deleteNotificationChannel].
+  ///
+  /// This returns a list of the arguments to all calls made
+  /// to [deleteNotificationChannel] since the last call to this method.
+  List<String> takeDeletedChannels() {
+    final result = _deletedChannels;
+    _deletedChannels = [];
+    return result;
+  }
+  List<String> _deletedChannels = [];
+
+  @override
+  Future<void> deleteNotificationChannel(String channelId) async {
+    _deletedChannels.add(channelId);
+    _activeChannels.remove(channelId);
   }
 
   /// Consume the log of calls made to [notify].


### PR DESCRIPTION
(Split from #717)

Needed for #340, when updating notification channels to use a custom notification sound.
