### PR TITLE
deps: Upgrade Flutter to 3.27.0-1.0.pre.166

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -315,10 +315,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   file_picker:
     dependency: "direct main"
     description:
@@ -1400,5 +1400,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.6.0-334.2.beta <4.0.0"
-  flutter: ">=3.27.0-1.0.pre.25"
+  dart: ">=3.7.0-50.0.dev <4.0.0"
+  flutter: ">=3.27.0-1.0.pre.166"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.6.0-334.2.beta <4.0.0'
-  flutter: '>=3.27.0-1.0.pre.25'
+  sdk: '>=3.7.0-50.0.dev <4.0.0'
+  flutter: '>=3.27.0-1.0.pre.166'
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
And update Flutter's supporting libraries to match.

Built successfully on my Android device; still need to confirm that it works on IOS.
This contains a major version bump to the dart SDK ([changelog](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#370)).

3.7.0 adds [Wildcard Variables](https://github.com/dart-lang/language/issues/3712), that we currently doesn't seem to use.

There is also changes to the Dart to Javascript Compiler (dart2js) and Dart Development Compiler (dartdevc), both are "switched to use an AOT snapshot instead of a JIT snapshot". Neither of them applies to us because we do not use the web builds.