### PR TITLE
app-responsiveness: fix renderflex overfow in widgets.

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -368,7 +368,6 @@ class HomePage extends StatelessWidget {
                     narrow: ChannelNarrow(testStreamId!))),
                 child: const Text("#test here")), // scaffolding hack, see above
             ],
-          ]),
-        )));
+          ]))));
   }
 }

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -311,62 +311,64 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       appBar: ZulipAppBar(title: const Text("Home")),
       body: Center(
-        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-          DefaultTextStyle.merge(
-            textAlign: TextAlign.center,
-            style: const TextStyle(fontSize: 18),
-            child: Column(children: [
-              const Text('🚧 Under construction 🚧'),
-              const SizedBox(height: 12),
-              Text.rich(TextSpan(
-                text: 'Connected to: ',
-                children: [bold(store.realmUrl.toString())])),
-              Text.rich(TextSpan(
-                text: 'Zulip server version: ',
-                children: [bold(store.zulipVersion)])),
-              Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
-            ])),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const CombinedFeedNarrow())),
-            child: Text(zulipLocalizations.combinedFeedPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const MentionsNarrow())),
-            child: Text(zulipLocalizations.mentionsPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const StarredMessagesNarrow())),
-            child: Text(zulipLocalizations.starredMessagesPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              InboxPage.buildRoute(context: context)),
-            child: const Text("Inbox")), // TODO(i18n)
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              SubscriptionListPage.buildRoute(context: context)),
-            child: const Text("Subscribed channels")),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              RecentDmConversationsPage.buildRoute(context: context)),
-            child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-          if (testStreamId != null) ...[
+        child: SingleChildScrollView(
+          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            DefaultTextStyle.merge(
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 18),
+              child: Column(children: [
+                const Text('🚧 Under construction 🚧'),
+                const SizedBox(height: 12),
+                Text.rich(TextSpan(
+                  text: 'Connected to: ',
+                  children: [bold(store.realmUrl.toString())])),
+                Text.rich(TextSpan(
+                  text: 'Zulip server version: ',
+                  children: [bold(store.zulipVersion)])),
+                Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
+              ])),
             const SizedBox(height: 16),
             ElevatedButton(
               onPressed: () => Navigator.push(context,
                 MessageListPage.buildRoute(context: context,
-                  narrow: ChannelNarrow(testStreamId!))),
-              child: const Text("#test here")), // scaffolding hack, see above
-          ],
-        ])));
+                  narrow: const CombinedFeedNarrow())),
+              child: Text(zulipLocalizations.combinedFeedPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: const MentionsNarrow())),
+              child: Text(zulipLocalizations.mentionsPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: const StarredMessagesNarrow())),
+              child: Text(zulipLocalizations.starredMessagesPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                InboxPage.buildRoute(context: context)),
+              child: const Text("Inbox")), // TODO(i18n)
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                SubscriptionListPage.buildRoute(context: context)),
+              child: const Text("Subscribed channels")),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                RecentDmConversationsPage.buildRoute(context: context)),
+              child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+            if (testStreamId != null) ...[
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  MessageListPage.buildRoute(context: context,
+                    narrow: ChannelNarrow(testStreamId!))),
+                child: const Text("#test here")), // scaffolding hack, see above
+            ],
+          ]),
+        )));
   }
 }

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -313,75 +313,74 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       appBar: ZulipAppBar(title: const Text("Home")),
       body: Center(
-        child:  ElevatedButtonTheme(
+        child: SingleChildScrollView(
+        child: ElevatedButtonTheme(
         data: ElevatedButtonThemeData(style: ButtonStyle(
           backgroundColor: WidgetStatePropertyAll(colorScheme.secondaryContainer),
           foregroundColor: WidgetStatePropertyAll(colorScheme.onSecondaryContainer))),
-        child: SingleChildScrollView(
-          child: Center(
-            child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-              DefaultTextStyle.merge(
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 18),
-                child: Column(children: [
-                  const Text('🚧 Under construction 🚧'),
-                  const SizedBox(height: 12),
-                  Text.rich(TextSpan(
-                    text: 'Connected to: ',
-                    children: [bold(store.realmUrl.toString())])),
-                  Text.rich(TextSpan(
-                    text: 'Zulip server version: ',
-                    children: [bold(store.zulipVersion)])),
-                  Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
-                ])),
+        child: Center(
+          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            DefaultTextStyle.merge(
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 18),
+              child: Column(children: [
+                const Text('🚧 Under construction 🚧'),
+                const SizedBox(height: 12),
+                Text.rich(TextSpan(
+                  text: 'Connected to: ',
+                  children: [bold(store.realmUrl.toString())])),
+                Text.rich(TextSpan(
+                  text: 'Zulip server version: ',
+                  children: [bold(store.zulipVersion)])),
+                Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
+              ])),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: const CombinedFeedNarrow())),
+              child: Text(zulipLocalizations.combinedFeedPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: const MentionsNarrow())),
+              child: Text(zulipLocalizations.mentionsPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: const MentionsNarrow())),
+              child: Text(zulipLocalizations.mentionsPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                MessageListPage.buildRoute(context: context,
+                  narrow: const StarredMessagesNarrow())),
+              child: Text(zulipLocalizations.starredMessagesPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                InboxPage.buildRoute(context: context)),
+              child: const Text("Inbox")), // TODO(i18n)
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                SubscriptionListPage.buildRoute(context: context)),
+              child: const Text("Subscribed channels")),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(context,
+                RecentDmConversationsPage.buildRoute(context: context)),
+              child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+            if (testStreamId != null) ...[
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () => Navigator.push(context,
                   MessageListPage.buildRoute(context: context,
-                    narrow: const CombinedFeedNarrow())),
-                child: Text(zulipLocalizations.combinedFeedPageTitle)),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  MessageListPage.buildRoute(context: context,
-                    narrow: const MentionsNarrow())),
-                child: Text(zulipLocalizations.mentionsPageTitle)),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  MessageListPage.buildRoute(context: context,
-                    narrow: const MentionsNarrow())),
-                child: Text(zulipLocalizations.mentionsPageTitle)),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  MessageListPage.buildRoute(context: context,
-                    narrow: const StarredMessagesNarrow())),
-                child: Text(zulipLocalizations.starredMessagesPageTitle)),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  InboxPage.buildRoute(context: context)),
-                child: const Text("Inbox")), // TODO(i18n)
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  SubscriptionListPage.buildRoute(context: context)),
-                child: const Text("Subscribed channels")),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  RecentDmConversationsPage.buildRoute(context: context)),
-                child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-              if (testStreamId != null) ...[
-                const SizedBox(height: 16),
-                ElevatedButton(
-                  onPressed: () => Navigator.push(context,
-                    MessageListPage.buildRoute(context: context,
-                      narrow: ChannelNarrow(testStreamId!))),
-                  child: const Text("#test here")), // scaffolding hack, see above
-              ],
-            ])),
-        ))));
+                    narrow: ChannelNarrow(testStreamId!))),
+                child: const Text("#test here")), // scaffolding hack, see above
+            ],
+          ]))))));
   }
 }

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -313,74 +313,75 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       appBar: ZulipAppBar(title: const Text("Home")),
       body: Center(
-        child: SingleChildScrollView(
-      body: ElevatedButtonTheme(
+        child:  ElevatedButtonTheme(
         data: ElevatedButtonThemeData(style: ButtonStyle(
           backgroundColor: WidgetStatePropertyAll(colorScheme.secondaryContainer),
           foregroundColor: WidgetStatePropertyAll(colorScheme.onSecondaryContainer))),
-        child: Center(
-          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-            DefaultTextStyle.merge(
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 18),
-              child: Column(children: [
-                const Text('🚧 Under construction 🚧'),
-                const SizedBox(height: 12),
-                Text.rich(TextSpan(
-                  text: 'Connected to: ',
-                  children: [bold(store.realmUrl.toString())])),
-                Text.rich(TextSpan(
-                  text: 'Zulip server version: ',
-                  children: [bold(store.zulipVersion)])),
-                Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
-              ])),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: const CombinedFeedNarrow())),
-              child: Text(zulipLocalizations.combinedFeedPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: const MentionsNarrow())),
-              child: Text(zulipLocalizations.mentionsPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: const MentionsNarrow())),
-              child: Text(zulipLocalizations.mentionsPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: const StarredMessagesNarrow())),
-              child: Text(zulipLocalizations.starredMessagesPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                InboxPage.buildRoute(context: context)),
-              child: const Text("Inbox")), // TODO(i18n)
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                SubscriptionListPage.buildRoute(context: context)),
-              child: const Text("Subscribed channels")),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                RecentDmConversationsPage.buildRoute(context: context)),
-              child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-            if (testStreamId != null) ...[
+        child: SingleChildScrollView(
+          child: Center(
+            child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              DefaultTextStyle.merge(
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 18),
+                child: Column(children: [
+                  const Text('🚧 Under construction 🚧'),
+                  const SizedBox(height: 12),
+                  Text.rich(TextSpan(
+                    text: 'Connected to: ',
+                    children: [bold(store.realmUrl.toString())])),
+                  Text.rich(TextSpan(
+                    text: 'Zulip server version: ',
+                    children: [bold(store.zulipVersion)])),
+                  Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
+                ])),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () => Navigator.push(context,
                   MessageListPage.buildRoute(context: context,
-                    narrow: ChannelNarrow(testStreamId!))),
-                child: const Text("#test here")), // scaffolding hack, see above
-            ],
-          ]))));
+                    narrow: const CombinedFeedNarrow())),
+                child: Text(zulipLocalizations.combinedFeedPageTitle)),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  MessageListPage.buildRoute(context: context,
+                    narrow: const MentionsNarrow())),
+                child: Text(zulipLocalizations.mentionsPageTitle)),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  MessageListPage.buildRoute(context: context,
+                    narrow: const MentionsNarrow())),
+                child: Text(zulipLocalizations.mentionsPageTitle)),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  MessageListPage.buildRoute(context: context,
+                    narrow: const StarredMessagesNarrow())),
+                child: Text(zulipLocalizations.starredMessagesPageTitle)),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  InboxPage.buildRoute(context: context)),
+                child: const Text("Inbox")), // TODO(i18n)
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  SubscriptionListPage.buildRoute(context: context)),
+                child: const Text("Subscribed channels")),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.push(context,
+                  RecentDmConversationsPage.buildRoute(context: context)),
+                child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+              if (testStreamId != null) ...[
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                    MessageListPage.buildRoute(context: context,
+                      narrow: ChannelNarrow(testStreamId!))),
+                  child: const Text("#test here")), // scaffolding hack, see above
+              ],
+            ])),
+        ))));
   }
 }

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -50,8 +50,7 @@ DialogStatus showErrorDialog({
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
-        ]),
-    ));
+        ])));
   return DialogStatus(future);
 }
 
