### PR TITLE
fix: added whole channel button for topic narrow #1040

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -342,7 +342,29 @@ class MessageListAppBarTitle extends StatelessWidget {
         final store = PerAccountStoreWidget.of(context);
         final stream = store.streams[streamId];
         final streamName = stream?.name ?? '(unknown channel)';
-        return _buildStreamRow(context, stream: stream, text: "$streamName > $topic");
+        // return _buildStreamRow(context, stream: stream, text: "$streamName > $topic");
+        return Row(
+          children: [
+            Expanded(
+              child: _buildStreamRow(
+                context,
+                stream: stream,
+                text: "$streamName > $topic",
+              ),
+            ),
+            IconButton(
+              icon: Icon(Icons.arrow_upward),
+              tooltip: 'Go to channel feed',
+              onPressed: () => Navigator.pushReplacement(
+                context,
+                MessageListPage.buildRoute(
+                  context: context,
+                  narrow: ChannelNarrow(streamId),
+                ),
+              ),
+            ),
+          ],
+        );
 
       case DmNarrow(:var otherRecipientIds):
         final store = PerAccountStoreWidget.of(context);

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -262,6 +262,23 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
     return Scaffold(
       appBar: ZulipAppBar(
         title: MessageListAppBarTitle(narrow: narrow),
+        actions: [
+          if (narrow is TopicNarrow)
+            IconButton(
+              icon: const Icon(Icons.arrow_upward),
+              color: Colors.white,
+              tooltip: 'Go to channel feed',
+              onPressed: () {
+                Navigator.pushReplacement(
+                  context,
+                  MessageListPage.buildRoute(
+                    context: context,
+                    narrow: ChannelNarrow((narrow as TopicNarrow).streamId),
+                  ),
+                );
+              },
+            ),
+        ],
         backgroundColor: appBarBackgroundColor,
         shape: removeAppBarBottomBorder
           ? const Border()
@@ -342,29 +359,7 @@ class MessageListAppBarTitle extends StatelessWidget {
         final store = PerAccountStoreWidget.of(context);
         final stream = store.streams[streamId];
         final streamName = stream?.name ?? '(unknown channel)';
-        // return _buildStreamRow(context, stream: stream, text: "$streamName > $topic");
-        return Row(
-          children: [
-            Expanded(
-              child: _buildStreamRow(
-                context,
-                stream: stream,
-                text: "$streamName > $topic",
-              ),
-            ),
-            IconButton(
-              icon: Icon(Icons.arrow_upward),
-              tooltip: 'Go to channel feed',
-              onPressed: () => Navigator.pushReplacement(
-                context,
-                MessageListPage.buildRoute(
-                  context: context,
-                  narrow: ChannelNarrow(streamId),
-                ),
-              ),
-            ),
-          ],
-        );
+        return _buildStreamRow(context, stream: stream, text: "$streamName > $topic");
 
       case DmNarrow(:var otherRecipientIds):
         final store = PerAccountStoreWidget.of(context);


### PR DESCRIPTION
Issue: #1040 

This PR introduces a new "Whole Channel" button in the MessageListAppBarTitle for TopicNarrow views. This feature enhances user navigation by providing a quick and efficient way to return to the full channel (stream) view from a topic discussion. This update aligns with the legacy functionality but it does not include a modified icon that reflects the newer design directions discussed in issue #1040.

Changes Made:

Navigation Enhancement: Implemented Navigator.pushReplacement for transitioning back to the channel view, ensuring that the navigation stack isn't unnecessarily extended, when clicked on the "up" arrow icon on the appbar of a topic narrow channel.

note:

I did'nt get "all messages" / "combined feed" icon that was asked to replace the "up" icon. this was just to demonstrate the functionality only, will change the icon once u guide me on that.

output:

https://github.com/user-attachments/assets/83ac306b-62bd-454e-b66f-4e2a4e2db57b
