### PR TITLE
msglist: Throttle fetchOlder retries

### DIFF
--- a/lib/api/backoff.dart
+++ b/lib/api/backoff.dart
@@ -36,6 +36,25 @@ class BackoffMachine {
   /// not the (random) previous wait duration itself.
   static const double base = 2;
 
+  /// In debug mode, overrides the duration of the backoff wait.
+  ///
+  /// Outside of debug mode, this is always `null` and the setter has no effect.
+  static Duration? get debugDuration {
+    Duration? result;
+    assert(() {
+      result = _debugDuration;
+      return true;
+    }());
+    return result;
+  }
+  static Duration? _debugDuration;
+  static set debugDuration(Duration? newValue) {
+    assert(() {
+      _debugDuration = newValue;
+      return true;
+    }());
+  }
+
   /// A future that resolves after an appropriate backoff time,
   /// with jitter applied to capped exponential growth.
   ///
@@ -66,8 +85,8 @@ class BackoffMachine {
   Future<void> wait() async {
     final bound = _minDuration(maxBound,
                                firstBound * pow(base, _waitsCompleted));
-    final duration = _maxDuration(const Duration(microseconds: 1),
-                                  bound * Random().nextDouble());
+    final duration = debugDuration ?? _maxDuration(const Duration(microseconds: 1),
+                                                   bound * Random().nextDouble());
     await Future<void>.delayed(duration);
     _waitsCompleted++;
   }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -288,6 +288,7 @@ mixin _MessageSequence {
 
   /// Update [items] to include markers at start and end as appropriate.
   void _updateEndMarkers() {
+    assert(fetched);
     assert(!(haveOldest && fetchingOlder));
     final startMarker = switch ((fetchingOlder, haveOldest)) {
       (true, _) => const MessageListLoadingItem(MessageListDirection.older),

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
+import '../api/backoff.dart';
 import '../api/model/events.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
@@ -89,8 +92,31 @@ mixin _MessageSequence {
   bool _haveOldest = false;
 
   /// Whether we are currently fetching the next batch of older messages.
+  ///
+  /// When this is true, [fetchOlder] is a no-op.
+  /// That method is called frequently by Flutter's scrolling logic,
+  /// and this field helps us avoid spamming the same request just to get
+  /// the same response each time.
+  ///
+  /// See also [fetchOlderCoolingDown].
   bool get fetchingOlder => _fetchingOlder;
   bool _fetchingOlder = false;
+
+  /// Whether [fetchOlder] had a request error recently.
+  ///
+  /// When this is true, [fetchOlder] is a no-op.
+  /// That method is called frequently by Flutter's scrolling logic,
+  /// and this field mitigates spamming the same request and getting
+  /// the same error each time.
+  ///
+  /// "Recently" is decided by a [BackoffMachine] that resets
+  /// when a [fetchOlder] request succeeds.
+  ///
+  /// See also [fetchingOlder].
+  bool get fetchOlderCoolingDown => _fetchOlderCoolingDown;
+  bool _fetchOlderCoolingDown = false;
+
+  BackoffMachine? _fetchOlderCooldownBackoffMachine;
 
   /// The parsed message contents, as a list parallel to [messages].
   ///
@@ -107,7 +133,7 @@ mixin _MessageSequence {
   /// before, between, or after the messages.
   ///
   /// This information is completely derived from [messages] and
-  /// the flags [haveOldest] and [fetchingOlder].
+  /// the flags [haveOldest], [fetchingOlder] and [fetchOlderCoolingDown].
   /// It exists as an optimization, to memoize that computation.
   final QueueList<MessageListItem> items = QueueList();
 
@@ -241,6 +267,8 @@ mixin _MessageSequence {
     _fetched = false;
     _haveOldest = false;
     _fetchingOlder = false;
+    _fetchOlderCoolingDown = false;
+    _fetchOlderCooldownBackoffMachine = null;
     contents.clear();
     items.clear();
   }
@@ -289,8 +317,10 @@ mixin _MessageSequence {
   /// Update [items] to include markers at start and end as appropriate.
   void _updateEndMarkers() {
     assert(fetched);
-    assert(!(haveOldest && fetchingOlder));
-    final startMarker = switch ((fetchingOlder, haveOldest)) {
+    assert(!(fetchingOlder && fetchOlderCoolingDown));
+    final effectiveFetchingOlder = fetchingOlder || fetchOlderCoolingDown;
+    assert(!(effectiveFetchingOlder && haveOldest));
+    final startMarker = switch ((effectiveFetchingOlder, haveOldest)) {
       (true, _) => const MessageListLoadingItem(MessageListDirection.older),
       (_, true) => const MessageListHistoryStartItem(),
       (_,    _) => null,
@@ -470,7 +500,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   Future<void> fetchInitial() async {
     // TODO(#80): fetch from anchor firstUnread, instead of newest
     // TODO(#82): fetch from a given message ID as anchor
-    assert(!fetched && !haveOldest && !fetchingOlder);
+    assert(!fetched && !haveOldest && !fetchingOlder && !fetchOlderCoolingDown);
     assert(messages.isEmpty && contents.isEmpty);
     // TODO schedule all this in another isolate
     final generation = this.generation;
@@ -498,20 +528,28 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   Future<void> fetchOlder() async {
     if (haveOldest) return;
     if (fetchingOlder) return;
+    if (fetchOlderCoolingDown) return;
     assert(fetched);
     assert(messages.isNotEmpty);
     _fetchingOlder = true;
     _updateEndMarkers();
     notifyListeners();
     final generation = this.generation;
+    bool hasFetchError = false;
     try {
-      final result = await getMessages(store.connection,
-        narrow: narrow.apiEncode(),
-        anchor: NumericAnchor(messages[0].id),
-        includeAnchor: false,
-        numBefore: kMessageListFetchBatchSize,
-        numAfter: 0,
-      );
+      final GetMessagesResult result;
+      try {
+        result = await getMessages(store.connection,
+          narrow: narrow.apiEncode(),
+          anchor: NumericAnchor(messages[0].id),
+          includeAnchor: false,
+          numBefore: kMessageListFetchBatchSize,
+          numAfter: 0,
+        );
+      } catch (e) {
+        hasFetchError = true;
+        rethrow;
+      }
       if (this.generation > generation) return;
 
       if (result.messages.isNotEmpty
@@ -532,6 +570,19 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     } finally {
       if (this.generation == generation) {
         _fetchingOlder = false;
+        if (hasFetchError) {
+          assert(!fetchOlderCoolingDown);
+          _fetchOlderCoolingDown = true;
+          unawaited((_fetchOlderCooldownBackoffMachine ??= BackoffMachine())
+            .wait().then((_) {
+              if (this.generation != generation) return;
+              _fetchOlderCoolingDown = false;
+              _updateEndMarkers();
+              notifyListeners();
+            }));
+        } else {
+          _fetchOlderCooldownBackoffMachine = null;
+        }
         _updateEndMarkers();
         notifyListeners();
       }


### PR DESCRIPTION
This approach is different from how a BackoffMachine is typically used,
because the message list doesn't send and retry requests in a loop; its
caller retries rapidly on scroll changes, and we want to ignore the
excessive requests.

The test drops irrelevant requests with `connection.takeRequests`
without checking, as we are only interested in verifying that no request
was sent.

Fixes: #945