@@ -67,7 +66,8 @@ void showSuggestedActionDialog({
     context: context,
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),
-      content: SingleChildScrollView(child: Text(message)),
+      content: Text(message),
+      scrollable: true,
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -34,8 +34,7 @@ Future<void> showErrorDialog({
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
-        ]),
-    ));
+        ])));
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -15,26 +15,27 @@ Widget _dialogActionText(String text) {
   );
 }
 
-/// Tracks the status of a dialog, in being still open or already closed.
+/// A wrapper providing access to the status of an [AlertDialog].
 ///
 /// See also:
 ///  * [showDialog], whose return value this class is intended to wrap.
-class DialogStatus {
-  const DialogStatus(this.closed);
+class DialogStatusController {
+  const DialogStatusController(this._closed);
 
   /// Resolves when the dialog is closed.
-  final Future<void> closed;
+  Future<void> get closed => _closed;
+  final Future<void> _closed;
 }
 
 /// Displays an [AlertDialog] with a dismiss button.
 ///
-/// The [DialogStatus.closed] field of the return value can be used
-/// for waiting for the dialog to be closed.
+/// Returns a [DialogStatusController]. Useful for checking if the dialog has
+/// been closed.
 // This API is inspired by [ScaffoldManager.showSnackBar].  We wrap
-// [showDialog]'s return value, a [Future], inside [DialogStatus]
+// [showDialog]'s return value, a [Future], inside [DialogStatusController]
 // whose documentation can be accessed.  This helps avoid confusion when
 // intepreting the meaning of the [Future].
-DialogStatus showErrorDialog({
+DialogStatusController showErrorDialog({
   required BuildContext context,
   required String title,
   String? message,
@@ -42,16 +43,16 @@ DialogStatus showErrorDialog({
   final zulipLocalizations = ZulipLocalizations.of(context);
   final future = showDialog<void>(
     context: context,
-    builder: (BuildContext context) => AlertDialog(
-      title: Text(title),
-      content: message != null ? Text(message) : null,
-      scrollable: true,
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
-      ]));
-  return DialogStatus(future);
+    builder: (BuildContext context) => SingleChildScrollView(
+      child: AlertDialog(
+        title: Text(title),
+        content: message != null ? Text(message) : null,
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
+        ])));
+  return DialogStatusController(future);
 }
 
 void showSuggestedActionDialog({
@@ -66,8 +67,7 @@ void showSuggestedActionDialog({
     context: context,
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),
-      content: Text(message),
-      scrollable: true,
+      content: SingleChildScrollView(child: Text(message)),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -42,18 +42,10 @@ DialogStatus showErrorDialog({
   final zulipLocalizations = ZulipLocalizations.of(context);
   final future = showDialog<void>(
     context: context,
-    builder: (BuildContext context) => SingleChildScrollView(
-      child: AlertDialog(
-        title: Text(title),
-        content: message != null ? SingleChildScrollView(child: Text(message)) : null,
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
-        ])));
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),
-      content: message != null ? SingleChildScrollView(child: Text(message)) : null,
+      content: message != null ? Text(message) : null,
+      scrollable: true,
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
@@ -74,7 +66,8 @@ void showSuggestedActionDialog({
     context: context,
     builder: (BuildContext context) => AlertDialog(
       title: Text(title),
-      content: SingleChildScrollView(child: Text(message)),
+      content: Text(message),
+      scrollable: true,
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -51,6 +51,7 @@ DialogStatus showErrorDialog({
           onPressed: () => Navigator.pop(context),
           child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
       ]));
+  return DialogStatus(future);
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -51,7 +51,6 @@ DialogStatus showErrorDialog({
           onPressed: () => Navigator.pop(context),
           child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
       ]));
-  return DialogStatus(future);
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -26,14 +26,16 @@ Future<void> showErrorDialog({
   final zulipLocalizations = ZulipLocalizations.of(context);
   return showDialog(
     context: context,
-    builder: (BuildContext context) => AlertDialog(
-      title: Text(title),
-      content: message != null ? SingleChildScrollView(child: Text(message)) : null,
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
-      ]));
+    builder: (BuildContext context) => SingleChildScrollView(
+      child: AlertDialog(
+        title: Text(title),
+        content: message != null ? SingleChildScrollView(child: Text(message)) : null,
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
+        ]),
+    ));
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -15,27 +15,26 @@ Widget _dialogActionText(String text) {
   );
 }
 
-/// A wrapper providing access to the status of an [AlertDialog].
+/// Tracks the status of a dialog, in being still open or already closed.
 ///
 /// See also:
 ///  * [showDialog], whose return value this class is intended to wrap.
-class DialogStatusController {
-  const DialogStatusController(this._closed);
+class DialogStatus {
+  const DialogStatus(this.closed);
 
   /// Resolves when the dialog is closed.
-  Future<void> get closed => _closed;
-  final Future<void> _closed;
+  final Future<void> closed;
 }
 
 /// Displays an [AlertDialog] with a dismiss button.
 ///
-/// Returns a [DialogStatusController]. Useful for checking if the dialog has
-/// been closed.
+/// The [DialogStatus.closed] field of the return value can be used
+/// for waiting for the dialog to be closed.
 // This API is inspired by [ScaffoldManager.showSnackBar].  We wrap
-// [showDialog]'s return value, a [Future], inside [DialogStatusController]
+// [showDialog]'s return value, a [Future], inside [DialogStatus]
 // whose documentation can be accessed.  This helps avoid confusion when
 // intepreting the meaning of the [Future].
-DialogStatusController showErrorDialog({
+DialogStatus showErrorDialog({
   required BuildContext context,
   required String title,
   String? message,
@@ -51,8 +50,9 @@ DialogStatusController showErrorDialog({
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: _dialogActionText(zulipLocalizations.errorDialogContinue)),
-        ])));
-  return DialogStatusController(future);
+        ]),
+    ));
+  return DialogStatus(future);
 }
 
 void showSuggestedActionDialog({

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -239,8 +239,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
                     ? () => _onSubmitted(context)
                     : null,
                   child: Text(zulipLocalizations.dialogContinue)),
-              ])),
-          ))));
+              ]))))));
   }
 }
 

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -211,34 +211,36 @@ class _AddAccountPageState extends State<AddAccountPage> {
       body: SafeArea(
         minimum: const EdgeInsets.all(8),
         child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400),
-            child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-              // TODO(#109) Link to doc about what a "server URL" is and how to find it
-              // TODO(#111) Perhaps give tappable realm URL suggestions based on text typed so far
-              TextField(
-                controller: _controller,
-                onSubmitted: (value) => _onSubmitted(context),
-                keyboardType: TextInputType.url,
-                autocorrect: false,
-                textInputAction: TextInputAction.go,
-                onEditingComplete: () {
-                  // Repeat default implementation by clearing IME compose session…
-                  _controller.clearComposing();
-                  // …but leave out unfocusing the input in case more editing is needed.
-                },
-                decoration: InputDecoration(
-                  labelText: zulipLocalizations.loginServerUrlInputLabel,
-                  errorText: errorText,
-                  helperText: kLayoutPinningHelperText,
-                  hintText: 'your-org.zulipchat.com')),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: !_inProgress && errorText == null
-                  ? () => _onSubmitted(context)
-                  : null,
-                child: Text(zulipLocalizations.dialogContinue)),
-            ])))));
+          child: SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+                // TODO(#109) Link to doc about what a "server URL" is and how to find it
+                // TODO(#111) Perhaps give tappable realm URL suggestions based on text typed so far
+                TextField(
+                  controller: _controller,
+                  onSubmitted: (value) => _onSubmitted(context),
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  textInputAction: TextInputAction.go,
+                  onEditingComplete: () {
+                    // Repeat default implementation by clearing IME compose session…
+                    _controller.clearComposing();
+                    // …but leave out unfocusing the input in case more editing is needed.
+                  },
+                  decoration: InputDecoration(
+                    labelText: zulipLocalizations.loginServerUrlInputLabel,
+                    errorText: errorText,
+                    helperText: kLayoutPinningHelperText,
+                    hintText: 'your-org.zulipchat.com')),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: !_inProgress && errorText == null
+                    ? () => _onSubmitted(context)
+                    : null,
+                  child: Text(zulipLocalizations.dialogContinue)),
+              ])),
+          ))));
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -315,10 +315,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   file_picker:
     dependency: "direct main"
     description:
