### PR TITLE
lightbox: Use a friendlier format for the date

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -142,6 +142,28 @@ class _LightboxPageLayoutState extends State<_LightboxPageLayout> {
     });
   }
 
+  String _formatDate(DateTime messageDate) {
+    final now = DateTime.now();
+    final difference = now.difference(messageDate);
+    final locale = Localizations.localeOf(context).toString();
+
+    if (difference.inSeconds < 60) {
+      return "A few seconds ago";
+    } else if (difference.inMinutes < 60) {
+      return "${difference.inMinutes} ${difference.inMinutes == 1 ? 'minute' : 'minutes'} ago";
+    } else if (difference.inHours < 24) {
+      final time = DateFormat.jm(locale).format(messageDate);
+      return "Today at $time";
+    } else if (difference.inHours < 48) {
+      final time = DateFormat.jm(locale).format(messageDate);
+      return "Yesterday at $time";
+    } else {
+      final date = DateFormat('MMM d, yyyy', locale).format(messageDate);
+      final time = DateFormat('hh:mm a', locale).format(messageDate);
+      return "$date at $time";
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
@@ -152,11 +174,8 @@ class _LightboxPageLayoutState extends State<_LightboxPageLayout> {
 
     PreferredSizeWidget? appBar;
     if (_headerFooterVisible) {
-      // TODO(#45): Format with e.g. "Yesterday at 4:47 PM"
-      final timestampText = DateFormat
-        .yMMMd(/* TODO(#278): Pass selected language here, I think? */)
-        .add_Hms()
-        .format(DateTime.fromMillisecondsSinceEpoch(widget.message.timestamp * 1000));
+      final messageDate = DateTime.fromMillisecondsSinceEpoch(widget.message.timestamp * 1000);
+      final timestampText = _formatDate(messageDate);
 
       // We use plain [AppBar] instead of [ZulipAppBar], even though this page
       // has a [PerAccountStore], because:

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -249,7 +249,7 @@ void main() {
           matching: find.textContaining(findRichText: true,
             eg.otherUser.fullName)));
       check(labelTextWidget.text.toPlainText())
-        .contains('Jul 23, 2024 23:12:24');
+        .contains('Jul 23, 2024 at 11:12 PM');
 
       debugNetworkImageHttpClientProvider = null;
     });


### PR DESCRIPTION
This PR resolves the issue of displaying a user friendly date format in the lightbox appbar rather than showing the normal timestamp.

fixes #45