### PR TITLE
lint: Re-enable analyzer on Pigeon-generated code; fix one revealed issue

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,15 +3,6 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  exclude:
-    # Skip analysis on Pigeon-generated code, because it currently
-    # triggers some stylistic lints and they aren't actionable for us.
-    # (Some lints could signal a bug, which would be good to catch...
-    # but typically those are lints Flutter upstream keeps enabled, so
-    # if Pigeon tripped them it'd immediately get caught.)
-    # TODO(pigeon) re-enable lints once clean: https://github.com/flutter/flutter/issues/145633
-    - lib/host/*.g.dart
-
   language:
     strict-inference: true
     strict-raw-types: true

--- a/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/Notifications.g.kt
@@ -428,7 +428,7 @@ interface AndroidNotificationHostApi {
    * The rest go to method calls on the builder.
    *
    * The `color` should be in the form 0xAARRGGBB.
-   * This is the form returned by [Color.value].
+   * See [ColorExtension.argbInt].
    *
    * The `smallIconResourceName` is passed to `android.content.res.Resources.getIdentifier`
    * to get a resource ID to pass to `Builder.setSmallIcon`.

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -462,7 +462,7 @@ class AndroidNotificationHostApi {
   /// The rest go to method calls on the builder.
   ///
   /// The `color` should be in the form 0xAARRGGBB.
-  /// This is the form returned by [Color.value].
+  /// See [ColorExtension.argbInt].
   ///
   /// The `smallIconResourceName` is passed to `android.content.res.Resources.getIdentifier`
   /// to get a resource ID to pass to `Builder.setSmallIcon`.

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -177,7 +177,7 @@ abstract class AndroidNotificationHostApi {
   /// The rest go to method calls on the builder.
   ///
   /// The `color` should be in the form 0xAARRGGBB.
-  /// This is the form returned by [Color.value].
+  /// See [ColorExtension.argbInt].
   ///
   /// The `smallIconResourceName` is passed to `android.content.res.Resources.getIdentifier`
   /// to get a resource ID to pass to `Builder.setSmallIcon`.


### PR DESCRIPTION
We'd been suppressing the analyzer on Pigeon-generated code, because of an upstream issue. That issue has been fixed:
  https://github.com/flutter/flutter/issues/145633

In fact it turns out it was fixed in pigeon 18.0.0, which we took in 8df306412 back in April; we just didn't notice at the time.

Meanwhile this file grew a different analyzer issue during the time it wasn't getting checked — and that one was an actual actionable one for us to fix, where a doc comment still referred to a deprecated bit of API, namely [Color.value].  So fix that too.  Glad to have the analyzer re-enabled here.