@@ -671,18 +671,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -1,16 +1,25 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart';
+import 'package:zulip/api/model/model.dart';
 import 'package:zulip/log.dart';
 import 'package:zulip/model/database.dart';
+import 'package:zulip/model/localizations.dart';
+import 'package:zulip/model/narrow.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/inbox.dart';
+import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
+import 'package:zulip/widgets/recent_dm_conversations.dart';
+import 'package:zulip/widgets/subscription_list.dart';
 
+import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../test_navigation.dart';
+import 'action_sheet_test.dart';
 import 'dialog_checks.dart';
 import 'page_checks.dart';
 import 'test_app.dart';
@@ -289,18 +298,62 @@ void main() {
     });
   });
     testWidgets('Home scrollable test, when contents do not fit to screen', (tester)async{
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(body: Center(child: SingleChildScrollView(child: Column(
-        children: List.generate(15, (count)=>Text('Pick $count')),
-      ))))));
+        children: [
+          DefaultTextStyle.merge(
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 18),
+              child: const Column(children: [
+                 Text('🚧 Under construction 🚧'),
+                 SizedBox(height: 12),
+                 Text.rich(TextSpan(
+                  text: 'Connected to: ',)),
+                 Text.rich(TextSpan(
+                  text: 'Zulip server version: ',)),
+              ])),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {},
+              child: Text(zulipLocalizations.combinedFeedPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: ()  {},
+              child: Text(zulipLocalizations.mentionsPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {},
+              child: Text(zulipLocalizations.starredMessagesPageTitle)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text("Inbox")),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text("Subscribed channels")),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: ()  {},
+              child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {},
+                child: const Text("#test here")),
+
+        ]))))));
       //make sure the added scrollable widget is functional
       expect(find.byType(SingleChildScrollView), findsOneWidget);
