### PR TITLE
deps: Make flutter_checks and legacy_checks direct dev dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -421,7 +421,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_checks:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: flutter_checks
       sha256: b0a40b15d38436b7c08b83353e74b0569c1ec687bd81c9556091fbb8807c1b99
@@ -692,7 +692,7 @@ packages:
     source: hosted
     version: "3.0.1"
   legacy_checks:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: legacy_checks
       sha256: b22e5b1ff55a14e8bd91acafbabff909e14829b73ca492dcdaf0fbbb70476079

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,8 +66,6 @@ dependencies:
   wakelock_plus: ^1.2.8
   zulip_plugin:
     path: ./packages/zulip_plugin
-  flutter_checks: ^0.1.1
-  legacy_checks: ^0.1.0
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 
 dependency_overrides:
@@ -99,8 +97,10 @@ dev_dependencies:
   clock: ^1.1.1
   drift_dev: ^2.5.2
   fake_async: ^1.3.1
+  flutter_checks: ^0.1.1
   flutter_lints: ^4.0.0
   json_serializable: ^6.5.4
+  legacy_checks: ^0.1.0
   pigeon: ^20.0.1
   plugin_platform_interface: ^2.1.8
   stack_trace: ^1.11.1


### PR DESCRIPTION
They are only used in tests.

I was reminded of this by https://github.com/zulip/zulip-flutter/pull/917#discussion_r1796280646