### PR TITLE
example_data [nfc]: Move {newest,older}Result

### DIFF
--- a/integration_test/unreadmarker_test.dart
+++ b/integration_test/unreadmarker_test.dart
@@ -9,7 +9,6 @@ import 'package:zulip/widgets/message_list.dart';
 import '../test/api/fake_api.dart';
 import '../test/example_data.dart' as eg;
 import '../test/model/binding.dart';
-import '../test/model/message_list_test.dart';
 import '../test/widgets/test_app.dart';
 
 void main() {
@@ -29,7 +28,7 @@ void main() {
     final messages = List.generate(messageCount,
       (i) => eg.streamMessage(flags: [MessageFlag.read]));
     connection.prepare(json:
-      newestResult(foundOldest: true, messages: messages).toJson());
+      eg.newestGetMessagesResult(foundOldest: true, messages: messages).toJson());
 
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
       child: const MessageListPage(initNarrow: CombinedFeedNarrow())));

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -5,6 +5,7 @@ import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/submessage.dart';
+import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/api/route/channels.dart';
 import 'package:zulip/model/narrow.dart';
@@ -449,6 +450,43 @@ DmMessage dmMessage({
     'timestamp': timestamp ?? 1678139636,
     'type': 'private',
   }) as Map<String, dynamic>);