-      expect(find.text('Pick 0'), findsOneWidget);
 
+      //Scroll down
       await tester.drag(find.byType(SingleChildScrollView), const Offset(0, -300));
-      //Test for items down the column
+
+      //Test for the last button down the column
       await tester.pump();
-      expect(find.text('Pick 14'), findsOneWidget);
+      expect(find.text('#test here'), findsOneWidget);
     });
 
 }

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -288,4 +288,19 @@ void main() {
       check(findSnackBarByText('unrelated').evaluate()).single;
     });
   });
+    testWidgets('Home scrollable test, when contents do not fit to screen', (tester)async{
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: Center(child: SingleChildScrollView(child: Column(
+        children: List.generate(15, (count)=>Text('Pick $count')),
+      ))))));
+      //make sure the added scrollable widget is functional
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      expect(find.text('Pick 0'), findsOneWidget);
+
+      await tester.drag(find.byType(SingleChildScrollView), const Offset(0, -300));
+      //Test for items down the column
+      await tester.pump();
+      expect(find.text('Pick 14'), findsOneWidget);
+    });
+
 }

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -1,25 +1,17 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:path/path.dart';
-import 'package:zulip/api/model/model.dart';
 import 'package:zulip/log.dart';
 import 'package:zulip/model/database.dart';
 import 'package:zulip/model/localizations.dart';
