### PR TITLE
deps: Upgrade flutter_color_models to fix build

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,7 +203,7 @@ packages:
     description:
       path: color_models
       ref: wide-gamut
-      resolved-ref: "27298bc2cbfc9f1da08503be68da472076bcb61c"
+      resolved-ref: fafe4b4d90acca4d56b9395e95a6797a1791c20c
       url: "https://github.com/gaaclarke/color_models.git"
     source: git
     version: "1.3.3"
@@ -433,7 +433,7 @@ packages:
     description:
       path: flutter_color_models
       ref: wide-gamut
-      resolved-ref: "27298bc2cbfc9f1da08503be68da472076bcb61c"
+      resolved-ref: fafe4b4d90acca4d56b9395e95a6797a1791c20c
       url: "https://github.com/gaaclarke/color_models.git"
     source: git
     version: "1.4.0"


### PR DESCRIPTION
An upstream change breaks our build by adding a method to Color;
this takes the corresponding update to package:flutter_color_models
that implements the method and so fixes our build.

Details in #1052, and in a chat thread:
  https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/tools.2Fcheck.20CI.20failure.20on.20main/near/1976890

and a Discord thread I started upstream:
  https://discord.com/channels/608014603317936148/608021010377080866/1303869787365179422

Upgrade done with the following command:
  $ flutter pub upgrade color_models flutter_color_models

Fixes: #1052
