### PR TITLE
home: Remove irrelevant information from early prototyping

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -376,13 +376,6 @@
   "@topicValidationErrorMandatoryButEmpty": {
     "description": "Topic validation error when topic is required but was empty."
   },
-  "subscribedToNChannels": "Subscribed to {num, plural, =0{no channels} =1{1 channel} other{{num} channels}}",
-  "@subscribedToNChannels": {
-    "description": "Test page label showing number of channels user is subscribed to.",
-    "placeholders": {
-      "num": {"type": "int", "example": "4"}
-    }
-  },
   "errorInvalidResponse": "The server sent an invalid response",
   "@errorInvalidResponse": {
     "description": "Error message when an API call returned an invalid response."

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -322,15 +322,9 @@ class HomePage extends StatelessWidget {
               textAlign: TextAlign.center,
               style: const TextStyle(fontSize: 18),
               child: Column(children: [
-                const Text('🚧 Under construction 🚧'),
-                const SizedBox(height: 12),
                 Text.rich(TextSpan(
                   text: 'Connected to: ',
                   children: [bold(store.realmUrl.toString())])),
-                Text.rich(TextSpan(
-                  text: 'Zulip server version: ',
-                  children: [bold(store.zulipVersion)])),
-                Text(zulipLocalizations.subscribedToNChannels(store.subscriptions.length)),
               ])),
             const SizedBox(height: 16),
             ElevatedButton(


### PR DESCRIPTION
This also removes the translated string as it becomes unused.

We keep the "Connected to:" line as an indicator for the current account.

Fixes: #614