### PR TITLE
test: Bump eg.recentZulipFeatureLevel and recentZulipVersion to 9.0

### DIFF
--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -24,8 +24,8 @@ void _checkPositive(int? value, String description) {
 final Uri realmUrl = Uri.parse('https://chat.example/');
 Uri get _realmUrl => realmUrl;
 
-const String recentZulipVersion = '8.0';
-const int recentZulipFeatureLevel = 185;
+const String recentZulipVersion = '9.0';
+const int recentZulipFeatureLevel = 278;
 const int futureZulipFeatureLevel = 9999;
 
 GetServerSettingsResult serverSettings({


### PR DESCRIPTION
This keeps eg.account and eg.initialSnapshot using recent versions by default.