### PR TITLE
deps: Upgrade video_player_android to 2.7.8

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1244,10 +1244,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "45d21bbba3d10b7182aa08ade5d4c68ed3367016d40f29732bb04a799b26842d"
+      sha256: "50740044e9b7d290bc6ee3dd39787e7e28dada9546b82f842d3a1799865548a9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.5"
+    version: "2.7.8"
   video_player_avfoundation:
     dependency: transitive
     description:


### PR DESCRIPTION
Changelog:
  https://pub.dev/packages/video_player_android/changelog

This update addresses a few bug fixes, including the removal of a flag that treats warnings as errors. Without this fix, Android builds fail in Android Studio 2024.2, which uses Java 21, with the following error:
```
…
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
error: warnings found and -Werror specified
```
With this update the warnings still stay, but are ignored by build system resulting in a successful build.