### PR TITLE
Clarify action sheet's "page context"; fix small bugs

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -484,10 +484,9 @@ class ShareButton extends MessageActionSheetMenuItemButton {
     // sheet. (We could do this after the sharing Future settles
     // with [ShareResultStatus.success], but on iOS I get impatient with
     // how slowly our action sheet dismisses in that case.)
-    // TODO(#24): Fix iOS bug where this call causes the keyboard to
-    //   reopen (if it was open at the time of this
-    //   `showMessageActionSheet` call) and cover a large part of the
-    //   share sheet.
+    // TODO(#591): Fix iOS bug where if the keyboard was open before the call
+    //   to `showMessageActionSheet`, it reappears briefly between
+    //   the `pop` of the action sheet and the appearance of the share sheet.
     Navigator.of(context).pop();
     final zulipLocalizations = ZulipLocalizations.of(pageContext);
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -183,11 +183,7 @@ class MessageActionSheetCancelButton extends StatelessWidget {
 // This button is very temporary, to complete #125 before we have a way to
 // choose an arbitrary reaction (#388). So, skipping i18n.
 class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
-  AddThumbsUpButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  AddThumbsUpButton({super.key, required super.message, required super.pageContext});
 
   @override IconData get icon => ZulipIcons.smile;
 
@@ -223,11 +219,7 @@ class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
 }
 
 class StarButton extends MessageActionSheetMenuItemButton {
-  StarButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  StarButton({super.key, required super.message, required super.pageContext});
 
   @override IconData get icon => _isStarred ? ZulipIcons.star_filled : ZulipIcons.star;
 
@@ -320,11 +312,7 @@ Future<String?> fetchRawContentWithFeedback({
 }
 
 class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
-  QuoteAndReplyButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  QuoteAndReplyButton({super.key, required super.message, required super.pageContext});
 
   @override IconData get icon => ZulipIcons.format_quote;
 
@@ -380,11 +368,7 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
 }
 
 class MarkAsUnreadButton extends MessageActionSheetMenuItemButton {
-  MarkAsUnreadButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  MarkAsUnreadButton({super.key, required super.message, required super.pageContext});
 
   @override IconData get icon => Icons.mark_chat_unread_outlined;
 
@@ -400,11 +384,7 @@ class MarkAsUnreadButton extends MessageActionSheetMenuItemButton {
 }
 
 class CopyMessageTextButton extends MessageActionSheetMenuItemButton {
-  CopyMessageTextButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  CopyMessageTextButton({super.key, required super.message, required super.pageContext});
 
   @override IconData get icon => ZulipIcons.copy;
 
@@ -437,11 +417,7 @@ class CopyMessageTextButton extends MessageActionSheetMenuItemButton {
 }
 
 class CopyMessageLinkButton extends MessageActionSheetMenuItemButton {
-  CopyMessageLinkButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  CopyMessageLinkButton({super.key, required super.message, required super.pageContext});
 
   @override IconData get icon => Icons.link;
 
@@ -467,11 +443,7 @@ class CopyMessageLinkButton extends MessageActionSheetMenuItemButton {
 }
 
 class ShareButton extends MessageActionSheetMenuItemButton {
-  ShareButton({
-    super.key,
-    required super.message,
-    required super.pageContext,
-  });
+  ShareButton({super.key, required super.message, required super.pageContext});
 
   @override
   IconData get icon => defaultTargetPlatform == TargetPlatform.iOS

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -99,6 +99,13 @@ abstract class MessageActionSheetMenuItemButton extends StatelessWidget {
 
   IconData get icon;
   String label(ZulipLocalizations zulipLocalizations);
+
+  /// Called when the button is pressed.
+  ///
+  /// Generally this method's implementation should begin by dismissing the
+  /// action sheet with [NavigatorState.pop].
+  /// After that step, the given `context` may no longer be mounted;
+  /// operations that need a [BuildContext] should typically use [pageContext].
   void onPressed(BuildContext context);
 
   final Message message;
@@ -200,7 +207,7 @@ class AddThumbsUpButton extends MessageActionSheetMenuItemButton {
         default:
       }
 
-      showErrorDialog(context: context,
+      showErrorDialog(context: pageContext,
         title: 'Adding reaction failed', message: errorMessage);
     }
   }

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -29,11 +29,12 @@ void showMessageActionSheet({required BuildContext context, required Message mes
 
   // The UI that's conditioned on this won't live-update during this appearance
   // of the action sheet (we avoid calling composeBoxControllerOf in a build
-  // method; see its doc). But currently it will be constant through the life of
-  // any message list, so that's fine.
+  // method; see its doc).
+  // So we rely on the fact that isComposeBoxOffered for any given message list
+  // will be constant through the page's life.
   final messageListPage = MessageListPage.ancestorOf(context);
   final isComposeBoxOffered = messageListPage.composeBoxController != null;
-  final narrow = messageListPage.narrow;
+
   final isMessageRead = message.flags.contains(MessageFlag.read);
   final markAsUnreadSupported = store.connection.zulipFeatureLevel! >= 155; // TODO(server-6)
   final showMarkAsUnreadButton = markAsUnreadSupported && isMessageRead;
@@ -52,7 +53,7 @@ void showMessageActionSheet({required BuildContext context, required Message mes
     if (isComposeBoxOffered)
       QuoteAndReplyButton(message: message, pageContext: context),
     if (showMarkAsUnreadButton)
-      MarkAsUnreadButton(message: message, pageContext: context, narrow: narrow),
+      MarkAsUnreadButton(message: message, pageContext: context),
     CopyMessageTextButton(message: message, pageContext: context),
     CopyMessageLinkButton(message: message, pageContext: context),
     ShareButton(message: message, pageContext: context),
@@ -383,10 +384,7 @@ class MarkAsUnreadButton extends MessageActionSheetMenuItemButton {
     super.key,
     required super.message,
     required super.pageContext,
-    required this.narrow,
   });
-
-  final Narrow narrow;
 
   @override IconData get icon => Icons.mark_chat_unread_outlined;
 
@@ -396,6 +394,7 @@ class MarkAsUnreadButton extends MessageActionSheetMenuItemButton {
   }
 
   @override void onPressed() async {
+    final narrow = findMessageListPage().narrow;
     unawaited(markNarrowAsUnreadFromMessage(pageContext, message, narrow));
   }
 }

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -13,7 +13,6 @@ import '../model/internal_link.dart';
 import '../model/narrow.dart';
 import 'actions.dart';
 import 'clipboard.dart';
-import 'compose_box.dart';
 import 'dialog.dart';
 import 'icons.dart';
 import 'inset_shadow.dart';
@@ -104,6 +103,16 @@ abstract class MessageActionSheetMenuItemButton extends StatelessWidget {
 
   final Message message;
   final BuildContext messageListContext;
+
+  /// The [MessageListPageState] this action sheet was triggered from.
+  ///
+  /// Uses the inefficient [BuildContext.findAncestorStateOfType];
+  /// don't call this in a build method.
+  MessageListPageState findMessageListPage() {
+    assert(messageListContext.mounted,
+      'findMessageListPage should be called only when messageListContext is known to still be mounted');
+    return MessageListPage.ancestorOf(messageListContext);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -315,8 +324,7 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     // This will be null only if the compose box disappeared after the
     // message action sheet opened, and before "Quote and reply" was pressed.
     // Currently a compose box can't ever disappear, so this is impossible.
-    ComposeBoxController composeBoxController =
-      MessageListPage.ancestorOf(messageListContext).composeBoxController!;
+    var composeBoxController = findMessageListPage().composeBoxController!;
     final topicController = composeBoxController.topicController;
     if (
       topicController != null
@@ -341,8 +349,7 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     // This will be null only if the compose box disappeared during the
     // quotation request. Currently a compose box can't ever disappear,
     // so this is impossible.
-    composeBoxController =
-      MessageListPage.ancestorOf(messageListContext).composeBoxController!;
+    composeBoxController = findMessageListPage().composeBoxController!;
     composeBoxController.contentController
       .registerQuoteAndReplyEnd(PerAccountStoreWidget.of(messageListContext), tag,
         message: message,

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -73,7 +73,7 @@ void main() {
   TestZulipBinding.ensureInitialized();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  void prepareRawContentResponseSuccess(PerAccountStore store, {
+  void prepareRawContentResponseSuccess({
     required Message message,
     required String rawContent,
     Duration delay = Duration.zero,
@@ -81,17 +81,17 @@ void main() {
     // Prepare fetch-raw-Markdown response
     // TODO: Message should really only differ from `message`
     //   in its content / content_type, not in `id` or anything else.
-    (store.connection as FakeApiConnection).prepare(delay: delay, json:
+    connection.prepare(delay: delay, json:
       GetMessageResult(message: eg.streamMessage(contentMarkdown: rawContent)).toJson());
   }
 
-  void prepareRawContentResponseError(PerAccountStore store) {
+  void prepareRawContentResponseError() {
     final fakeResponseJson = {
       'code': 'BAD_REQUEST',
       'msg': 'Invalid message(s)',
       'result': 'error',
     };
-    (store.connection as FakeApiConnection).prepare(httpStatus: 400, json: fakeResponseJson);
+    connection.prepare(httpStatus: 400, json: fakeResponseJson);
   }
 
   group('AddThumbsUpButton', () {
@@ -288,7 +288,7 @@ void main() {
       topicController?.value = const TextEditingValue(text: kNoTopicTopic);
 
       final valueBefore = contentController.value;
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
       await tapQuoteAndReplyButton(tester);
       checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
       await tester.pump(Duration.zero); // message is fetched; compose box updates
@@ -305,7 +305,7 @@ void main() {
       final contentController = composeBoxController.contentController;
 
       final valueBefore = contentController.value;
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
       await tapQuoteAndReplyButton(tester);
       checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
       await tester.pump(Duration.zero); // message is fetched; compose box updates
@@ -323,7 +323,7 @@ void main() {
       final contentController = composeBoxController.contentController;
 
       final valueBefore = contentController.value;
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
       await tapQuoteAndReplyButton(tester);
       checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
       await tester.pump(Duration.zero); // message is fetched; compose box updates
@@ -340,7 +340,7 @@ void main() {
       final contentController = composeBoxController.contentController;
 
       final valueBefore = contentController.value = TextEditingValue.empty;
-      prepareRawContentResponseError(store);
+      prepareRawContentResponseError();
       await tapQuoteAndReplyButton(tester);
       checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
       await tester.pump(Duration.zero); // error arrives; error dialog shows
@@ -498,7 +498,7 @@ void main() {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
       await tapCopyMessageTextButton(tester);
       await tester.pump(Duration.zero);
       check(await Clipboard.getData('text/plain')).isNotNull().text.equals('Hello world');
@@ -512,7 +512,7 @@ void main() {
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
       // Make the request take a bit of time to complete…
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world',
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world',
         delay: const Duration(milliseconds: 500));
       await tapCopyMessageTextButton(tester);
       // … and pump a frame to finish the NavigationState.pop animation…
@@ -532,7 +532,7 @@ void main() {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      prepareRawContentResponseError(store);
+      prepareRawContentResponseError();
       await tapCopyMessageTextButton(tester);
       await tester.pump(Duration.zero); // error arrives; error dialog shows
 
@@ -592,7 +592,7 @@ void main() {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
       await tapShareButton(tester);
       await tester.pump(Duration.zero);
       check(mockSharePlus.sharedString).equals('Hello world');
@@ -603,7 +603,7 @@ void main() {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
+      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
       mockSharePlus.resultString = 'dev.fluttercommunity.plus/share/unavailable';
       await tapShareButton(tester);
       await tester.pump(Duration.zero);
@@ -618,7 +618,7 @@ void main() {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      prepareRawContentResponseError(store);
+      prepareRawContentResponseError();
       await tapShareButton(tester);
       await tester.pump(Duration.zero); // error arrives; error dialog shows
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -25,6 +25,7 @@ import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
+import '../model/message_list_test.dart';
 import '../model/test_store.dart';
 import '../stdlib_checks.dart';
 import '../test_clipboard.dart';
@@ -52,16 +53,8 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   }
   connection = store.connection as FakeApiConnection;
 
-  // prepare message list data
-  connection.prepare(json: GetMessagesResult(
-    anchor: message.id,
-    foundNewest: true,
-    foundOldest: true,
-    foundAnchor: true,
-    historyLimited: false,
-    messages: [message],
-  ).toJson());
-
+  connection.prepare(json: newestResult(
+    foundOldest: true, messages: [message]).toJson());
   await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
     child: MessageListPage(initNarrow: narrow)));
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -35,6 +35,7 @@ import 'compose_box_checks.dart';
 import 'dialog_checks.dart';
 import 'test_app.dart';
 
+late PerAccountStore store;
 late FakeApiConnection connection;
 
 /// Simulates loading a [MessageListPage] and long-pressing on [message].
@@ -45,7 +46,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   addTearDown(testBinding.reset);
 
   await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-  final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+  store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
   await store.addUser(eg.user(userId: message.senderId));
   if (message is StreamMessage) {
     final stream = eg.stream(streamId: message.streamId);
@@ -103,9 +104,7 @@ void main() {
     testWidgets('success', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-      final connection = store.connection as FakeApiConnection;
       connection.prepare(json: {});
       await tapButton(tester);
       await tester.pump(Duration.zero);
@@ -123,9 +122,6 @@ void main() {
     testWidgets('request has an error', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-
-      final connection = store.connection as FakeApiConnection;
 
       connection.prepare(httpStatus: 400, json: {
         'code': 'BAD_REQUEST',
@@ -157,9 +153,7 @@ void main() {
     testWidgets('star success', (tester) async {
       final message = eg.streamMessage(flags: []);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-      final connection = store.connection as FakeApiConnection;
       connection.prepare(json: {});
       await tapButton(tester);
       await tester.pump(Duration.zero);
@@ -177,9 +171,7 @@ void main() {
     testWidgets('unstar success', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.starred]);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-      final connection = store.connection as FakeApiConnection;
       connection.prepare(json: {});
       await tapButton(tester, starred: true);
       await tester.pump(Duration.zero);
@@ -197,10 +189,7 @@ void main() {
     testWidgets('star request has an error', (tester) async {
       final message = eg.streamMessage(flags: []);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-
-      final connection = store.connection as FakeApiConnection;
 
       connection.prepare(httpStatus: 400, json: {
         'code': 'BAD_REQUEST',
@@ -218,10 +207,7 @@ void main() {
     testWidgets('unstar request has an error', (tester) async {
       final message = eg.streamMessage(flags: [MessageFlag.starred]);
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-
-      final connection = store.connection as FakeApiConnection;
 
       connection.prepare(httpStatus: 400, json: {
         'code': 'BAD_REQUEST',
@@ -291,7 +277,6 @@ void main() {
     testWidgets('in channel narrow', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: ChannelNarrow(message.streamId));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -315,7 +300,6 @@ void main() {
     testWidgets('in topic narrow', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -334,7 +318,6 @@ void main() {
       final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
       await setupToMessageActionSheet(tester,
         message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -352,7 +335,6 @@ void main() {
     testWidgets('request has an error', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       final composeBoxController = findComposeBoxController(tester)!;
       final contentController = composeBoxController.contentController;
@@ -452,7 +434,6 @@ void main() {
         // by giving the code maximum opportunity to latch onto the old topic.)
         await tester.pumpAndSettle();
 
-        final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
         final newStream = eg.stream();
         const newTopic = 'other topic';
         // This result isn't quite realistic for this request: it should get
@@ -516,7 +497,6 @@ void main() {
     testWidgets('success', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
       await tapCopyMessageTextButton(tester);
@@ -530,7 +510,6 @@ void main() {
 
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       // Make the request take a bit of time to complete…
       prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world',
@@ -552,7 +531,6 @@ void main() {
     testWidgets('request has an error', (tester) async {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseError(store);
       await tapCopyMessageTextButton(tester);
@@ -584,7 +562,6 @@ void main() {
       final message = eg.streamMessage();
       final narrow = TopicNarrow.ofMessage(message);
       await setupToMessageActionSheet(tester, message: message, narrow: narrow);
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       await tapCopyMessageLinkButton(tester);
       await tester.pump(Duration.zero);
@@ -614,7 +591,6 @@ void main() {
       final mockSharePlus = setupMockSharePlus();
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
       await tapShareButton(tester);
@@ -626,7 +602,6 @@ void main() {
       final mockSharePlus = setupMockSharePlus();
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseSuccess(store, message: message, rawContent: 'Hello world');
       mockSharePlus.resultString = 'dev.fluttercommunity.plus/share/unavailable';
@@ -642,7 +617,6 @@ void main() {
       final mockSharePlus = setupMockSharePlus();
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       prepareRawContentResponseError(store);
       await tapShareButton(tester);


### PR DESCRIPTION
This was prompted by my comment at https://github.com/zulip/zulip-flutter/pull/1041#discussion_r1828562960 (/cc @PIG208). But then as I got into this code I found some other small cleanups to make, and also spotted a couple of bugs to fix.

## Selected commit messages

action_sheet [nfc]: Rename pageContext field on button widgets

Most of the ways we use this field (specifically, all the ways we
use it other than in findMessageListPage) aren't related to it
being the message list in particular.

When we add action sheets other than the message action sheet,
they'll still need a page context.  So prepare the way for those
by giving this a name that can generalize.

---

action_sheet [nfc]: Avoid passing footgun context to onPressed methods

The usual Flutter idiom, which we use across the rest of the app,
would call for using the parameter called `context` wherever a
BuildContext is required: for getting the store or localizations,
or passing to a method like showErrorDialog, and so on.

That idiom doesn't work here, because that context belongs to the
action sheet itself, which gets dismissed at the start of the method.
Worse, it will sometimes seem to work, nondeterministically: the
context only gets unmounted after the animation to dismiss the action
sheet is complete, which takes something like 200ms.  So the
temptation to use it has been a recurring source of small bugs.

Fix the problem by not passing the action sheet's context to these
methods at all.

---

action_sheet: Mark as unread in current narrow, vs. from when action sheet opened

The narrow of a given MessageListPage can change over time,
in particular if viewing a topic that gets moved.

If it does, the mark-unread action should follow along.  Otherwise
we'd have a frustrating race where mark-unread just didn't work
if, for example, someone happened to resolve the topic while you
were in the middle of trying to mark as unread.

Fixes: #1045 