### PR TITLE
compose_box test: Use a layout similar to the message list page

### DIFF
--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -51,7 +51,13 @@ void main() {
 
     final controllerKey = GlobalKey<ComposeBoxController>();
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-      child: ComposeBox(controllerKey: controllerKey, narrow: narrow)));
+      child: Column(
+        // This positions the compose box at the bottom of the screen,
+        // simulating the layout of the message list page.
+        children: [
+          const Expanded(child: SizedBox.expand()),
+          ComposeBox(controllerKey: controllerKey, narrow: narrow),
+        ])));
     await tester.pumpAndSettle();
 
     return controllerKey;


### PR DESCRIPTION
This gives more vertical space above the compose box.  This will provide enough space for the autocomplete to appear without overflowing when we add tests for it.

This should be useful for both #928 and #1033. It doesn't aim to reproduce the exact things we do with `MessageListPage`.


| before | after |
| - | - |
| ![image](https://github.com/user-attachments/assets/8be03a3e-6ada-4e1d-8630-f28599d9395f) | ![image](https://github.com/user-attachments/assets/313b4d8c-a410-4453-af9e-98f06d12af86) |