### PR TITLE
linux build: Disable a warning that url_launcher_linux can trigger

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
-  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror -Wno-unused-function)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
This works around the following issue in url_launcher_linux:
  https://github.com/flutter/flutter/issues/153083

The issue only appears on some hosts, namely those with "older versions of glib".