### PR TITLE
Support setting typing status in more situations

### DIFF
--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -113,6 +113,11 @@ abstract class ZulipBinding {
   /// This wraps [url_launcher.closeInAppWebView].
   Future<void> closeInAppWebView();
 
+  /// Provides access to a new stopwatch.
+  ///
+  /// Outside tests, this just calls the [Stopwatch] constructor.
+  Stopwatch stopwatch();
+
   /// Provides device and operating system information,
   /// via package:device_info_plus.
   ///
@@ -359,6 +364,9 @@ class LiveZulipBinding extends ZulipBinding {
   Future<void> closeInAppWebView() async {
     return url_launcher.closeInAppWebView();
   }
+
+  @override
+  Stopwatch stopwatch() => Stopwatch();
 
   @override
   Future<BaseDeviceInfo?> get deviceInfo => _deviceInfo;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -277,6 +277,13 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
       accountId: accountId,
       selfUserId: account.userId,
       userSettings: initialSnapshot.userSettings,
+      typingNotifier: TypingNotifier(
+        connection: connection,
+        typingStoppedWaitPeriod: Duration(
+          milliseconds: initialSnapshot.serverTypingStoppedWaitPeriodMilliseconds),
+        typingStartedWaitPeriod: Duration(
+          milliseconds: initialSnapshot.serverTypingStartedWaitPeriodMilliseconds),
+      ),
       users: Map.fromEntries(
         initialSnapshot.realmUsers
         .followedBy(initialSnapshot.realmNonActiveUsers)
@@ -311,6 +318,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
     required this.accountId,
     required this.selfUserId,
     required this.userSettings,
+    required this.typingNotifier,
     required this.users,
     required this.typingStatus,
     required ChannelStoreImpl channels,
@@ -413,6 +421,8 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
 
   final UserSettings? userSettings; // TODO(server-5)
 
+  final TypingNotifier typingNotifier;
+
   ////////////////////////////////
   // Users and data about them.
 
@@ -493,6 +503,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
     unreads.dispose();
     _messages.dispose();
     typingStatus.dispose();
+    typingNotifier.dispose();
     updateMachine?.dispose();
     connection.close();
     _disposed = true;

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -26,7 +26,7 @@ class TypingStatus extends ChangeNotifier {
     _timerMapsByNarrow[narrow]?.keys ?? [];
 
   // Using SendableNarrow as the key covers the narrows
-  // where typing notifications are supported (topics and DMs).
+  // where typing notices are supported (topics and DMs).
   final Map<SendableNarrow, Map<int, Timer>> _timerMapsByNarrow = {};
 
   @override

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../api/core.dart';
 import '../api/model/events.dart';
+import '../api/route/typing.dart';
+import 'binding.dart';
 import 'narrow.dart';
 
 /// The model for tracking the typing status organized by narrows.
@@ -82,5 +85,150 @@ class TypingStatus extends ChangeNotifier {
     if (hasUpdate) {
       notifyListeners();
     }
+  }
+}
+
+/// Sends the self-user's typing-status updates.
+///
+/// See also:
+///  * https://github.com/zulip/zulip/blob/52a9846cdf4abfbe937a94559690d508e95f4065/web/shared/src/typing_status.ts
+///  * https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html
+class TypingNotifier {
+  TypingNotifier({
+    required this.connection,
+    required this.typingStoppedWaitPeriod,
+    required this.typingStartedWaitPeriod,
+  });
+
+  final ApiConnection connection;
+  final Duration typingStoppedWaitPeriod;
+  final Duration typingStartedWaitPeriod;
+
+  SendableNarrow? _currentDestination;
+
+  /// Records time elapsed since the last time we notify the server;
+  /// this is `null` when the user is not actively typing.
+  Stopwatch? _sinceLastPing;
+
+  /// A timer that resets on every [keystroke].
+  ///
+  /// Upon its expiry, the user is considered idle and
+  /// a "typing stopped" notice will be sent.
+  Timer? _idleTimer;
+
+  void dispose() {
+    _idleTimer?.cancel();
+  }
+
+  /// Updates the server, if needed, that a keystroke was made when
+  /// composing a new message to [destination].
+  ///
+  /// To be called on all keystrokes in the composing session.
+  /// Sends "typing started" notices, throttled appropriately,
+  /// for repeated calls to the same [destination].
+  ///
+  /// If [destination] differs from the previous call, such as after a topic
+  /// input change, sends a "typing stopped" notice for the old destination.
+  ///
+  /// Keeps a timer to send a "typing stopped" notice when this and
+  /// [stoppedComposing] haven't been called in some time.
+  void keystroke(SendableNarrow destination) {
+    if (!debugEnable) return;
+
+    if (_currentDestination != null) {
+      if (destination == _currentDestination) {
+        // Nothing has really changed, except we may need
+        // to send a ping to the server and extend out our idle time.
+        if (_sinceLastPing!.elapsed > typingStartedWaitPeriod) {
+          _actuallyPingServer();
+        }
+        _startOrExtendIdleTimer();
+        return;
+      }
+
+      _stopLastNotification();
+    }
+
+    // We just started typing to this destination, so notify the server.
+    _currentDestination = destination;
+    _startOrExtendIdleTimer();
+    return _actuallyPingServer();
+  }
+
+  /// Sends the server a "typing stopped" notice for the destination of
+  /// the current composing session, if there is one.
+  ///
+  /// To be called on cues that the user has exited a new-message composing session,
+  /// e.g., send button tapped, compose box unfocused, nav changed, app quit.
+  ///
+  /// If [keystroke] hasn't been called in some time, does nothing.
+  ///
+  /// Otherwise:
+  /// - Users will see our user's typing indicator disappear immediately
+  ///   instead of after [keystroke]'s timer.
+  /// - [keystroke]'s timer is canceled.
+  ///
+  /// (This has no "destination" param because the user can really only compose
+  /// to one destination at a time. This function acts on the current session
+  /// regardless of its destination.)
+  void stoppedComposing() {
+    if (!debugEnable) return;
+
+    if (_currentDestination != null) {
+      _stopLastNotification();
+    }
+  }
+
+  void _startOrExtendIdleTimer() {
+    _idleTimer?.cancel();
+    _idleTimer = Timer(typingStoppedWaitPeriod, _stopLastNotification);
+  }
+
+  void _actuallyPingServer() {
+    // This allows us to use [clock.stopwatch] only when testing.
+    _sinceLastPing = ZulipBinding.instance.stopwatch()..start();
+
+    unawaited(setTypingStatus(
+      connection,
+      op: TypingOp.start,
+      destination: _currentDestination!.destination));
+  }
+
+  void _stopLastNotification() {
+    assert(_currentDestination != null);
+    final destination = _currentDestination!;
+
+    _idleTimer!.cancel();
+    _currentDestination = null;
+    _sinceLastPing = null;
+
+    unawaited(setTypingStatus(
+      connection,
+      op: TypingOp.stop,
+      destination: destination.destination));
+  }
+
+  /// In debug mode, controls whether typing notices should be sent.
+  ///
+  /// Outside of debug mode, this is always true and the setter has no effect.
+  static bool get debugEnable {
+    bool result = true;
+    assert(() {
+      result = _debugEnable;
+      return true;
+    }());
+    return result;
+  }
+  static bool _debugEnable = true;
+  static set debugEnable(bool value) {
+    assert(() {
+      _debugEnable = value;
+      return true;
+    }());
+  }
+
+  @visibleForTesting
+  static void debugReset() {
+    _debugEnable = true;
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -622,6 +622,31 @@ Future<void> _uploadFiles({
   }
 }
 
+class _ComposeButtonRow extends StatelessWidget {
+  const _ComposeButtonRow({
+    required this.contentController,
+    required this.contentFocusNode,
+  });
+
+  final ComposeContentController contentController;
+  final FocusNode contentFocusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    ColorScheme colorScheme = themeData.colorScheme;
+
+    return Theme(
+      data: themeData.copyWith(
+        iconTheme: themeData.iconTheme.copyWith(color: colorScheme.onSurfaceVariant)),
+      child: Row(children: [
+        _AttachFileButton(contentController: contentController, contentFocusNode: contentFocusNode),
+        _AttachMediaButton(contentController: contentController, contentFocusNode: contentFocusNode),
+        _AttachFromCameraButton(contentController: contentController, contentFocusNode: contentFocusNode),
+      ]));
+  }
+}
+
 abstract class _AttachUploadsButton extends StatelessWidget {
   const _AttachUploadsButton({required this.contentController, required this.contentFocusNode});
 
@@ -992,15 +1017,13 @@ class _ComposeBoxLayout extends StatelessWidget {
     required this.topicInput,
     required this.contentInput,
     required this.sendButton,
-    required this.contentController,
-    required this.contentFocusNode,
+    required this.composeButtonRow,
   });
 
   final Widget? topicInput;
   final Widget contentInput;
   final Widget sendButton;
-  final ComposeContentController contentController;
-  final FocusNode contentFocusNode;
+  final Widget composeButtonRow;
 
   @override
   Widget build(BuildContext context) {
@@ -1035,14 +1058,7 @@ class _ComposeBoxLayout extends StatelessWidget {
           const SizedBox(width: 8),
           sendButton,
         ]),
-        Theme(
-          data: themeData.copyWith(
-            iconTheme: themeData.iconTheme.copyWith(color: colorScheme.onSurfaceVariant)),
-          child: Row(children: [
-            _AttachFileButton(contentController: contentController, contentFocusNode: contentFocusNode),
-            _AttachMediaButton(contentController: contentController, contentFocusNode: contentFocusNode),
-            _AttachFromCameraButton(contentController: contentController, contentFocusNode: contentFocusNode),
-          ])),
+        composeButtonRow,
       ]));
   }
 }
