### PR TITLE
api [nfc]: Update notif-token routes based on API docs

### DIFF
--- a/lib/api/route/notifications.dart
+++ b/lib/api/route/notifications.dart
@@ -1,29 +1,21 @@
 
 import '../core.dart';
 
-// This endpoint is undocumented.  Compare zulip-mobile:
-//   https://github.com/zulip/zulip-mobile/blob/86d94fa89/src/api/notifications/savePushToken.js
-// and see the server implementation:
-//   https://github.com/zulip/zulip/blob/34ceafadd/zproject/urls.py#L383
-//   https://github.com/zulip/zulip/blob/34ceafadd/zerver/views/push_notifications.py#L47
-Future<void> registerFcmToken(ApiConnection connection, {
+/// https://zulip.com/api/add-fcm-token
+Future<void> addFcmToken(ApiConnection connection, {
   required String token,
 }) {
-  return connection.post('registerFcmToken', (_) {}, 'users/me/android_gcm_reg_id', {
+  return connection.post('addFcmToken', (_) {}, 'users/me/android_gcm_reg_id', {
     'token': RawParameter(token),
   });
 }
 
-// This endpoint is undocumented.  Compare zulip-mobile:
-//   https://github.com/zulip/zulip-mobile/blob/86d94fa89/src/api/notifications/savePushToken.js
-// and see the server implementation:
-//   https://github.com/zulip/zulip/blob/34ceafadd/zproject/urls.py#L378-L381
-//   https://github.com/zulip/zulip/blob/34ceafadd/zerver/views/push_notifications.py#L34
-Future<void> registerApnsToken(ApiConnection connection, {
+/// https://zulip.com/api/add-apns-token
+Future<void> addApnsToken(ApiConnection connection, {
   required String token,
   String? appid,
 }) {
-  return connection.post('registerApnsToken', (_) {}, 'users/me/apns_device_token', {
+  return connection.post('addApnsToken', (_) {}, 'users/me/apns_device_token', {
     'token': RawParameter(token),
     if (appid != null) 'appid': RawParameter(appid),
   });

--- a/lib/api/route/notifications.dart
+++ b/lib/api/route/notifications.dart
@@ -13,10 +13,10 @@ Future<void> addFcmToken(ApiConnection connection, {
 /// https://zulip.com/api/add-apns-token
 Future<void> addApnsToken(ApiConnection connection, {
   required String token,
-  String? appid,
+  required String appid,
 }) {
   return connection.post('addApnsToken', (_) {}, 'users/me/apns_device_token', {
     'token': RawParameter(token),
-    if (appid != null) 'appid': RawParameter(appid),
+    'appid': RawParameter(appid),
   });
 }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -924,7 +924,7 @@ class UpdateMachine {
   ///   mean we actually sent the token).  Make it just `void` once we fix the
   ///   one test that relies on the future.
   // TODO(#322) save acked token, to dedupe updating it on the server
-  // TODO(#323) track the registerFcmToken/etc request, warn if not succeeding
+  // TODO(#323) track the addFcmToken/etc request, warn if not succeeding
   Future<void> registerNotificationToken() async {
     if (!debugEnableRegisterNotificationToken) {
       return;

--- a/lib/notifications/receive.dart
+++ b/lib/notifications/receive.dart
@@ -145,11 +145,11 @@ class NotificationService {
   static Future<void> registerToken(ApiConnection connection, {required String token}) async {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        await registerFcmToken(connection, token: token);
+        await addFcmToken(connection, token: token);
 
       case TargetPlatform.iOS:
         const appBundleId = 'com.zulip.flutter'; // TODO(#407) find actual value live
-        await registerApnsToken(connection, token: token, appid: appBundleId);
+        await addApnsToken(connection, token: token, appid: appBundleId);
 
       case TargetPlatform.linux:
       case TargetPlatform.macOS:

--- a/test/api/route/notifications_test.dart
+++ b/test/api/route/notifications_test.dart
@@ -31,7 +31,7 @@ void main() {
   group('addApnsToken', () {
     Future<void> checkAddApnsToken(FakeApiConnection connection, {
       required String token,
-      required String? appid,
+      required String appid,
     }) async {
       connection.prepare(json: {});
       await addApnsToken(connection, token: token, appid: appid);
@@ -40,17 +40,11 @@ void main() {
         ..url.path.equals('/api/v1/users/me/apns_device_token')
         ..bodyFields.deepEquals({
           'token': token,
-          if (appid != null) 'appid': appid,
+          'appid': appid,
         });
     }
 
-    test('no appid', () {
-      return FakeApiConnection.with_((connection) async {
-        await checkAddApnsToken(connection, token: 'asdf', appid: null);
-      });
-    });
-
-    test('with appid', () {
+    test('smoke', () {
       return FakeApiConnection.with_((connection) async {
         await checkAddApnsToken(connection, token: 'asdf', appid: 'qwer');
       });

--- a/test/api/route/notifications_test.dart
+++ b/test/api/route/notifications_test.dart
@@ -7,12 +7,12 @@ import '../../stdlib_checks.dart';
 import '../fake_api.dart';
 
 void main() {
-  group('registerFcmToken', () {
-    Future<void> checkRegisterFcmToken(FakeApiConnection connection, {
+  group('addFcmToken', () {
+    Future<void> checkAddFcmToken(FakeApiConnection connection, {
       required String token,
     }) async {
       connection.prepare(json: {});
-      await registerFcmToken(connection, token: token);
+      await addFcmToken(connection, token: token);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
         ..url.path.equals('/api/v1/users/me/android_gcm_reg_id')
@@ -23,18 +23,18 @@ void main() {
 
     test('smoke', () {
       return FakeApiConnection.with_((connection) async {
-        await checkRegisterFcmToken(connection, token: 'asdf');
+        await checkAddFcmToken(connection, token: 'asdf');
       });
     });
   });
 
-  group('registerApnsToken', () {
-    Future<void> checkRegisterApnsToken(FakeApiConnection connection, {
+  group('addApnsToken', () {
+    Future<void> checkAddApnsToken(FakeApiConnection connection, {
       required String token,
       required String? appid,
     }) async {
       connection.prepare(json: {});
-      await registerApnsToken(connection, token: token, appid: appid);
+      await addApnsToken(connection, token: token, appid: appid);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
         ..url.path.equals('/api/v1/users/me/apns_device_token')
@@ -46,13 +46,13 @@ void main() {
 
     test('no appid', () {
       return FakeApiConnection.with_((connection) async {
-        await checkRegisterApnsToken(connection, token: 'asdf', appid: null);
+        await checkAddApnsToken(connection, token: 'asdf', appid: null);
       });
     });
 
     test('with appid', () {
       return FakeApiConnection.with_((connection) async {
-        await checkRegisterApnsToken(connection, token: 'asdf', appid: 'qwer');
+        await checkAddApnsToken(connection, token: 'asdf', appid: 'qwer');
       });
     });
   });


### PR DESCRIPTION
When we originally wrote the bindings for these routes, they weren't
yet documented, so we invented our own names for them.  Now they are,
so the API docs give canonical names.  Switch to those,
and mark the `appid` parameter required as the docs say.
