### PR TITLE
initial_snapshot: Add emailAddressVisibility override in InitialSnapshot method

### DIFF
--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -801,7 +801,7 @@ InitialSnapshot initialSnapshot({
     zulipMergeBase: zulipMergeBase ?? recentZulipVersion,
     alertWords: alertWords ?? ['klaxon'],
     customProfileFields: customProfileFields ?? [],
-    emailAddressVisibility: EmailAddressVisibility.everyone,
+    emailAddressVisibility: emailAddressVisibility ?? EmailAddressVisibility.everyone,
     serverTypingStartedExpiryPeriodMilliseconds:
       serverTypingStartedExpiryPeriodMilliseconds ?? 15000,
     serverTypingStoppedWaitPeriodMilliseconds:


### PR DESCRIPTION
I noticed a bug where the value passed for the `emailAddressVisibility` in the `initialSnapshot` method in the `example_data.dart` file was not being passed down to the class but rather defaulted to `EmailAddressVisibility.everyone` even though a different value was passed. When I looked deeper into it, I noticed that they forgot to add the override. This PR adds a fix for that. There isn't an open issue for this yet, so I am unable to link to it.

Please review when available.
Thank you.