@@ -1091,8 +1107,6 @@ class _StreamComposeBoxState extends State<_StreamComposeBox> implements Compose
   @override
   Widget build(BuildContext context) {
     return _ComposeBoxLayout(
-      contentController: _contentController,
-      contentFocusNode: _contentFocusNode,
       topicInput: _TopicInput(
         streamId: widget.narrow.streamId,
         controller: _topicController,
@@ -1110,6 +1124,10 @@ class _StreamComposeBoxState extends State<_StreamComposeBox> implements Compose
         contentController: _contentController,
         getDestination: () => StreamDestination(
           widget.narrow.streamId, _topicController.textNormalized),
+      ),
+      composeButtonRow: _ComposeButtonRow(
+        contentController: contentController,
+        contentFocusNode: contentFocusNode,
       ));
   }
 }
@@ -1181,8 +1199,6 @@ class _FixedDestinationComposeBoxState extends State<_FixedDestinationComposeBox
     }
 
     return _ComposeBoxLayout(
-      contentController: _contentController,
-      contentFocusNode: _contentFocusNode,
       topicInput: null,
       contentInput: _FixedDestinationContentInput(
         narrow: widget.narrow,
@@ -1193,6 +1209,10 @@ class _FixedDestinationComposeBoxState extends State<_FixedDestinationComposeBox
         topicController: null,
         contentController: _contentController,
         getDestination: () => widget.narrow.destination,
+      ),
+      composeButtonRow: _ComposeButtonRow(
+        contentController: contentController,
+        contentFocusNode: contentFocusNode,
       ));
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -269,7 +269,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   }
 }
 
