### PR TITLE
check: Add step to install `libsqlite3-dev` system dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4.1.7
+
+    - name: Install system dependencies
+      run: TERM=dumb sudo apt install libsqlite3-dev -y
 
     - name: Set up JDK
       uses: actions/setup-java@v4.2.1


### PR DESCRIPTION
The `package:sqlite3` requires the system-installed sqlite3 shared library (`libsqlite3.so`) when running directly via Dart, on Linux. Whereas, when running under Flutter, it uses bundled libraries provided by `package:sqlite3_flutter_libs`.

Recently, the `ubuntu-latest` runner image has switched to defaulting to `ubuntu-24.04`:
  https://github.com/actions/runner-images/issues/10636
Previously, it used `ubuntu-22.04`, which had the `libsqlite3-dev` package pre-installed:
  https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#installed-apt-packages
However, the `ubuntu-24.04` image no longer includes this package by default:
  https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#installed-apt-packages

As a result, five unit tests now fail with the following error:
```
Invalid argument(s): Failed to load dynamic library 'libsqlite3.so': libsqlite3.so: cannot open shared object file: No such file or directory
  dart:ffi                                                        new DynamicLibrary.open
  package:sqlite3/src/ffi/load_library.dart 52:27                 _defaultOpen
  package:sqlite3/src/ffi/load_library.dart 127:12                OpenDynamicLibrary.openSqlite
  package:sqlite3/src/ffi/api.dart 13:39                          sqlite3
  package:drift/native.dart 313:12                                _NativeDelegate.openDatabase
  package:drift/src/sqlite3/database.dart 79:19                   Sqlite3Delegate.open
  package:drift/src/runtime/executor/helpers/engines.dart 431:22  DelegatedDatabase.ensureOpen.<fn>
```
To resolve these test failures, add a step to manually install the `libsqlite3-dev` package.