-import 'package:zulip/model/narrow.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/inbox.dart';
-import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
-import 'package:zulip/widgets/recent_dm_conversations.dart';
-import 'package:zulip/widgets/subscription_list.dart';
 
-import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../test_navigation.dart';
-import 'action_sheet_test.dart';
 import 'dialog_checks.dart';
 import 'page_checks.dart';
 import 'test_app.dart';

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -94,9 +94,7 @@ void main() {
           const SizedBox(height: 8),
           ElevatedButton(onPressed:() {},
             child: Text(zulipLocalizations.dialogContinue),
-          )]))
-          )),
-        ))));
+          )]))))))));
 
 
     // Check that the TextField and button are present

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -62,7 +62,54 @@ void main() {
   });
 
   // TODO test AddAccountPage
+  testWidgets('Test if Add Accout is Scrollable When on Smaller Screen', (WidgetTester tester) async {
+    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+    String? errorText;
+    final TextEditingController controller = TextEditingController();
 
+    // Define the Add Account widgets to test
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+        body: SafeArea(
+            minimum: const EdgeInsets.all(6),
+        child: Center(child: SingleChildScrollView(child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: Column(mainAxisAlignment: MainAxisAlignment.center,children: [
+               TextField(
+                 controller: controller,
+                 keyboardType: TextInputType.url,
+                 autocorrect: false,
+                 textInputAction: TextInputAction.go,
+                 onEditingComplete: controller.clearComposing,
+                 decoration: InputDecoration(
+                   labelText: zulipLocalizations.loginServerUrlInputLabel,
+                   errorText: errorText,
+                   helperText: 'Your Zulip server URL',
+                   hintText: 'your-org.zulipchat.com',
+                 )
+               ),
+          const SizedBox(height: 8),
+          ElevatedButton(onPressed:() {},
+            child: Text(zulipLocalizations.dialogContinue),
+          )]))
+          )),
+        ))));
+
+
+    // Check that the TextField and button are present
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+
+    // Simulate entering text into the URL TextField
+    await tester.enterText(find.byType(TextField), 'chat.zulipchat.com');
+    expect(controller.text, 'chat.zulipchat.com');
+
+    // Implemet pressing the Continue button
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+    expect(find.text('Continue'), findsOneWidget);
+  });
   group('LoginPage', () {
     late FakeApiConnection connection;
     late List<Route<dynamic>> pushedRoutes;


### PR DESCRIPTION
Fix renderflex overflow in the Home, Add Account
and AlertDialog widgets, by making them scrollable, when all contents in a screen do not fit in the
screen. Which are fixes to these observed [issues](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Responsiveness.3A.20RenderFlex.20Overflow/near/1954905 ).