### PR TITLE
intl: Migrate from `package:flutter_gen`; include generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,9 @@
 # Dart files generated from the files next to them, or by Pigeon:
 *.g.dart -diff
 
+# Generated files for localizations.
+lib/generated/l10n/*.dart -diff
+
 # Generated files for testing migrations:
 test/model/schemas/*.dart -diff
 test/model/schemas/*.json -diff

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -56,7 +56,7 @@ changes to the ARB file.
 
 To use in our widgets, you need to import the generated bindings:
 ```
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
+import '../generated/l10n/zulip_localizations.dart';
 ```
 
 Then in your widget code, pull the localizations object

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -54,12 +54,7 @@ changes to the ARB file.
 
 ### Using a translated string in the code
 
-To use in our widgets, you need to import the generated bindings:
-```
-import '../generated/l10n/zulip_localizations.dart';
-```
-
-Then in your widget code, pull the localizations object
+To use in your widget code, pull the localizations object
 off of the Flutter build context:
 ```
 Widget build(BuildContext context) {

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,7 +1,9 @@
 # Docs on this config file:
 #   https://docs.flutter.dev/ui/accessibility-and-localization/internationalization#configuring-the-l10nyaml-file
 
+synthetic-package: false
 arb-dir: assets/l10n
+output-dir: lib/generated/l10n
 template-arb-file: app_en.arb
 required-resource-attributes: true
 output-localization-file: zulip_localizations.dart

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1,0 +1,912 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'zulip_localizations_ar.dart';
+import 'zulip_localizations_en.dart';
+import 'zulip_localizations_ja.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of ZulipLocalizations
+/// returned by `ZulipLocalizations.of(context)`.
+///
+/// Applications need to include `ZulipLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/zulip_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: ZulipLocalizations.localizationsDelegates,
+///   supportedLocales: ZulipLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the ZulipLocalizations.supportedLocales
+/// property.
+abstract class ZulipLocalizations {
+  ZulipLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static ZulipLocalizations of(BuildContext context) {
+    return Localizations.of<ZulipLocalizations>(context, ZulipLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<ZulipLocalizations> delegate = _ZulipLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ar'),
+    Locale('ja')
+  ];
+
+  /// Title for About Zulip page
+  ///
+  /// In en, this message translates to:
+  /// **'About Zulip'**
+  String get aboutPageTitle;
+
+  /// Label for Zulip app version in About Zulip page
+  ///
+  /// In en, this message translates to:
+  /// **'App version'**
+  String get aboutPageAppVersion;
+
+  /// Item title in About Zulip page to navigate to Licenses page
+  ///
+  /// In en, this message translates to:
+  /// **'Open-source licenses'**
+  String get aboutPageOpenSourceLicenses;
+
+  /// Item subtitle in About Zulip page to navigate to Licenses page
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to view'**
+  String get aboutPageTapToView;
+
+  /// Title for ChooseAccountPage
+  ///
+  /// In en, this message translates to:
+  /// **'Choose account'**
+  String get chooseAccountPageTitle;
+
+  /// Label for the 'Log out' button for an account on the choose-account page
+  ///
+  /// In en, this message translates to:
+  /// **'Log out'**
+  String get chooseAccountPageLogOutButton;
+
+  /// Title for a confirmation dialog for logging out.
+  ///
+  /// In en, this message translates to:
+  /// **'Log out?'**
+  String get logOutConfirmationDialogTitle;
+
+  /// Message for a confirmation dialog for logging out.
+  ///
+  /// In en, this message translates to:
+  /// **'To use this account in the future, you will have to re-enter the URL for your organization and your account information.'**
+  String get logOutConfirmationDialogMessage;
+
+  /// Label for the 'Log out' button on a confirmation dialog for logging out.
+  ///
+  /// In en, this message translates to:
+  /// **'Log out'**
+  String get logOutConfirmationDialogConfirmButton;
+
+  /// Label for ChooseAccountPage button to add an account
+  ///
+  /// In en, this message translates to:
+  /// **'Add an account'**
+  String get chooseAccountButtonAddAnAccount;
+
+  /// Label for button in profile screen to navigate to DMs with the shown user.
+  ///
+  /// In en, this message translates to:
+  /// **'Send direct message'**
+  String get profileButtonSendDirectMessage;
+
+  /// Title for dialog asking the user to grant additional permissions.
+  ///
+  /// In en, this message translates to:
+  /// **'Permissions needed'**
+  String get permissionsNeededTitle;
+
+  /// Button label for permissions dialog button that opens the system settings screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Open settings'**
+  String get permissionsNeededOpenSettings;
+
+  /// Message for dialog asking the user to grant permissions for camera access.
+  ///
+  /// In en, this message translates to:
+  /// **'To upload an image, please grant Zulip additional permissions in Settings.'**
+  String get permissionsDeniedCameraAccess;
+
+  /// Message for dialog asking the user to grant permissions for external storage read access.
+  ///
+  /// In en, this message translates to:
+  /// **'To upload files, please grant Zulip additional permissions in Settings.'**
+  String get permissionsDeniedReadExternalStorage;
+
+  /// Label for copy message text button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy message text'**
+  String get actionSheetOptionCopyMessageText;
+
+  /// Label for copy message link button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy link to message'**
+  String get actionSheetOptionCopyMessageLink;
+
+  /// Label for mark as unread button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark as unread from here'**
+  String get actionSheetOptionMarkAsUnread;
+
+  /// Label for share button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Share'**
+  String get actionSheetOptionShare;
+
+  /// Label for Quote and reply button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Quote and reply'**
+  String get actionSheetOptionQuoteAndReply;
+
+  /// Label for star button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Star message'**
+  String get actionSheetOptionStarMessage;
+
+  /// Label for unstar button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Unstar message'**
+  String get actionSheetOptionUnstarMessage;
+
+  /// Error title when third-party authentication has an operational error (not necessarily caused by invalid credentials).
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get errorWebAuthOperationalErrorTitle;
+
+  /// Error message when third-party authentication has an operational error (not necessarily caused by invalid credentials).
+  ///
+  /// In en, this message translates to:
+  /// **'An unexpected error occurred.'**
+  String get errorWebAuthOperationalError;
+
+  /// Error title on attempting to log into an account that's already logged in.
+  ///
+  /// In en, this message translates to:
+  /// **'Account already logged in'**
+  String get errorAccountLoggedInTitle;
+
+  /// Error message on attempting to log into an account that's already logged in.
+  ///
+  /// In en, this message translates to:
+  /// **'The account {email} at {server} is already in your list of accounts.'**
+  String errorAccountLoggedIn(String email, String server);
+
+  /// Error message when the source of a message could not be fetched.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not fetch message source'**
+  String get errorCouldNotFetchMessageSource;
+
+  /// Error message when copying the text of a message to the user's system clipboard failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Copying failed'**
+  String get errorCopyingFailed;
+
+  /// Error title when the specified file failed to upload.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to upload file: {filename}'**
+  String errorFailedToUploadFileTitle(String filename);
+
+  /// Error message when attached files are too large in size.
+  ///
+  /// In en, this message translates to:
+  /// **'{num, plural, =1{File is} other{{num} files are}} larger than the server\'s limit of {maxFileUploadSizeMib} MiB and will not be uploaded:\n\n{listMessage}'**
+  String errorFilesTooLarge(int num, int maxFileUploadSizeMib, String listMessage);
+
+  /// Error title when attached files are too large in size.
+  ///
+  /// In en, this message translates to:
+  /// **'{num, plural, =1{File} other{Files}} too large'**
+  String errorFilesTooLargeTitle(int num);
+
+  /// Error title for login when input is invalid.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid input'**
+  String get errorLoginInvalidInputTitle;
+
+  /// Error title for login when signing into a Zulip server fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Login failed'**
+  String get errorLoginFailedTitle;
+
+  /// Error message for compose box when a message could not be sent.
+  ///
+  /// In en, this message translates to:
+  /// **'Message not sent'**
+  String get errorMessageNotSent;
+
+  /// Error message when the app could not connect to the server.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to connect to server:\n{url}'**
+  String errorLoginCouldNotConnect(String url);
+
+  /// Error title when the app could not connect to the server.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not connect'**
+  String get errorLoginCouldNotConnectTitle;
+
+  /// Error message when loading a message that does not exist.
+  ///
+  /// In en, this message translates to:
+  /// **'That message does not seem to exist.'**
+  String get errorMessageDoesNotSeemToExist;
+
+  /// Error message when quoting a message failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Quotation failed'**
+  String get errorQuotationFailed;
+
+  /// Error message that quotes an error from the server.
+  ///
+  /// In en, this message translates to:
+  /// **'The server said:\n\n{message}'**
+  String errorServerMessage(String message);
+
+  /// Short error message for a generic unknown error connecting to the server.
+  ///
+  /// In en, this message translates to:
+  /// **'Error connecting to Zulip. Retrying…'**
+  String get errorConnectingToServerShort;
+
+  /// Dialog error message for a generic unknown error connecting to the server with details.
+  ///
+  /// In en, this message translates to:
+  /// **'Error connecting to Zulip at {serverUrl}. Will retry:\n\n{error}'**
+  String errorConnectingToServerDetails(String serverUrl, String error);
+
+  /// Error message when sharing a message failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Sharing failed'**
+  String get errorSharingFailed;
+
+  /// Error title when starring a message failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to star message'**
+  String get errorStarMessageFailedTitle;
+
+  /// Error title when unstarring a message failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to unstar message'**
+  String get errorUnstarMessageFailedTitle;
+
+  /// Success message after copy link action completed.
+  ///
+  /// In en, this message translates to:
+  /// **'Link copied'**
+  String get successLinkCopied;
+
+  /// Message when content of a message was copied to the user's system clipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Message text copied'**
+  String get successMessageTextCopied;
+
+  /// Message when link of a message was copied to the user's system clipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Message link copied'**
+  String get successMessageLinkCopied;
+
+  /// Label text for error banner when sending a message to one or multiple deactivated users.
+  ///
+  /// In en, this message translates to:
+  /// **'You cannot send messages to deactivated users.'**
+  String get errorBannerDeactivatedDmLabel;
+
+  /// Error-banner text replacing the compose box when you do not have permission to send a message to the channel.
+  ///
+  /// In en, this message translates to:
+  /// **'You do not have permission to post in this channel.'**
+  String get errorBannerCannotPostInChannelLabel;
+
+  /// Tooltip for compose box icon to attach a file to the message.
+  ///
+  /// In en, this message translates to:
+  /// **'Attach files'**
+  String get composeBoxAttachFilesTooltip;
+
+  /// Tooltip for compose box icon to attach media to the message.
+  ///
+  /// In en, this message translates to:
+  /// **'Attach images or videos'**
+  String get composeBoxAttachMediaTooltip;
+
+  /// Tooltip for compose box icon to attach an image from the camera to the message.
+  ///
+  /// In en, this message translates to:
+  /// **'Take a photo'**
+  String get composeBoxAttachFromCameraTooltip;
+
+  /// Hint text for content input when sending a message.
+  ///
+  /// In en, this message translates to:
+  /// **'Type a message'**
+  String get composeBoxGenericContentHint;
+
+  /// Hint text for content input when sending a message to one other person.
+  ///
+  /// In en, this message translates to:
+  /// **'Message @{user}'**
+  String composeBoxDmContentHint(String user);
+
+  /// Hint text for content input when sending a message to a group.
+  ///
+  /// In en, this message translates to:
+  /// **'Message group'**
+  String get composeBoxGroupDmContentHint;
+
+  /// Hint text for content input when sending a message to yourself.
+  ///
+  /// In en, this message translates to:
+  /// **'Jot down something'**
+  String get composeBoxSelfDmContentHint;
+
+  /// Hint text for content input when sending a message to a channel
+  ///
+  /// In en, this message translates to:
+  /// **'Message #{channel} > {topic}'**
+  String composeBoxChannelContentHint(String channel, String topic);
+
+  /// Tooltip for send button in compose box.
+  ///
+  /// In en, this message translates to:
+  /// **'Send'**
+  String get composeBoxSendTooltip;
+
+  /// Replacement name for channel when it cannot be found in the store.
+  ///
+  /// In en, this message translates to:
+  /// **'(unknown channel)'**
+  String get composeBoxUnknownChannelName;
+
+  /// Hint text for topic input widget in compose box.
+  ///
+  /// In en, this message translates to:
+  /// **'Topic'**
+  String get composeBoxTopicHintText;
+
+  /// Placeholder in compose box showing the specified file is currently uploading.
+  ///
+  /// In en, this message translates to:
+  /// **'Uploading {filename}…'**
+  String composeBoxUploadingFilename(String filename);
+
+  /// Name placeholder to use for a user when we don't know their name.
+  ///
+  /// In en, this message translates to:
+  /// **'(unknown user)'**
+  String get unknownUserName;
+
+  /// Message list recipient header for a DM group with others.
+  ///
+  /// In en, this message translates to:
+  /// **'You and {others}'**
+  String messageListGroupYouAndOthers(String others);
+
+  /// Message list recipient header for a DM group that only includes yourself.
+  ///
+  /// In en, this message translates to:
+  /// **'You with yourself'**
+  String get messageListGroupYouWithYourself;
+
+  /// Content validation error message when the message is too long.
+  ///
+  /// In en, this message translates to:
+  /// **'Message length shouldn\'t be greater than 10000 characters.'**
+  String get contentValidationErrorTooLong;
+
+  /// Content validation error message when the message is empty.
+  ///
+  /// In en, this message translates to:
+  /// **'You have nothing to send!'**
+  String get contentValidationErrorEmpty;
+
+  /// Content validation error message when a quotation has not completed yet.
+  ///
+  /// In en, this message translates to:
+  /// **'Please wait for the quotation to complete.'**
+  String get contentValidationErrorQuoteAndReplyInProgress;
+
+  /// Content validation error message when attachments have not finished uploading.
+  ///
+  /// In en, this message translates to:
+  /// **'Please wait for the upload to complete.'**
+  String get contentValidationErrorUploadInProgress;
+
+  /// Button label in dialogs to cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get dialogCancel;
+
+  /// Button label in dialogs to proceed.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get dialogContinue;
+
+  /// Button label in error dialogs to acknowledge the error and close the dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get errorDialogContinue;
+
+  /// Generic title for error dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get errorDialogTitle;
+
+  /// Button label for snack bar button that opens a dialog with more details.
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get snackBarDetails;
+
+  /// Tooltip in lightbox for the copy link action.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy link'**
+  String get lightboxCopyLinkTooltip;
+
+  /// Page title for login page.
+  ///
+  /// In en, this message translates to:
+  /// **'Log in'**
+  String get loginPageTitle;
+
+  /// Button text to submit login credentials.
+  ///
+  /// In en, this message translates to:
+  /// **'Log in'**
+  String get loginFormSubmitLabel;
+
+  /// Text on the divider between the username/password form and the third-party login options. Uppercase (for languages with letter case).
+  ///
+  /// In en, this message translates to:
+  /// **'OR'**
+  String get loginMethodDivider;
+
+  /// Button to use {method} to sign in to the app.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign in with {method}'**
+  String signInWithFoo(String method);
+
+  /// Page title for screen to add a Zulip account.
+  ///
+  /// In en, this message translates to:
+  /// **'Add an account'**
+  String get loginAddAnAccountPageTitle;
+
+  /// Input label in login page for Zulip server URL entry.
+  ///
+  /// In en, this message translates to:
+  /// **'Your Zulip server URL'**
+  String get loginServerUrlInputLabel;
+
+  /// Icon label for button to hide password in input form.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide password'**
+  String get loginHidePassword;
+
+  /// Label for input when an email is required to log in.
+  ///
+  /// In en, this message translates to:
+  /// **'Email address'**
+  String get loginEmailLabel;
+
+  /// Error message when an empty email was provided.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email.'**
+  String get loginErrorMissingEmail;
+
+  /// Label for password input field.
+  ///
+  /// In en, this message translates to:
+  /// **'Password'**
+  String get loginPasswordLabel;
+
+  /// Error message when an empty password was provided.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your password.'**
+  String get loginErrorMissingPassword;
+
+  /// Label for input when a username is required to log in.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get loginUsernameLabel;
+
+  /// Error message when an empty username was provided.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your username.'**
+  String get loginErrorMissingUsername;
+
+  /// Topic validation error when topic is too long.
+  ///
+  /// In en, this message translates to:
+  /// **'Topic length shouldn\'t be greater than 60 characters.'**
+  String get topicValidationErrorTooLong;
+
+  /// Topic validation error when topic is required but was empty.
+  ///
+  /// In en, this message translates to:
+  /// **'Topics are required in this organization.'**
+  String get topicValidationErrorMandatoryButEmpty;
+
+  /// Error message when an API call returned an invalid response.
+  ///
+  /// In en, this message translates to:
+  /// **'The server sent an invalid response'**
+  String get errorInvalidResponse;
+
+  /// Error message when a network request fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Network request failed'**
+  String get errorNetworkRequestFailed;
+
+  /// Error message when an API call fails because we could not parse the response.
+  ///
+  /// In en, this message translates to:
+  /// **'Server gave malformed response; HTTP status {httpStatus}'**
+  String errorMalformedResponse(int httpStatus);
+
+  /// Error message when an API call fails because we could not parse the response, with details of the failure.
+  ///
+  /// In en, this message translates to:
+  /// **'Server gave malformed response; HTTP status {httpStatus}; {details}'**
+  String errorMalformedResponseWithCause(int httpStatus, String details);
+
+  /// Error message when an API call fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Network request failed: HTTP status {httpStatus}'**
+  String errorRequestFailed(int httpStatus);
+
+  /// Error message when a video fails to play.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to play the video'**
+  String get errorVideoPlayerFailed;
+
+  /// Error message when URL is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a URL.'**
+  String get serverUrlValidationErrorEmpty;
+
+  /// Error message when URL is not in a valid format.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a valid URL.'**
+  String get serverUrlValidationErrorInvalidUrl;
+
+  /// Error message when URL looks like an email
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter the server URL, not your email.'**
+  String get serverUrlValidationErrorNoUseEmail;
+
+  /// Error message when URL has an unsupported scheme.
+  ///
+  /// In en, this message translates to:
+  /// **'The server URL must start with http:// or https://.'**
+  String get serverUrlValidationErrorUnsupportedScheme;
+
+  /// The default header text in a spoiler block ( https://zulip.com/help/spoilers ).
+  ///
+  /// In en, this message translates to:
+  /// **'Spoiler'**
+  String get spoilerDefaultHeaderText;
+
+  /// Button text to mark messages as read.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark all messages as read'**
+  String get markAllAsReadLabel;
+
+  /// Message when marking messages as read has completed.
+  ///
+  /// In en, this message translates to:
+  /// **'Marked {num, plural, =1{1 message} other{{num} messages}} as read.'**
+  String markAsReadComplete(int num);
+
+  /// Progress message when marking messages as read.
+  ///
+  /// In en, this message translates to:
+  /// **'Marking messages as read…'**
+  String get markAsReadInProgress;
+
+  /// Error title when mark as read action failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark as read failed'**
+  String get errorMarkAsReadFailedTitle;
+
+  /// Message when marking messages as unread has completed.
+  ///
+  /// In en, this message translates to:
+  /// **'Marked {num, plural, =1{1 message} other{{num} messages}} as unread.'**
+  String markAsUnreadComplete(int num);
+
+  /// Progress message when marking messages as unread.
+  ///
+  /// In en, this message translates to:
+  /// **'Marking messages as unread…'**
+  String get markAsUnreadInProgress;
+
+  /// Error title when mark as unread action failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark as unread failed'**
+  String get errorMarkAsUnreadFailedTitle;
+
+  /// Term to use to reference the current day.
+  ///
+  /// In en, this message translates to:
+  /// **'Today'**
+  String get today;
+
+  /// Term to use to reference the previous day.
+  ///
+  /// In en, this message translates to:
+  /// **'Yesterday'**
+  String get yesterday;
+
+  /// Label for UserRole.owner
+  ///
+  /// In en, this message translates to:
+  /// **'Owner'**
+  String get userRoleOwner;
+
+  /// Label for UserRole.administrator
+  ///
+  /// In en, this message translates to:
+  /// **'Administrator'**
+  String get userRoleAdministrator;
+
+  /// Label for UserRole.moderator
+  ///
+  /// In en, this message translates to:
+  /// **'Moderator'**
+  String get userRoleModerator;
+
+  /// Label for UserRole.member
+  ///
+  /// In en, this message translates to:
+  /// **'Member'**
+  String get userRoleMember;
+
+  /// Label for UserRole.guest
+  ///
+  /// In en, this message translates to:
+  /// **'Guest'**
+  String get userRoleGuest;
+
+  /// Label for UserRole.unknown
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get userRoleUnknown;
+
+  /// Title for the page of recent DM conversations
+  ///
+  /// In en, this message translates to:
+  /// **'Direct messages'**
+  String get recentDmConversationsPageTitle;
+
+  /// Title for the page of combined feed.
+  ///
+  /// In en, this message translates to:
+  /// **'Combined feed'**
+  String get combinedFeedPageTitle;
+
+  /// Title for the page of @-mentions.
+  ///
+  /// In en, this message translates to:
+  /// **'Mentions'**
+  String get mentionsPageTitle;
+
+  /// Title for the page of starred messages.
+  ///
+  /// In en, this message translates to:
+  /// **'Starred messages'**
+  String get starredMessagesPageTitle;
+
+  /// Label for a group DM conversation notification.
+  ///
+  /// In en, this message translates to:
+  /// **'{senderFullName} to you and {numOthers, plural, =1{1 other} other{{numOthers} others}}'**
+  String notifGroupDmConversationLabel(String senderFullName, int numOthers);
+
+  /// Display name for the user themself, to show after replying in an Android notification
+  ///
+  /// In en, this message translates to:
+  /// **'You'**
+  String get notifSelfUser;
+
+  /// Text to display when there is one user typing.
+  ///
+  /// In en, this message translates to:
+  /// **'{typist} is typing…'**
+  String onePersonTyping(String typist);
+
+  /// Text to display when there are two users typing.
+  ///
+  /// In en, this message translates to:
+  /// **'{typist} and {otherTypist} are typing…'**
+  String twoPeopleTyping(String typist, String otherTypist);
+
+  /// Text to display when there are multiple users typing.
+  ///
+  /// In en, this message translates to:
+  /// **'Several people are typing…'**
+  String get manyPeopleTyping;
+
+  /// Label for an edited message. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)
+  ///
+  /// In en, this message translates to:
+  /// **'EDITED'**
+  String get messageIsEditedLabel;
+
+  /// Label for a moved message. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)
+  ///
+  /// In en, this message translates to:
+  /// **'MOVED'**
+  String get messageIsMovedLabel;
+
+  /// Text to display for a poll when the question is missing
+  ///
+  /// In en, this message translates to:
+  /// **'No question.'**
+  String get pollWidgetQuestionMissing;
+
+  /// Text to display for a poll when it has no options
+  ///
+  /// In en, this message translates to:
+  /// **'This poll has no options yet.'**
+  String get pollWidgetOptionsMissing;
+
+  /// Error title when notification opening fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to open notification'**
+  String get errorNotificationOpenTitle;
+
+  /// Error message when the account associated with the notification is not found
+  ///
+  /// In en, this message translates to:
+  /// **'The account associated with this notification no longer exists.'**
+  String get errorNotificationOpenAccountMissing;
+}
+
+class _ZulipLocalizationsDelegate extends LocalizationsDelegate<ZulipLocalizations> {
+  const _ZulipLocalizationsDelegate();
+
+  @override
+  Future<ZulipLocalizations> load(Locale locale) {
+    return SynchronousFuture<ZulipLocalizations>(lookupZulipLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['ar', 'en', 'ja'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_ZulipLocalizationsDelegate old) => false;
+}
+
+ZulipLocalizations lookupZulipLocalizations(Locale locale) {
+
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'ar': return ZulipLocalizationsAr();
+    case 'en': return ZulipLocalizationsEn();
+    case 'ja': return ZulipLocalizationsJa();
+  }
+
+  throw FlutterError(
+    'ZulipLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1,0 +1,470 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'zulip_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Arabic (`ar`).
+class ZulipLocalizationsAr extends ZulipLocalizations {
+  ZulipLocalizationsAr([String locale = 'ar']) : super(locale);
+
+  @override
+  String get aboutPageTitle => 'About Zulip';
+
+  @override
+  String get aboutPageAppVersion => 'App version';
+
+  @override
+  String get aboutPageOpenSourceLicenses => 'Open-source licenses';
+
+  @override
+  String get aboutPageTapToView => 'Tap to view';
+
+  @override
+  String get chooseAccountPageTitle => 'Choose account';
+
+  @override
+  String get chooseAccountPageLogOutButton => 'Log out';
+
+  @override
+  String get logOutConfirmationDialogTitle => 'Log out?';
+
+  @override
+  String get logOutConfirmationDialogMessage => 'To use this account in the future, you will have to re-enter the URL for your organization and your account information.';
+
+  @override
+  String get logOutConfirmationDialogConfirmButton => 'Log out';
+
+  @override
+  String get chooseAccountButtonAddAnAccount => 'Add an account';
+
+  @override
+  String get profileButtonSendDirectMessage => 'Send direct message';
+
+  @override
+  String get permissionsNeededTitle => 'Permissions needed';
+
+  @override
+  String get permissionsNeededOpenSettings => 'Open settings';
+
+  @override
+  String get permissionsDeniedCameraAccess => 'To upload an image, please grant Zulip additional permissions in Settings.';
+
+  @override
+  String get permissionsDeniedReadExternalStorage => 'To upload files, please grant Zulip additional permissions in Settings.';
+
+  @override
+  String get actionSheetOptionCopyMessageText => 'Copy message text';
+
+  @override
+  String get actionSheetOptionCopyMessageLink => 'Copy link to message';
+
+  @override
+  String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
+
+  @override
+  String get actionSheetOptionShare => 'Share';
+
+  @override
+  String get actionSheetOptionQuoteAndReply => 'Quote and reply';
+
+  @override
+  String get actionSheetOptionStarMessage => 'Star message';
+
+  @override
+  String get actionSheetOptionUnstarMessage => 'Unstar message';
+
+  @override
+  String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
+
+  @override
+  String get errorWebAuthOperationalError => 'An unexpected error occurred.';
+
+  @override
+  String get errorAccountLoggedInTitle => 'Account already logged in';
+
+  @override
+  String errorAccountLoggedIn(String email, String server) {
+    return 'The account $email at $server is already in your list of accounts.';
+  }
+
+  @override
+  String get errorCouldNotFetchMessageSource => 'Could not fetch message source';
+
+  @override
+  String get errorCopyingFailed => 'Copying failed';
+
+  @override
+  String errorFailedToUploadFileTitle(String filename) {
+    return 'Failed to upload file: $filename';
+  }
+
+  @override
+  String errorFilesTooLarge(int num, int maxFileUploadSizeMib, String listMessage) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num files are',
+      one: 'File is',
+    );
+    return '$_temp0 larger than the server\'s limit of $maxFileUploadSizeMib MiB and will not be uploaded:\n\n$listMessage';
+  }
+
+  @override
+  String errorFilesTooLargeTitle(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: 'Files',
+      one: 'File',
+    );
+    return '$_temp0 too large';
+  }
+
+  @override
+  String get errorLoginInvalidInputTitle => 'Invalid input';
+
+  @override
+  String get errorLoginFailedTitle => 'Login failed';
+
+  @override
+  String get errorMessageNotSent => 'Message not sent';
+
+  @override
+  String errorLoginCouldNotConnect(String url) {
+    return 'Failed to connect to server:\n$url';
+  }
+
+  @override
+  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+
+  @override
+  String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';
+
+  @override
+  String get errorQuotationFailed => 'Quotation failed';
+
+  @override
+  String errorServerMessage(String message) {
+    return 'The server said:\n\n$message';
+  }
+
+  @override
+  String get errorConnectingToServerShort => 'Error connecting to Zulip. Retrying…';
+
+  @override
+  String errorConnectingToServerDetails(String serverUrl, String error) {
+    return 'Error connecting to Zulip at $serverUrl. Will retry:\n\n$error';
+  }
+
+  @override
+  String get errorSharingFailed => 'Sharing failed';
+
+  @override
+  String get errorStarMessageFailedTitle => 'Failed to star message';
+
+  @override
+  String get errorUnstarMessageFailedTitle => 'Failed to unstar message';
+
+  @override
+  String get successLinkCopied => 'Link copied';
+
+  @override
+  String get successMessageTextCopied => 'Message text copied';
+
+  @override
+  String get successMessageLinkCopied => 'Message link copied';
+
+  @override
+  String get errorBannerDeactivatedDmLabel => 'You cannot send messages to deactivated users.';
+
+  @override
+  String get errorBannerCannotPostInChannelLabel => 'You do not have permission to post in this channel.';
+
+  @override
+  String get composeBoxAttachFilesTooltip => 'Attach files';
+
+  @override
+  String get composeBoxAttachMediaTooltip => 'Attach images or videos';
+
+  @override
+  String get composeBoxAttachFromCameraTooltip => 'Take a photo';
+
+  @override
+  String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String composeBoxDmContentHint(String user) {
+    return 'Message @$user';
+  }
+
+  @override
+  String get composeBoxGroupDmContentHint => 'Message group';
+
+  @override
+  String get composeBoxSelfDmContentHint => 'Jot down something';
+
+  @override
+  String composeBoxChannelContentHint(String channel, String topic) {
+    return 'Message #$channel > $topic';
+  }
+
+  @override
+  String get composeBoxSendTooltip => 'Send';
+
+  @override
+  String get composeBoxUnknownChannelName => '(unknown channel)';
+
+  @override
+  String get composeBoxTopicHintText => 'Topic';
+
+  @override
+  String composeBoxUploadingFilename(String filename) {
+    return 'Uploading $filename…';
+  }
+
+  @override
+  String get unknownUserName => '(unknown user)';
+
+  @override
+  String messageListGroupYouAndOthers(String others) {
+    return 'You and $others';
+  }
+
+  @override
+  String get messageListGroupYouWithYourself => 'You with yourself';
+
+  @override
+  String get contentValidationErrorTooLong => 'Message length shouldn\'t be greater than 10000 characters.';
+
+  @override
+  String get contentValidationErrorEmpty => 'You have nothing to send!';
+
+  @override
+  String get contentValidationErrorQuoteAndReplyInProgress => 'Please wait for the quotation to complete.';
+
+  @override
+  String get contentValidationErrorUploadInProgress => 'Please wait for the upload to complete.';
+
+  @override
+  String get dialogCancel => 'Cancel';
+
+  @override
+  String get dialogContinue => 'Continue';
+
+  @override
+  String get errorDialogContinue => 'OK';
+
+  @override
+  String get errorDialogTitle => 'Error';
+
+  @override
+  String get snackBarDetails => 'Details';
+
+  @override
+  String get lightboxCopyLinkTooltip => 'Copy link';
+
+  @override
+  String get loginPageTitle => 'Log in';
+
+  @override
+  String get loginFormSubmitLabel => 'Log in';
+
+  @override
+  String get loginMethodDivider => 'OR';
+
+  @override
+  String signInWithFoo(String method) {
+    return 'Sign in with $method';
+  }
+
+  @override
+  String get loginAddAnAccountPageTitle => 'Add an account';
+
+  @override
+  String get loginServerUrlInputLabel => 'Your Zulip server URL';
+
+  @override
+  String get loginHidePassword => 'Hide password';
+
+  @override
+  String get loginEmailLabel => 'Email address';
+
+  @override
+  String get loginErrorMissingEmail => 'Please enter your email.';
+
+  @override
+  String get loginPasswordLabel => 'Password';
+
+  @override
+  String get loginErrorMissingPassword => 'Please enter your password.';
+
+  @override
+  String get loginUsernameLabel => 'Username';
+
+  @override
+  String get loginErrorMissingUsername => 'Please enter your username.';
+
+  @override
+  String get topicValidationErrorTooLong => 'Topic length shouldn\'t be greater than 60 characters.';
+
+  @override
+  String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
+
+  @override
+  String get errorInvalidResponse => 'The server sent an invalid response';
+
+  @override
+  String get errorNetworkRequestFailed => 'Network request failed';
+
+  @override
+  String errorMalformedResponse(int httpStatus) {
+    return 'Server gave malformed response; HTTP status $httpStatus';
+  }
+
+  @override
+  String errorMalformedResponseWithCause(int httpStatus, String details) {
+    return 'Server gave malformed response; HTTP status $httpStatus; $details';
+  }
+
+  @override
+  String errorRequestFailed(int httpStatus) {
+    return 'Network request failed: HTTP status $httpStatus';
+  }
+
+  @override
+  String get errorVideoPlayerFailed => 'Unable to play the video';
+
+  @override
+  String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
+
+  @override
+  String get serverUrlValidationErrorInvalidUrl => 'Please enter a valid URL.';
+
+  @override
+  String get serverUrlValidationErrorNoUseEmail => 'Please enter the server URL, not your email.';
+
+  @override
+  String get serverUrlValidationErrorUnsupportedScheme => 'The server URL must start with http:// or https://.';
+
+  @override
+  String get spoilerDefaultHeaderText => 'Spoiler';
+
+  @override
+  String get markAllAsReadLabel => 'Mark all messages as read';
+
+  @override
+  String markAsReadComplete(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num messages',
+      one: '1 message',
+    );
+    return 'Marked $_temp0 as read.';
+  }
+
+  @override
+  String get markAsReadInProgress => 'Marking messages as read…';
+
+  @override
+  String get errorMarkAsReadFailedTitle => 'Mark as read failed';
+
+  @override
+  String markAsUnreadComplete(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num messages',
+      one: '1 message',
+    );
+    return 'Marked $_temp0 as unread.';
+  }
+
+  @override
+  String get markAsUnreadInProgress => 'Marking messages as unread…';
+
+  @override
+  String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
+
+  @override
+  String get today => 'Today';
+
+  @override
+  String get yesterday => 'Yesterday';
+
+  @override
+  String get userRoleOwner => 'Owner';
+
+  @override
+  String get userRoleAdministrator => 'Administrator';
+
+  @override
+  String get userRoleModerator => 'Moderator';
+
+  @override
+  String get userRoleMember => 'Member';
+
+  @override
+  String get userRoleGuest => 'Guest';
+
+  @override
+  String get userRoleUnknown => 'Unknown';
+
+  @override
+  String get recentDmConversationsPageTitle => 'Direct messages';
+
+  @override
+  String get combinedFeedPageTitle => 'Combined feed';
+
+  @override
+  String get mentionsPageTitle => 'Mentions';
+
+  @override
+  String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String notifGroupDmConversationLabel(String senderFullName, int numOthers) {
+    String _temp0 = intl.Intl.pluralLogic(
+      numOthers,
+      locale: localeName,
+      other: '$numOthers others',
+      one: '1 other',
+    );
+    return '$senderFullName to you and $_temp0';
+  }
+
+  @override
+  String get notifSelfUser => 'You';
+
+  @override
+  String onePersonTyping(String typist) {
+    return '$typist is typing…';
+  }
+
+  @override
+  String twoPeopleTyping(String typist, String otherTypist) {
+    return '$typist and $otherTypist are typing…';
+  }
+
+  @override
+  String get manyPeopleTyping => 'Several people are typing…';
+
+  @override
+  String get messageIsEditedLabel => 'EDITED';
+
+  @override
+  String get messageIsMovedLabel => 'MOVED';
+
+  @override
+  String get pollWidgetQuestionMissing => 'No question.';
+
+  @override
+  String get pollWidgetOptionsMissing => 'This poll has no options yet.';
+
+  @override
+  String get errorNotificationOpenTitle => 'Failed to open notification';
+
+  @override
+  String get errorNotificationOpenAccountMissing => 'The account associated with this notification no longer exists.';
+}

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1,0 +1,470 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'zulip_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class ZulipLocalizationsEn extends ZulipLocalizations {
+  ZulipLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get aboutPageTitle => 'About Zulip';
+
+  @override
+  String get aboutPageAppVersion => 'App version';
+
+  @override
+  String get aboutPageOpenSourceLicenses => 'Open-source licenses';
+
+  @override
+  String get aboutPageTapToView => 'Tap to view';
+
+  @override
+  String get chooseAccountPageTitle => 'Choose account';
+
+  @override
+  String get chooseAccountPageLogOutButton => 'Log out';
+
+  @override
+  String get logOutConfirmationDialogTitle => 'Log out?';
+
+  @override
+  String get logOutConfirmationDialogMessage => 'To use this account in the future, you will have to re-enter the URL for your organization and your account information.';
+
+  @override
+  String get logOutConfirmationDialogConfirmButton => 'Log out';
+
+  @override
+  String get chooseAccountButtonAddAnAccount => 'Add an account';
+
+  @override
+  String get profileButtonSendDirectMessage => 'Send direct message';
+
+  @override
+  String get permissionsNeededTitle => 'Permissions needed';
+
+  @override
+  String get permissionsNeededOpenSettings => 'Open settings';
+
+  @override
+  String get permissionsDeniedCameraAccess => 'To upload an image, please grant Zulip additional permissions in Settings.';
+
+  @override
+  String get permissionsDeniedReadExternalStorage => 'To upload files, please grant Zulip additional permissions in Settings.';
+
+  @override
+  String get actionSheetOptionCopyMessageText => 'Copy message text';
+
+  @override
+  String get actionSheetOptionCopyMessageLink => 'Copy link to message';
+
+  @override
+  String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
+
+  @override
+  String get actionSheetOptionShare => 'Share';
+
+  @override
+  String get actionSheetOptionQuoteAndReply => 'Quote and reply';
+
+  @override
+  String get actionSheetOptionStarMessage => 'Star message';
+
+  @override
+  String get actionSheetOptionUnstarMessage => 'Unstar message';
+
+  @override
+  String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
+
+  @override
+  String get errorWebAuthOperationalError => 'An unexpected error occurred.';
+
+  @override
+  String get errorAccountLoggedInTitle => 'Account already logged in';
+
+  @override
+  String errorAccountLoggedIn(String email, String server) {
+    return 'The account $email at $server is already in your list of accounts.';
+  }
+
+  @override
+  String get errorCouldNotFetchMessageSource => 'Could not fetch message source';
+
+  @override
+  String get errorCopyingFailed => 'Copying failed';
+
+  @override
+  String errorFailedToUploadFileTitle(String filename) {
+    return 'Failed to upload file: $filename';
+  }
+
+  @override
+  String errorFilesTooLarge(int num, int maxFileUploadSizeMib, String listMessage) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num files are',
+      one: 'File is',
+    );
+    return '$_temp0 larger than the server\'s limit of $maxFileUploadSizeMib MiB and will not be uploaded:\n\n$listMessage';
+  }
+
+  @override
+  String errorFilesTooLargeTitle(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: 'Files',
+      one: 'File',
+    );
+    return '$_temp0 too large';
+  }
+
+  @override
+  String get errorLoginInvalidInputTitle => 'Invalid input';
+
+  @override
+  String get errorLoginFailedTitle => 'Login failed';
+
+  @override
+  String get errorMessageNotSent => 'Message not sent';
+
+  @override
+  String errorLoginCouldNotConnect(String url) {
+    return 'Failed to connect to server:\n$url';
+  }
+
+  @override
+  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+
+  @override
+  String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';
+
+  @override
+  String get errorQuotationFailed => 'Quotation failed';
+
+  @override
+  String errorServerMessage(String message) {
+    return 'The server said:\n\n$message';
+  }
+
+  @override
+  String get errorConnectingToServerShort => 'Error connecting to Zulip. Retrying…';
+
+  @override
+  String errorConnectingToServerDetails(String serverUrl, String error) {
+    return 'Error connecting to Zulip at $serverUrl. Will retry:\n\n$error';
+  }
+
+  @override
+  String get errorSharingFailed => 'Sharing failed';
+
+  @override
+  String get errorStarMessageFailedTitle => 'Failed to star message';
+
+  @override
+  String get errorUnstarMessageFailedTitle => 'Failed to unstar message';
+
+  @override
+  String get successLinkCopied => 'Link copied';
+
+  @override
+  String get successMessageTextCopied => 'Message text copied';
+
+  @override
+  String get successMessageLinkCopied => 'Message link copied';
+
+  @override
+  String get errorBannerDeactivatedDmLabel => 'You cannot send messages to deactivated users.';
+
+  @override
+  String get errorBannerCannotPostInChannelLabel => 'You do not have permission to post in this channel.';
+
+  @override
+  String get composeBoxAttachFilesTooltip => 'Attach files';
+
+  @override
+  String get composeBoxAttachMediaTooltip => 'Attach images or videos';
+
+  @override
+  String get composeBoxAttachFromCameraTooltip => 'Take a photo';
+
+  @override
+  String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String composeBoxDmContentHint(String user) {
+    return 'Message @$user';
+  }
+
+  @override
+  String get composeBoxGroupDmContentHint => 'Message group';
+
+  @override
+  String get composeBoxSelfDmContentHint => 'Jot down something';
+
+  @override
+  String composeBoxChannelContentHint(String channel, String topic) {
+    return 'Message #$channel > $topic';
+  }
+
+  @override
+  String get composeBoxSendTooltip => 'Send';
+
+  @override
+  String get composeBoxUnknownChannelName => '(unknown channel)';
+
+  @override
+  String get composeBoxTopicHintText => 'Topic';
+
+  @override
+  String composeBoxUploadingFilename(String filename) {
+    return 'Uploading $filename…';
+  }
+
+  @override
+  String get unknownUserName => '(unknown user)';
+
+  @override
+  String messageListGroupYouAndOthers(String others) {
+    return 'You and $others';
+  }
+
+  @override
+  String get messageListGroupYouWithYourself => 'You with yourself';
+
+  @override
+  String get contentValidationErrorTooLong => 'Message length shouldn\'t be greater than 10000 characters.';
+
+  @override
+  String get contentValidationErrorEmpty => 'You have nothing to send!';
+
+  @override
+  String get contentValidationErrorQuoteAndReplyInProgress => 'Please wait for the quotation to complete.';
+
+  @override
+  String get contentValidationErrorUploadInProgress => 'Please wait for the upload to complete.';
+
+  @override
+  String get dialogCancel => 'Cancel';
+
+  @override
+  String get dialogContinue => 'Continue';
+
+  @override
+  String get errorDialogContinue => 'OK';
+
+  @override
+  String get errorDialogTitle => 'Error';
+
+  @override
+  String get snackBarDetails => 'Details';
+
+  @override
+  String get lightboxCopyLinkTooltip => 'Copy link';
+
+  @override
+  String get loginPageTitle => 'Log in';
+
+  @override
+  String get loginFormSubmitLabel => 'Log in';
+
+  @override
+  String get loginMethodDivider => 'OR';
+
+  @override
+  String signInWithFoo(String method) {
+    return 'Sign in with $method';
+  }
+
+  @override
+  String get loginAddAnAccountPageTitle => 'Add an account';
+
+  @override
+  String get loginServerUrlInputLabel => 'Your Zulip server URL';
+
+  @override
+  String get loginHidePassword => 'Hide password';
+
+  @override
+  String get loginEmailLabel => 'Email address';
+
+  @override
+  String get loginErrorMissingEmail => 'Please enter your email.';
+
+  @override
+  String get loginPasswordLabel => 'Password';
+
+  @override
+  String get loginErrorMissingPassword => 'Please enter your password.';
+
+  @override
+  String get loginUsernameLabel => 'Username';
+
+  @override
+  String get loginErrorMissingUsername => 'Please enter your username.';
+
+  @override
+  String get topicValidationErrorTooLong => 'Topic length shouldn\'t be greater than 60 characters.';
+
+  @override
+  String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
+
+  @override
+  String get errorInvalidResponse => 'The server sent an invalid response';
+
+  @override
+  String get errorNetworkRequestFailed => 'Network request failed';
+
+  @override
+  String errorMalformedResponse(int httpStatus) {
+    return 'Server gave malformed response; HTTP status $httpStatus';
+  }
+
+  @override
+  String errorMalformedResponseWithCause(int httpStatus, String details) {
+    return 'Server gave malformed response; HTTP status $httpStatus; $details';
+  }
+
+  @override
+  String errorRequestFailed(int httpStatus) {
+    return 'Network request failed: HTTP status $httpStatus';
+  }
+
+  @override
+  String get errorVideoPlayerFailed => 'Unable to play the video';
+
+  @override
+  String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
+
+  @override
+  String get serverUrlValidationErrorInvalidUrl => 'Please enter a valid URL.';
+
+  @override
+  String get serverUrlValidationErrorNoUseEmail => 'Please enter the server URL, not your email.';
+
+  @override
+  String get serverUrlValidationErrorUnsupportedScheme => 'The server URL must start with http:// or https://.';
+
+  @override
+  String get spoilerDefaultHeaderText => 'Spoiler';
+
+  @override
+  String get markAllAsReadLabel => 'Mark all messages as read';
+
+  @override
+  String markAsReadComplete(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num messages',
+      one: '1 message',
+    );
+    return 'Marked $_temp0 as read.';
+  }
+
+  @override
+  String get markAsReadInProgress => 'Marking messages as read…';
+
+  @override
+  String get errorMarkAsReadFailedTitle => 'Mark as read failed';
+
+  @override
+  String markAsUnreadComplete(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num messages',
+      one: '1 message',
+    );
+    return 'Marked $_temp0 as unread.';
+  }
+
+  @override
+  String get markAsUnreadInProgress => 'Marking messages as unread…';
+
+  @override
+  String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
+
+  @override
+  String get today => 'Today';
+
+  @override
+  String get yesterday => 'Yesterday';
+
+  @override
+  String get userRoleOwner => 'Owner';
+
+  @override
+  String get userRoleAdministrator => 'Administrator';
+
+  @override
+  String get userRoleModerator => 'Moderator';
+
+  @override
+  String get userRoleMember => 'Member';
+
+  @override
+  String get userRoleGuest => 'Guest';
+
+  @override
+  String get userRoleUnknown => 'Unknown';
+
+  @override
+  String get recentDmConversationsPageTitle => 'Direct messages';
+
+  @override
+  String get combinedFeedPageTitle => 'Combined feed';
+
+  @override
+  String get mentionsPageTitle => 'Mentions';
+
+  @override
+  String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String notifGroupDmConversationLabel(String senderFullName, int numOthers) {
+    String _temp0 = intl.Intl.pluralLogic(
+      numOthers,
+      locale: localeName,
+      other: '$numOthers others',
+      one: '1 other',
+    );
+    return '$senderFullName to you and $_temp0';
+  }
+
+  @override
+  String get notifSelfUser => 'You';
+
+  @override
+  String onePersonTyping(String typist) {
+    return '$typist is typing…';
+  }
+
+  @override
+  String twoPeopleTyping(String typist, String otherTypist) {
+    return '$typist and $otherTypist are typing…';
+  }
+
+  @override
+  String get manyPeopleTyping => 'Several people are typing…';
+
+  @override
+  String get messageIsEditedLabel => 'EDITED';
+
+  @override
+  String get messageIsMovedLabel => 'MOVED';
+
+  @override
+  String get pollWidgetQuestionMissing => 'No question.';
+
+  @override
+  String get pollWidgetOptionsMissing => 'This poll has no options yet.';
+
+  @override
+  String get errorNotificationOpenTitle => 'Failed to open notification';
+
+  @override
+  String get errorNotificationOpenAccountMissing => 'The account associated with this notification no longer exists.';
+}

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1,0 +1,470 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'zulip_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Japanese (`ja`).
+class ZulipLocalizationsJa extends ZulipLocalizations {
+  ZulipLocalizationsJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get aboutPageTitle => 'About Zulip';
+
+  @override
+  String get aboutPageAppVersion => 'App version';
+
+  @override
+  String get aboutPageOpenSourceLicenses => 'Open-source licenses';
+
+  @override
+  String get aboutPageTapToView => 'Tap to view';
+
+  @override
+  String get chooseAccountPageTitle => 'アカウントを選択';
+
+  @override
+  String get chooseAccountPageLogOutButton => 'Log out';
+
+  @override
+  String get logOutConfirmationDialogTitle => 'Log out?';
+
+  @override
+  String get logOutConfirmationDialogMessage => 'To use this account in the future, you will have to re-enter the URL for your organization and your account information.';
+
+  @override
+  String get logOutConfirmationDialogConfirmButton => 'Log out';
+
+  @override
+  String get chooseAccountButtonAddAnAccount => '新しいアカウントを追加';
+
+  @override
+  String get profileButtonSendDirectMessage => 'ダイレクトメッセージを送信';
+
+  @override
+  String get permissionsNeededTitle => 'Permissions needed';
+
+  @override
+  String get permissionsNeededOpenSettings => 'Open settings';
+
+  @override
+  String get permissionsDeniedCameraAccess => 'To upload an image, please grant Zulip additional permissions in Settings.';
+
+  @override
+  String get permissionsDeniedReadExternalStorage => 'To upload files, please grant Zulip additional permissions in Settings.';
+
+  @override
+  String get actionSheetOptionCopyMessageText => 'Copy message text';
+
+  @override
+  String get actionSheetOptionCopyMessageLink => 'Copy link to message';
+
+  @override
+  String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
+
+  @override
+  String get actionSheetOptionShare => 'Share';
+
+  @override
+  String get actionSheetOptionQuoteAndReply => 'Quote and reply';
+
+  @override
+  String get actionSheetOptionStarMessage => 'Star message';
+
+  @override
+  String get actionSheetOptionUnstarMessage => 'Unstar message';
+
+  @override
+  String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
+
+  @override
+  String get errorWebAuthOperationalError => 'An unexpected error occurred.';
+
+  @override
+  String get errorAccountLoggedInTitle => 'Account already logged in';
+
+  @override
+  String errorAccountLoggedIn(String email, String server) {
+    return 'The account $email at $server is already in your list of accounts.';
+  }
+
+  @override
+  String get errorCouldNotFetchMessageSource => 'Could not fetch message source';
+
+  @override
+  String get errorCopyingFailed => 'Copying failed';
+
+  @override
+  String errorFailedToUploadFileTitle(String filename) {
+    return 'Failed to upload file: $filename';
+  }
+
+  @override
+  String errorFilesTooLarge(int num, int maxFileUploadSizeMib, String listMessage) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num files are',
+      one: 'File is',
+    );
+    return '$_temp0 larger than the server\'s limit of $maxFileUploadSizeMib MiB and will not be uploaded:\n\n$listMessage';
+  }
+
+  @override
+  String errorFilesTooLargeTitle(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: 'Files',
+      one: 'File',
+    );
+    return '$_temp0 too large';
+  }
+
+  @override
+  String get errorLoginInvalidInputTitle => 'Invalid input';
+
+  @override
+  String get errorLoginFailedTitle => 'Login failed';
+
+  @override
+  String get errorMessageNotSent => 'Message not sent';
+
+  @override
+  String errorLoginCouldNotConnect(String url) {
+    return 'Failed to connect to server:\n$url';
+  }
+
+  @override
+  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+
+  @override
+  String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';
+
+  @override
+  String get errorQuotationFailed => 'Quotation failed';
+
+  @override
+  String errorServerMessage(String message) {
+    return 'The server said:\n\n$message';
+  }
+
+  @override
+  String get errorConnectingToServerShort => 'Error connecting to Zulip. Retrying…';
+
+  @override
+  String errorConnectingToServerDetails(String serverUrl, String error) {
+    return 'Error connecting to Zulip at $serverUrl. Will retry:\n\n$error';
+  }
+
+  @override
+  String get errorSharingFailed => 'Sharing failed';
+
+  @override
+  String get errorStarMessageFailedTitle => 'Failed to star message';
+
+  @override
+  String get errorUnstarMessageFailedTitle => 'Failed to unstar message';
+
+  @override
+  String get successLinkCopied => 'Link copied';
+
+  @override
+  String get successMessageTextCopied => 'Message text copied';
+
+  @override
+  String get successMessageLinkCopied => 'Message link copied';
+
+  @override
+  String get errorBannerDeactivatedDmLabel => 'You cannot send messages to deactivated users.';
+
+  @override
+  String get errorBannerCannotPostInChannelLabel => 'You do not have permission to post in this channel.';
+
+  @override
+  String get composeBoxAttachFilesTooltip => 'Attach files';
+
+  @override
+  String get composeBoxAttachMediaTooltip => 'Attach images or videos';
+
+  @override
+  String get composeBoxAttachFromCameraTooltip => 'Take a photo';
+
+  @override
+  String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String composeBoxDmContentHint(String user) {
+    return 'Message @$user';
+  }
+
+  @override
+  String get composeBoxGroupDmContentHint => 'Message group';
+
+  @override
+  String get composeBoxSelfDmContentHint => 'Jot down something';
+
+  @override
+  String composeBoxChannelContentHint(String channel, String topic) {
+    return 'Message #$channel > $topic';
+  }
+
+  @override
+  String get composeBoxSendTooltip => 'Send';
+
+  @override
+  String get composeBoxUnknownChannelName => '(unknown channel)';
+
+  @override
+  String get composeBoxTopicHintText => 'Topic';
+
+  @override
+  String composeBoxUploadingFilename(String filename) {
+    return 'Uploading $filename…';
+  }
+
+  @override
+  String get unknownUserName => '(unknown user)';
+
+  @override
+  String messageListGroupYouAndOthers(String others) {
+    return 'You and $others';
+  }
+
+  @override
+  String get messageListGroupYouWithYourself => 'You with yourself';
+
+  @override
+  String get contentValidationErrorTooLong => 'Message length shouldn\'t be greater than 10000 characters.';
+
+  @override
+  String get contentValidationErrorEmpty => 'You have nothing to send!';
+
+  @override
+  String get contentValidationErrorQuoteAndReplyInProgress => 'Please wait for the quotation to complete.';
+
+  @override
+  String get contentValidationErrorUploadInProgress => 'Please wait for the upload to complete.';
+
+  @override
+  String get dialogCancel => 'Cancel';
+
+  @override
+  String get dialogContinue => 'Continue';
+
+  @override
+  String get errorDialogContinue => 'OK';
+
+  @override
+  String get errorDialogTitle => 'Error';
+
+  @override
+  String get snackBarDetails => 'Details';
+
+  @override
+  String get lightboxCopyLinkTooltip => 'Copy link';
+
+  @override
+  String get loginPageTitle => 'Log in';
+
+  @override
+  String get loginFormSubmitLabel => 'Log in';
+
+  @override
+  String get loginMethodDivider => 'OR';
+
+  @override
+  String signInWithFoo(String method) {
+    return 'Sign in with $method';
+  }
+
+  @override
+  String get loginAddAnAccountPageTitle => 'Add an account';
+
+  @override
+  String get loginServerUrlInputLabel => 'Your Zulip server URL';
+
+  @override
+  String get loginHidePassword => 'Hide password';
+
+  @override
+  String get loginEmailLabel => 'Email address';
+
+  @override
+  String get loginErrorMissingEmail => 'Please enter your email.';
+
+  @override
+  String get loginPasswordLabel => 'Password';
+
+  @override
+  String get loginErrorMissingPassword => 'Please enter your password.';
+
+  @override
+  String get loginUsernameLabel => 'Username';
+
+  @override
+  String get loginErrorMissingUsername => 'Please enter your username.';
+
+  @override
+  String get topicValidationErrorTooLong => 'Topic length shouldn\'t be greater than 60 characters.';
+
+  @override
+  String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
+
+  @override
+  String get errorInvalidResponse => 'The server sent an invalid response';
+
+  @override
+  String get errorNetworkRequestFailed => 'Network request failed';
+
+  @override
+  String errorMalformedResponse(int httpStatus) {
+    return 'Server gave malformed response; HTTP status $httpStatus';
+  }
+
+  @override
+  String errorMalformedResponseWithCause(int httpStatus, String details) {
+    return 'Server gave malformed response; HTTP status $httpStatus; $details';
+  }
+
+  @override
+  String errorRequestFailed(int httpStatus) {
+    return 'Network request failed: HTTP status $httpStatus';
+  }
+
+  @override
+  String get errorVideoPlayerFailed => 'Unable to play the video';
+
+  @override
+  String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
+
+  @override
+  String get serverUrlValidationErrorInvalidUrl => 'Please enter a valid URL.';
+
+  @override
+  String get serverUrlValidationErrorNoUseEmail => 'Please enter the server URL, not your email.';
+
+  @override
+  String get serverUrlValidationErrorUnsupportedScheme => 'The server URL must start with http:// or https://.';
+
+  @override
+  String get spoilerDefaultHeaderText => 'Spoiler';
+
+  @override
+  String get markAllAsReadLabel => 'Mark all messages as read';
+
+  @override
+  String markAsReadComplete(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num messages',
+      one: '1 message',
+    );
+    return 'Marked $_temp0 as read.';
+  }
+
+  @override
+  String get markAsReadInProgress => 'Marking messages as read…';
+
+  @override
+  String get errorMarkAsReadFailedTitle => 'Mark as read failed';
+
+  @override
+  String markAsUnreadComplete(int num) {
+    String _temp0 = intl.Intl.pluralLogic(
+      num,
+      locale: localeName,
+      other: '$num messages',
+      one: '1 message',
+    );
+    return 'Marked $_temp0 as unread.';
+  }
+
+  @override
+  String get markAsUnreadInProgress => 'Marking messages as unread…';
+
+  @override
+  String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
+
+  @override
+  String get today => 'Today';
+
+  @override
+  String get yesterday => 'Yesterday';
+
+  @override
+  String get userRoleOwner => 'オーナー';
+
+  @override
+  String get userRoleAdministrator => '管理者';
+
+  @override
+  String get userRoleModerator => 'モデレータ';
+
+  @override
+  String get userRoleMember => 'メンバー';
+
+  @override
+  String get userRoleGuest => 'ゲスト';
+
+  @override
+  String get userRoleUnknown => '不明';
+
+  @override
+  String get recentDmConversationsPageTitle => 'Direct messages';
+
+  @override
+  String get combinedFeedPageTitle => 'Combined feed';
+
+  @override
+  String get mentionsPageTitle => 'Mentions';
+
+  @override
+  String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String notifGroupDmConversationLabel(String senderFullName, int numOthers) {
+    String _temp0 = intl.Intl.pluralLogic(
+      numOthers,
+      locale: localeName,
+      other: '$numOthers others',
+      one: '1 other',
+    );
+    return '$senderFullName to you and $_temp0';
+  }
+
+  @override
+  String get notifSelfUser => 'You';
+
+  @override
+  String onePersonTyping(String typist) {
+    return '$typist is typing…';
+  }
+
+  @override
+  String twoPeopleTyping(String typist, String otherTypist) {
+    return '$typist and $otherTypist are typing…';
+  }
+
+  @override
+  String get manyPeopleTyping => 'Several people are typing…';
+
+  @override
+  String get messageIsEditedLabel => 'EDITED';
+
+  @override
+  String get messageIsMovedLabel => 'MOVED';
+
+  @override
+  String get pollWidgetQuestionMissing => 'No question.';
+
+  @override
+  String get pollWidgetOptionsMissing => 'This poll has no options yet.';
+
+  @override
+  String get errorNotificationOpenTitle => 'Failed to open notification';
+
+  @override
+  String get errorNotificationOpenAccountMissing => 'The account associated with this notification no longer exists.';
+}

--- a/lib/model/localizations.dart
+++ b/lib/model/localizations.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
+import '../generated/l10n/zulip_localizations.dart';
 
 abstract final class GlobalLocalizations {
   static ZulipLocalizations zulipLocalizations =

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -3,11 +3,11 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:collection/collection.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart' hide Notification;
 
 import '../api/notifications.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../host/android_notifications.dart';
 import '../log.dart';
 import '../model/binding.dart';

--- a/lib/widgets/about_zulip.dart
+++ b/lib/widgets/about_zulip.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/binding.dart';
 import 'page.dart';
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -3,12 +3,12 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/internal_link.dart';
 import '../model/narrow.dart';
 import 'actions.dart';

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -9,11 +9,11 @@ library;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
 import '../api/model/model.dart';
 import '../api/model/narrow.dart';
 import '../api/route/messages.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import '../model/store.dart';
 import '../notifications/receive.dart';

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
+import '../generated/l10n/zulip_localizations.dart';
 import '../log.dart';
 import '../model/localizations.dart';
 import '../model/narrow.dart';

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -3,12 +3,12 @@ import 'dart:math';
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:mime/mime.dart';
 
 import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/binding.dart';
 import '../model/compose.dart';
 import '../model/narrow.dart';

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -7,10 +7,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:html/dom.dart' as dom;
 import 'package:intl/intl.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
 import '../api/core.dart';
 import '../api/model/model.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/avatar_url.dart';
 import '../model/binding.dart';
 import '../model/content.dart';

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
+
+import '../generated/l10n/zulip_localizations.dart';
 
 Widget _dialogActionText(String text) {
   return Text(

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:video_player/video_player.dart';
 
 import '../api/core.dart';
 import '../api/model/model.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../log.dart';
 import '../model/binding.dart';
 import 'content.dart';

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../api/exception.dart';
@@ -11,6 +10,7 @@ import '../api/model/web_auth.dart';
 import '../api/route/account.dart';
 import '../api/route/realm.dart';
 import '../api/route/users.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../log.dart';
 import '../model/binding.dart';
 import '../model/store.dart';

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -3,10 +3,10 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_color_models/flutter_color_models.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 import 'package:intl/intl.dart';
 
 import '../api/model/model.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/message_list.dart';
 import '../model/narrow.dart';
 import '../model/store.dart';

--- a/lib/widgets/poll.dart
+++ b/lib/widgets/poll.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
 import '../api/model/submessage.dart';
 import '../api/route/submessage.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import 'content.dart';
 import 'store.dart';
 import 'text.dart';

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
 import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/content.dart';
 import '../model/narrow.dart';
 import '../model/store.dart';

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1368,5 +1368,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.7.0-123.0.dev <4.0.0"
-  flutter: ">=3.27.0-1.0.pre.443"
+  dart: ">=3.7.0-140.0.dev <4.0.0"
+  flutter: ">=3.27.0-1.0.pre.518"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.7.0-123.0.dev <4.0.0'
-  flutter: '>=3.27.0-1.0.pre.443'
+  sdk: '>=3.7.0-140.0.dev <4.0.0'
+  flutter: '>=3.27.0-1.0.pre.518'
 
 # To update dependencies, see instructions in README.md.
 dependencies:

--- a/test/widgets/test_app.dart
+++ b/test/widgets/test_app.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/zulip_localizations.dart';
 
+import 'package:zulip/generated/l10n/zulip_localizations.dart';
 import 'package:zulip/widgets/store.dart';
 import 'package:zulip/widgets/theme.dart';
 

--- a/tools/check
+++ b/tools/check
@@ -334,20 +334,6 @@ run_pigeon() {
         > >(filter_flutter_pub_run_output) \
     || return
 
-    # The `flutter pub run` disrupts `.dart_tool/package_config.json`,
-    # removing `flutter_gen`, which causes analysis failures everywhere
-    # that we use localization.  (And `dart run` has the same problem.)
-    # Fix it back, with `flutter pub get`.
-    # TODO(upstream): Find or file a bug for this `pub run` vs. `flutter_gen` issue.
-    if [ -n "${opt_verbose}" ]; then
-        flutter pub get \
-        || return
-    else
-        flutter pub get \
-            >/dev/null \
-        || return
-    fi
-
     check_no_changes "changes to pigeons" "${outputs[@]}"
 }
 

--- a/tools/check
+++ b/tools/check
@@ -26,7 +26,7 @@ this_dir=${BASH_SOURCE[0]%/*}
 
 default_suites=(
     analyze test
-    build_runner drift pigeon icons
+    build_runner l10n drift pigeon icons
     android  # This takes multiple minutes in CI, so do it last.
 )
 
@@ -82,7 +82,7 @@ while (( $# )); do
         --all) opt_files=all; opt_all=1; shift;;
         --fix) opt_fix=1; shift;;
         --verbose) opt_verbose=1; shift;;
-        analyze|test|build_runner|drift|pigeon|icons|android|shellcheck)
+        analyze|test|build_runner|l10n|drift|pigeon|icons|android|shellcheck)
             opt_suites+=("$1"); shift;;
         *) usage;;
     esac
@@ -277,6 +277,23 @@ run_build_runner() {
     check_no_changes "updates to *.g.dart files" '*.g.dart'
 }
 
+run_l10n() {
+    local output_pathspec=lib/generated/l10n/zulip_localizations'*'.dart
+
+    # Omitted from this check:
+    #   pubspec.{yaml,lock} tools/check
+    files_check l10n.yaml assets/l10n/ "${output_pathspec}" \
+    || return 0
+
+    check_no_uncommitted_or_untracked "${output_pathspec}" \
+    || return
+
+    flutter gen-l10n > /dev/null \
+    || return
+
+    check_no_changes "updates to l10n" "${output_pathspec}"
+}
+
 run_drift() {
     local schema_dir=test/model/schemas/
 
@@ -444,6 +461,7 @@ for suite in "${opt_suites[@]}"; do
         analyze)      run_analyze ;;
         test)         run_test ;;
         build_runner) run_build_runner ;;
+        l10n)         run_l10n ;;
         drift)        run_drift ;;
         pigeon)       run_pigeon ;;
         icons)        run_icons ;;


### PR DESCRIPTION
`flutter` tool deprecated the `package:flutter_gen` synthetic package:
  https://flutter.dev/to/flutter-gen-deprecation

The generated localization source files are now included in the
repository and referenced directly.

Without this change, `flutter run` generates the following warning:
```
Synthetic package output (package:flutter_gen) is deprecated:
https://flutter.dev/to/flutter-gen-deprecation. In a future
release, synthetic-package will default to `false` and will
later be removed entirely.
```