### PR TITLE
test [nfc]: Introduce "finish" helper for async checks

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1113,7 +1113,7 @@ packages:
     source: hosted
     version: "1.25.8"
   test_api:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: test_api
       sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,6 +105,7 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.8
   stack_trace: ^1.11.1
   test: ^1.23.1
+  test_api: ^0.7.3
   video_player_platform_interface: ^6.2.2
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 

--- a/test/test_async.dart
+++ b/test/test_async.dart
@@ -1,0 +1,18 @@
+import 'package:test_api/hooks.dart';
+
+/// Ensure the test runner will wait for the given future to complete
+/// before considering the current test complete.
+///
+/// Consider using this function, instead of `await`, when a test invokes
+/// a check which is asynchronous and has no interaction with other tasks
+/// the test will do later.
+///
+/// Use `await`, instead of this function, when it matters what order the
+/// rest of the test's logic runs in relative to the asynchronous work
+/// represented by the given future.  In particular, when calling a function
+/// that performs setup for later logic in the test, the returned future
+/// should always be awaited.
+void finish(Future<void> future) {
+  final outstandingWork = TestHandle.current.markPending();
+  future.whenComplete(outstandingWork.complete);
+}


### PR DESCRIPTION
This brings the file test/api/core_test.dart up to being clean against the `unawaited_futures` lint rule, toward #731.

It does so with a smaller diff, and simpler resulting code, than by adding `await` on each of the futures.  For comparison:
  https://github.com/zulip/zulip-flutter/pull/934#discussion_r1788454470