-class _ContentInput extends StatelessWidget {
+class _ContentInput extends StatefulWidget {
   const _ContentInput({
     required this.narrow,
     required this.controller,
@@ -282,6 +282,11 @@ class _ContentInput extends StatelessWidget {
   final FocusNode focusNode;
   final String hintText;
 
+  @override
+  State<_ContentInput> createState() => _ContentInputState();
+}
+
+class _ContentInputState extends State<_ContentInput> {
   @override
   Widget build(BuildContext context) {
     ColorScheme colorScheme = Theme.of(context).colorScheme;
@@ -296,15 +301,15 @@ class _ContentInput extends StatelessWidget {
           maxHeight: 200,
         ),
         child: ComposeAutocomplete(
-          narrow: narrow,
-          controller: controller,
-          focusNode: focusNode,
+          narrow: widget.narrow,
+          controller: widget.controller,
+          focusNode: widget.focusNode,
           fieldViewBuilder: (context) {
             return TextField(
-              controller: controller,
-              focusNode: focusNode,
+              controller: widget.controller,
+              focusNode: widget.focusNode,
               style: TextStyle(color: colorScheme.onSurface),
-              decoration: InputDecoration.collapsed(hintText: hintText),
+              decoration: InputDecoration.collapsed(hintText: widget.hintText),
               maxLines: null,
               textCapitalization: TextCapitalization.sentences,
             );

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -339,6 +339,12 @@ class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserve
     store.typingNotifier.stoppedComposing();
   }
 
+  bool _handleScroll(ScrollNotification notification) {
+    final store = PerAccountStoreWidget.of(context);
+    store.typingNotifier.keystroke(widget.destination);
+    return false;
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
@@ -377,21 +383,23 @@ class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserve
           // TODO constrain this adaptively (i.e. not hard-coded 200)
           maxHeight: 200,
         ),
-        child: ComposeAutocomplete(
-          narrow: widget.narrow,
-          controller: widget.controller,
-          focusNode: widget.focusNode,
-          fieldViewBuilder: (context) {
-            return TextField(
-              controller: widget.controller,
-              focusNode: widget.focusNode,
-              style: TextStyle(color: colorScheme.onSurface),
-              decoration: InputDecoration.collapsed(hintText: widget.hintText),
-              maxLines: null,
-              textCapitalization: TextCapitalization.sentences,
-            );
-          }),
-        ));
+        child: NotificationListener<ScrollNotification>(
+          onNotification: _handleScroll,
+          child: ComposeAutocomplete(
+            narrow: widget.narrow,
+            controller: widget.controller,
+            focusNode: widget.focusNode,
+            fieldViewBuilder: (context) {
+              return TextField(
+                controller: widget.controller,
+                focusNode: widget.focusNode,
+                style: TextStyle(color: colorScheme.onSurface),
+                decoration: InputDecoration.collapsed(hintText: widget.hintText),
+                maxLines: null,
+                textCapitalization: TextCapitalization.sentences,
+              );
+            }),
+        )));
   }
 }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -218,8 +218,8 @@ class ComposeContentController extends ComposeController<ContentValidationError>
     final linkText = zulipLocalizations.composeBoxUploadingFilename(filename);
     final placeholder = inlineLink(linkText, null);
     _uploads[tag] = (filename: filename, placeholder: placeholder);
-    notifyListeners(); // _uploads change could affect validationErrors
     value = value.replaced(insertionIndex(), '$placeholder\n\n');
+    notifyListeners(); // _uploads change could affect validationErrors
     return tag;
   }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -272,12 +272,14 @@ class ComposeContentController extends ComposeController<ContentValidationError>
 class _ContentInput extends StatefulWidget {
   const _ContentInput({
     required this.narrow,
+    required this.destination,
     required this.controller,
     required this.focusNode,
     required this.hintText,
   });
 
   final Narrow narrow;
+  final SendableNarrow destination;
   final ComposeContentController controller;
   final FocusNode focusNode;
   final String hintText;
@@ -287,6 +289,54 @@ class _ContentInput extends StatefulWidget {
 }
 
 class _ContentInputState extends State<_ContentInput> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_contentChanged);
