### PR TITLE
tools: Add bump-version, simplifying a release step

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -6,23 +6,11 @@
   Flutter and packages dependencies, do that first.
   For details of how, see our README.
 
-* Write an entry in `docs/changelog.md`, as "Unreleased".
+* Write an entry in `docs/changelog.md`, under "Unreleased".
   Commit that change.
 
-* Increment the version number in `pubspec.yaml`:
-
-  Take the line near the top that looks like `version: 0.0.42+42`,
-  and increment both of the last two numbers.
-  They should remain equal to each other.
-
-  Edit the "Unreleased" heading in `docs/changelog.md` to the
-  new version number.
-
-* Commit the version-number changes, and tag:
-  `git commit pubspec.yaml docs/changelog.md -m 'version: Bump version to 0.0.NNN'
-  && git tag v0.0.NNN`
-
-* Push the tag to our central repo: `git push origin main v0.0.NNN`
+* Run `tools/bump-version` to update the version number.
+  Inspect the resulting commit and tag, and push.
 
 
 ## Build and upload alpha: Android

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -e
+
+usage () {
+    cat <<EOF >&2
+usage: bump-version
+
+Increments the version number in our pubspec and changelog.
+EOF
+    exit 2
+}
+
+shift && usage;
+
+date="$(date --iso)"
+
+old_version_int="$(perl -lne '
+print $1 if (/^version: 0\.0\.(\d+)\+\1$/);
+' pubspec.yaml)"
+version_int=$(( old_version_int + 1 ))
+version_name="0.0.${version_int}"
+tag_name=v"${version_name}"
+
+had_uncommitted=
+if ! git diff-index --quiet HEAD; then
+    had_uncommitted=1
+fi
+
+perl -i -0pe '
+s<^version: \K0\.0\.(\d+)\+\1$>
+ <0.0.'"${version_int}"'+'"${version_int}"'>m;
+' pubspec.yaml
+
+perl -i -0pe '
+s/^\#\#\ Unreleased\n\K
+/
+
+## '"${version_name}"' ('"${date}"')
+/xms
+' docs/changelog.md
+
+msg="version: Bump version to $version_name"
+
+if [ -n "$had_uncommitted" ]; then
+    {
+        echo "There were uncommitted changes.  To commit:"
+        echo "  git commit -am ${msg@Q}"
+        # NB if tempted to use the ${...@Q} feature: it's new in bash 4.4,
+        # released 2016-09, found in stretch and bionic but not xenial.
+        echo
+        echo "Then tag the commit:"
+        echo "  git tag ${tag_name}"
+        echo "inspect the result, and push:"
+        echo "  git push origin main ${tag_name}"
+    } >&2
+    exit 1
+fi
+
+git commit -am "$msg"
+
+git tag "${tag_name}"
+
+{
+    echo
+    echo "Committed and tagged."
+    echo "Inspect the result, then push; for example:"
+    echo "  git push origin main ${tag_name}"
+} >&2


### PR DESCRIPTION
This is adapted from the tools/bump-version in zulip-mobile.