+}
+
+/// A GetMessagesResult the server might return on an `anchor=newest` request.
+GetMessagesResult newestGetMessagesResult({
+  required bool foundOldest,
+  bool historyLimited = false,
+  required List<Message> messages,
+}) {
+  return GetMessagesResult(
+    // These anchor, foundAnchor, and foundNewest values are what the server
+    // appears to always return when the request had `anchor=newest`.
+    anchor: 10000000000000000, // that's 16 zeros
+    foundAnchor: false,
+    foundNewest: true,
+
+    foundOldest: foundOldest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
+}
+
+/// A GetMessagesResult the server might return when we request older messages.
+GetMessagesResult olderGetMessagesResult({
+  required int anchor,
+  bool foundAnchor = false, // the value if the server understood includeAnchor false
+  required bool foundOldest,
+  bool historyLimited = false,
+  required List<Message> messages,
+}) {
+  return GetMessagesResult(
+    anchor: anchor,
+    foundAnchor: foundAnchor,
+    foundNewest: false, // empirically always this, even when anchor happens to be latest
+    foundOldest: foundOldest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
 }
 
 PollWidgetData pollWidgetData({

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -6,7 +6,6 @@ import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/narrow.dart';
-import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/algorithms.dart';
 import 'package:zulip/model/content.dart';
 import 'package:zulip/model/message_list.dart';
@@ -21,6 +20,9 @@ import '../stdlib_checks.dart';
 import 'content_checks.dart';
 import 'recent_senders_test.dart' as recent_senders_test;
 import 'test_store.dart';
+
+const newestResult = eg.newestGetMessagesResult;
+const olderResult = eg.olderGetMessagesResult;
 
 void main() {
   // These variables are the common state operated on by each test.
@@ -1847,41 +1849,4 @@ extension MessageListViewChecks on Subject<MessageListView> {
   Subject<bool> get fetched => has((x) => x.fetched, 'fetched');
   Subject<bool> get haveOldest => has((x) => x.haveOldest, 'haveOldest');
   Subject<bool> get fetchingOlder => has((x) => x.fetchingOlder, 'fetchingOlder');
-}
-
-/// A GetMessagesResult the server might return on an `anchor=newest` request.
-GetMessagesResult newestResult({
-  required bool foundOldest,
-  bool historyLimited = false,
-  required List<Message> messages,
-}) {
-  return GetMessagesResult(
-    // These anchor, foundAnchor, and foundNewest values are what the server
-    // appears to always return when the request had `anchor=newest`.
-    anchor: 10000000000000000, // that's 16 zeros
-    foundAnchor: false,
-    foundNewest: true,
-
-    foundOldest: foundOldest,
-    historyLimited: historyLimited,
-    messages: messages,
-  );
-}
-
-/// A GetMessagesResult the server might return when we request older messages.
-GetMessagesResult olderResult({
-  required int anchor,
-  bool foundAnchor = false, // the value if the server understood includeAnchor false
-  required bool foundOldest,
-  bool historyLimited = false,
-  required List<Message> messages,
-}) {
-  return GetMessagesResult(
-    anchor: anchor,
-    foundAnchor: foundAnchor,
-    foundNewest: false, // empirically always this, even when anchor happens to be latest
-    foundOldest: foundOldest,
-    historyLimited: historyLimited,
-    messages: messages,
-  );
 }

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -65,7 +65,7 @@ void main() {
   }) async {
     assert(messages.every((message) => message.poll == null));
     connection.prepare(json:
-      newestResult(foundOldest: foundOldest, messages: messages).toJson());
+      eg.newestGetMessagesResult(foundOldest: foundOldest, messages: messages).toJson());
     await messageList.fetchInitial();
     checkNotifiedOnce();
   }
@@ -645,7 +645,7 @@ void main() {
         // Perform a single-message initial message fetch for [messageList] with
         // submessages.
         connection.prepare(json:
-          newestResult(foundOldest: true, messages: []).toJson()
+          eg.newestGetMessagesResult(foundOldest: true, messages: []).toJson()
             ..['messages'] = [{
               ...message.toJson(),
               "submessages": submessages.map(deepToJson).toList(),

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -26,7 +26,6 @@ import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
-import '../model/message_list_test.dart';
 import '../model/test_store.dart';
 import '../stdlib_checks.dart';
 import '../test_clipboard.dart';
@@ -55,7 +54,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   }
   connection = store.connection as FakeApiConnection;
 
-  connection.prepare(json: newestResult(
+  connection.prepare(json: eg.newestGetMessagesResult(
     foundOldest: true, messages: [message]).toJson());
   await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
     child: MessageListPage(initNarrow: narrow)));
@@ -443,7 +442,7 @@ void main() {
         // it doesn't matter anyway: [MessageStoreImpl.reconcileMessages] will
         // keep the version updated by the event.  If that somehow changes in
         // some future refactor, it'll cause this test to fail.
-        connection.prepare(json: newestResult(
+        connection.prepare(json: eg.newestGetMessagesResult(
           foundOldest: true, messages: [message]).toJson());
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           newStreamId: newStream.streamId, newTopic: newTopic,

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -28,7 +28,6 @@ import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../model/binding.dart';
 import '../model/content_test.dart';
-import '../model/message_list_test.dart';
 import '../model/test_store.dart';
 import '../flutter_checks.dart';
 import '../stdlib_checks.dart';
@@ -70,7 +69,7 @@ void main() {
       return eg.streamMessage(sender: eg.selfUser);
     });
     connection.prepare(json:
-      newestResult(foundOldest: foundOldest, messages: messages).toJson());
+      eg.newestGetMessagesResult(foundOldest: foundOldest, messages: messages).toJson());
 
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
       child: MessageListPage(initNarrow: narrow)));
@@ -189,7 +188,7 @@ void main() {
       await tester.pump();
 
       // ... and we should fetch more messages as we go.
-      connection.prepare(json: olderResult(anchor: 950, foundOldest: false,
+      connection.prepare(json: eg.olderGetMessagesResult(anchor: 950, foundOldest: false,
         messages: List.generate(100, (i) => eg.streamMessage(id: 850 + i, sender: eg.selfUser))).toJson());
       await tester.pump(const Duration(seconds: 3)); // Fast-forward to end of fling.
       await tester.pump(Duration.zero); // Allow a frame for the response to arrive.
@@ -208,7 +207,7 @@ void main() {
       await tester.pump();
 
       // ... and we fetch more messages as we go.
-      connection.prepare(json: olderResult(anchor: 950, foundOldest: false,
+      connection.prepare(json: eg.olderGetMessagesResult(anchor: 950, foundOldest: false,
         messages: List.generate(100, (i) => eg.streamMessage(id: 850 + i, sender: eg.selfUser))).toJson());
       for (int i = 0; i < 30; i++) {
         // Find the point in the fling where the fetch starts.
@@ -220,7 +219,7 @@ void main() {
 
       // On the next frame, we promptly fetch *another* batch.
       // This is a glitch and it'd be nicer if we didn't.
-      connection.prepare(json: olderResult(anchor: 850, foundOldest: false,
+      connection.prepare(json: eg.olderGetMessagesResult(anchor: 850, foundOldest: false,
         messages: List.generate(100, (i) => eg.streamMessage(id: 750 + i, sender: eg.selfUser))).toJson());
       await tester.pump(const Duration(milliseconds: 1));
       await tester.pump(Duration.zero);
@@ -619,7 +618,7 @@ void main() {
     final narrow = TopicNarrow(channel.streamId, topic);
 
     void prepareGetMessageResponse(List<Message> messages) {
-      connection.prepare(json: newestResult(
+      connection.prepare(json: eg.newestGetMessagesResult(
         foundOldest: false, messages: messages).toJson());
     }
 


### PR DESCRIPTION
Shared by a few tests, they fit better in example_data.

Inspired by https://github.com/zulip/zulip-flutter/pull/1044#discussion_r1831997129