+    widget.focusNode.addListener(_focusChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ContentInput oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller.removeListener(_contentChanged);
+      widget.controller.addListener(_contentChanged);
+    }
+    if (widget.focusNode != oldWidget.focusNode) {
+      oldWidget.focusNode.removeListener(_focusChanged);
+      widget.focusNode.addListener(_focusChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_contentChanged);
+    widget.focusNode.removeListener(_focusChanged);
+    super.dispose();
+  }
+
+  void _contentChanged() {
+    final store = PerAccountStoreWidget.of(context);
+    (widget.controller.text.isEmpty)
+      ? store.typingNotifier.stoppedComposing()
+      : store.typingNotifier.keystroke(widget.destination);
+  }
+
+  void _focusChanged() {
+    if (widget.focusNode.hasFocus) {
+      // Content input getting focus doesn't necessarily mean that
+      // the user started typing, so do nothing.
+      return;
+    }
+    // Losing focus usually indicates that the user has navigated away or
+    // clicked on other UI elements.  On Android, this does not get triggered
+    // unless the user navigates away from the page or focuses on another input.
+    // See: https://github.com/zulip/zulip-flutter/pull/897#discussion_r1818188643
+    final store = PerAccountStoreWidget.of(context);
+    store.typingNotifier.stoppedComposing();
+  }
+
   @override
   Widget build(BuildContext context) {
     ColorScheme colorScheme = Theme.of(context).colorScheme;
@@ -375,6 +425,8 @@ class _StreamContentInputState extends State<_StreamContentInput> {
       ?? zulipLocalizations.composeBoxUnknownChannelName;
     return _ContentInput(
       narrow: widget.narrow,
+      destination: TopicNarrow(
+        widget.narrow.streamId, widget.topicController.textNormalized),
       controller: widget.controller,
       focusNode: widget.focusNode,
       hintText: zulipLocalizations.composeBoxChannelContentHint(streamName, _topicTextNormalized));
@@ -451,6 +503,7 @@ class _FixedDestinationContentInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return _ContentInput(
       narrow: narrow,
+      destination: narrow,
       controller: controller,
       focusNode: focusNode,
       hintText: _hintText(context));
@@ -823,6 +876,10 @@ class _SendButtonState extends State<_SendButton> {
     final content = widget.contentController.textNormalized;
 
     widget.contentController.clear();
+    // The following `stoppedComposing` call is currently redundant,
+    // because clearing input sends a "typing stopped" notice.
+    // It will be necessary once we resolve #720.
+    store.typingNotifier.stoppedComposing();
 
     try {
       // TODO(#720) clear content input only on success response;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -288,12 +288,13 @@ class _ContentInput extends StatefulWidget {
   State<_ContentInput> createState() => _ContentInputState();
 }
 
-class _ContentInputState extends State<_ContentInput> {
+class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
     widget.controller.addListener(_contentChanged);
     widget.focusNode.addListener(_focusChanged);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -313,6 +314,7 @@ class _ContentInputState extends State<_ContentInput> {
   void dispose() {
     widget.controller.removeListener(_contentChanged);
     widget.focusNode.removeListener(_focusChanged);
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
@@ -335,6 +337,31 @@ class _ContentInputState extends State<_ContentInput> {
     // See: https://github.com/zulip/zulip-flutter/pull/897#discussion_r1818188643
     final store = PerAccountStoreWidget.of(context);
     store.typingNotifier.stoppedComposing();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        // Transition to either of these states signals that
+        // > [the] application is not currently visible to the user, and not
+        // > responding to user input.
+        final store = PerAccountStoreWidget.of(context);
+        store.typingNotifier.stoppedComposing();
+      case AppLifecycleState.detached:
+        // > The application defaults to this state before it initializes, and
+        // > can be in this state (applicable on Android, iOS, and web) after
+        // > all views have been detached.
+        // At the point, the compose box might not exist, so it is irrelevant
+        // to the composing session.
+      case AppLifecycleState.inactive:
+        // > At least one view of the application is visible, but none have
+        // > input focus. The application is otherwise running normally.
+        // For example, we expect this state when the user is selecting a file
+        // to upload.
+      case AppLifecycleState.resumed:
+    }
   }
 
   @override

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -208,6 +209,9 @@ class TestZulipBinding extends ZulipBinding {
   Future<void> closeInAppWebView() async {
     _closeInAppWebViewCallCount++;
   }
+
+  @override
+  Stopwatch stopwatch() => clock.stopwatch();
 
   /// The value that `ZulipBinding.instance.deviceInfo` should return.
   BaseDeviceInfo deviceInfoResult = _defaultDeviceInfoResult;

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -325,7 +325,8 @@ class TestZulipBinding extends ZulipBinding {
     FileType? type,
   }) async {
     (_pickFilesCalls ??= []).add((allowMultiple: allowMultiple, withReadStream: withReadStream, type: type));
-    return pickFilesResult;
+    return Future<FilePickerResult?>.delayed(
+      Duration.zero, () => pickFilesResult);
   }
 
   /// The value that `ZulipBinding.instance.pickImage()` should return.
@@ -364,7 +365,7 @@ class TestZulipBinding extends ZulipBinding {
     bool requestFullMetadata = true,
   }) async {
     (_pickImageCalls ??= []).add((source: source, requestFullMetadata: requestFullMetadata));
-    return pickImageResult;
+    return Future<XFile?>.delayed(Duration.zero, () => pickImageResult);
   }
 
   /// Returns the current status of wakelock, which can be

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -1,14 +1,25 @@
+import 'dart:convert';
+
 import 'package:checks/checks.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/narrow.dart';
+import 'package:zulip/model/store.dart';
 import 'package:zulip/model/typing_status.dart';
 
+import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../fake_async.dart';
+import '../stdlib_checks.dart';
+import 'binding.dart';
+import 'test_store.dart';
 
 void main() {
+  TestZulipBinding.ensureInitialized();
+
   late TypingStatus model;
   late int notifiedCount;
 
@@ -208,6 +219,285 @@ void main() {
       checkTypists({});
       check(async.pendingTimers).isEmpty();
       checkNotifiedOnce();
+    }));
+  });
+
+  group('handle set typing status', () {
+    late PerAccountStore store;
+    late TypingNotifier model;
+    late FakeApiConnection connection;
+    late TopicNarrow narrow;
+
+    void checkSetTypingStatusRequests(
+      FakeApiConnection connection,
+      List<(TypingOp, SendableNarrow)> requests,
+    ) {
+      Condition<Object?> conditionTypingRequest(Map<String, String> expected) {
+        return (Subject<Object?> it) => it.isA<http.Request>()
+          ..method.equals('POST')
+          ..url.path.equals('/api/v1/typing')
+          ..bodyFields.deepEquals(expected);
+      }
+
+      check(connection.takeRequests()).deepEquals([
+        for (final (op, narrow) in requests)
+          switch (narrow) {
+            TopicNarrow() => conditionTypingRequest({
+              'type': 'channel',
+              'op': op.toJson(),
+              'stream_id': narrow.streamId.toString(),
+              'topic': narrow.topic}),
+            DmNarrow() => conditionTypingRequest({
+              'type': 'direct',
+              'op': op.toJson(),
+              'to': jsonEncode(narrow.allRecipientIds)}),
+          }
+      ]);
+    }
+
+    void checkTypingRequest(TypingOp op, SendableNarrow narrow) =>
+      checkSetTypingStatusRequests(connection, [(op, narrow)]);
+
+    Future<void> prepare() async {
+      addTearDown(testBinding.reset);
+      // Only test with the latest behavior of the setTypingStatus API.
+      // (Legacy variations are covered by setTypingStatus's own tests.)
+      final account = eg.account(
+        user: eg.selfUser, zulipFeatureLevel: eg.futureZulipFeatureLevel);
+      store = eg.store(account: account, initialSnapshot: eg.initialSnapshot(
+        zulipFeatureLevel: eg.futureZulipFeatureLevel));
+      model = store.typingNotifier;
+      connection = store.connection as FakeApiConnection;
+
+      final channel = eg.stream();
+      await store.addStream(channel);
+      await store.addSubscription(eg.subscription(channel));
+      narrow = TopicNarrow(channel.streamId, 'topic');
+    }
+
+    /// Prepares store and triggers a "typing started" notice.
+    Future<void> prepareStartTyping(FakeAsync async) async {
+      await prepare();
+      connection.prepare(json: {});
+      model.keystroke(narrow);
+      checkTypingRequest(TypingOp.start, narrow);
+
+      // Finish the pending API request first,
+      // so that the idle timer is the only timer left.
+      async.elapse(Duration.zero);
+      check(async.pendingTimers).single;
+    }
+
+    test('start typing repeatedly extends idle timer', () => awaitFakeAsync((async) async {
+      // t = 0ms: Start typing. The idle timer is set to typingStoppedWaitPeriod.
+      await prepareStartTyping(async);
+
+      const waitTime = Duration(milliseconds: 100);
+      // [waitTime] should not be long enough
+      // to trigger a "typing stopped" notice.
+      assert(waitTime < model.typingStoppedWaitPeriod);
+
+      async.elapse(waitTime);
+      // t = 100ms: The idle timer is reset to typingStoppedWaitPeriod.
+      connection.prepare(json: {});
+      model.keystroke(narrow);
+      check(connection.lastRequest).isNull();
+      check(async.pendingTimers).single;
+
+      async.elapse(model.typingStoppedWaitPeriod - const Duration(milliseconds: 1));
+      // t = typingStoppedWaitPeriod + 99ms:
+      //   Since the timer was reset at t = 100ms, the "typing stopped" notice has
+      //   not been sent yet.
+      check(connection.lastRequest).isNull();
+      check(async.pendingTimers).single;
+
+      async.elapse(const Duration(milliseconds: 1));
+      // t = typingStoppedWaitPeriod + 100ms:
+      //   The new timer expires and the "typing stopped" notice is sent.
+      checkTypingRequest(TypingOp.stop, narrow);
+    }));
+
+    test('start typing repeatedly does not resend "typing started" notices', () => awaitFakeAsync((async) async {
+      // t = 0ms: Start typing.
+      await prepareStartTyping(async);
+
+      const waitInterval = Duration(milliseconds: 2000);
+      // [waitInterval] should not be long enough
+      // to trigger a "typing stopped" notice.
+      assert(waitInterval < model.typingStoppedWaitPeriod);
+      // [waitInterval] should be short enough
+      // that the loop below runs more than once.
+      assert(waitInterval < model.typingStartedWaitPeriod);
+
+      while (async.elapsed <= model.typingStartedWaitPeriod) {
+        // t <= typingStartedWaitPeriod: "Typing started" notices are throttled.
+        model.keystroke(narrow);
+        check(connection.lastRequest).isNull();
+
+        async.elapse(waitInterval);
+      }
+
+      // t > typingStartedWaitPeriod: Resume sending "typing started" notices.
+      connection.prepare(json: {});
+      model.keystroke(narrow);
+      checkTypingRequest(TypingOp.start, narrow);
+
+      // Ensures that a "typing stopped" notice is sent when the test ends.
+      connection.prepare(json: {});
+      async.flushTimers();
+      checkTypingRequest(TypingOp.stop, narrow);
+    }));
+
+    test('after stopped wait period, send a "typing stopped" notice', () => awaitFakeAsync((async) async {
+      await prepareStartTyping(async);
+
+      connection.prepare(json: {});
+      async.elapse(model.typingStoppedWaitPeriod);
+      checkTypingRequest(TypingOp.stop, narrow);
+      check(async.pendingTimers).isEmpty();
+    }));
+
+    test('actively stopping typing cancels the idle timer', () => awaitFakeAsync((async) async {
+      await prepareStartTyping(async);
+
+      connection.prepare(json: {});
+      model.stoppedComposing();
+      checkTypingRequest(TypingOp.stop, narrow);
+
+      async.elapse(Duration.zero);
+      check(async.pendingTimers).isEmpty();
+    }));
+
+    test('stop typing then start typing should result in a new "typing started" notice', () => awaitFakeAsync((async) async {
+      await prepareStartTyping(async);
+
+      connection.prepare(json: {});
+      model.stoppedComposing();
+      checkTypingRequest(TypingOp.stop, narrow);
+
+      // The "typing started" notice would have been throttled if we did not
+      // reset the TypingNotifier internal states before sending the "typing
+      // stopped" notice.
+      connection.prepare(json: {});
+      model.keystroke(narrow);
+      checkTypingRequest(TypingOp.start, narrow);
+
+      // Ensures that a "typing stopped" notice is sent when the test ends.
+      connection.prepare(json: {});
+      async.flushTimers();
+      checkTypingRequest(TypingOp.stop, narrow);
+    }));
+
+    test('disposing store cancels the idle timer', () => awaitFakeAsync((async) async {
+      await prepareStartTyping(async);
+
+      store.dispose();
+      check(async.pendingTimers).isEmpty();
+    }));
+
+    test('start typing in a different destination resets the idle timer', () => awaitFakeAsync((async) async {
+      await prepare();
+      final topicNarrow = narrow;
+      final dmNarrow = DmNarrow.withUsers(
+        [eg.otherUser.userId], selfUserId: eg.selfUser.userId);
+
+      const waitTime = Duration(milliseconds: 100);
+      // [waitTime] should not be long enough
+      // to trigger a "typing stopped" notice.
+      assert(waitTime < model.typingStoppedWaitPeriod);
+
+      // t = 0ms: Start typing. The idle timer is set to typingStoppedWaitPeriod.
+      connection.prepare(json: {});
+      model.keystroke(topicNarrow);
+      checkTypingRequest(TypingOp.start, topicNarrow);
+
+      async.elapse(Duration.zero);
+      check(async.pendingTimers).single;
+
+      async.elapse(waitTime);
+      // t = 100ms:
+      //   Start typing in a different narrow. The timer should be reset
+      //   and the previous typing indicator should be dismissed.
+      connection.prepare(json: {});
+      connection.prepare(json: {});
+      model.keystroke(dmNarrow);
+      checkSetTypingStatusRequests(connection,
+        [(TypingOp.stop, topicNarrow), (TypingOp.start, dmNarrow)]);
+
+      async.elapse(Duration.zero);
+      check(async.pendingTimers).single;
+
+      async.elapse(model.typingStoppedWaitPeriod - waitTime);
+      // t = typingStoppedPeriod:
+      //   Because the old timer has been canceled at t = 100ms,
+      //   no "typing stopped" notice has been sent yet.
+      check(connection.lastRequest).isNull();
+      check(async.pendingTimers).single;
+
+      connection.prepare(json: {});
+      async.elapse(waitTime);
+      // t = typingStoppedPeriod + 100ms:
+      //   The new timer has expired, and a "typing stopped" notice is expected.
+      checkTypingRequest(TypingOp.stop, dmNarrow);
+    }));
+
+    test('start typing in a different destination resets typing started wait timeout', () => awaitFakeAsync((async) async {
+      await prepare();
+      final topicNarrow = narrow;
+      final dmNarrow = DmNarrow.withUsers(
+        [eg.otherUser.userId], selfUserId: eg.selfUser.userId);
+
+      const waitInterval = Duration(milliseconds: 2000);
+      // [waitInterval] should not be long enough
+      // to trigger a "typing stopped" notice.
+      assert(waitInterval < model.typingStoppedWaitPeriod);
+
+      // t = 0ms: Start typing. The typing started time is set to 0ms.
+      connection.prepare(json: {});
+      model.keystroke(topicNarrow);
+      checkTypingRequest(TypingOp.start, topicNarrow);
+
+      async.elapse(waitInterval);
+      // t = waitInterval * 1:
+      //   Start typing in a different narrow.  The last time we sent
+      //   a "typing started" notice should be reset to t.
+      //   The previous typing indicator should be dismissed
+      //   as we start the new one, which results in two requests.
+      connection.prepare(json: {});
+      connection.prepare(json: {});
+      model.keystroke(dmNarrow);
+      checkSetTypingStatusRequests(connection,
+        [(TypingOp.stop, topicNarrow), (TypingOp.start, dmNarrow)]);
+
+      while (async.elapsed <= model.typingStartedWaitPeriod) {
+        // t <= typingStartedWaitPeriod: "still typing" requests are throttled.
+        model.keystroke(dmNarrow);
+        check(connection.lastRequest).isNull();
+
+        async.elapse(waitInterval);
+      }
+
+      assert(async.elapsed > model.typingStartedWaitPeriod);
+      assert(async.elapsed <= model.typingStartedWaitPeriod + waitInterval);
+      // typingStartedWaitPeriod < t <= typingStartedWaitPeriod + waitInterval * 1:
+      //   The "still typing" requests are still throttled, because it hasn't
+      //   been a full typingStartedWaitPeriod since the last time we sent
+      //   a "typing started" notice at t = waitInterval * 1.
+      model.keystroke(dmNarrow);
+      check(connection.lastRequest).isNull();
+
+      async.elapse(waitInterval);
+      // t > typingStartedWaitPeriod + waitInterval * 1:
+      //   Resume sending "typing started" notices, because it has been just
+      //   enough time since the last time we sent a "typing started" notice.
+      connection.prepare(json: {});
+      model.keystroke(dmNarrow);
+      checkTypingRequest(TypingOp.start, dmNarrow);
+
+      // Ensures that a "typing stopped" notice is sent when the test ends.
+      connection.prepare(json: {});
+      async.flushTimers();
+      checkTypingRequest(TypingOp.stop, dmNarrow);
     }));
   });
 }

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -229,8 +229,8 @@ void main() {
     late TopicNarrow narrow;
 
     void checkSetTypingStatusRequests(
-      FakeApiConnection connection,
-      List<(TypingOp, SendableNarrow)> requests,
+      List<http.BaseRequest> requests,
+      List<(TypingOp, SendableNarrow)> expected,
     ) {
       Condition<Object?> conditionTypingRequest(Map<String, String> expected) {
         return (Subject<Object?> it) => it.isA<http.Request>()
@@ -239,8 +239,8 @@ void main() {
           ..bodyFields.deepEquals(expected);
       }
 
-      check(connection.takeRequests()).deepEquals([
-        for (final (op, narrow) in requests)
+      check(requests).deepEquals([
+        for (final (op, narrow) in expected)
           switch (narrow) {
             TopicNarrow() => conditionTypingRequest({
               'type': 'channel',
@@ -256,7 +256,7 @@ void main() {
     }
 
     void checkTypingRequest(TypingOp op, SendableNarrow narrow) =>
-      checkSetTypingStatusRequests(connection, [(op, narrow)]);
+      checkSetTypingStatusRequests(connection.takeRequests(), [(op, narrow)]);
 
     Future<void> prepare() async {
       addTearDown(testBinding.reset);
@@ -421,7 +421,7 @@ void main() {
       connection.prepare(json: {});
       connection.prepare(json: {});
       model.keystroke(dmNarrow);
-      checkSetTypingStatusRequests(connection,
+      checkSetTypingStatusRequests(connection.takeRequests(),
         [(TypingOp.stop, topicNarrow), (TypingOp.start, dmNarrow)]);
 
       async.elapse(Duration.zero);
@@ -466,7 +466,7 @@ void main() {
       connection.prepare(json: {});
       connection.prepare(json: {});
       model.keystroke(dmNarrow);
-      checkSetTypingStatusRequests(connection,
+      checkSetTypingStatusRequests(connection.takeRequests(),
         [(TypingOp.stop, topicNarrow), (TypingOp.start, dmNarrow)]);
 
       while (async.elapsed <= model.typingStartedWaitPeriod) {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -14,6 +14,7 @@ import 'package:zulip/model/internal_link.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
+import 'package:zulip/model/typing_status.dart';
 import 'package:zulip/widgets/compose_box.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/icons.dart';
@@ -259,6 +260,8 @@ void main() {
       await tester.ensureVisible(find.byIcon(ZulipIcons.format_quote, skipOffstage: false));
       final quoteAndReplyButton = findQuoteAndReplyButton(tester);
       check(quoteAndReplyButton).isNotNull();
+      TypingNotifier.debugEnable = false;
+      addTearDown(TypingNotifier.debugReset);
       await tester.tap(find.byWidget(quoteAndReplyButton!));
       await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
     }

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -8,6 +8,7 @@ import 'package:zulip/model/compose.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
+import 'package:zulip/model/typing_status.dart';
 import 'package:zulip/widgets/message_list.dart';
 
 import '../api/fake_api.dart';
@@ -129,6 +130,9 @@ void main() {
       final composeInputFinder = await setupToComposeInput(tester, users: [user1, user2, user3]);
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
+      TypingNotifier.debugEnable = false;
+      addTearDown(TypingNotifier.debugReset);
+
       // Options are filtered correctly for query
       // TODO(#226): Remove this extra edit when this bug is fixed.
       await tester.enterText(composeInputFinder, 'hello @user ');
@@ -179,6 +183,9 @@ void main() {
       final topic3 = eg.getStreamTopicsEntry(maxId: 3, name: 'Topic three');
       final topicInputFinder = await setupToTopicInput(tester, topics: [topic1, topic2, topic3]);
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+
+      TypingNotifier.debugEnable = false;
+      addTearDown(TypingNotifier.debugReset);
 
       // Options are filtered correctly for query
       // TODO(#226): Remove this extra edit when this bug is fixed.

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -57,7 +57,13 @@ void main() {
 
     final controllerKey = GlobalKey<ComposeBoxController>();
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-      child: ComposeBox(controllerKey: controllerKey, narrow: narrow)));
+      child: Column(
+        // This positions the compose box at the bottom of the screen,
+        // simulating the layout of the message list page.
+        children: [
+          const Expanded(child: SizedBox.expand()),
+          ComposeBox(controllerKey: controllerKey, narrow: narrow),
+        ])));
     await tester.pumpAndSettle();
 
     if (topic != null) {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -486,6 +486,7 @@ void main() {
         final errorDialogs = tester.widgetList(find.byType(AlertDialog));
         check(errorDialogs).isEmpty();
 
+        await tester.pump(Duration.zero); // picked a file
         check(composeBoxController.contentController.text)
           .equals('see image: [Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
@@ -543,6 +544,7 @@ void main() {
         final errorDialogs = tester.widgetList(find.byType(AlertDialog));
         check(errorDialogs).isEmpty();
 
+        await tester.pump(Duration.zero); // picked an image
         check(composeBoxController.contentController.text)
           .equals('see image: [Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -14,6 +14,7 @@ import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
+import 'package:zulip/model/typing_status.dart';
 import 'package:zulip/widgets/compose_box.dart';
 
 import '../api/fake_api.dart';
@@ -199,6 +200,9 @@ void main() {
     Future<void> setupAndTapSend(WidgetTester tester, {
       required void Function(int messageId) prepareResponse,
     }) async {
+      TypingNotifier.debugEnable = false;
+      addTearDown(TypingNotifier.debugReset);
+
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       await prepareComposeBox(tester, narrow: const TopicNarrow(123, 'some topic'));
 
@@ -264,6 +268,9 @@ void main() {
 
     group('attach from media library', () {
       testWidgets('success', (tester) async {
+        TypingNotifier.debugEnable = false;
+        addTearDown(TypingNotifier.debugReset);
+
         final controllerKey = await prepareComposeBox(tester, narrow: ChannelNarrow(eg.stream().streamId));
         final composeBoxController = controllerKey.currentState!;
 
@@ -320,6 +327,9 @@ void main() {
 
     group('attach from camera', () {
       testWidgets('success', (tester) async {
+        TypingNotifier.debugEnable = false;
+        addTearDown(TypingNotifier.debugReset);
+
         final controllerKey = await prepareComposeBox(tester, narrow: ChannelNarrow(eg.stream().streamId));
         final composeBoxController = controllerKey.currentState!;
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -15,6 +15,7 @@ import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
+import 'package:zulip/model/typing_status.dart';
 import 'package:zulip/widgets/autocomplete.dart';
 import 'package:zulip/widgets/color.dart';
 import 'package:zulip/widgets/content.dart';
@@ -52,6 +53,8 @@ void main() {
     List<Subscription>? subscriptions,
     UnreadMessagesSnapshot? unreadMsgs,
   }) async {
+    TypingNotifier.debugEnable = false;
+    addTearDown(TypingNotifier.debugReset);
     addTearDown(testBinding.reset);
     streams ??= subscriptions ??= [eg.subscription(eg.stream(streamId: eg.defaultStreamMessageStreamId))];
     await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(


### PR DESCRIPTION
A follow-up to #897. This will cover more types of interactions described [here](https://github.com/zulip/zulip-flutter/pull/897#discussion_r1818182796).

Specifically, this will track interactions with compose buttons and autocomplete scroll view, and send typing notices.