### PR TITLE
Emoji autocomplete

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -208,6 +208,15 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
 
   final PerAccountStore store;
 
+  /// The last query this [AutocompleteView] was asked to perform for the user.
+  ///
+  /// If this view-model is currently performing a search,
+  /// the search is for this query.
+  /// If not, then [results] reflect this query.
+  ///
+  /// When set, the existing query is aborted if still in progress,
+  /// and a search for the new query is begun.
+  /// Any existing value in [results] remains until the new query finishes.
   QueryT get query => _query;
   QueryT _query;
   set query(QueryT query) {
@@ -222,6 +231,13 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
     _startSearch();
   }
 
+  /// The latest set of results available for any value of [query].
+  ///
+  /// When this changes, listeners will be notified with [notifyListeners].
+  ///
+  /// These results might not correspond to the current value of [query],
+  /// if a search is still in progress.
+  /// Before any search completes, [results] will be empty.
   Iterable<ResultT> get results => _results;
   List<ResultT> _results = [];
 

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -18,12 +20,13 @@ extension ComposeContentAutocomplete on ComposeContentController {
       // see below.
       return null;
     }
+
+    // To avoid spending a lot of time searching for autocomplete intents
+    // in long messages, we bound how far back we look for the intent's start.
+    final earliest = max(0, selection.end - 30);
+
     final textUntilCursor = text.substring(0, selection.end);
