### PR TITLE
Comprehensively retry event-poll failures

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -188,6 +188,19 @@
       "error": {"type": "String", "example": "Invalid format"}
     }
   },
+  "errorHandlingEventTitle": "Error handling a Zulip event. Retrying connection…",
+  "@errorHandlingEventTitle": {
+    "description": "Error title on failing to handle a Zulip server event."
+  },
+  "errorHandlingEventDetails": "Error handling a Zulip event from {serverUrl}; will retry.\n\nError: {error}\n\nEvent: {event}",
+  "@errorHandlingEventDetails": {
+    "description": "Error details on failing to handle a Zulip server event.",
+    "placeholders": {
+      "serverUrl": {"type":  "String", "example":  "https://chat.example.com"},
+      "error": {"type": "String", "example": "Unexpected null value"},
+      "event": {"type": "String", "example": "UpdateMessageEvent(id: 123, messageIds: [2345, 3456], newTopic: 'dinner')"}
+    }
+  },
   "errorSharingFailed": "Sharing failed",
   "@errorSharingFailed": {
     "description": "Error message when sharing a message failed."

--- a/lib/api/exception.dart
+++ b/lib/api/exception.dart
@@ -91,7 +91,7 @@ class NetworkException extends ApiRequestException {
 /// This should always represent either some kind of operational issue
 /// on the server, or a bug in the server where its responses don't
 /// agree with the documented API.
-abstract class ServerException extends ApiRequestException {
+sealed class ServerException extends ApiRequestException {
   final int httpStatus;
 
   /// The response body, decoded as a JSON object.

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -215,6 +215,7 @@ sealed class RealmUserEvent extends Event {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class RealmUserAddEvent extends RealmUserEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'add';
 
   final User person;
@@ -231,6 +232,7 @@ class RealmUserAddEvent extends RealmUserEvent {
 /// A [RealmUserEvent] with op `remove`: https://zulip.com/api/get-events#realm_user-remove
 class RealmUserRemoveEvent extends RealmUserEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'remove';
 
   final int userId;
@@ -268,6 +270,7 @@ class RealmUserUpdateCustomProfileField {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class RealmUserUpdateEvent extends RealmUserEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'update';
 
   @JsonKey(readValue: _readFromPerson) final int userId;
@@ -351,6 +354,7 @@ sealed class ChannelEvent extends Event {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class ChannelCreateEvent extends ChannelEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'create';
 
   final List<ZulipStream> streams;
@@ -368,6 +372,7 @@ class ChannelCreateEvent extends ChannelEvent {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class ChannelDeleteEvent extends ChannelEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'delete';
 
   final List<ZulipStream> streams;
@@ -385,6 +390,7 @@ class ChannelDeleteEvent extends ChannelEvent {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class ChannelUpdateEvent extends ChannelEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'update';
 
   final int streamId;
@@ -666,6 +672,7 @@ class UserTopicEvent extends Event {
 //   in order to skip the boilerplate in [fromJson] and [toJson].
 class MessageEvent extends Event {
   @override
+  @JsonKey(includeToJson: true)
   String get type => 'message';
 
   // In the server API, the `flags` field appears directly on the event rather
@@ -857,6 +864,7 @@ sealed class UpdateMessageFlagsEvent extends Event {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class UpdateMessageFlagsAddEvent extends UpdateMessageFlagsEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'add';
 
   final bool all;
@@ -879,6 +887,7 @@ class UpdateMessageFlagsAddEvent extends UpdateMessageFlagsEvent {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class UpdateMessageFlagsRemoveEvent extends UpdateMessageFlagsEvent {
   @override
+  @JsonKey(includeToJson: true)
   String get op => 'remove';
 
   // final bool all; // deprecated, ignore

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -94,6 +94,7 @@ Map<String, dynamic> _$RealmUserAddEventToJson(RealmUserAddEvent instance) =>
     <String, dynamic>{
       'id': instance.id,
       'type': instance.type,
+      'op': instance.op,
       'person': instance.person,
     };
 
@@ -160,6 +161,7 @@ Map<String, dynamic> _$RealmUserUpdateEventToJson(
     <String, dynamic>{
       'id': instance.id,
       'type': instance.type,
+      'op': instance.op,
       'user_id': instance.userId,
       'full_name': instance.fullName,
       'avatar_url': instance.avatarUrl,
@@ -210,6 +212,7 @@ Map<String, dynamic> _$ChannelCreateEventToJson(ChannelCreateEvent instance) =>
     <String, dynamic>{
       'id': instance.id,
       'type': instance.type,
+      'op': instance.op,
       'streams': instance.streams,
     };
 
@@ -225,6 +228,7 @@ Map<String, dynamic> _$ChannelDeleteEventToJson(ChannelDeleteEvent instance) =>
     <String, dynamic>{
       'id': instance.id,
       'type': instance.type,
+      'op': instance.op,
       'streams': instance.streams,
     };
 
@@ -247,6 +251,7 @@ Map<String, dynamic> _$ChannelUpdateEventToJson(ChannelUpdateEvent instance) =>
     <String, dynamic>{
       'id': instance.id,
       'type': instance.type,
+      'op': instance.op,
       'stream_id': instance.streamId,
       'name': instance.name,
       'property': _$ChannelPropertyNameEnumMap[instance.property],
@@ -517,6 +522,7 @@ Map<String, dynamic> _$UpdateMessageFlagsAddEventToJson(
       'type': instance.type,
       'flag': instance.flag,
       'messages': instance.messages,
+      'op': instance.op,
       'all': instance.all,
     };
 
@@ -544,6 +550,7 @@ Map<String, dynamic> _$UpdateMessageFlagsRemoveEventToJson(
       'type': instance.type,
       'flag': instance.flag,
       'messages': instance.messages,
+      'op': instance.op,
       'message_details':
           instance.messageDetails?.map((k, e) => MapEntry(k.toString(), e)),
     };

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -343,6 +343,18 @@ abstract class ZulipLocalizations {
   /// **'Error connecting to Zulip at {serverUrl}. Will retry:\n\n{error}'**
   String errorConnectingToServerDetails(String serverUrl, String error);
 
+  /// Error title on failing to handle a Zulip server event.
+  ///
+  /// In en, this message translates to:
+  /// **'Error handling a Zulip event. Retrying connection…'**
+  String get errorHandlingEventTitle;
+
+  /// Error details on failing to handle a Zulip server event.
+  ///
+  /// In en, this message translates to:
+  /// **'Error handling a Zulip event from {serverUrl}; will retry.\n\nError: {error}\n\nEvent: {event}'**
+  String errorHandlingEventDetails(String serverUrl, String error, String event);
+
   /// Error message when sharing a message failed.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -158,6 +158,14 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   }
 
   @override
+  String get errorHandlingEventTitle => 'Error handling a Zulip event. Retrying connection…';
+
+  @override
+  String errorHandlingEventDetails(String serverUrl, String error, String event) {
+    return 'Error handling a Zulip event from $serverUrl; will retry.\n\nError: $error\n\nEvent: $event';
+  }
+
+  @override
   String get errorSharingFailed => 'Sharing failed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -158,6 +158,14 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   }
 
   @override
+  String get errorHandlingEventTitle => 'Error handling a Zulip event. Retrying connection…';
+
+  @override
+  String errorHandlingEventDetails(String serverUrl, String error, String event) {
+    return 'Error handling a Zulip event from $serverUrl; will retry.\n\nError: $error\n\nEvent: $event';
+  }
+
+  @override
   String get errorSharingFailed => 'Sharing failed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -158,6 +158,14 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   }
 
   @override
+  String get errorHandlingEventTitle => 'Error handling a Zulip event. Retrying connection…';
+
+  @override
+  String errorHandlingEventDetails(String serverUrl, String error, String event) {
+    return 'Error handling a Zulip event from $serverUrl; will retry.\n\nError: $error\n\nEvent: $event';
+  }
+
+  @override
   String get errorSharingFailed => 'Sharing failed';
 
   @override

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1054,6 +1054,13 @@ class UpdateMachine {
             isUnexpected = false;
             shouldReportToUser = true;
 
+          case ServerException(httpStatus: 429):
+          case ZulipApiException(httpStatus: 429):
+          case ZulipApiException(code: 'RATE_LIMIT_HIT'):
+            // TODO(#946) handle rate-limit errors more generally, in ApiConnection
+            isUnexpected = false;
+            shouldReportToUser = true;
+
           default:
             isUnexpected = true;
             shouldReportToUser = true;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1101,6 +1101,7 @@ class UpdateMachine {
       // duration (which is 10 seconds).  So if we're getting a mix of successes
       // and failures, the successes themselves should space out the requests.
       backoffMachine = null;
+
       store.isLoading = false;
       // Dismiss existing errors, if any.
       reportErrorToUserBriefly(null);

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1033,6 +1033,7 @@ class UpdateMachine {
               details: localizations.errorConnectingToServerDetails(
                 serverUrl, e.toString()));
             await (backoffMachine ??= BackoffMachine()).wait();
+            if (_disposed) return;
             assert(debugLog('… Backoff wait complete, retrying poll.'));
             continue;
 
@@ -1048,6 +1049,7 @@ class UpdateMachine {
                   serverUrl, e.toString()));
             }
             await (backoffMachine ??= BackoffMachine()).wait();
+            if (_disposed) return;
             assert(debugLog('… Backoff wait complete, retrying poll.'));
             continue;
 
@@ -1060,6 +1062,7 @@ class UpdateMachine {
               details: localizations.errorConnectingToServerDetails(
                 serverUrl, e.toString()));
             await (backoffMachine ??= BackoffMachine()).wait();
+            if (_disposed) return;
             assert(debugLog('… Backoff wait complete, retrying poll.'));
             continue;
         }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1022,7 +1022,7 @@ class UpdateMachine {
             assert(debugLog('Lost event queue for $store.  Replacing…'));
             // This disposes the store, which disposes this update machine.
             await store._globalStore._reloadPerAccount(store.accountId);
-            debugLog('… Event queue replaced.');
+            assert(debugLog('… Event queue replaced.'));
             return;
 
           case Server5xxException():

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1016,7 +1016,7 @@ class UpdateMachine {
 
         store.isLoading = true;
         final localizations = GlobalLocalizations.zulipLocalizations;
-        final serverUrl = store.connection.realmUrl.origin;
+        final serverUrl = store.realmUrl.origin;
         switch (e) {
           case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
             assert(debugLog('Lost event queue for $store.  Replacing…'));

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1016,7 +1016,7 @@ class UpdateMachine {
 
         store.isLoading = true;
         final localizations = GlobalLocalizations.zulipLocalizations;
-        final serverUrl = store.realmUrl.origin;
+        final serverUrl = store.realmUrl.toString();
         switch (e) {
           case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
             assert(debugLog('Lost event queue for $store.  Replacing…'));

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -18,6 +18,10 @@ void _checkPositive(int? value, String description) {
   assert(value == null || value > 0, '$description should be positive');
 }
 
+Object nullCheckError() {
+  try { null!; } catch (e) { return e; } // ignore: null_check_always_fails
+}
+
 ////////////////////////////////////////////////////////////////
 // Realm-wide (or server-wide) metadata.
 //

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -611,7 +611,7 @@ void main() {
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
       checkLastRequest(lastEventId: 1);
-      await Future<void>.delayed(Duration.zero);
+      async.elapse(Duration.zero);
       check(updateMachine.lastEventId).equals(2);
 
       // Loop makes second request, and processes result.
@@ -621,7 +621,7 @@ void main() {
       updateMachine.debugAdvanceLoop();
       async.flushMicrotasks();
       checkLastRequest(lastEventId: 2);
-      await Future<void>.delayed(Duration.zero);
+      async.elapse(Duration.zero);
       check(updateMachine.lastEventId).equals(3);
     }));
 
@@ -635,8 +635,7 @@ void main() {
           property: UserSettingName.twentyFourHourTime, value: true),
       ], queueId: null).toJson());
       updateMachine.debugAdvanceLoop();
-      async.flushMicrotasks();
-      await Future<void>.delayed(Duration.zero);
+      async.elapse(Duration.zero);
       check(store.userSettings!.twentyFourHourTime).isTrue();
     }));
 
@@ -647,8 +646,7 @@ void main() {
 
         prepareError();
         updateMachine.debugAdvanceLoop();
-        async.flushMicrotasks();
-        await Future<void>.delayed(Duration.zero);
+        async.elapse(Duration.zero);
         check(store).isLoading.isTrue();
 
         // The global store has a new store.
@@ -665,8 +663,7 @@ void main() {
             property: UserSettingName.twentyFourHourTime, value: true),
         ], queueId: null).toJson());
         updateMachine.debugAdvanceLoop();
-        async.flushMicrotasks();
-        await Future<void>.delayed(Duration.zero);
+        async.elapse(Duration.zero);
         check(store.userSettings!.twentyFourHourTime).isTrue();
       });
     }
@@ -805,8 +802,7 @@ void main() {
       // Let the server expire the event queue.
       prepareExpiredEventQueue();
       updateMachine.debugAdvanceLoop();
-      async.flushMicrotasks();
-      await Future<void>.delayed(Duration.zero);
+      async.elapse(Duration.zero);
 
       // The old store's [MessageListView]s have been disposed.
       // (And no exception was thrown; that was #810.)

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -736,7 +736,7 @@ void main() {
       checkRetry(() => connection.prepare(exception: Exception("failed")));
     });
 
-    test('retries on ZulipApiException', () {
+    test('retries on generic ZulipApiException', () {
       checkRetry(() => connection.prepare(httpStatus: 400, json: {
         'result': 'error', 'code': 'BAD_REQUEST', 'msg': 'Bad request'}));
     });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -728,21 +728,23 @@ void main() {
       });
     }
 
-    test('retries on Server5xxException', () {
-      checkRetry(() => connection.prepare(httpStatus: 500, body: 'splat'));
-    });
+    // These cases are ordered by how far the request got before it failed.
 
     test('retries on NetworkException', () {
       checkRetry(() => connection.prepare(exception: Exception("failed")));
     });
 
-    test('retries on generic ZulipApiException', () {
-      checkRetry(() => connection.prepare(httpStatus: 400, json: {
-        'result': 'error', 'code': 'BAD_REQUEST', 'msg': 'Bad request'}));
+    test('retries on Server5xxException', () {
+      checkRetry(() => connection.prepare(httpStatus: 500, body: 'splat'));
     });
 
     test('retries on MalformedServerResponseException', () {
       checkRetry(() => connection.prepare(httpStatus: 200, body: 'nonsense'));
+    });
+
+    test('retries on generic ZulipApiException', () {
+      checkRetry(() => connection.prepare(httpStatus: 400, json: {
+        'result': 'error', 'code': 'BAD_REQUEST', 'msg': 'Bad request'}));
     });
 
     group('report error', () {

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -848,10 +848,8 @@ void main() {
         });
       }
 
-      test('report generic ZulipApiException', () {
-        checkReported(prepareZulipApiExceptionBadRequest).startsWith(
-          "Error connecting to Zulip. Retrying…\n"
-          "Error connecting to Zulip at");
+      test('ignore NetworkException from SocketException', () {
+        checkNotReported(prepareNetworkExceptionSocketException);
       });
 
       test('eventually report Server5xxException', () {
@@ -860,8 +858,10 @@ void main() {
           "Error connecting to Zulip at");
       });
 
-      test('ignore NetworkException from SocketException', () {
-        checkNotReported(prepareNetworkExceptionSocketException);
+      test('report generic ZulipApiException', () {
+        checkReported(prepareZulipApiExceptionBadRequest).startsWith(
+          "Error connecting to Zulip. Retrying…\n"
+          "Error connecting to Zulip at");
       });
     });
   });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -796,8 +796,8 @@ void main() {
       checkRetry(prepareServer5xxException);
     });
 
-    test('retries on MalformedServerResponseException', () {
-      checkRetry(prepareMalformedServerResponseException);
+    test('reloads on MalformedServerResponseException', () {
+      checkReload(prepareMalformedServerResponseException);
     });
 
     test('retries on rate limit: code RATE_LIMIT_HIT', () {
@@ -812,8 +812,8 @@ void main() {
       checkRetry(prepareRateLimitExceptionMalformed);
     });
 
-    test('retries on generic ZulipApiException', () {
-      checkRetry(prepareZulipApiExceptionBadRequest);
+    test('reloads on generic ZulipApiException', () {
+      checkReload(prepareZulipApiExceptionBadRequest);
     });
 
     test('reloads immediately on expired queue', () {

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -732,7 +732,12 @@ void main() {
       });
     }
 
-    test('retries on NetworkException', () {
+    test('retries on NetworkException from SocketException', () {
+      // We skip reporting errors on these; check we retry them all the same.
+      checkRetry(prepareNetworkExceptionSocketException);
+    });
+
+    test('retries on generic NetworkException', () {
       checkRetry(prepareNetworkException);
     });
 

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -982,10 +982,13 @@ void main() {
         checkNotReported(prepareExpiredEventQueue);
       });
 
-      test('report handleEvent error', () {
-        checkReported(prepareHandleEventError).startsWith(
-          "Error connecting to Zulip. Retrying…\n"
-          "Error connecting to Zulip at");
+      test('nicely report handleEvent error', () {
+        checkReported(prepareHandleEventError).matchesPattern(RegExp(
+          r"Error handling a Zulip event\. Retrying connection…\n"
+          r"Error handling a Zulip event from \S+; will retry\.\n"
+          r"\n"
+          r"Error: .*channel\.dart.. Failed assertion.*"
+        ));
       });
     });
   });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -821,6 +821,12 @@ void main() {
             pollAndFail(async);
             check(takeLastReportedError()).isNull();
             async.flushTimers();
+            if (!identical(store, globalStore.perAccountSync(store.accountId))) {
+              // Store was reloaded.
+              updateFromGlobalStore();
+              updateMachine.debugPauseLoop();
+              updateMachine.poll();
+            }
           }
 
           prepareError();
@@ -838,6 +844,12 @@ void main() {
             pollAndFail(async);
             check(takeLastReportedError()).isNull();
             async.flushTimers();
+            if (!identical(store, globalStore.perAccountSync(store.accountId))) {
+              // Store was reloaded.
+              updateFromGlobalStore();
+              updateMachine.debugPauseLoop();
+              updateMachine.poll();
+            }
           }
 
           prepareError();
@@ -862,6 +874,10 @@ void main() {
         checkReported(prepareZulipApiExceptionBadRequest).startsWith(
           "Error connecting to Zulip. Retrying…\n"
           "Error connecting to Zulip at");
+      });
+
+      test('ignore expired queue', () {
+        checkNotReported(prepareExpiredEventQueue);
       });
     });
   });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -864,8 +864,20 @@ void main() {
         checkNotReported(prepareNetworkExceptionSocketException);
       });
 
+      test('eventually report generic NetworkException', () {
+        checkLateReported(prepareNetworkException).startsWith(
+          "Error connecting to Zulip. Retrying…\n"
+          "Error connecting to Zulip at");
+      });
+
       test('eventually report Server5xxException', () {
         checkLateReported(prepareServer5xxException).startsWith(
+          "Error connecting to Zulip. Retrying…\n"
+          "Error connecting to Zulip at");
+      });
+
+      test('report MalformedServerResponseException', () {
+        checkReported(prepareMalformedServerResponseException).startsWith(
           "Error connecting to Zulip. Retrying…\n"
           "Error connecting to Zulip at");
       });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -753,17 +753,13 @@ void main() {
         return result;
       }
 
-      /// This is an alternative to [ZulipApp]'s implementation of
-      /// [reportErrorToUserBriefly] for testing.
-      Future<void> logAndReportErrorToUserBriefly(String? message, {
-        String? details,
-      }) async {
+      Future<void> logReportedError(String? message, {String? details}) async {
         if (message == null) return;
         lastReportedError = '$message\n$details';
       }
 
       Future<void> prepare() async {
-        reportErrorToUserBriefly = logAndReportErrorToUserBriefly;
+        reportErrorToUserBriefly = logReportedError;
         addTearDown(() => reportErrorToUserBriefly = defaultReportErrorToUserBriefly);
         await preparePoll(lastEventId: 1);
       }

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -919,19 +919,19 @@ void main() {
       });
 
       test('report rate limit: code RATE_LIMIT_HIT', () {
-        checkReported(prepareRateLimitExceptionCode).startsWith(
+        checkLateReported(prepareRateLimitExceptionCode).startsWith(
           "Error connecting to Zulip. Retrying…\n"
           "Error connecting to Zulip at");
       });
 
       test('report rate limit: status 429 ZulipApiException', () {
-        checkReported(prepareRateLimitExceptionStatus).startsWith(
+        checkLateReported(prepareRateLimitExceptionStatus).startsWith(
           "Error connecting to Zulip. Retrying…\n"
           "Error connecting to Zulip at");
       });
 
       test('report rate limit: status 429 MalformedServerResponseException', () {
-        checkReported(prepareRateLimitExceptionMalformed).startsWith(
+        checkLateReported(prepareRateLimitExceptionMalformed).startsWith(
           "Error connecting to Zulip. Retrying…\n"
           "Error connecting to Zulip at");
       });


### PR DESCRIPTION
This is a bit of a long branch, as I ended up going into a variety of related cleanups and other prep work.

Fixes: #563 

Selected commit messages:

---

store: On rate-limit error in poll, explicitly back off and retry

This covers a particular case of #946.

This commit is actually NFC as far as the interaction with the server
goes; its only change in behavior is that we treat the error as
"expected", and therefore skip reporting it to the user unless it
follows a string of other errors.

But then this also sets us up so that these rate-limit errors will
continue to be handled with backoff-retry when we change the handling
of unexpected errors, coming next.

---

store: Handle unexpected event-poll errors by reloading store, with backoff

This fixes #563.  We'll follow up with a few more commits that give
more-informative errors in some cases, or change the handling of others
from retrying getEvents to reloading the data from scratch.

The if-disposed and store.isLoading lines have no effect in the case
of a BAD_EVENT_QUEUE_ID error, because those can only come from the
getEvents request, and then the inner catch block will have already
taken the same steps.

Fixes: #563

---

store: Better error message on handleEvent failure

---

store: On non-transient request errors, reload rather than retry

This hopefully gives us a greater chance of getting past whatever
the underlying problem is, by resetting more of our state.
