### PR TITLE
store [nfc]: Offer singleton global store on binding

### DIFF
--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -60,7 +60,7 @@ class _GlobalStoreWidgetState extends State<GlobalStoreWidget> {
   void initState() {
     super.initState();
     (() async {
-      final store = await ZulipBinding.instance.loadGlobalStore();
+      final store = await ZulipBinding.instance.getGlobalStoreUniquely();
       setState(() {
         this.store = store;
       });

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -100,7 +100,10 @@ class TestZulipBinding extends ZulipBinding {
   }
 
   @override
-  Future<GlobalStore> loadGlobalStore() {
+  Future<GlobalStore> getGlobalStore() => Future.value(globalStore);
+
+  @override
+  Future<GlobalStore> getGlobalStoreUniquely() {
     assert(() {
       if (_debugAlreadyLoadedStore) {
         throw FlutterError.fromParts([
@@ -121,7 +124,7 @@ class TestZulipBinding extends ZulipBinding {
       _debugAlreadyLoadedStore = true;
       return true;
     }());
-    return Future.value(globalStore);
+    return getGlobalStore();
   }
 
   /// The value that `ZulipBinding.instance.canLaunchUrl()` should return.


### PR DESCRIPTION
This will be useful in the context of showing a notification, where there may not exist an element tree at all (because we may be in a background isolate), and even if there happens to be one (because we happen to be in the foreground) it doesn't otherwise relate to anything the code is doing.

Prompted by #856 (/cc @rajveermalviya).