-    for (
-      int position = selection.end - 1;
-      position >= 0 && (selection.end - position <= 30);
-      position--
-    ) {
+    for (int position = selection.end - 1; position >= earliest; position--) {
       if (textUntilCursor[position] != '@') {
         continue;
       }

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -32,20 +32,20 @@ extension ComposeContentAutocomplete on ComposeContentController {
     }
 
     final textUntilCursor = text.substring(0, selection.end);
-    for (int position = selection.end - 1; position >= earliest; position--) {
-      if (textUntilCursor[position] != '@') {
+    for (int pos = selection.end - 1; pos >= earliest; pos--) {
+      if (textUntilCursor[pos] != '@') {
         continue;
       }
-      final match = mentionAutocompleteMarkerRegex.matchAsPrefix(textUntilCursor, position);
+      final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
       if (match == null) {
         continue;
       }
-      if (selection.start < position) {
+      if (selection.start < pos) {
         // See comment about [TextSelection.isCollapsed] above.
         return null;
       }
       return AutocompleteIntent(
-        syntaxStart: position,
+        syntaxStart: pos,
         query: MentionAutocompleteQuery(match[2]!, silent: match[1]! == '_'),
         textEditingValue: value);
     }
@@ -62,7 +62,7 @@ extension ComposeTopicAutocomplete on ComposeTopicController {
   }
 }
 
-final RegExp mentionAutocompleteMarkerRegex = (() {
+final RegExp _mentionIntentRegex = (() {
   // What's likely to come before an @-mention: the start of the string,
   // whitespace, or punctuation. Letters are unlikely; in that case an email
   // might be intended. (By punctuation, we mean *some* punctuation, like "(".

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -33,21 +33,21 @@ extension ComposeContentAutocomplete on ComposeContentController {
 
     final textUntilCursor = text.substring(0, selection.end);
     for (int pos = selection.end - 1; pos >= earliest; pos--) {
-      if (textUntilCursor[pos] != '@') {
-        continue;
+      final charAtPos = textUntilCursor[pos];
+      if (charAtPos == '@') {
+        final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
+        if (match == null) {
+          continue;
+        }
+        if (selection.start < pos) {
+          // See comment about [TextSelection.isCollapsed] above.
+          return null;
+        }
+        return AutocompleteIntent(
+          syntaxStart: pos,
+          query: MentionAutocompleteQuery(match[2]!, silent: match[1]! == '_'),
+          textEditingValue: value);
       }
-      final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
-      if (match == null) {
-        continue;
-      }
-      if (selection.start < pos) {
-        // See comment about [TextSelection.isCollapsed] above.
-        return null;
-      }
-      return AutocompleteIntent(
-        syntaxStart: pos,
-        query: MentionAutocompleteQuery(match[2]!, silent: match[1]! == '_'),
-        textEditingValue: value);
     }
     return null;
   }

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -25,6 +25,12 @@ extension ComposeContentAutocomplete on ComposeContentController {
     // in long messages, we bound how far back we look for the intent's start.
     final earliest = max(0, selection.end - 30);
 
+    if (selection.start < earliest) {
+      // The selection extends to before any position we'd consider
+      // for the start of the intent.  So there can't be a match.
+      return null;
+    }
+
     final textUntilCursor = text.substring(0, selection.end);
     for (int position = selection.end - 1; position >= earliest; position--) {
       if (textUntilCursor[position] != '@') {

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -7,6 +7,7 @@ import '../api/model/events.dart';
 import '../api/model/model.dart';
 import '../api/route/channels.dart';
 import '../widgets/compose_box.dart';
+import 'emoji.dart';
 import 'narrow.dart';
 import 'store.dart';
 
@@ -142,6 +143,7 @@ class AutocompleteIntent<QueryT extends AutocompleteQuery> {
 class AutocompleteViewManager {
   final Set<MentionAutocompleteView> _mentionAutocompleteViews = {};
   final Set<TopicAutocompleteView> _topicAutocompleteViews = {};
+  final Set<EmojiAutocompleteView> _emojiAutocompleteViews = {};
 
   AutocompleteDataCache autocompleteDataCache = AutocompleteDataCache();
 
@@ -162,6 +164,16 @@ class AutocompleteViewManager {
 
   void unregisterTopicAutocomplete(TopicAutocompleteView view) {
     final removed = _topicAutocompleteViews.remove(view);
+    assert(removed);
+  }
+
+  void registerEmojiAutocomplete(EmojiAutocompleteView view) {
+    final added = _emojiAutocompleteViews.add(view);
+    assert(added);
+  }
+
+  void unregisterEmojiAutocomplete(EmojiAutocompleteView view) {
+    final removed = _emojiAutocompleteViews.remove(view);
     assert(removed);
   }
 
@@ -682,6 +694,13 @@ class AutocompleteResult {}
 /// the compose box's content input, initiated by a [ComposeAutocompleteQuery]
 /// and managed by some [ComposeAutocompleteView].
 sealed class ComposeAutocompleteResult extends AutocompleteResult {}
+
+/// An emoji chosen in an autocomplete interaction, via [EmojiAutocompleteView].
+class EmojiAutocompleteResult extends ComposeAutocompleteResult {
+  EmojiAutocompleteResult(this.candidate);
+
+  final EmojiCandidate candidate;
+}
 
 /// A result from an @-mention autocomplete interaction,
 /// managed by a [MentionAutocompleteView].

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -32,23 +32,33 @@ extension ComposeContentAutocomplete on ComposeContentController {
     }
 
     final textUntilCursor = text.substring(0, selection.end);
-    for (int pos = selection.end - 1; pos >= earliest; pos--) {
+    int pos;
+    for (pos = selection.end - 1; pos > selection.start; pos--) {
       final charAtPos = textUntilCursor[pos];
       if (charAtPos == '@') {
         final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
-        if (match == null) {
-          continue;
-        }
-        if (selection.start < pos) {
-          // See comment about [TextSelection.isCollapsed] above.
-          return null;
-        }
-        return AutocompleteIntent(
-          syntaxStart: pos,
-          query: MentionAutocompleteQuery(match[2]!, silent: match[1]! == '_'),
-          textEditingValue: value);
+        if (match == null) continue;
+      } else {
+        continue;
       }
+      // See comment about [TextSelection.isCollapsed] above.
+      return null;
     }
+
+    for (; pos >= earliest; pos--) {
+      final charAtPos = textUntilCursor[pos];
+      final ComposeAutocompleteQuery query;
+      if (charAtPos == '@') {
+        final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
+        if (match == null) continue;
+        query = MentionAutocompleteQuery(match[2]!, silent: match[1]! == '_');
+      } else {
+        continue;
+      }
+      return AutocompleteIntent(syntaxStart: pos, textEditingValue: value,
+        query: query);
+    }
+
     return null;
   }
 }

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -307,8 +307,8 @@ class EmojiAutocompleteQuery extends ComposeAutocompleteQuery {
   }
 
   @override
-  ComposeAutocompleteView initViewModel(PerAccountStore store, Narrow narrow) {
-    throw UnimplementedError(); // TODO(#670)
+  EmojiAutocompleteView initViewModel(PerAccountStore store, Narrow narrow) {
+    return EmojiAutocompleteView.init(store: store, query: this);
   }
 
   // Compare get_emoji_matcher in Zulip web:shared/src/typeahead.ts .

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -268,6 +268,34 @@ class EmojiStoreImpl with EmojiStore {
   }
 }
 
+class EmojiAutocompleteView extends AutocompleteView<EmojiAutocompleteQuery, EmojiAutocompleteResult> {
+  EmojiAutocompleteView._({required super.store, required super.query});
+
+  factory EmojiAutocompleteView.init({
+    required PerAccountStore store,
+    required EmojiAutocompleteQuery query,
+  }) {
+    final view = EmojiAutocompleteView._(store: store, query: query);
+    store.autocompleteViewManager.registerEmojiAutocomplete(view);
+    return view;
+  }
+
+  @override
+  Future<List<EmojiAutocompleteResult>?> computeResults() async {
+    // TODO(#1068): rank emoji results (popular, realm, other; exact match, prefix, other)
+    final results = <EmojiAutocompleteResult>[];
+    if (await filterCandidates(filter: _testCandidate,
+          candidates: store.allEmojiCandidates(), results: results)) {
+      return null;
+    }
+    return results;
+  }
+
+  EmojiAutocompleteResult? _testCandidate(EmojiAutocompleteQuery query, EmojiCandidate candidate) {
+    return query.matches(candidate) ? EmojiAutocompleteResult(candidate) : null;
+  }
+}
+
 class EmojiAutocompleteQuery extends ComposeAutocompleteQuery {
   EmojiAutocompleteQuery(super.raw)
     : _adjusted = _adjustQuery(raw);

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -408,6 +408,9 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
     notifyListeners();
   }
 
+  @override
+  Iterable<EmojiCandidate> allEmojiCandidates() => _emoji.allEmojiCandidates();
+
   EmojiStoreImpl _emoji;
 
   ////////////////////////////////

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../model/emoji.dart';
 import 'content.dart';
 import 'store.dart';
 import '../model/autocomplete.dart';
@@ -38,7 +39,8 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
   }
 
   void _handleControllerChange() {
-    final newQuery = widget.autocompleteIntent()?.query;
+    var newQuery = widget.autocompleteIntent()?.query;
+    if (newQuery is EmojiAutocompleteQuery) newQuery = null; // TODO(#670)
     // First, tear down the old view-model if necessary.
     if (_viewModel != null
         && (newQuery == null

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -187,6 +187,8 @@ class ComposeAutocomplete extends AutocompleteField<ComposeAutocompleteQuery, Co
     final store = PerAccountStoreWidget.of(context);
     final String replacementString;
     switch (option) {
+      case EmojiAutocompleteResult():
+        throw UnimplementedError(); // TODO(#670)
       case UserMentionAutocompleteResult(:var userId):
         if (query is! MentionAutocompleteQuery) {
           return; // Shrug; similar to `intent == null` case above.
@@ -208,6 +210,7 @@ class ComposeAutocomplete extends AutocompleteField<ComposeAutocompleteQuery, Co
   Widget buildItem(BuildContext context, int index, ComposeAutocompleteResult option) {
     final child = switch (option) {
       MentionAutocompleteResult() => _MentionAutocompleteItem(option: option),
+      EmojiAutocompleteResult() => throw UnimplementedError(), // TODO(#670)
     };
     return InkWell(
       onTap: () {

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -23,7 +23,7 @@ abstract class AutocompleteField<QueryT extends AutocompleteQuery, ResultT exten
 
   Widget buildItem(BuildContext context, int index, ResultT option);
 
-  AutocompleteView<QueryT, ResultT> initViewModel(BuildContext context);
+  AutocompleteView<QueryT, ResultT> initViewModel(BuildContext context, QueryT query);
 
   @override
   State<AutocompleteField<QueryT, ResultT>> createState() => _AutocompleteFieldState<QueryT, ResultT>();
@@ -32,18 +32,18 @@ abstract class AutocompleteField<QueryT extends AutocompleteQuery, ResultT exten
 class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult> extends State<AutocompleteField<QueryT, ResultT>> with PerAccountStoreAwareStateMixin<AutocompleteField<QueryT, ResultT>> {
   AutocompleteView<QueryT, ResultT>? _viewModel;
 
-  void _initViewModel() {
-    _viewModel = widget.initViewModel(context)
+  void _initViewModel(QueryT query) {
+    _viewModel = widget.initViewModel(context, query)
       ..addListener(_viewModelChanged);
   }
 
   void _handleControllerChange() {
-    final newAutocompleteIntent = widget.autocompleteIntent();
-    if (newAutocompleteIntent != null) {
+    final newQuery = widget.autocompleteIntent()?.query;
+    if (newQuery != null) {
       if (_viewModel == null) {
-        _initViewModel();
+        _initViewModel(newQuery);
       }
-      _viewModel!.query = newAutocompleteIntent.query;
+      _viewModel!.query = newQuery;
     } else {
       if (_viewModel != null) {
         _viewModel!.dispose(); // removes our listener
@@ -64,7 +64,7 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
     if (_viewModel != null) {
       final query = _viewModel!.query;
       _viewModel!.dispose();
-      _initViewModel();
+      _initViewModel(query);
       _viewModel!.query = query;
     }
   }
@@ -162,9 +162,9 @@ class ComposeAutocomplete extends AutocompleteField<MentionAutocompleteQuery, Me
   AutocompleteIntent<MentionAutocompleteQuery>? autocompleteIntent() => controller.autocompleteIntent();
 
   @override
-  MentionAutocompleteView initViewModel(BuildContext context) {
+  MentionAutocompleteView initViewModel(BuildContext context, MentionAutocompleteQuery query) {
     final store = PerAccountStoreWidget.of(context);
-    return MentionAutocompleteView.init(store: store, narrow: narrow);
+    return MentionAutocompleteView.init(store: store, narrow: narrow, query: query);
   }
 
   void _onTapOption(BuildContext context, MentionAutocompleteResult option) {
@@ -238,9 +238,9 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
   AutocompleteIntent<TopicAutocompleteQuery>? autocompleteIntent() => controller.autocompleteIntent();
 
   @override
-  TopicAutocompleteView initViewModel(BuildContext context) {
+  TopicAutocompleteView initViewModel(BuildContext context, TopicAutocompleteQuery query) {
     final store = PerAccountStoreWidget.of(context);
-    return TopicAutocompleteView.init(store: store, streamId: streamId);
+    return TopicAutocompleteView.init(store: store, streamId: streamId, query: query);
   }
 
   void _onTapOption(BuildContext context, TopicAutocompleteResult option) {

--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import '../model/emoji.dart';
+import 'content.dart';
+
+class ImageEmojiWidget extends StatelessWidget {
+  const ImageEmojiWidget({
+    super.key,
+    required this.emojiDisplay,
+    required this.size,
+    this.textScaler = TextScaler.noScaling,
+    this.errorBuilder,
+  });
+
+  final ImageEmojiDisplay emojiDisplay;
+
+  /// The base width and height to use for the emoji.
+  ///
+  /// This will be scaled by [textScaler].
+  final double size;
+
+  /// The text scaler to apply to [size].
+  ///
+  /// Defaults to [TextScaler.noScaling].
+  final TextScaler textScaler;
+
+  final ImageErrorWidgetBuilder? errorBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    // Some people really dislike animated emoji.
+    final doNotAnimate =
+      // From reading code, this doesn't actually get set on iOS:
+      //   https://github.com/zulip/zulip-flutter/pull/410#discussion_r1408522293
+      MediaQuery.disableAnimationsOf(context)
+      || (defaultTargetPlatform == TargetPlatform.iOS
+        // TODO(upstream) On iOS 17+ (new in 2023), there's a more closely
+        //   relevant setting than "reduce motion". It's called "auto-play
+        //   animated images", and we should file an issue to expose it.
+        //   See GitHub comment linked above.
+        && WidgetsBinding.instance.platformDispatcher.accessibilityFeatures.reduceMotion);
+
+    final size = textScaler.scale(this.size);
+
+    final resolvedUrl = doNotAnimate
+      ? (emojiDisplay.resolvedStillUrl ?? emojiDisplay.resolvedUrl)
+      : emojiDisplay.resolvedUrl;
+
+    return RealmContentNetworkImage(
+      width: size, height: size,
+      errorBuilder: errorBuilder,
+      resolvedUrl);
+  }
+}

--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -4,6 +4,82 @@ import 'package:flutter/widgets.dart';
 import '../model/emoji.dart';
 import 'content.dart';
 
+class UnicodeEmojiWidget extends StatelessWidget {
+  const UnicodeEmojiWidget({
+    super.key,
+    required this.emojiDisplay,
+    required this.size,
+    required this.notoColorEmojiTextSize,
+    this.textScaler = TextScaler.noScaling,
+  });
+
+  final UnicodeEmojiDisplay emojiDisplay;
+
+  /// The base width and height to use for the emoji.
+  ///
+  /// This will be scaled by [textScaler].
+  final double size;
+
+  /// A font size that, with Noto Color Emoji and our line-height config,
+  /// causes a Unicode emoji to occupy a square of size [size] in the layout.
+  ///
+  /// This has to be determined experimentally, as far as we know.
+  final double notoColorEmojiTextSize;
+
+  /// The text scaler to apply to [size].
+  ///
+  /// Defaults to [TextScaler.noScaling].
+  final TextScaler textScaler;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return Text(
+          textScaler: textScaler,
+          style: TextStyle(
+            fontFamily: 'Noto Color Emoji',
+            fontSize: notoColorEmojiTextSize,
+          ),
+          strutStyle: StrutStyle(
+            fontSize: notoColorEmojiTextSize, forceStrutHeight: true),
+          emojiDisplay.emojiUnicode);
+
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        // We expect the font "Apple Color Emoji" to be used. There are some
+        // surprises in how Flutter ends up rendering emojis in this font:
+        // - With a font size of 17px, the emoji visually seems to be about 17px
+        //   square. (Unlike on Android, with Noto Color Emoji, where a 14.5px font
+        //   size gives an emoji that looks 17px square.) See:
+        //     <https://github.com/flutter/flutter/issues/28894>
+        // - The emoji doesn't fill the space taken by the [Text] in the layout.
+        //   There's whitespace above, below, and on the right. See:
+        //     <https://github.com/flutter/flutter/issues/119623>
+        //
+        // That extra space would be problematic, except we've used a [Stack] to
+        // make the [Text] "positioned" so the space doesn't add margins around the
+        // visible part. Key points that enable the [Stack] workaround:
+        // - The emoji seems approximately vertically centered (this is
+        //   accomplished with help from a [StrutStyle]; see below).
+        // - There seems to be approximately no space on its left.
+        final boxSize = textScaler.scale(size);
+        return Stack(alignment: Alignment.centerLeft, clipBehavior: Clip.none, children: [
+          SizedBox(height: boxSize, width: boxSize),
+          PositionedDirectional(start: 0, child: Text(
+            textScaler: textScaler,
+            style: TextStyle(fontSize: size),
+            strutStyle: StrutStyle(fontSize: size, forceStrutHeight: true),
+            emojiDisplay.emojiUnicode)),
+        ]);
+    }
+  }
+}
+
+
 class ImageEmojiWidget extends StatelessWidget {
   const ImageEmojiWidget({
     super.key,

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -182,7 +182,7 @@ class ReactionChip extends StatelessWidget {
 
     final emoji = switch (emojiDisplay) {
       UnicodeEmojiDisplay() => _UnicodeEmoji(
-        emojiDisplay: emojiDisplay, selected: selfVoted),
+        emojiDisplay: emojiDisplay),
       ImageEmojiDisplay() => _ImageEmoji(
         emojiDisplay: emojiDisplay, emojiName: emojiName, selected: selfVoted),
       TextEmojiDisplay() => _TextEmoji(
@@ -293,13 +293,9 @@ TextScaler _labelTextScalerClamped(BuildContext context) =>
   MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 2);
 
 class _UnicodeEmoji extends StatelessWidget {
-  const _UnicodeEmoji({
-    required this.emojiDisplay,
-    required this.selected,
-  });
+  const _UnicodeEmoji({required this.emojiDisplay});
 
   final UnicodeEmojiDisplay emojiDisplay;
-  final bool selected;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -5,7 +5,7 @@ import '../api/model/model.dart';
 import '../api/route/messages.dart';
 import '../model/emoji.dart';
 import 'color.dart';
-import 'content.dart';
+import 'emoji.dart';
 import 'store.dart';
 import 'text.dart';
 
@@ -361,29 +361,11 @@ class _ImageEmoji extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Some people really dislike animated emoji.
-    final doNotAnimate =
-      // From reading code, this doesn't actually get set on iOS:
-      //   https://github.com/zulip/zulip-flutter/pull/410#discussion_r1408522293
-      MediaQuery.disableAnimationsOf(context)
-      || (defaultTargetPlatform == TargetPlatform.iOS
-        // TODO(upstream) On iOS 17+ (new in 2023), there's a more closely
-        //   relevant setting than "reduce motion". It's called "auto-play
-        //   animated images", and we should file an issue to expose it.
-        //   See GitHub comment linked above.
-        && WidgetsBinding.instance.platformDispatcher.accessibilityFeatures.reduceMotion);
-
-    final resolvedUrl = doNotAnimate
-      ? (emojiDisplay.resolvedStillUrl ?? emojiDisplay.resolvedUrl)
-      : emojiDisplay.resolvedUrl;
-
-    // Unicode and text emoji get scaled; it would look weird if image emoji didn't.
-    final size = _squareEmojiScalerClamped(context).scale(_squareEmojiSize);
-
-    return RealmContentNetworkImage(
-      resolvedUrl,
-      width: size,
-      height: size,
+    return ImageEmojiWidget(
+      size: _squareEmojiSize,
+      // Unicode and text emoji get scaled; it would look weird if image emoji didn't.
+      textScaler: _squareEmojiScalerClamped(context),
+      emojiDisplay: emojiDisplay,
       errorBuilder: (context, _, __) => _TextEmoji(
         emojiDisplay: TextEmojiDisplay(emojiName: emojiName), selected: selected),
     );

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../api/model/model.dart';
@@ -304,47 +303,11 @@ class _UnicodeEmoji extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return Text(
-          textScaler: _squareEmojiScalerClamped(context),
-          style: const TextStyle(
-            fontFamily: 'Noto Color Emoji',
-            fontSize: _notoColorEmojiTextSize,
-          ),
-          strutStyle: const StrutStyle(fontSize: _notoColorEmojiTextSize, forceStrutHeight: true),
-          emojiDisplay.emojiUnicode);
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        // We expect the font "Apple Color Emoji" to be used. There are some
-        // surprises in how Flutter ends up rendering emojis in this font:
-        // - With a font size of 17px, the emoji visually seems to be about 17px
-        //   square. (Unlike on Android, with Noto Color Emoji, where a 14.5px font
-        //   size gives an emoji that looks 17px square.) See:
-        //     <https://github.com/flutter/flutter/issues/28894>
-        // - The emoji doesn't fill the space taken by the [Text] in the layout.
-        //   There's whitespace above, below, and on the right. See:
-        //     <https://github.com/flutter/flutter/issues/119623>
-        //
-        // That extra space would be problematic, except we've used a [Stack] to
-        // make the [Text] "positioned" so the space doesn't add margins around the
-        // visible part. Key points that enable the [Stack] workaround:
-        // - The emoji seems approximately vertically centered (this is
-        //   accomplished with help from a [StrutStyle]; see below).
-        // - There seems to be approximately no space on its left.
-        final boxSize = _squareEmojiScalerClamped(context).scale(_squareEmojiSize);
-        return Stack(alignment: Alignment.centerLeft, clipBehavior: Clip.none, children: [
-          SizedBox(height: boxSize, width: boxSize),
-          PositionedDirectional(start: 0, child: Text(
-            textScaler: _squareEmojiScalerClamped(context),
-            style: const TextStyle(fontSize: _squareEmojiSize),
-            strutStyle: const StrutStyle(fontSize: _squareEmojiSize, forceStrutHeight: true),
-            emojiDisplay.emojiUnicode)),
-        ]);
-    }
+    return UnicodeEmojiWidget(
+      size: _squareEmojiSize,
+      notoColorEmojiTextSize: _notoColorEmojiTextSize,
+      textScaler: _squareEmojiScalerClamped(context),
+      emojiDisplay: emojiDisplay);
   }
 }
 

--- a/test/model/autocomplete_checks.dart
+++ b/test/model/autocomplete_checks.dart
@@ -3,7 +3,7 @@ import 'package:zulip/model/autocomplete.dart';
 import 'package:zulip/widgets/compose_box.dart';
 
 extension ComposeContentControllerChecks on Subject<ComposeContentController> {
-  Subject<AutocompleteIntent<MentionAutocompleteQuery>?> get autocompleteIntent => has((c) => c.autocompleteIntent(), 'autocompleteIntent');
+  Subject<AutocompleteIntent<ComposeAutocompleteQuery>?> get autocompleteIntent => has((c) => c.autocompleteIntent(), 'autocompleteIntent');
 }
 
 extension ComposeTopicControllerChecks on Subject<ComposeTopicController> {

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -175,11 +175,11 @@ void main() {
     const narrow = ChannelNarrow(1);
     final store = eg.store();
     await store.addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
-    final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
+    final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+      query: MentionAutocompleteQuery('Third'));
     bool done = false;
     view.addListener(() { done = true; });
-    view.query = MentionAutocompleteQuery('Third');
     await Future(() {});
     await Future(() {});
     check(done).isTrue();
@@ -193,12 +193,8 @@ void main() {
       const narrow = ChannelNarrow(1);
       final store = eg.store();
       await store.addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
-      final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
       bool searchDone = false;
-      view.addListener(() {
-        searchDone = true;
-      });
 
       // Schedule a timer event with zero delay.
       // This stands in for a user interaction, or frame rendering timer,
@@ -210,9 +206,11 @@ void main() {
         check(searchDone).isFalse();
       });
 
-      view.query = MentionAutocompleteQuery('Third');
-      check(timerDone).isFalse();
-      check(searchDone).isFalse();
+      final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+        query: MentionAutocompleteQuery('Third'));
+      view.addListener(() {
+        searchDone = true;
+      });
 
       binding.elapse(const Duration(seconds: 1));
 
@@ -230,11 +228,11 @@ void main() {
     for (int i = 1; i <= 2500; i++) {
       await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
-    final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
     bool done = false;
+    final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+      query: MentionAutocompleteQuery('User 2222'));
     view.addListener(() { done = true; });
-    view.query = MentionAutocompleteQuery('User 2222');
 
     await Future(() {});
     check(done).isFalse();
@@ -253,11 +251,11 @@ void main() {
     for (int i = 1; i <= 1500; i++) {
       await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
-    final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
     bool done = false;
+    final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+      query: MentionAutocompleteQuery('User 1111'));
     view.addListener(() { done = true; });
-    view.query = MentionAutocompleteQuery('User 1111');
 
     await Future(() {});
     check(done).isFalse();
@@ -288,11 +286,11 @@ void main() {
     for (int i = 1; i <= 2500; i++) {
       await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
     }
-    final view = MentionAutocompleteView.init(store: store, narrow: narrow);
 
     bool done = false;
+    final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+      query: MentionAutocompleteQuery('User 110'));
     view.addListener(() { done = true; });
-    view.query = MentionAutocompleteQuery('User 110');
 
     await Future(() {});
     check(done).isFalse();
@@ -544,7 +542,8 @@ void main() {
 
     group('ranking across signals', () {
       void checkPrecedes(Narrow narrow, User userA, Iterable<User> usersB) {
-        final view = MentionAutocompleteView.init(store: store, narrow: narrow);
+        final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+          query: MentionAutocompleteQuery(''));
         for (final userB in usersB) {
           check(view.debugCompareUsers(userA, userB)).isLessThan(0);
           check(view.debugCompareUsers(userB, userA)).isGreaterThan(0);
@@ -552,7 +551,8 @@ void main() {
       }
 
       void checkRankEqual(Narrow narrow, List<User> users) {
-        final view = MentionAutocompleteView.init(store: store, narrow: narrow);
+        final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+          query: MentionAutocompleteQuery(''));
         for (int i = 0; i < users.length; i++) {
           for (int j = i + 1; j < users.length; j++) {
             check(view.debugCompareUsers(users[i], users[j])).equals(0);
@@ -669,21 +669,24 @@ void main() {
       test('CombinedFeedNarrow gives error', () async {
         await prepare(users: [eg.user(), eg.user()], messages: []);
         const narrow = CombinedFeedNarrow();
-        check(() => MentionAutocompleteView.init(store: store, narrow: narrow))
+        check(() => MentionAutocompleteView.init(store: store, narrow: narrow,
+                      query: MentionAutocompleteQuery('')))
           .throws<AssertionError>();
       });
 
       test('MentionsNarrow gives error', () async {
         await prepare(users: [eg.user(), eg.user()], messages: []);
         const narrow = MentionsNarrow();
-        check(() => MentionAutocompleteView.init(store: store, narrow: narrow))
+        check(() => MentionAutocompleteView.init(store: store, narrow: narrow,
+                      query: MentionAutocompleteQuery('')))
           .throws<AssertionError>();
       });
 
       test('StarredMessagesNarrow gives error', () async {
         await prepare(users: [eg.user(), eg.user()], messages: []);
         const narrow = StarredMessagesNarrow();
-        check(() => MentionAutocompleteView.init(store: store, narrow: narrow))
+        check(() => MentionAutocompleteView.init(store: store, narrow: narrow,
+                      query: MentionAutocompleteQuery('')))
           .throws<AssertionError>();
       });
     });
@@ -692,9 +695,9 @@ void main() {
       Future<Iterable<int>> getResults(
           Narrow narrow, MentionAutocompleteQuery query) async {
         bool done = false;
-        final view = MentionAutocompleteView.init(store: store, narrow: narrow);
+        final view = MentionAutocompleteView.init(store: store, narrow: narrow,
+          query: query);
         view.addListener(() { done = true; });
-        view.query = query;
         await Future(() {});
         check(done).isTrue();
         final results = view.results
@@ -777,13 +780,14 @@ void main() {
     final third = eg.getStreamTopicsEntry(maxId: 3, name: 'Third Topic');
     connection.prepare(json: GetStreamTopicsResult(
       topics: [first, second, third]).toJson());
+
     final view = TopicAutocompleteView.init(
       store: store,
-      streamId: eg.stream().streamId);
-
+      streamId: eg.stream().streamId,
+      query: TopicAutocompleteQuery('Third'));
     bool done = false;
     view.addListener(() { done = true; });
-    view.query = TopicAutocompleteQuery('Third');
+
     // those are here to wait for topics to be loaded
     await Future(() {});
     await Future(() {});
@@ -802,11 +806,10 @@ void main() {
 
     final view = TopicAutocompleteView.init(
       store: store,
-      streamId: eg.stream().streamId);
-
+      streamId: eg.stream().streamId,
+      query: TopicAutocompleteQuery('te'));
     bool done = false;
     view.addListener(() { done = true; });
-    view.query = TopicAutocompleteQuery('te');
 
     check(done).isFalse();
     await Future(() {});

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -224,6 +224,18 @@ void main() {
     doTest('~:１^', emoji('１')); // U+FF11 FULLWIDTH DIGIT ONE
     doTest('~:٢^', emoji('٢')); // U+0662 ARABIC-INDIC DIGIT TWO
 
+    // Emoji names may have dashes '-'.
+    doTest('~:e-m^', emoji('e-m'));
+    doTest('~:jack-o-l^', emoji('jack-o-l'));
+
+    // Just one emoji has a '+' in its name, namely ':+1:'.
+    doTest('~:+^', emoji('+'));
+    doTest('~:+1^', emoji('+1'));
+    doTest(':+2^', null);
+    doTest(':+100^', null);
+    doTest(':+1 ^', null);
+    doTest(':1+1^', null);
+
     // Accept punctuation before the emoji: opening…
     doTest('(~:^', emoji('')); doTest('(~:a^', emoji('a'));
     doTest('[~:^', emoji('')); doTest('[~:a^', emoji('a'));

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:checks/checks.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
@@ -15,6 +14,7 @@ import 'package:zulip/widgets/compose_box.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
+import '../fake_async.dart';
 import 'test_store.dart';
 import 'autocomplete_checks.dart';
 
@@ -189,7 +189,7 @@ void main() {
   });
 
   test('MentionAutocompleteView not starve timers', () {
-    fakeAsync((binding) async {
+    return awaitFakeAsync((binding) async {
       const narrow = ChannelNarrow(1);
       final store = eg.store();
       await store.addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -68,7 +68,7 @@ void main() {
     ///
     /// For example, "~@chris^" means the text is "@chris", the selection is
     /// collapsed at index 6, and we expect the syntax to start at index 0.
-    void doTest(String markedText, MentionAutocompleteQuery? expectedQuery) {
+    void doTest(String markedText, ComposeAutocompleteQuery? expectedQuery) {
       final description = expectedQuery != null
         ? 'in ${jsonEncode(markedText)}, query ${jsonEncode(expectedQuery.raw)}'
         : 'no query in ${jsonEncode(markedText)}';
@@ -87,8 +87,8 @@ void main() {
       });
     }
 
-    MentionAutocompleteQuery queryOf(String raw) => MentionAutocompleteQuery(raw, silent: false);
-    MentionAutocompleteQuery silentQueryOf(String raw) => MentionAutocompleteQuery(raw, silent: true);
+    MentionAutocompleteQuery mention(String raw) => MentionAutocompleteQuery(raw, silent: false);
+    MentionAutocompleteQuery silentMention(String raw) => MentionAutocompleteQuery(raw, silent: true);
 
     doTest('', null);
     doTest('^', null);
@@ -125,48 +125,48 @@ void main() {
 
     doTest('`@chris^', null); doTest('`@_chris^', null);
 
-    doTest('~@^_', queryOf('')); // Odd/unlikely, but should not crash
+    doTest('~@^_', mention('')); // Odd/unlikely, but should not crash
 
-    doTest('~@__^', silentQueryOf('_'));
+    doTest('~@__^', silentMention('_'));
 
-    doTest('~@^abc^', queryOf('abc')); doTest('~@_^abc^', silentQueryOf('abc'));
-    doTest('~@a^bc^', queryOf('abc')); doTest('~@_a^bc^', silentQueryOf('abc'));
-    doTest('~@ab^c^', queryOf('abc')); doTest('~@_ab^c^', silentQueryOf('abc'));
-    doTest('~^@^', queryOf(''));       doTest('~^@_^', silentQueryOf(''));
+    doTest('~@^abc^', mention('abc')); doTest('~@_^abc^', silentMention('abc'));
+    doTest('~@a^bc^', mention('abc')); doTest('~@_a^bc^', silentMention('abc'));
+    doTest('~@ab^c^', mention('abc')); doTest('~@_ab^c^', silentMention('abc'));
+    doTest('~^@^', mention(''));       doTest('~^@_^', silentMention(''));
     // but:
     doTest('^hello @chris^', null);    doTest('^hello @_chris^', null);
 
-    doTest('~@me@zulip.com^', queryOf('me@zulip.com'));  doTest('~@_me@zulip.com^', silentQueryOf('me@zulip.com'));
-    doTest('~@me@^zulip.com^', queryOf('me@zulip.com')); doTest('~@_me@^zulip.com^', silentQueryOf('me@zulip.com'));
-    doTest('~@me^@zulip.com^', queryOf('me@zulip.com')); doTest('~@_me^@zulip.com^', silentQueryOf('me@zulip.com'));
-    doTest('~@^me@zulip.com^', queryOf('me@zulip.com')); doTest('~@_^me@zulip.com^', silentQueryOf('me@zulip.com'));
+    doTest('~@me@zulip.com^', mention('me@zulip.com'));  doTest('~@_me@zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@me@^zulip.com^', mention('me@zulip.com')); doTest('~@_me@^zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@me^@zulip.com^', mention('me@zulip.com')); doTest('~@_me^@zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@^me@zulip.com^', mention('me@zulip.com')); doTest('~@_^me@zulip.com^', silentMention('me@zulip.com'));
 
-    doTest('~@abc^', queryOf('abc'));   doTest('~@_abc^', silentQueryOf('abc'));
-    doTest(' ~@abc^', queryOf('abc'));  doTest(' ~@_abc^', silentQueryOf('abc'));
-    doTest('(~@abc^', queryOf('abc'));  doTest('(~@_abc^', silentQueryOf('abc'));
-    doTest('—~@abc^', queryOf('abc'));  doTest('—~@_abc^', silentQueryOf('abc'));
-    doTest('"~@abc^', queryOf('abc'));  doTest('"~@_abc^', silentQueryOf('abc'));
-    doTest('“~@abc^', queryOf('abc'));  doTest('“~@_abc^', silentQueryOf('abc'));
-    doTest('。~@abc^', queryOf('abc')); doTest('。~@_abc^', silentQueryOf('abc'));
-    doTest('«~@abc^', queryOf('abc'));  doTest('«~@_abc^', silentQueryOf('abc'));
+    doTest('~@abc^', mention('abc'));   doTest('~@_abc^', silentMention('abc'));
+    doTest(' ~@abc^', mention('abc'));  doTest(' ~@_abc^', silentMention('abc'));
+    doTest('(~@abc^', mention('abc'));  doTest('(~@_abc^', silentMention('abc'));
+    doTest('—~@abc^', mention('abc'));  doTest('—~@_abc^', silentMention('abc'));
+    doTest('"~@abc^', mention('abc'));  doTest('"~@_abc^', silentMention('abc'));
+    doTest('“~@abc^', mention('abc'));  doTest('“~@_abc^', silentMention('abc'));
+    doTest('。~@abc^', mention('abc')); doTest('。~@_abc^', silentMention('abc'));
+    doTest('«~@abc^', mention('abc'));  doTest('«~@_abc^', silentMention('abc'));
 
-    doTest('~@ab^c', queryOf('ab')); doTest('~@_ab^c', silentQueryOf('ab'));
-    doTest('~@a^bc', queryOf('a'));  doTest('~@_a^bc', silentQueryOf('a'));
-    doTest('~@^abc', queryOf(''));   doTest('~@_^abc', silentQueryOf(''));
-    doTest('~@^', queryOf(''));      doTest('~@_^', silentQueryOf(''));
+    doTest('~@ab^c', mention('ab')); doTest('~@_ab^c', silentMention('ab'));
+    doTest('~@a^bc', mention('a'));  doTest('~@_a^bc', silentMention('a'));
+    doTest('~@^abc', mention(''));   doTest('~@_^abc', silentMention(''));
+    doTest('~@^', mention(''));      doTest('~@_^', silentMention(''));
 
-    doTest('~@abc ^', queryOf('abc '));  doTest('~@_abc ^', silentQueryOf('abc '));
-    doTest('~@abc^ ^', queryOf('abc ')); doTest('~@_abc^ ^', silentQueryOf('abc '));
-    doTest('~@ab^c ^', queryOf('abc ')); doTest('~@_ab^c ^', silentQueryOf('abc '));
-    doTest('~@^abc ^', queryOf('abc ')); doTest('~@_^abc ^', silentQueryOf('abc '));
+    doTest('~@abc ^', mention('abc '));  doTest('~@_abc ^', silentMention('abc '));
+    doTest('~@abc^ ^', mention('abc ')); doTest('~@_abc^ ^', silentMention('abc '));
+    doTest('~@ab^c ^', mention('abc ')); doTest('~@_ab^c ^', silentMention('abc '));
+    doTest('~@^abc ^', mention('abc ')); doTest('~@_^abc ^', silentMention('abc '));
 
-    doTest('Please ask ~@chris^', queryOf('chris'));             doTest('Please ask ~@_chris^', silentQueryOf('chris'));
-    doTest('Please ask ~@chris bobbe^', queryOf('chris bobbe')); doTest('Please ask ~@_chris bobbe^', silentQueryOf('chris bobbe'));
+    doTest('Please ask ~@chris^', mention('chris'));             doTest('Please ask ~@_chris^', silentMention('chris'));
+    doTest('Please ask ~@chris bobbe^', mention('chris bobbe')); doTest('Please ask ~@_chris bobbe^', silentMention('chris bobbe'));
 
-    doTest('~@Rodion Romanovich Raskolnikov^', queryOf('Rodion Romanovich Raskolnikov'));
-    doTest('~@_Rodion Romanovich Raskolniko^', silentQueryOf('Rodion Romanovich Raskolniko'));
-    doTest('~@Родион Романович Раскольников^', queryOf('Родион Романович Раскольников'));
-    doTest('~@_Родион Романович Раскольнико^', silentQueryOf('Родион Романович Раскольнико'));
+    doTest('~@Rodion Romanovich Raskolnikov^', mention('Rodion Romanovich Raskolnikov'));
+    doTest('~@_Rodion Romanovich Raskolniko^', silentMention('Rodion Romanovich Raskolniko'));
+    doTest('~@Родион Романович Раскольников^', mention('Родион Романович Раскольников'));
+    doTest('~@_Родион Романович Раскольнико^', silentMention('Родион Романович Раскольнико'));
     doTest('If @chris is around, please ask him.^', null); // @ sign is too far away from cursor
     doTest('If @_chris is around, please ask him.^', null); // @ sign is too far away from cursor
   });

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -30,6 +30,9 @@ import 'test_app.dart';
 Future<Finder> setupToComposeInput(WidgetTester tester, {
   required List<User> users,
 }) async {
+  TypingNotifier.debugEnable = false;
+  addTearDown(TypingNotifier.debugReset);
+
   addTearDown(testBinding.reset);
   await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
   final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
@@ -132,9 +135,6 @@ void main() {
       final composeInputFinder = await setupToComposeInput(tester, users: [user1, user2, user3]);
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
-      TypingNotifier.debugEnable = false;
-      addTearDown(TypingNotifier.debugReset);
-
       // Options are filtered correctly for query
       // TODO(#226): Remove this extra edit when this bug is fixed.
       await tester.enterText(composeInputFinder, 'hello @user ');
@@ -185,9 +185,6 @@ void main() {
       final topic3 = eg.getStreamTopicsEntry(maxId: 3, name: 'Topic three');
       final topicInputFinder = await setupToTopicInput(tester, topics: [topic1, topic2, topic3]);
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-
-      TypingNotifier.debugEnable = false;
-      addTearDown(TypingNotifier.debugReset);
 
       // Options are filtered correctly for query
       // TODO(#226): Remove this extra edit when this bug is fixed.


### PR DESCRIPTION
This adds autocomplete for emoji in the compose box, so e.g. typing `:zu` offers an autocomplete option of `:zulip:`.

The first part of the branch makes some refactors to the autocomplete subsystem, in order to prepare to accommodate emoji autocomplete alongside @-mention autocomplete. The changes are all in basically the direction we had in mind when initially building the system; mostly we left some concepts collapsed that we knew we'd eventually need to separate, deferring the details of actually separating them until we had a concrete situation where they came apart.

Fixes: #669 
Fixes: #670

### Selected commit messages

autocomplete [nfc]: Document how query, view-model, and results classes relate

---

autocomplete [nfc]: Separate ComposeAutocompleteQuery/Result from Mention-etc.

The two concepts have meant the same set of possible values so far,
because @-mentions are the only type of autocomplete we've had so far
in the compose box's content input.  As a result we've taken some
shortcuts by conflating them.

But as we introduce other types of autocomplete in the content input,
like for emoji and #-mentions, we have some places that will need to
refer to the more general concept while others refer to the more
specific one.  So separate them out.

---

emoji [nfc]: Factor out ImageEmojiWidget

---

emoji [nfc]: Factor out UnicodeEmojiWidget

---

emoji: Make list of emoji to consider for autocomplete or emoji picker

This leaves the emojiDisplay field of these objects untested.  I
skipped that because it seems like pretty boring low-risk code,
just invoking emojiDisplayFor.  (And emojiDisplayFor has its own
tests.)  But included a TODO comment for completeness in thinking
about what logic there is to test here.

Fixes: #669

---

autocomplete: Identify when the user intends an emoji autocomplete

The "forbid preceding ':'" wrinkle is one I discovered because of
writing tests: I wrote down the '::^' test, was surprised to find
that it failed, and then went back and extended the regexp to
make it pass.

[…]

---

emoji: Finish emoji autocomplete for compose box

Fixes: #670
