### PR TITLE
Implement bottom tabs and main menu

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -19,6 +19,19 @@
   "@chooseAccountPageTitle": {
     "description": "Title for the page to choose between Zulip accounts."
   },
+  "switchAccountButton": "Switch account",
+  "@switchAccountButton": {
+    "description": "Label for main-menu button leading to the choose-account page."
+  },
+  "tryAnotherAccountMessage": "Your account at {url} is taking a while to load.",
+  "@tryAnotherAccountMessage": {
+    "description": "Message that appears on the loading screen after waiting for some time.",
+    "url": {"type": "String", "example": "http://chat.example.com/"}
+  },
+  "tryAnotherAccountButton": "Try another account",
+  "@tryAnotherAccountButton": {
+    "description": "Label for loading screen button prompting user to try another account."
+  },
   "chooseAccountPageLogOutButton": "Log out",
   "@chooseAccountPageLogOutButton": {
     "description": "Label for the 'Log out' button for an account on the choose-account page"
@@ -561,6 +574,10 @@
   "@userRoleUnknown": {
     "description": "Label for UserRole.unknown"
   },
+  "inboxPageTitle": "Inbox",
+  "@inboxPageTitle": {
+    "description": "Title for the page with unreads."
+  },
   "recentDmConversationsPageTitle": "Direct messages",
   "@recentDmConversationsPageTitle": {
     "description": "Title for the page with a list of DM conversations."
@@ -576,6 +593,14 @@
   "starredMessagesPageTitle": "Starred messages",
   "@starredMessagesPageTitle": {
     "description": "Page title for the 'Starred messages' message view."
+  },
+  "channelsPageTitle": "Channels",
+  "@channelsPageTitle": {
+    "description": "Title for the page with a list of subscribed channels."
+  },
+  "mainMenuMyProfile": "My profile",
+  "@mainMenuMyProfile": {
+    "description": "Label for main-menu button leading to the user's own profile."
   },
   "channelFeedButtonTooltip": "Channel feed",
   "@channelFeedButtonTooltip": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -133,6 +133,24 @@ abstract class ZulipLocalizations {
   /// **'Choose account'**
   String get chooseAccountPageTitle;
 
+  /// Label for main-menu button leading to the choose-account page.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch account'**
+  String get switchAccountButton;
+
+  /// Message that appears on the loading screen after waiting for some time.
+  ///
+  /// In en, this message translates to:
+  /// **'Your account at {url} is taking a while to load.'**
+  String tryAnotherAccountMessage(Object url);
+
+  /// Label for loading screen button prompting user to try another account.
+  ///
+  /// In en, this message translates to:
+  /// **'Try another account'**
+  String get tryAnotherAccountButton;
+
   /// Label for the 'Log out' button for an account on the choose-account page
   ///
   /// In en, this message translates to:
@@ -853,6 +871,12 @@ abstract class ZulipLocalizations {
   /// **'Unknown'**
   String get userRoleUnknown;
 
+  /// Title for the page with unreads.
+  ///
+  /// In en, this message translates to:
+  /// **'Inbox'**
+  String get inboxPageTitle;
+
   /// Title for the page with a list of DM conversations.
   ///
   /// In en, this message translates to:
@@ -876,6 +900,18 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Starred messages'**
   String get starredMessagesPageTitle;
+
+  /// Title for the page with a list of subscribed channels.
+  ///
+  /// In en, this message translates to:
+  /// **'Channels'**
+  String get channelsPageTitle;
+
+  /// Label for main-menu button leading to the user's own profile.
+  ///
+  /// In en, this message translates to:
+  /// **'My profile'**
+  String get mainMenuMyProfile;
 
   /// Tooltip for button to navigate to a given channel's feed
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -24,6 +24,17 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
+  String get switchAccountButton => 'Switch account';
+
+  @override
+  String tryAnotherAccountMessage(Object url) {
+    return 'Your account at $url is taking a while to load.';
+  }
+
+  @override
+  String get tryAnotherAccountButton => 'Try another account';
+
+  @override
   String get chooseAccountPageLogOutButton => 'Log out';
 
   @override
@@ -444,6 +455,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get userRoleUnknown => 'Unknown';
 
   @override
+  String get inboxPageTitle => 'Inbox';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
@@ -454,6 +468,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String get channelsPageTitle => 'Channels';
+
+  @override
+  String get mainMenuMyProfile => 'My profile';
 
   @override
   String get channelFeedButtonTooltip => 'Channel feed';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -24,6 +24,17 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
+  String get switchAccountButton => 'Switch account';
+
+  @override
+  String tryAnotherAccountMessage(Object url) {
+    return 'Your account at $url is taking a while to load.';
+  }
+
+  @override
+  String get tryAnotherAccountButton => 'Try another account';
+
+  @override
   String get chooseAccountPageLogOutButton => 'Log out';
 
   @override
@@ -444,6 +455,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get userRoleUnknown => 'Unknown';
 
   @override
+  String get inboxPageTitle => 'Inbox';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
@@ -454,6 +468,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String get channelsPageTitle => 'Channels';
+
+  @override
+  String get mainMenuMyProfile => 'My profile';
 
   @override
   String get channelFeedButtonTooltip => 'Channel feed';

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -24,6 +24,17 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
+  String get switchAccountButton => 'Switch account';
+
+  @override
+  String tryAnotherAccountMessage(Object url) {
+    return 'Your account at $url is taking a while to load.';
+  }
+
+  @override
+  String get tryAnotherAccountButton => 'Try another account';
+
+  @override
   String get chooseAccountPageLogOutButton => 'Log out';
 
   @override
@@ -444,6 +455,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get userRoleUnknown => 'Unknown';
 
   @override
+  String get inboxPageTitle => 'Inbox';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
@@ -454,6 +468,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
 
   @override
   String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String get channelsPageTitle => 'Channels';
+
+  @override
+  String get mainMenuMyProfile => 'My profile';
 
   @override
   String get channelFeedButtonTooltip => 'Channel feed';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -24,6 +24,17 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get chooseAccountPageTitle => 'アカウントを選択';
 
   @override
+  String get switchAccountButton => 'Switch account';
+
+  @override
+  String tryAnotherAccountMessage(Object url) {
+    return 'Your account at $url is taking a while to load.';
+  }
+
+  @override
+  String get tryAnotherAccountButton => 'Try another account';
+
+  @override
   String get chooseAccountPageLogOutButton => 'Log out';
 
   @override
@@ -444,6 +455,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get userRoleUnknown => '不明';
 
   @override
+  String get inboxPageTitle => 'Inbox';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
@@ -454,6 +468,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get starredMessagesPageTitle => 'Starred messages';
+
+  @override
+  String get channelsPageTitle => 'Channels';
+
+  @override
+  String get mainMenuMyProfile => 'My profile';
 
   @override
   String get channelFeedButtonTooltip => 'Channel feed';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -24,6 +24,17 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get chooseAccountPageTitle => 'Wybierz konto';
 
   @override
+  String get switchAccountButton => 'Switch account';
+
+  @override
+  String tryAnotherAccountMessage(Object url) {
+    return 'Your account at $url is taking a while to load.';
+  }
+
+  @override
+  String get tryAnotherAccountButton => 'Try another account';
+
+  @override
   String get chooseAccountPageLogOutButton => 'Wyloguj';
 
   @override
@@ -444,6 +455,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get userRoleUnknown => 'Nieznany';
 
   @override
+  String get inboxPageTitle => 'Inbox';
+
+  @override
   String get recentDmConversationsPageTitle => 'Wiadomości bezpośrednie';
 
   @override
@@ -454,6 +468,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get starredMessagesPageTitle => 'Wiadomości z gwiazdką';
+
+  @override
+  String get channelsPageTitle => 'Channels';
+
+  @override
+  String get mainMenuMyProfile => 'My profile';
 
   @override
   String get channelFeedButtonTooltip => 'Strumień kanału';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -24,6 +24,17 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get chooseAccountPageTitle => 'Выберите учетную запись';
 
   @override
+  String get switchAccountButton => 'Switch account';
+
+  @override
+  String tryAnotherAccountMessage(Object url) {
+    return 'Your account at $url is taking a while to load.';
+  }
+
+  @override
+  String get tryAnotherAccountButton => 'Try another account';
+
+  @override
   String get chooseAccountPageLogOutButton => 'Выход из системы';
 
   @override
@@ -444,6 +455,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get userRoleUnknown => 'Unknown';
 
   @override
+  String get inboxPageTitle => 'Inbox';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
@@ -454,6 +468,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get starredMessagesPageTitle => 'Отмеченные сообщения';
+
+  @override
+  String get channelsPageTitle => 'Channels';
+
+  @override
+  String get mainMenuMyProfile => 'My profile';
 
   @override
   String get channelFeedButtonTooltip => 'Channel feed';

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -126,6 +126,7 @@ class ActionSheetCancelButton extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
     return TextButton(
       style: TextButton.styleFrom(
+        minimumSize: const Size.fromHeight(44),
         padding: const EdgeInsets.all(10),
         foregroundColor: designVariables.contextMenuCancelText,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(7)),
@@ -139,8 +140,7 @@ class ActionSheetCancelButton extends StatelessWidget {
       },
       child: Text(ZulipLocalizations.of(context).dialogCancel,
         style: const TextStyle(fontSize: 20, height: 24 / 20)
-          .merge(weightVariableTextStyle(context, wght: 600))),
-    );
+          .merge(weightVariableTextStyle(context, wght: 600))));
   }
 }
 

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -279,6 +279,7 @@ class ChooseAccountPage extends StatelessWidget {
     final globalStore = GlobalStoreWidget.of(context);
     return Scaffold(
       appBar: AppBar(
+        titleSpacing: 16,
         title: Text(zulipLocalizations.chooseAccountPageTitle),
         actions: const [ChooseAccountPageOverflowButton()]),
       body: SafeArea(

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -13,7 +13,6 @@ import 'about_zulip.dart';
 import 'actions.dart';
 import 'dialog.dart';
 import 'home.dart';
-import 'inbox.dart';
 import 'login.dart';
 import 'page.dart';
 import 'store.dart';
@@ -209,11 +208,10 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
 
           onGenerateInitialRoutes: (_) {
             return [
-              MaterialWidgetRoute(page: const ChooseAccountPage()),
-              if (initialAccountId != null) ...[
+              if (initialAccountId == null)
+                MaterialWidgetRoute(page: const ChooseAccountPage())
+              else
                 HomePage.buildRoute(accountId: initialAccountId),
-                InboxPage.buildRoute(accountId: initialAccountId),
-              ],
             ];
           });
         }));
@@ -271,8 +269,7 @@ class ChooseAccountPage extends StatelessWidget {
         // The default trailing padding with M3 is 24px. Decrease by 12 because
         // IconButton (the "…" button) comes with 12px padding on all sides.
         contentPadding: const EdgeInsetsDirectional.only(start: 16, end: 12),
-        onTap: () => Navigator.push(context,
-          HomePage.buildRoute(accountId: accountId))));
+        onTap: () => HomePage.navigate(context, accountId: accountId)));
   }
 
   @override
@@ -281,13 +278,20 @@ class ChooseAccountPage extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     assert(!PerAccountStoreWidget.debugExistsOf(context));
     final globalStore = GlobalStoreWidget.of(context);
+
+    // Borrowed from [AppBar.build].
+    // See documentation on [ModalRoute.impliesAppBarDismissal]:
+    // > Whether an [AppBar] in the route should automatically add a back button or
+    // > close button.
+    final hasBackButton = ModalRoute.of(context)?.impliesAppBarDismissal ?? false;
+
     return MenuButtonTheme(
       data: MenuButtonThemeData(style: MenuItemButton.styleFrom(
         backgroundColor: colorScheme.secondaryContainer,
         foregroundColor: colorScheme.onSecondaryContainer)),
       child: Scaffold(
         appBar: AppBar(
-          titleSpacing: 16,
+          titleSpacing: hasBackButton ? null : 16,
           title: Text(zulipLocalizations.chooseAccountPageTitle),
           actions: const [ChooseAccountPageOverflowButton()]),
         body: SafeArea(

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -229,6 +229,7 @@ class ChooseAccountPage extends StatelessWidget {
     required Widget title,
     Widget? subtitle,
   }) {
+    final colorScheme = ColorScheme.of(context);
     final designVariables = DesignVariables.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
     final materialLocalizations = MaterialLocalizations.of(context);
@@ -237,6 +238,8 @@ class ChooseAccountPage extends StatelessWidget {
       child: ListTile(
         title: title,
         subtitle: subtitle,
+        tileColor: colorScheme.secondaryContainer,
+        textColor: colorScheme.onSecondaryContainer,
         trailing: MenuAnchor(
           menuChildren: [
             MenuItemButton(
@@ -274,36 +277,40 @@ class ChooseAccountPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = ColorScheme.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
     assert(!PerAccountStoreWidget.debugExistsOf(context));
     final globalStore = GlobalStoreWidget.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        titleSpacing: 16,
-        title: Text(zulipLocalizations.chooseAccountPageTitle),
-        actions: const [ChooseAccountPageOverflowButton()]),
-      body: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400),
-            child: Column(mainAxisSize: MainAxisSize.min, children: [
-              Flexible(child: SingleChildScrollView(
-                padding: const EdgeInsets.only(top: 8),
-                child: Column(mainAxisSize: MainAxisSize.min, children: [
-                  for (final (:accountId, :account) in globalStore.accountEntries)
-                    _buildAccountItem(context,
-                      accountId: accountId,
-                      title: Text(account.realmUrl.toString()),
-                      subtitle: Text(account.email)),
-                ]))),
-              const SizedBox(height: 12),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  AddAccountPage.buildRoute()),
-                child: Text(zulipLocalizations.chooseAccountButtonAddAnAccount)),
-            ]))),
-      ));
+    return MenuButtonTheme(
+      data: MenuButtonThemeData(style: MenuItemButton.styleFrom(
+        backgroundColor: colorScheme.secondaryContainer,
+        foregroundColor: colorScheme.onSecondaryContainer)),
+      child: Scaffold(
+        appBar: AppBar(
+          titleSpacing: 16,
+          title: Text(zulipLocalizations.chooseAccountPageTitle),
+          actions: const [ChooseAccountPageOverflowButton()]),
+        body: SafeArea(
+          minimum: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: Column(mainAxisSize: MainAxisSize.min, children: [
+                Flexible(child: SingleChildScrollView(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Column(mainAxisSize: MainAxisSize.min, children: [
+                    for (final (:accountId, :account) in globalStore.accountEntries)
+                      _buildAccountItem(context,
+                        accountId: accountId,
+                        title: Text(account.realmUrl.toString()),
+                        subtitle: Text(account.email)),
+                  ]))),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                    AddAccountPage.buildRoute()),
+                  child: Text(zulipLocalizations.chooseAccountButtonAddAnAccount)),
+              ]))))));
   }
 }
 

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -8,6 +8,7 @@ import 'store.dart';
 class ZulipAppBar extends AppBar {
   ZulipAppBar({
     super.key,
+    super.titleSpacing,
     required super.title,
     super.backgroundColor,
     super.shape,

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -24,8 +24,6 @@ class HomePage extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    final colorScheme = ColorScheme.of(context);
-
     InlineSpan bold(String text) => TextSpan(
       style: const TextStyle().merge(weightVariableTextStyle(context, wght: 700)),
       text: text);
@@ -37,61 +35,57 @@ class HomePage extends StatelessWidget {
 
     return Scaffold(
       appBar: ZulipAppBar(title: const Text("Home")),
-      body: ElevatedButtonTheme(
-        data: ElevatedButtonThemeData(style: ButtonStyle(
-          backgroundColor: WidgetStatePropertyAll(colorScheme.secondaryContainer),
-          foregroundColor: WidgetStatePropertyAll(colorScheme.onSecondaryContainer))),
-        child: Center(
-          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-            DefaultTextStyle.merge(
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 18),
-              child: Column(children: [
-                Text.rich(TextSpan(
-                  text: 'Connected to: ',
-                  children: [bold(store.realmUrl.toString())])),
-              ])),
+      body: Center(
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          DefaultTextStyle.merge(
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 18),
+            child: Column(children: [
+              Text.rich(TextSpan(
+                text: 'Connected to: ',
+                children: [bold(store.realmUrl.toString())])),
+            ])),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
+              MessageListPage.buildRoute(context: context,
+                narrow: const CombinedFeedNarrow())),
+            child: Text(zulipLocalizations.combinedFeedPageTitle)),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
+              MessageListPage.buildRoute(context: context,
+                narrow: const MentionsNarrow())),
+            child: Text(zulipLocalizations.mentionsPageTitle)),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
+              MessageListPage.buildRoute(context: context,
+                narrow: const StarredMessagesNarrow())),
+            child: Text(zulipLocalizations.starredMessagesPageTitle)),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
+              InboxPage.buildRoute(context: context)),
+            child: const Text("Inbox")), // TODO(i18n)
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
+              SubscriptionListPage.buildRoute(context: context)),
+            child: const Text("Subscribed channels")),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => Navigator.push(context,
+              RecentDmConversationsPage.buildRoute(context: context)),
+            child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
+          if (testStreamId != null) ...[
             const SizedBox(height: 16),
             ElevatedButton(
               onPressed: () => Navigator.push(context,
                 MessageListPage.buildRoute(context: context,
-                  narrow: const CombinedFeedNarrow())),
-              child: Text(zulipLocalizations.combinedFeedPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: const MentionsNarrow())),
-              child: Text(zulipLocalizations.mentionsPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: const StarredMessagesNarrow())),
-              child: Text(zulipLocalizations.starredMessagesPageTitle)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                InboxPage.buildRoute(context: context)),
-              child: const Text("Inbox")), // TODO(i18n)
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                SubscriptionListPage.buildRoute(context: context)),
-              child: const Text("Subscribed channels")),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                RecentDmConversationsPage.buildRoute(context: context)),
-              child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-            if (testStreamId != null) ...[
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.push(context,
-                  MessageListPage.buildRoute(context: context,
-                    narrow: ChannelNarrow(testStreamId!))),
-                child: const Text("#test here")), // scaffolding hack, see above
-            ],
-          ]))));
+                  narrow: ChannelNarrow(testStreamId!))),
+              child: const Text("#test here")), // scaffolding hack, see above
+          ],
+        ])));
   }
 }

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -1,91 +1,598 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
+import 'action_sheet.dart';
+import 'app.dart';
 import 'app_bar.dart';
+import 'color.dart';
+import 'content.dart';
+import 'icons.dart';
 import 'inbox.dart';
+import 'inset_shadow.dart';
 import 'message_list.dart';
 import 'page.dart';
+import 'profile.dart';
 import 'recent_dm_conversations.dart';
 import 'store.dart';
 import 'subscription_list.dart';
 import 'text.dart';
+import 'theme.dart';
 
-class HomePage extends StatelessWidget {
+enum _HomePageTab {
+  inbox,
+  channels,
+  directMessages,
+}
+
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
   static Route<void> buildRoute({required int accountId}) {
     return MaterialAccountWidgetRoute(accountId: accountId,
-        page: const HomePage());
+      loadingPlaceholderPage: _LoadingPlaceholderPage(accountId: accountId),
+      page: const HomePage());
+  }
+
+  /// Navigate to [HomePage], ensuring that its route is at the root level.
+  static void navigate(BuildContext context, {required int accountId}) {
+    final navigator = Navigator.of(context);
+    navigator.popUntil((route) => route.isFirst);
+    unawaited(navigator.pushReplacement(
+      HomePage.buildRoute(accountId: accountId)));
+  }
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  late final _tab = ValueNotifier(_HomePageTab.inbox);
+
+  @override
+  void initState() {
+    super.initState();
+    _tab.addListener(_tabChanged);
+  }
+
+  @override
+  void dispose() {
+    _tab.dispose();
+    super.dispose();
+  }
+
+  void _tabChanged() {
+    setState(() {
+      // The actual state lives in [_tab].
+    });
+  }
+
+  String get _currentTabTitle {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    switch(_tab.value) {
+      case _HomePageTab.inbox:
+        return zulipLocalizations.inboxPageTitle;
+      case _HomePageTab.channels:
+        return zulipLocalizations.channelsPageTitle;
+      case _HomePageTab.directMessages:
+        return zulipLocalizations.recentDmConversationsPageTitle;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final store = PerAccountStoreWidget.of(context);
-    final zulipLocalizations = ZulipLocalizations.of(context);
+    const pageBodies = [
+      (_HomePageTab.inbox,          InboxPageBody()),
+      (_HomePageTab.channels,       SubscriptionListPageBody()),
+      // TODO(#1094): Users
+      (_HomePageTab.directMessages, RecentDmConversationsPageBody()),
+    ];
 
-    InlineSpan bold(String text) => TextSpan(
-      style: const TextStyle().merge(weightVariableTextStyle(context, wght: 700)),
-      text: text);
-
-    int? testStreamId;
-    if (store.connection.realmUrl.origin == 'https://chat.zulip.org') {
-      testStreamId = 7; // i.e. `#test here`; TODO cut this scaffolding hack
+    _NavigationBarButton button(_HomePageTab tab, IconData icon) {
+      return _NavigationBarButton(icon: icon,
+        selected: _tab.value == tab,
+        onPressed: () {
+          _tab.value = tab;
+        });
     }
 
+    // TODO(a11y): add tooltips for these buttons
+    final navigationBarButtons = [
+      button(_HomePageTab.inbox,          ZulipIcons.inbox),
+      button(_HomePageTab.channels,       ZulipIcons.hash_italic),
+      // TODO(#1094): Users
+      button(_HomePageTab.directMessages, ZulipIcons.user),
+      _NavigationBarButton(        icon: ZulipIcons.menu,
+        selected: false,
+        onPressed: () => _showMainMenu(context, tabNotifier: _tab)),
+    ];
+
+    final designVariables = DesignVariables.of(context);
     return Scaffold(
-      appBar: ZulipAppBar(title: const Text("Home")),
+      appBar: ZulipAppBar(titleSpacing: 16,
+        title: Text(_currentTabTitle)),
+      body: Stack(
+        children: [
+          for (final (tab, body) in pageBodies)
+            // TODO(#535): Decide if we find it helpful to use something like
+            //   [SemanticsProperties.namesRoute] to structure this UI better
+            //   for screen-reader software.
+            Offstage(offstage: tab != _tab.value, child: body),
+        ]),
+      bottomNavigationBar: DecoratedBox(
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: designVariables.borderBar)),
+          color: designVariables.bgBotBar),
+        child: SafeArea(
+          child: SizedBox(height: 48,
+            child: Center(
+              child: ConstrainedBox(
+                // TODO(design): determine a suitable max width for bottom nav bar
+                constraints: const BoxConstraints(maxWidth: 600),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (final navigationBarButton in navigationBarButtons)
+                      Expanded(child: navigationBarButton),
+                  ])))))));
+  }
+}
+
+const kTryAnotherAccountWaitPeriod = Duration(seconds: 5);
+
+class _LoadingPlaceholderPage extends StatefulWidget {
+  const _LoadingPlaceholderPage({required this.accountId});
+
+  final int accountId;
+
+  @override
+  State<_LoadingPlaceholderPage> createState() => _LoadingPlaceholderPageState();
+}
+
+class _LoadingPlaceholderPageState extends State<_LoadingPlaceholderPage> {
+  Timer? tryAnotherAccountTimer;
+  bool showTryAnotherAccount = false;
+
+  @override
+  void initState() {
+    super.initState();
+    tryAnotherAccountTimer = Timer(kTryAnotherAccountWaitPeriod, () {
+      setState(() {
+        showTryAnotherAccount = true;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    tryAnotherAccountTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final realmUrl = GlobalStoreWidget.of(context)
+      .getAccount(widget.accountId)!.realmUrl;
+
+    return Scaffold(
+      appBar: AppBar(),
       body: Center(
-        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-          DefaultTextStyle.merge(
-            textAlign: TextAlign.center,
-            style: const TextStyle(fontSize: 18),
-            child: Column(children: [
-              Text.rich(TextSpan(
-                text: 'Connected to: ',
-                children: [bold(store.realmUrl.toString())])),
-            ])),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const CombinedFeedNarrow())),
-            child: Text(zulipLocalizations.combinedFeedPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const MentionsNarrow())),
-            child: Text(zulipLocalizations.mentionsPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              MessageListPage.buildRoute(context: context,
-                narrow: const StarredMessagesNarrow())),
-            child: Text(zulipLocalizations.starredMessagesPageTitle)),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              InboxPage.buildRoute(context: context)),
-            child: const Text("Inbox")), // TODO(i18n)
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              SubscriptionListPage.buildRoute(context: context)),
-            child: const Text("Subscribed channels")),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () => Navigator.push(context,
-              RecentDmConversationsPage.buildRoute(context: context)),
-            child: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-          if (testStreamId != null) ...[
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.push(context,
-                MessageListPage.buildRoute(context: context,
-                  narrow: ChannelNarrow(testStreamId!))),
-              child: const Text("#test here")), // scaffolding hack, see above
-          ],
-        ])));
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            Visibility(
+              visible: showTryAnotherAccount,
+              maintainSize: true,
+              maintainAnimation: true,
+              maintainState: true,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Column(
+                  children: [
+                    const SizedBox(height: 16),
+                    Text(zulipLocalizations.tryAnotherAccountMessage(realmUrl.toString())),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: () => Navigator.push(context,
+                        MaterialWidgetRoute(page: const ChooseAccountPage())),
+                      child: Text(zulipLocalizations.tryAnotherAccountButton)),
+                  ]))),
+          ])));
+  }
+}
+
+class _NavigationBarButton extends StatelessWidget {
+  const _NavigationBarButton({
+    required this.icon,
+    required this.selected,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final bool selected;
+  final void Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    final iconColor = WidgetStateColor.fromMap({
+      WidgetState.pressed:  designVariables.iconSelected,
+      ~WidgetState.pressed: selected ? designVariables.iconSelected
+                                     : designVariables.icon,
+    });
+
+    return AnimatedScaleOnTap(
+      scaleEnd: 0.875,
+      duration: const Duration(milliseconds: 100),
+      child: IconButton(
+        icon: Icon(icon, size: 24),
+        onPressed: onPressed,
+        style: IconButton.styleFrom(
+          // TODO(#417): Disable splash effects for all buttons globally.
+          splashFactory: NoSplash.splashFactory,
+          highlightColor: designVariables.navigationButtonBg,
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(4))),
+        ).copyWith(foregroundColor: iconColor)));
+  }
+}
+
+void _showMainMenu(BuildContext context, {
+  required ValueNotifier<_HomePageTab> tabNotifier,
+}) {
+  final menuItems = <Widget>[
+    // TODO(#252): Search
+    // const SizedBox(height: 8),
+    _InboxButton(tabNotifier: tabNotifier),
+    // TODO: Recent conversations
+    const _MentionsButton(),
+    const _StarredMessagesButton(),
+    const _CombinedFeedButton(),
+    // TODO: Drafts
+    _ChannelsButton(tabNotifier: tabNotifier),
+    _DirectMessagesButton(tabNotifier: tabNotifier),
+    // TODO(#1094): Users
+    const _MyProfileButton(),
+    const _SwitchAccountButton(),
+    // TODO(#198): Set my status
+    // const SizedBox(height: 8),
+    // TODO(#97): Settings
+    // TODO(#661): Notifications
+    // const SizedBox(height: 8),
+    // TODO(#1095): VersionInfo
+  ];
+
+  final designVariables = DesignVariables.of(context);
+  final accountId = PerAccountStoreWidget.accountIdOf(context);
+  showModalBottomSheet<void>(
+    context: context,
+    // Clip.hardEdge looks bad; Clip.antiAliasWithSaveLayer looks pixel-perfect
+    // on my iPhone 13 Pro but is marked as "much slower":
+    //   https://api.flutter.dev/flutter/dart-ui/Clip.html
+    clipBehavior: Clip.antiAlias,
+    useSafeArea: true,
+    isScrollControlled: true,
+    // TODO: Fix the issue that the color does not respond when the theme
+    //   changes, because `designVariables` was retrieved from a gesture handler,
+    //   not a build method.  Discussion and screenshots:
+    //     https://github.com/zulip/zulip-flutter/pull/1076/files#r1872659043
+    backgroundColor: designVariables.bgBotBar,
+    builder: (BuildContext _) {
+      return PerAccountStoreWidget(
+        accountId: accountId,
+        child: SafeArea(
+          minimum: const EdgeInsets.only(bottom: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(child: InsetShadowBox(
+                top: 8, bottom: 8,
+                color: designVariables.bgBotBar,
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+                  child: Column(children: menuItems)))),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                child: AnimatedScaleOnTap(
+                  scaleEnd: 0.95,
+                  duration: Duration(milliseconds: 100),
+                  child: ActionSheetCancelButton())),
+            ])));
+    });
+}
+
+abstract class _MenuButton extends StatelessWidget {
+  const _MenuButton();
+
+  String label(ZulipLocalizations zulipLocalizations);
+
+  bool get selected => false;
+
+  /// An icon to display before [label].
+  ///
+  /// Must be non-null unless [buildLeading] is overridden.
+  IconData? get icon;
+
+  static const _iconSize = 24.0;
+
+  Widget buildLeading(BuildContext context) {
+    assert(icon != null);
+    final designVariables = DesignVariables.of(context);
+    return Icon(icon, size: _iconSize,
+      color: selected ? designVariables.iconSelected : designVariables.icon);
+  }
+
+  void onPressed(BuildContext context);
+
+  void _handlePress(BuildContext context) {
+    // Dismiss the enclosing action sheet immediately,
+    // for swift UI feedback that the user's selection was received.
+    Navigator.of(context).pop();
+
+    onPressed(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
+
+    final borderSideSelected = BorderSide(width: 1,
+      strokeAlign: BorderSide.strokeAlignOutside,
+      color: designVariables.borderMenuButtonSelected);
+    final buttonStyle = TextButton.styleFrom(
+      padding: const EdgeInsets.symmetric(vertical: 9, horizontal: 8),
+      foregroundColor: designVariables.labelMenuButton,
+      // This has a default behavior of affecting the background color of the
+      // button for states including "hovered", "focused" and "pressed".
+      // Make this transparent so that we can have full control of these colors.
+      overlayColor: Colors.transparent,
+      splashFactory: NoSplash.splashFactory,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+    ).copyWith(
+      backgroundColor: WidgetStateColor.fromMap({
+        WidgetState.hovered: designVariables.bgMenuButtonActive.withFadedAlpha(0.5),
+        WidgetState.focused: designVariables.bgMenuButtonActive,
+        WidgetState.pressed: designVariables.bgMenuButtonActive,
+        WidgetState.any:
+          selected ? designVariables.bgMenuButtonSelected : Colors.transparent,
+      }),
+      side: WidgetStateBorderSide.fromMap({
+        WidgetState.pressed: null,
+        ~WidgetState.pressed: selected ? borderSideSelected : null,
+      }));
+
+    return AnimatedScaleOnTap(
+      duration: const Duration(milliseconds: 100),
+      scaleEnd: 0.95,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 44),
+        child: TextButton(
+          onPressed: () => _handlePress(context),
+          style: buttonStyle,
+          child: Row(spacing: 8, children: [
+            SizedBox.square(dimension: _iconSize,
+              child: buildLeading(context)),
+            Expanded(child: Text(label(zulipLocalizations),
+              // TODO(design): determine if we prefer to wrap
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 19, height: 26 / 19)
+                .merge(weightVariableTextStyle(context, wght: selected ? 600 : 400)))),
+          ]))));
+  }
+}
+
+/// A menu button controlling the selected [_HomePageTab] on the bottom nav bar.
+abstract class _NavigationBarMenuButton extends _MenuButton {
+  const _NavigationBarMenuButton({required this.tabNotifier});
+
+  final ValueNotifier<_HomePageTab> tabNotifier;
+
+  _HomePageTab get navigationTarget;
+
+  @override
+  bool get selected => tabNotifier.value == navigationTarget;
+
+  @override
+  void onPressed(BuildContext context) {
+    tabNotifier.value = navigationTarget;
+  }
+}
+
+class _InboxButton extends _NavigationBarMenuButton {
+  const _InboxButton({required super.tabNotifier});
+
+  @override
+  IconData get icon => ZulipIcons.inbox;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.inboxPageTitle;
+  }
+
+  @override
+  _HomePageTab get navigationTarget => _HomePageTab.inbox;
+}
+
+class _MentionsButton extends _MenuButton {
+  const _MentionsButton();
+
+  @override
+  IconData get icon => ZulipIcons.at_sign;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.mentionsPageTitle;
+  }
+
+  @override
+  void onPressed(BuildContext context) {
+    Navigator.of(context).push(MessageListPage.buildRoute(
+      context: context, narrow: const MentionsNarrow()));
+  }
+}
+
+class _StarredMessagesButton extends _MenuButton {
+  const _StarredMessagesButton();
+
+  @override
+  IconData get icon => ZulipIcons.star;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.starredMessagesPageTitle;
+  }
+
+  @override
+  void onPressed(BuildContext context) {
+    Navigator.of(context).push(MessageListPage.buildRoute(
+      context: context, narrow: const StarredMessagesNarrow()));
+  }
+}
+
+class _CombinedFeedButton extends _MenuButton {
+  const _CombinedFeedButton();
+
+  @override
+  IconData get icon => ZulipIcons.message_feed;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.combinedFeedPageTitle;
+  }
+
+  @override
+  void onPressed(BuildContext context) {
+    Navigator.of(context).push(MessageListPage.buildRoute(
+      context: context, narrow: const CombinedFeedNarrow()));
+  }
+}
+
+class _ChannelsButton extends _NavigationBarMenuButton {
+  const _ChannelsButton({required super.tabNotifier});
+
+  @override
+  IconData get icon => ZulipIcons.hash_italic;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.channelsPageTitle;
+  }
+
+  @override
+  _HomePageTab get navigationTarget => _HomePageTab.channels;
+}
+
+class _DirectMessagesButton extends _NavigationBarMenuButton {
+  const _DirectMessagesButton({required super.tabNotifier});
+
+  @override
+  IconData get icon => ZulipIcons.user;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.recentDmConversationsPageTitle;
+  }
+
+  @override
+  _HomePageTab get navigationTarget => _HomePageTab.directMessages;
+}
+
+class _MyProfileButton extends _MenuButton {
+  const _MyProfileButton();
+
+  @override
+  IconData? get icon => null;
+
+  @override
+  Widget buildLeading(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+    return Avatar(
+      userId: store.selfUserId, size: _MenuButton._iconSize, borderRadius: 4);
+  }
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.mainMenuMyProfile;
+  }
+
+  @override
+  void onPressed(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+    Navigator.of(context).push(
+      ProfilePage.buildRoute(context: context, userId: store.selfUserId));
+  }
+}
+
+class _SwitchAccountButton extends _MenuButton {
+  const _SwitchAccountButton();
+
+  @override
+  // TODO(design): choose an icon
+  IconData? get icon => null;
+
+  @override
+  Widget buildLeading(BuildContext context) => const SizedBox.shrink();
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.switchAccountButton;
+  }
+
+  @override
+  void onPressed(BuildContext context) {
+    Navigator.of(context).push(MaterialWidgetRoute(page: const ChooseAccountPage()));
+  }
+}
+
+/// Apply [Transform.scale] to the child widget when tapped, and reset its scale
+/// when released, while animating the transitions.
+class AnimatedScaleOnTap extends StatefulWidget {
+  const AnimatedScaleOnTap({
+    super.key,
+    required this.scaleEnd,
+    required this.duration,
+    required this.child,
+  });
+
+  /// The terminal scale to animate to.
+  final double scaleEnd;
+
+  /// The duration over which to animate the scale change.
+  final Duration duration;
+
+  final Widget child;
+
+  @override
+  State<AnimatedScaleOnTap> createState() => _AnimatedScaleOnTapState();
+}
+
+class _AnimatedScaleOnTapState extends State<AnimatedScaleOnTap> {
+  double _scale = 1;
+
+  void _changeScale(double scale) {
+    setState(() {
+      _scale = scale;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTapDown: (_) =>  _changeScale(widget.scaleEnd),
+      onTapUp: (_) =>    _changeScale(1),
+      onTapCancel: () => _changeScale(1),
+      child: AnimatedScale(
+        scale: _scale,
+        duration: widget.duration,
+        curve: Curves.easeOut,
+        child: widget.child));
   }
 }

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -5,31 +5,13 @@ import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
 import 'action_sheet.dart';
-import 'app_bar.dart';
 import 'icons.dart';
 import 'message_list.dart';
-import 'page.dart';
 import 'sticky_header.dart';
 import 'store.dart';
 import 'text.dart';
 import 'theme.dart';
 import 'unread_count_badge.dart';
-
-class InboxPage extends StatelessWidget {
-  const InboxPage({super.key});
-
-  static Route<void> buildRoute({int? accountId, BuildContext? context}) {
-    return MaterialAccountWidgetRoute(accountId: accountId, context: context,
-      page: const InboxPage());
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: ZulipAppBar(title: const Text('Inbox')),
-      body: const InboxPageBody());
-  }
-}
 
 class InboxPageBody extends StatefulWidget {
   const InboxPageBody({super.key});

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -395,10 +395,7 @@ class _LoginPageState extends State<LoginPage> {
       return;
     }
 
-    unawaited(Navigator.of(context).pushAndRemoveUntil(
-      HomePage.buildRoute(accountId: accountId),
-      (route) => (route is! _LoginSequenceRoute)),
-    );
+    HomePage.navigate(context, accountId: accountId);
   }
 
   Future<int> _getUserId(String email, String apiKey) async {

--- a/lib/widgets/page.dart
+++ b/lib/widgets/page.dart
@@ -34,12 +34,13 @@ class MaterialWidgetRoute<T extends Object?> extends MaterialPageRoute<T> implem
 /// A mixin for providing a given account's per-account store on a page route.
 mixin AccountPageRouteMixin<T extends Object?> on PageRoute<T> {
   int get accountId;
+  Widget? get loadingPlaceholderPage;
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     return PerAccountStoreWidget(
       accountId: accountId,
-      placeholder: const LoadingPlaceholderPage(),
+      placeholder: loadingPlaceholderPage ?? const LoadingPlaceholderPage(),
       routeToRemoveOnLogout: this,
       child: super.buildPage(context, animation, secondaryAnimation));
   }
@@ -67,6 +68,7 @@ class MaterialAccountPageRoute<T extends Object?> extends MaterialPageRoute<T> w
   MaterialAccountPageRoute({
     int? accountId,
     BuildContext? context,
+    this.loadingPlaceholderPage,
     required super.builder,
     super.settings,
     super.maintainState,
@@ -78,6 +80,9 @@ class MaterialAccountPageRoute<T extends Object?> extends MaterialPageRoute<T> w
 
   @override
   final int accountId;
+
+  @override
+  final Widget? loadingPlaceholderPage;
 }
 
 /// A [MaterialPageRoute] that provides a per-account store for a given account
@@ -105,6 +110,7 @@ class MaterialAccountWidgetRoute<T extends Object?> extends MaterialAccountPageR
   MaterialAccountWidgetRoute({
     super.accountId,
     super.context,
+    super.loadingPlaceholderPage,
     required this.page,
     super.settings,
     super.maintainState,
@@ -134,6 +140,7 @@ class AccountPageRouteBuilder<T extends Object?> extends PageRouteBuilder<T> wit
   AccountPageRouteBuilder({
     int? accountId,
     BuildContext? context,
+    this.loadingPlaceholderPage,
     super.settings,
     required super.pageBuilder,
     super.transitionsBuilder,
@@ -152,6 +159,9 @@ class AccountPageRouteBuilder<T extends Object?> extends PageRouteBuilder<T> wit
 
   @override
   final int accountId;
+
+  @override
+  final Widget? loadingPlaceholderPage;
 }
 
 class LoadingPlaceholderPage extends StatelessWidget {

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -1,35 +1,14 @@
 import 'package:flutter/material.dart';
 
-import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
-import 'app_bar.dart';
 import 'content.dart';
 import 'icons.dart';
 import 'message_list.dart';
-import 'page.dart';
 import 'store.dart';
 import 'theme.dart';
 import 'unread_count_badge.dart';
-
-class RecentDmConversationsPage extends StatelessWidget {
-  const RecentDmConversationsPage({super.key});
-
-  static Route<void> buildRoute({int? accountId, BuildContext? context}) {
-    return MaterialAccountWidgetRoute(accountId: accountId, context: context,
-      page: const RecentDmConversationsPage());
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final zulipLocalizations = ZulipLocalizations.of(context);
-    return Scaffold(
-      appBar: ZulipAppBar(
-        title: Text(zulipLocalizations.recentDmConversationsPageTitle)),
-      body: const RecentDmConversationsPageBody());
-  }
-}
 
 class RecentDmConversationsPageBody extends StatefulWidget {
   const RecentDmConversationsPageBody({super.key});

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -3,32 +3,14 @@ import 'package:flutter/material.dart';
 import '../api/model/model.dart';
 import '../model/narrow.dart';
 import '../model/unreads.dart';
-import 'app_bar.dart';
 import 'icons.dart';
 import 'message_list.dart';
-import 'page.dart';
 import 'store.dart';
 import 'text.dart';
 import 'theme.dart';
 import 'unread_count_badge.dart';
 
 /// Scrollable listing of subscribed streams.
-class SubscriptionListPage extends StatelessWidget {
-  const SubscriptionListPage({super.key});
-
-  static Route<void> buildRoute({int? accountId, BuildContext? context}) {
-    return MaterialAccountWidgetRoute(accountId: accountId, context: context,
-      page: const SubscriptionListPage());
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: ZulipAppBar(title: const Text("Channels")),
-      body: const SubscriptionListPageBody());
-  }
-}
-
 class SubscriptionListPageBody extends StatefulWidget {
   const SubscriptionListPageBody({super.key});
 

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -121,10 +121,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     this._(
       background: const Color(0xffffffff),
       bannerBgIntDanger: const Color(0xfff2e4e4),
+      bgBotBar: const Color(0xfff6f6f6),
       bgContextMenu: const Color(0xfff2f2f2),
       bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.15),
+      bgMenuButtonActive: Colors.black.withValues(alpha: 0.05),
+      bgMenuButtonSelected: Colors.white,
       bgTopBar: const Color(0xfff5f5f5),
       borderBar: Colors.black.withValues(alpha: 0.2),
+      borderMenuButtonSelected: Colors.black.withValues(alpha: 0.2),
       btnLabelAttLowIntDanger: const Color(0xffc0070a),
       btnLabelAttMediumIntDanger: const Color(0xffac0508),
       composeBoxBg: const Color(0xffffffff),
@@ -134,6 +138,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       editorButtonPressedBg: Colors.black.withValues(alpha: 0.06),
       foreground: const Color(0xff000000),
       icon: const Color(0xff6159e1),
+      iconSelected: const Color(0xff222222),
       labelCounterUnread: const Color(0xff222222),
       labelEdited: const HSLColor.fromAHSL(0.35, 0, 0, 0).toColor(),
       labelMenuButton: const Color(0xff222222),
@@ -152,6 +157,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: const Color(0xff575757),
       modalBarrierColor: const Color(0xff000000).withValues(alpha: 0.3),
       mutedUnreadBadge: const HSLColor.fromAHSL(0.5, 0, 0, 0.8).toColor(),
+      navigationButtonBg: Colors.black.withValues(alpha: 0.05),
       sectionCollapseIcon: const Color(0x7f1e2e48),
       star: const HSLColor.fromAHSL(0.5, 47, 1, 0.41).toColor(),
       subscriptionListHeaderLine: const HSLColor.fromAHSL(0.2, 240, 0.1, 0.5).toColor(),
@@ -163,10 +169,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     this._(
       background: const Color(0xff000000),
       bannerBgIntDanger: const Color(0xff461616),
+      bgBotBar: const Color(0xff222222),
       bgContextMenu: const Color(0xff262626),
       bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
+      bgMenuButtonActive: Colors.black.withValues(alpha: 0.2),
+      bgMenuButtonSelected: Colors.black.withValues(alpha: 0.25),
       bgTopBar: const Color(0xff242424),
       borderBar: Colors.black.withValues(alpha: 0.5),
+      borderMenuButtonSelected: Colors.white.withValues(alpha: 0.1),
       btnLabelAttLowIntDanger: const Color(0xffff8b7c),
       btnLabelAttMediumIntDanger: const Color(0xffff8b7c),
       composeBoxBg: const Color(0xff0f0f0f),
@@ -176,6 +186,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       editorButtonPressedBg: Colors.white.withValues(alpha: 0.06),
       foreground: const Color(0xffffffff),
       icon: const Color(0xff7977fe),
+      iconSelected: Colors.white.withValues(alpha: 0.8),
       labelCounterUnread: const Color(0xffffffff).withValues(alpha: 0.7),
       labelEdited: const HSLColor.fromAHSL(0.35, 0, 0, 1).toColor(),
       labelMenuButton: const Color(0xffffffff).withValues(alpha: 0.85),
@@ -198,6 +209,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       modalBarrierColor: const Color(0xff000000).withValues(alpha: 0.5),
       // TODO(design-dark) need proper dark-theme color (this is ad hoc)
       mutedUnreadBadge: const HSLColor.fromAHSL(0.5, 0, 0, 0.6).toColor(),
+      navigationButtonBg: Colors.white.withValues(alpha: 0.05),
       // TODO(design-dark) need proper dark-theme color (this is ad hoc)
       sectionCollapseIcon: const Color(0x7fb6c8e2),
       // TODO(design-dark) unchanged in dark theme?
@@ -212,10 +224,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   DesignVariables._({
     required this.background,
     required this.bannerBgIntDanger,
+    required this.bgBotBar,
     required this.bgContextMenu,
     required this.bgCounterUnread,
+    required this.bgMenuButtonActive,
+    required this.bgMenuButtonSelected,
     required this.bgTopBar,
     required this.borderBar,
+    required this.borderMenuButtonSelected,
     required this.btnLabelAttLowIntDanger,
     required this.btnLabelAttMediumIntDanger,
     required this.composeBoxBg,
@@ -225,6 +241,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.editorButtonPressedBg,
     required this.foreground,
     required this.icon,
+    required this.iconSelected,
     required this.labelCounterUnread,
     required this.labelEdited,
     required this.labelMenuButton,
@@ -243,6 +260,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.loginOrDividerText,
     required this.modalBarrierColor,
     required this.mutedUnreadBadge,
+    required this.navigationButtonBg,
     required this.sectionCollapseIcon,
     required this.star,
     required this.subscriptionListHeaderLine,
@@ -262,10 +280,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
 
   final Color background;
   final Color bannerBgIntDanger;
+  final Color bgBotBar;
   final Color bgContextMenu;
   final Color bgCounterUnread;
+  final Color bgMenuButtonActive;
+  final Color bgMenuButtonSelected;
   final Color bgTopBar;
   final Color borderBar;
+  final Color borderMenuButtonSelected;
   final Color btnLabelAttLowIntDanger;
   final Color btnLabelAttMediumIntDanger;
   final Color composeBoxBg;
@@ -275,6 +297,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color editorButtonPressedBg;
   final Color foreground;
   final Color icon;
+  final Color iconSelected;
   final Color labelCounterUnread;
   final Color labelEdited;
   final Color labelMenuButton;
@@ -297,6 +320,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color loginOrDividerText; // TODO(design-dark) need proper dark-theme color (this is ad hoc)
   final Color modalBarrierColor;
   final Color mutedUnreadBadge;
+  final Color navigationButtonBg;
   final Color sectionCollapseIcon;
   final Color star;
   final Color subscriptionListHeaderLine;
@@ -307,10 +331,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   DesignVariables copyWith({
     Color? background,
     Color? bannerBgIntDanger,
+    Color? bgBotBar,
     Color? bgContextMenu,
     Color? bgCounterUnread,
+    Color? bgMenuButtonActive,
+    Color? bgMenuButtonSelected,
     Color? bgTopBar,
     Color? borderBar,
+    Color? borderMenuButtonSelected,
     Color? btnLabelAttLowIntDanger,
     Color? btnLabelAttMediumIntDanger,
     Color? composeBoxBg,
@@ -320,6 +348,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? editorButtonPressedBg,
     Color? foreground,
     Color? icon,
+    Color? iconSelected,
     Color? labelCounterUnread,
     Color? labelEdited,
     Color? labelMenuButton,
@@ -338,6 +367,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? loginOrDividerText,
     Color? modalBarrierColor,
     Color? mutedUnreadBadge,
+    Color? navigationButtonBg,
     Color? sectionCollapseIcon,
     Color? star,
     Color? subscriptionListHeaderLine,
@@ -347,10 +377,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     return DesignVariables._(
       background: background ?? this.background,
       bannerBgIntDanger: bannerBgIntDanger ?? this.bannerBgIntDanger,
+      bgBotBar: bgBotBar ?? this.bgBotBar,
       bgContextMenu: bgContextMenu ?? this.bgContextMenu,
       bgCounterUnread: bgCounterUnread ?? this.bgCounterUnread,
+      bgMenuButtonActive: bgMenuButtonActive ?? this.bgMenuButtonActive,
+      bgMenuButtonSelected: bgMenuButtonSelected ?? this.bgMenuButtonSelected,
       bgTopBar: bgTopBar ?? this.bgTopBar,
       borderBar: borderBar ?? this.borderBar,
+      borderMenuButtonSelected: borderMenuButtonSelected ?? this.borderMenuButtonSelected,
       btnLabelAttLowIntDanger: btnLabelAttLowIntDanger ?? this.btnLabelAttLowIntDanger,
       btnLabelAttMediumIntDanger: btnLabelAttMediumIntDanger ?? this.btnLabelAttMediumIntDanger,
       composeBoxBg: composeBoxBg ?? this.composeBoxBg,
@@ -360,6 +394,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       editorButtonPressedBg: editorButtonPressedBg ?? this.editorButtonPressedBg,
       foreground: foreground ?? this.foreground,
       icon: icon ?? this.icon,
+      iconSelected: iconSelected ?? this.iconSelected,
       labelCounterUnread: labelCounterUnread ?? this.labelCounterUnread,
       labelEdited: labelEdited ?? this.labelEdited,
       labelMenuButton: labelMenuButton ?? this.labelMenuButton,
@@ -378,6 +413,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: loginOrDividerText ?? this.loginOrDividerText,
       modalBarrierColor: modalBarrierColor ?? this.modalBarrierColor,
       mutedUnreadBadge: mutedUnreadBadge ?? this.mutedUnreadBadge,
+      navigationButtonBg: navigationButtonBg ?? this.navigationButtonBg,
       sectionCollapseIcon: sectionCollapseIcon ?? this.sectionCollapseIcon,
       star: star ?? this.star,
       subscriptionListHeaderLine: subscriptionListHeaderLine ?? this.subscriptionListHeaderLine,
@@ -394,10 +430,14 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     return DesignVariables._(
       background: Color.lerp(background, other.background, t)!,
       bannerBgIntDanger: Color.lerp(bannerBgIntDanger, other.bannerBgIntDanger, t)!,
+      bgBotBar: Color.lerp(bgBotBar, other.bgBotBar, t)!,
       bgContextMenu: Color.lerp(bgContextMenu, other.bgContextMenu, t)!,
       bgCounterUnread: Color.lerp(bgCounterUnread, other.bgCounterUnread, t)!,
+      bgMenuButtonActive: Color.lerp(bgMenuButtonActive, other.bgMenuButtonActive, t)!,
+      bgMenuButtonSelected: Color.lerp(bgMenuButtonSelected, other.bgMenuButtonSelected, t)!,
       bgTopBar: Color.lerp(bgTopBar, other.bgTopBar, t)!,
       borderBar: Color.lerp(borderBar, other.borderBar, t)!,
+      borderMenuButtonSelected: Color.lerp(borderMenuButtonSelected, other.borderMenuButtonSelected, t)!,
       btnLabelAttLowIntDanger: Color.lerp(btnLabelAttLowIntDanger, other.btnLabelAttLowIntDanger, t)!,
       btnLabelAttMediumIntDanger: Color.lerp(btnLabelAttMediumIntDanger, other.btnLabelAttMediumIntDanger, t)!,
       composeBoxBg: Color.lerp(composeBoxBg, other.composeBoxBg, t)!,
@@ -407,6 +447,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       editorButtonPressedBg: Color.lerp(editorButtonPressedBg, other.editorButtonPressedBg, t)!,
       foreground: Color.lerp(foreground, other.foreground, t)!,
       icon: Color.lerp(icon, other.icon, t)!,
+      iconSelected: Color.lerp(iconSelected, other.iconSelected, t)!,
       labelCounterUnread: Color.lerp(labelCounterUnread, other.labelCounterUnread, t)!,
       labelEdited: Color.lerp(labelEdited, other.labelEdited, t)!,
       labelMenuButton: Color.lerp(labelMenuButton, other.labelMenuButton, t)!,
@@ -425,6 +466,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       loginOrDividerText: Color.lerp(loginOrDividerText, other.loginOrDividerText, t)!,
       modalBarrierColor: Color.lerp(modalBarrierColor, other.modalBarrierColor, t)!,
       mutedUnreadBadge: Color.lerp(mutedUnreadBadge, other.mutedUnreadBadge, t)!,
+      navigationButtonBg: Color.lerp(navigationButtonBg, other.navigationButtonBg, t)!,
       sectionCollapseIcon: Color.lerp(sectionCollapseIcon, other.sectionCollapseIcon, t)!,
       star: Color.lerp(star, other.star, t)!,
       subscriptionListHeaderLine: Color.lerp(subscriptionListHeaderLine, other.subscriptionListHeaderLine, t)!,

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -11,6 +11,19 @@ ThemeData zulipThemeData(BuildContext context) {
   final DesignVariables designVariables;
   final List<ThemeExtension> themeExtensions;
   Brightness brightness = MediaQuery.platformBrightnessOf(context);
+
+  // This applies Material 3's color system to produce a palette of
+  // appropriately matching and contrasting colors for use in a UI.
+  // The Zulip brand color is a starting point, but doesn't end up as
+  // one that's directly used.  (After all, we didn't design it for that
+  // purpose; we designed a logo.)  See docs:
+  //   https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html
+  // Or try this tool to see the whole palette:
+  //   https://m3.material.io/theme-builder#/custom
+  final colorScheme = ColorScheme.fromSeed(
+    brightness: brightness,
+    seedColor: kZulipBrandColor);
+
   switch (brightness) {
     case Brightness.light: {
       designVariables = DesignVariables.light();
@@ -38,6 +51,10 @@ ThemeData zulipThemeData(BuildContext context) {
     extensions: themeExtensions,
     iconButtonTheme: IconButtonThemeData(style: IconButton.styleFrom(
       foregroundColor: designVariables.icon,
+    )),
+    elevatedButtonTheme: ElevatedButtonThemeData(style: ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.secondaryContainer,
+      foregroundColor: colorScheme.onSecondaryContainer,
     )),
     appBarTheme: AppBarTheme(
       // Set these two fields to prevent a color change in [AppBar]s when
@@ -74,18 +91,7 @@ ThemeData zulipThemeData(BuildContext context) {
         strokeAlign: BorderSide.strokeAlignInside, // (default restated for explicitness)
       )),
     ),
-    // This applies Material 3's color system to produce a palette of
-    // appropriately matching and contrasting colors for use in a UI.
-    // The Zulip brand color is a starting point, but doesn't end up as
-    // one that's directly used.  (After all, we didn't design it for that
-    // purpose; we designed a logo.)  See docs:
-    //   https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html
-    // Or try this tool to see the whole palette:
-    //   https://m3.material.io/theme-builder#/custom
-    colorScheme: ColorScheme.fromSeed(
-      brightness: brightness,
-      seedColor: kZulipBrandColor,
-    ),
+    colorScheme: colorScheme,
     scaffoldBackgroundColor: designVariables.mainBackground,
     tooltipTheme: const TooltipThemeData(preferBelow: false),
     bottomSheetTheme: BottomSheetThemeData(

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -44,6 +44,7 @@ extension IconChecks on Subject<Icon> {
 }
 
 extension RouteChecks<T> on Subject<Route<T>> {
+  Subject<bool> get isFirst => has((r) => r.isFirst, 'isFirst');
   Subject<RouteSettings> get settings => has((r) => r.settings, 'settings');
 }
 

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -125,6 +125,7 @@ class TestGlobalStore extends GlobalStore {
   }
 
   static const Duration removeAccountDuration = Duration(milliseconds: 1);
+  Duration? loadPerAccountDuration;
 
   /// Consume the log of calls made to [doRemoveAccount].
   List<int> takeDoRemoveAccountCalls() {
@@ -142,7 +143,10 @@ class TestGlobalStore extends GlobalStore {
   }
 
   @override
-  Future<PerAccountStore> doLoadPerAccount(int accountId) {
+  Future<PerAccountStore> doLoadPerAccount(int accountId) async {
+    if (loadPerAccountDuration != null) {
+      await Future<void>.delayed(loadPerAccountDuration!);
+    }
     final initialSnapshot = _initialSnapshots[accountId]!;
     final store = PerAccountStore.fromInitialSnapshot(
       globalStore: this,

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -22,7 +22,6 @@ import 'package:zulip/notifications/receive.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/color.dart';
 import 'package:zulip/widgets/home.dart';
-import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/theme.dart';
@@ -930,15 +929,12 @@ void main() {
 
     void takeStartingRoutes({bool withAccount = true}) {
       final expected = <Condition<Object?>>[
-        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
-        if (withAccount) ...[
+        if (withAccount)
           (it) => it.isA<MaterialAccountWidgetRoute>()
             ..accountId.equals(eg.selfAccount.id)
-            ..page.isA<HomePage>(),
-          (it) => it.isA<MaterialAccountWidgetRoute>()
-            ..accountId.equals(eg.selfAccount.id)
-            ..page.isA<InboxPage>(),
-        ],
+            ..page.isA<HomePage>()
+        else
+          (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
       ];
       check(pushedRoutes.take(expected.length)).deepEquals(expected);
       pushedRoutes.removeRange(0, expected.length);

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -21,6 +21,7 @@ import 'package:zulip/widgets/action_sheet.dart';
 import 'package:zulip/widgets/app_bar.dart';
 import 'package:zulip/widgets/compose_box.dart';
 import 'package:zulip/widgets/content.dart';
+import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/message_list.dart';
@@ -125,8 +126,9 @@ void main() {
     testWidgets('show from inbox', (tester) async {
       await prepare();
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-        child: const InboxPage()));
+        child: const HomePage()));
       await tester.pump();
+      check(find.byType(InboxPageBody)).findsOne();
 
       await tester.longPress(find.text(topic));
       // sheet appears onscreen; default duration of bottom-sheet enter animation

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -182,8 +182,12 @@ void main() {
 
       final pushedRoutes = <Route<dynamic>>[];
       testNavObserver.onPushed = (route, prevRoute) => pushedRoutes.add(route);
-      final account1Route = InboxPage.buildRoute(accountId: account1.id);
-      final account2Route = InboxPage.buildRoute(accountId: account2.id);
+      // TODO(#737): switch to a realistic setup:
+      //   https://github.com/zulip/zulip-flutter/pull/1076#discussion_r1874124363
+      final account1Route = MaterialAccountWidgetRoute(
+        accountId: account1.id, page: const InboxPageBody());
+      final account2Route = MaterialAccountWidgetRoute(
+        accountId: account2.id, page: const InboxPageBody());
       unawaited(navigator.push(account1Route));
       unawaited(navigator.push(account2Route));
       await tester.pumpAndSettle();

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,7 +7,6 @@ import 'package:zulip/log.dart';
 import 'package:zulip/model/database.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/home.dart';
-import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/page.dart';
 
 import '../example_data.dart' as eg;
@@ -41,7 +42,7 @@ void main() {
       ]);
     });
 
-    testWidgets('when have accounts, go to inbox for first account', (tester) async {
+    testWidgets('when have accounts, go to home page for first account', (tester) async {
       // We'll need per-account data for the account that a page will be opened
       // for, but not for the other account.
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
@@ -49,13 +50,9 @@ void main() {
       await prepare(tester);
 
       check(pushedRoutes).deepEquals(<Condition<Object?>>[
-        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
         (it) => it.isA<MaterialAccountWidgetRoute>()
           ..accountId.equals(eg.selfAccount.id)
           ..page.isA<HomePage>(),
-        (it) => it.isA<MaterialAccountWidgetRoute>()
-          ..accountId.equals(eg.selfAccount.id)
-          ..page.isA<InboxPage>(),
       ]);
     });
   });
@@ -160,6 +157,46 @@ void main() {
       check(tester.getRect(findButton(withText: buttonText)))
         ..top.isGreaterThan(1 / 3 * screenHeight)
         ..bottom.isLessThan(2 / 3 * screenHeight);
+    });
+
+    testWidgets('choosing an account clears the navigator stack', (tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      await testBinding.globalStore.add(eg.otherAccount, eg.initialSnapshot());
+
+      final pushedRoutes = <Route<void>>[];
+      final poppedRoutes = <Route<void>>[];
+      final testNavObserver = TestNavigatorObserver();
+      testNavObserver.onPushed = (route, prevRoute) => pushedRoutes.add(route);
+      testNavObserver.onPopped = (route, prevRoute) => poppedRoutes.add(route);
+      testNavObserver.onReplaced = (route, prevRoute) {
+        poppedRoutes.add(prevRoute!);
+        pushedRoutes.add(route!);
+      };
+      await tester.pumpWidget(ZulipApp(navigatorObservers: [testNavObserver]));
+      await tester.pump();
+
+      final navigator = await ZulipApp.navigator;
+      unawaited(navigator.push(
+        MaterialWidgetRoute(page: const ChooseAccountPage())));
+      await tester.pump();
+      await tester.pump();
+
+      check(poppedRoutes).isEmpty();
+      check(pushedRoutes).deepEquals(<Condition<Object?>>[
+        (it) => it.isA<MaterialAccountWidgetRoute>()
+          ..accountId.equals(eg.selfAccount.id)
+          ..page.isA<HomePage>(),
+        (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>()
+      ]);
+      pushedRoutes.clear();
+
+      await tester.tap(find.text(eg.otherAccount.email));
+      await tester.pump();
+      check(poppedRoutes).length.equals(2);
+      check(pushedRoutes).single.isA<MaterialAccountWidgetRoute>()
+        ..accountId.equals(eg.otherAccount.id)
+        ..page.isA<HomePage>();
     });
 
     group('log out', () {

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -24,31 +24,31 @@ void main() {
   group('ZulipApp initial navigation', () {
     late List<Route<dynamic>> pushedRoutes = [];
 
-    Future<List<Route<dynamic>>> initialRoutes(WidgetTester tester) async {
+    Future<void> prepare(WidgetTester tester) async {
+      addTearDown(testBinding.reset);
+
       pushedRoutes = [];
       final testNavObserver = TestNavigatorObserver()
         ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
       await tester.pumpWidget(ZulipApp(navigatorObservers: [testNavObserver]));
       await tester.pump();
-      return pushedRoutes;
     }
 
     testWidgets('when no accounts, go to choose account', (tester) async {
-      addTearDown(testBinding.reset);
-      check(await initialRoutes(tester)).deepEquals(<Condition<Object?>>[
+      await prepare(tester);
+      check(pushedRoutes).deepEquals(<Condition<Object?>>[
         (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
       ]);
     });
 
     testWidgets('when have accounts, go to inbox for first account', (tester) async {
-      addTearDown(testBinding.reset);
-
       // We'll need per-account data for the account that a page will be opened
       // for, but not for the other account.
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       await testBinding.globalStore.insertAccount(eg.otherAccount.toCompanion(false));
+      await prepare(tester);
 
-      check(await initialRoutes(tester)).deepEquals(<Condition<Object?>>[
+      check(pushedRoutes).deepEquals(<Condition<Object?>>[
         (it) => it.isA<WidgetRoute>().page.isA<ChooseAccountPage>(),
         (it) => it.isA<MaterialAccountWidgetRoute>()
           ..accountId.equals(eg.selfAccount.id)

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -1,0 +1,411 @@
+import 'package:checks/checks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/model/events.dart';
+import 'package:zulip/model/store.dart';
+import 'package:zulip/widgets/app.dart';
+import 'package:zulip/widgets/app_bar.dart';
+import 'package:zulip/widgets/home.dart';
+import 'package:zulip/widgets/icons.dart';
+import 'package:zulip/widgets/inbox.dart';
+import 'package:zulip/widgets/page.dart';
+import 'package:zulip/widgets/profile.dart';
+import 'package:zulip/widgets/subscription_list.dart';
+import 'package:zulip/widgets/theme.dart';
+
+import '../api/fake_api.dart';
+import '../example_data.dart' as eg;
+import '../flutter_checks.dart';
+import '../model/binding.dart';
+import '../model/test_store.dart';
+import 'page_checks.dart';
+import 'test_app.dart';
+
+void main () {
+  TestZulipBinding.ensureInitialized();
+
+  late PerAccountStore store;
+
+  Future<void> prepare(WidgetTester tester) async {
+    addTearDown(testBinding.reset);
+    await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+    store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+
+    await store.addUsers([eg.selfUser, eg.otherUser]);
+    final stream = eg.stream();
+    await store.addStream(stream);
+    await store.addSubscription(eg.subscription(stream));
+
+    await tester.pumpWidget(TestZulipApp(
+      accountId: eg.selfAccount.id,
+      child: const HomePage()));
+    await tester.pump();
+  }
+
+  group('bottom nav navigation', () {
+    testWidgets('preserve states when switching between views', (tester) async {
+      await prepare(tester);
+      await store.handleEvent(MessageEvent(
+        id: 0, message: eg.dmMessage(from: eg.otherUser, to: [eg.selfUser])));
+      await tester.pump();
+
+      check(find.byIcon(ZulipIcons.arrow_down)).findsExactly(2);
+      check(find.byIcon(ZulipIcons.arrow_right)).findsNothing();
+
+      // Collapsing the header updates inbox's internal state.
+      await tester.tap(find.byIcon(ZulipIcons.arrow_down).first);
+      await tester.pump();
+      check(find.byIcon(ZulipIcons.arrow_down)).findsNothing();
+      check(find.byIcon(ZulipIcons.arrow_right)).findsExactly(2);
+
+      // Switch to channels view.
+      await tester.tap(find.byIcon(ZulipIcons.hash_italic));
+      await tester.pump();
+      check(find.byIcon(ZulipIcons.arrow_down)).findsNothing();
+      check(find.byIcon(ZulipIcons.arrow_right)).findsNothing();
+
+      // The header should remain collapsed when we return to the inbox.
+      await tester.tap(find.byIcon(ZulipIcons.inbox));
+      await tester.pump();
+      check(find.byIcon(ZulipIcons.arrow_down)).findsNothing();
+      check(find.byIcon(ZulipIcons.arrow_right)).findsExactly(2);
+    });
+
+    testWidgets('update app bar title when switching between views', (tester) async {
+      await prepare(tester);
+
+      check(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.text('Inbox'))).findsOne();
+
+      await tester.tap(find.byIcon(ZulipIcons.hash_italic));
+      await tester.pump();
+      check(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.text('Channels'))).findsOne();
+
+      await tester.tap(find.byIcon(ZulipIcons.user));
+      await tester.pump();
+      check(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.text('Direct messages'))).findsOne();
+    });
+  });
+
+  group('menu', () {
+    final designVariables = DesignVariables.light();
+
+    final inboxMenuIconFinder = find.descendant(
+      of: find.byType(BottomSheet),
+      matching: find.byIcon(ZulipIcons.inbox));
+    final channelsMenuIconFinder = find.descendant(
+      of: find.byType(BottomSheet),
+      matching: find.byIcon(ZulipIcons.hash_italic));
+    final combinedFeedMenuIconFinder = find.descendant(
+      of: find.byType(BottomSheet),
+      matching: find.byIcon(ZulipIcons.message_feed));
+
+    Future<void> tapOpenMenu(WidgetTester tester) async {
+      await tester.tap(find.byIcon(ZulipIcons.menu));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+      check(find.byType(BottomSheet)).findsOne();
+    }
+
+    void checkIconSelected(WidgetTester tester, Finder finder) {
+      check(tester.widget(finder)).isA<Icon>().color.isNotNull()
+        .isSameColorAs(designVariables.iconSelected);
+    }
+
+    void checkIconNotSelected(WidgetTester tester, Finder finder) {
+      check(tester.widget(finder)).isA<Icon>().color.isNotNull()
+        .isSameColorAs(designVariables.icon);
+    }
+
+    testWidgets('navigation states reflect on navigation bar menu buttons', (tester) async {
+      await prepare(tester);
+
+      await tapOpenMenu(tester);
+      checkIconSelected(tester, inboxMenuIconFinder);
+      checkIconNotSelected(tester, channelsMenuIconFinder);
+      await tester.tap(find.text('Cancel'));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+
+      await tester.tap(find.byIcon(ZulipIcons.hash_italic));
+      await tester.pump();
+
+      await tapOpenMenu(tester);
+      checkIconNotSelected(tester, inboxMenuIconFinder);
+      checkIconSelected(tester, channelsMenuIconFinder);
+    });
+
+    testWidgets('navigation bar menu buttons control navigation states', (tester) async {
+      await prepare(tester);
+
+      await tapOpenMenu(tester);
+      checkIconSelected(tester, inboxMenuIconFinder);
+      checkIconNotSelected(tester, channelsMenuIconFinder);
+      check(find.byType(InboxPageBody)).findsOne();
+      check(find.byType(SubscriptionListPageBody)).findsNothing();
+
+      await tester.tap(channelsMenuIconFinder);
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+      check(find.byType(BottomSheet)).findsNothing();
+      check(find.byType(InboxPageBody)).findsNothing();
+      check(find.byType(SubscriptionListPageBody)).findsOne();
+
+      await tapOpenMenu(tester);
+      checkIconNotSelected(tester, inboxMenuIconFinder);
+      checkIconSelected(tester, channelsMenuIconFinder);
+    });
+
+    testWidgets('navigation bar menu buttons dismiss the menu', (tester) async {
+      await prepare(tester);
+      await tapOpenMenu(tester);
+
+      await tester.tap(channelsMenuIconFinder);
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+      check(find.byType(BottomSheet)).findsNothing();
+    });
+
+    testWidgets('cancel button dismisses the menu', (tester) async {
+      await prepare(tester);
+      await tapOpenMenu(tester);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+      check(find.byType(BottomSheet)).findsNothing();
+    });
+
+    testWidgets('menu buttons dismiss the menu', (tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+
+      await tester.pumpWidget(const ZulipApp());
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      final connection = store.connection as FakeApiConnection;
+      await tester.pump();
+
+      await tapOpenMenu(tester);
+
+      connection.prepare(json: eg.newestGetMessagesResult(
+        foundOldest: true, messages: [eg.streamMessage()]).toJson());
+      await tester.tap(combinedFeedMenuIconFinder);
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+
+      // When we go back to the home page, the menu sheet should be gone.
+      (await ZulipApp.navigator).pop();
+      await tester.pump(const Duration(milliseconds: 350)); // wait for pop animation
+      check(find.byType(BottomSheet)).findsNothing();
+    });
+
+    testWidgets('_MyProfileButton', (tester) async {
+      await prepare(tester);
+      await tapOpenMenu(tester);
+
+      await tester.tap(find.text('My profile'));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+      check(find.byType(ProfilePage)).findsOne();
+      check(find.text(eg.selfUser.fullName)).findsAny();
+    });
+  });
+
+  group('_LoadingPlaceholderPage', () {
+    const loadPerAccountDuration = Duration(seconds: 30);
+    assert(loadPerAccountDuration > kTryAnotherAccountWaitPeriod);
+
+    void checkOnLoadingPage() {
+      check(find.byType(CircularProgressIndicator).hitTestable()).findsOne();
+      check(find.byType(ChooseAccountPage)).findsNothing();
+      check(find.byType(HomePage)).findsNothing();
+    }
+
+    void checkOnChooseAccountPage() {
+      // Ignore the possible loading page in the background.
+      check(find.byType(CircularProgressIndicator).hitTestable()).findsNothing();
+      check(find.byType(ChooseAccountPage)).findsOne();
+      check(find.byType(HomePage)).findsNothing();
+    }
+
+    ModalRoute<void>? getRouteOf(WidgetTester tester, Finder finder) =>
+      ModalRoute.of(tester.element(finder));
+
+    void checkOnHomePage(WidgetTester tester, {required Account expectedAccount}) {
+      check(find.byType(CircularProgressIndicator)).findsNothing();
+      check(find.byType(ChooseAccountPage)).findsNothing();
+      check(find.byType(HomePage).hitTestable()).findsOne();
+      check(getRouteOf(tester, find.byType(HomePage)))
+        .isA<MaterialAccountWidgetRoute>().accountId.equals(expectedAccount.id);
+    }
+
+    Future<void> prepare(WidgetTester tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      await testBinding.globalStore.add(eg.otherAccount, eg.initialSnapshot());
+      await tester.pumpWidget(const ZulipApp());
+      await tester.pump(Duration.zero); // wait for the loading page
+      checkOnLoadingPage();
+    }
+
+    Future<void> tapChooseAccount(WidgetTester tester) async {
+      await tester.tap(find.text('Try another account'));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 250)); // wait for animation
+      checkOnChooseAccountPage();
+    }
+
+    Future<void> chooseAccountWithEmail(WidgetTester tester, String email) async {
+      await tester.tap(find.text(email));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 350)); // wait for push & pop animations
+      checkOnLoadingPage();
+    }
+
+    testWidgets('smoke', (tester) async {
+      addTearDown(testBinding.reset);
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      await tester.pump(loadPerAccountDuration);
+      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+    });
+
+    testWidgets('"Try another account" button appears after timeout', (tester) async {
+      addTearDown(testBinding.reset);
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      checkOnLoadingPage();
+      check(find.text('Try another account').hitTestable()).findsNothing();
+
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      checkOnLoadingPage();
+      check(find.text('Try another account').hitTestable()).findsOne();
+
+      await tester.pump(loadPerAccountDuration);
+      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+    });
+
+    testWidgets('while loading, go back from ChooseAccountPage', (tester) async {
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      await tapChooseAccount(tester);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 350)); // wait for pop animation
+      checkOnLoadingPage();
+
+      await tester.pump(loadPerAccountDuration);
+      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+    });
+
+    testWidgets('while loading, choose a different account', (tester) async {
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      await tapChooseAccount(tester);
+
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration * 2;
+      await chooseAccountWithEmail(tester, eg.otherAccount.email);
+
+      await tester.pump(loadPerAccountDuration);
+      // The second loadPerAccount is still pending.
+      checkOnLoadingPage();
+
+      await tester.pump(loadPerAccountDuration);
+      // The second loadPerAccount finished.
+      checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+    });
+
+    testWidgets('while loading, choosing an account disallows going back', (tester) async {
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      await tapChooseAccount(tester);
+
+      // While still loading, choose a different account.
+      await chooseAccountWithEmail(tester, eg.otherAccount.email);
+
+      // User cannot go back because the navigator stack
+      // was cleared after choosing an account.
+      check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
+        .isNotNull().isFirst.isTrue();
+
+      await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
+      checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+    });
+
+    testWidgets('while loading, go to nested levels of ChooseAccountPage', (tester) async {
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      final thirdAccount = eg.account(user: eg.thirdUser);
+      await testBinding.globalStore.add(thirdAccount, eg.initialSnapshot());
+      await prepare(tester);
+
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      // While still loading the first account, choose a different account.
+      await tapChooseAccount(tester);
+      await chooseAccountWithEmail(tester, eg.otherAccount.email);
+      // User cannot go back because the navigator stack
+      // was cleared after choosing an account.
+      check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
+        .isA<MaterialAccountWidgetRoute>()
+          ..isFirst.isTrue()
+          ..accountId.equals(eg.otherAccount.id);
+
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      // While still loading the second account, choose a different account.
+      await tapChooseAccount(tester);
+      await chooseAccountWithEmail(tester, thirdAccount.email);
+      // User cannot go back because the navigator stack
+      // was cleared after choosing an account.
+      check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
+        .isA<MaterialAccountWidgetRoute>()
+          ..isFirst.isTrue()
+          ..accountId.equals(thirdAccount.id);
+
+      await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
+      checkOnHomePage(tester, expectedAccount: thirdAccount);
+    });
+
+    testWidgets('after finishing loading, go back from ChooseAccountPage', (tester) async {
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      await tapChooseAccount(tester);
+
+      // Stall while on ChoooseAccountPage so that the account finished loading.
+      await tester.pump(loadPerAccountDuration);
+      checkOnChooseAccountPage();
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 350)); // wait for pop animation
+      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+    });
+
+    testWidgets('after finishing loading, choose the loaded account', (tester) async {
+      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+      await prepare(tester);
+      await tester.pump(kTryAnotherAccountWaitPeriod);
+      await tapChooseAccount(tester);
+
+      // Stall while on ChoooseAccountPage so that the account finished loading.
+      await tester.pump(loadPerAccountDuration);
+      checkOnChooseAccountPage();
+
+      // Choosing the already loaded account should result in no loading page.
+      await tester.tap(find.text(eg.selfAccount.email));
+      await tester.pump(Duration.zero); // tap the button
+      await tester.pump(const Duration(milliseconds: 350)); // wait for push & pop animations
+      // No additional wait for loadPerAccount.
+      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+    });
+  });
+}

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -6,8 +6,8 @@ import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/color.dart';
+import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
-import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/channel_colors.dart';
 
 import '../example_data.dart' as eg;
@@ -76,7 +76,7 @@ void main() {
     await tester.pumpWidget(TestZulipApp(
       accountId: eg.selfAccount.id,
       navigatorObservers: [if (navigatorObserver != null) navigatorObserver],
-      child: const InboxPage(),
+      child: const HomePage(),
     ));
     await tester.pump();
 

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -96,8 +96,6 @@ void main() {
       final navigator = await ZulipApp.navigator;
       unawaited(navigator.push(LoginPage.buildRoute(serverSettings: serverSettings)));
       await tester.pumpAndSettle();
-      takeStartingRoutes();
-      check(pushedRoutes).isEmpty();
     }
 
     final findUsernameInput = find.byWidgetPredicate((widget) =>
@@ -136,6 +134,8 @@ void main() {
       testWidgets('basic happy case', (tester) async {
         final serverSettings = eg.serverSettings();
         await prepare(tester, serverSettings);
+        takeStartingRoutes();
+        check(pushedRoutes).isEmpty();
         check(testBinding.globalStore.accounts).isEmpty();
 
         await login(tester, eg.selfAccount);
@@ -147,6 +147,8 @@ void main() {
       testWidgets('trims whitespace on username', (tester) async {
         final serverSettings = eg.serverSettings();
         await prepare(tester, serverSettings);
+        takeStartingRoutes();
+        check(pushedRoutes).isEmpty();
         check(testBinding.globalStore.accounts).isEmpty();
 
         await tester.enterText(findUsernameInput, '  ${eg.selfAccount.email}  ');
@@ -168,6 +170,8 @@ void main() {
       testWidgets('account already exists', (tester) async {
         final serverSettings = eg.serverSettings();
         await prepare(tester, serverSettings);
+        takeStartingRoutes();
+        check(pushedRoutes).isEmpty();
         check(testBinding.globalStore.accounts).isEmpty();
         await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
 
@@ -207,6 +211,8 @@ void main() {
           externalAuthenticationMethods: [method]);
         prepareBoringImageHttpClient(); // icon on social-auth button
         await prepare(tester, serverSettings);
+        takeStartingRoutes();
+        check(pushedRoutes).isEmpty();
         check(testBinding.globalStore.accounts).isEmpty();
 
         const otp = '186f6d085a5621ebaf1ccfc05033e8acba57dae03f061705ac1e58c402c30a31';

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -6,6 +6,7 @@ import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/widgets/content.dart';
+import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
@@ -49,10 +50,16 @@ Future<void> setupPage(WidgetTester tester, {
   await tester.pumpWidget(TestZulipApp(
     accountId: eg.selfAccount.id,
     navigatorObservers: navigatorObserver != null ? [navigatorObserver] : [],
-    child: const RecentDmConversationsPage()));
+    child: const HomePage()));
 
   // global store, per-account store, and page get loaded
   await tester.pumpAndSettle();
+
+  // Switch to direct messages tab.
+  await tester.tap(find.descendant(
+    of: find.byType(Center),
+    matching: find.byIcon(ZulipIcons.user)));
+  await tester.pump();
 }
 
 void main() {
@@ -96,7 +103,7 @@ void main() {
         DmNarrow.ofMessage(messages.first, selfUserId: eg.selfUser.userId));
 
       check(tester.any(oldestConversationFinder)).isFalse(); // not onscreen
-      await tester.fling(find.byType(RecentDmConversationsPage),
+      await tester.fling(find.byType(RecentDmConversationsPageBody),
         const Offset(0, -200), 4000);
       await tester.pumpAndSettle();
       check(tester.any(oldestConversationFinder)).isTrue(); // onscreen

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/widgets/color.dart';
+import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/channel_colors.dart';
 import 'package:zulip/widgets/subscription_list.dart';
@@ -34,10 +35,14 @@ void main() {
     await testBinding.globalStore.add(eg.selfAccount, initialSnapshot);
 
     await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-      child: const SubscriptionListPage()));
+      child: const HomePage()));
 
     // global store, per-account store
     await tester.pumpAndSettle();
+
+    // Switch to channels tab.
+    await tester.tap(find.byIcon(ZulipIcons.hash_italic));
+    await tester.pump();
   }
 
   bool isPinnedHeaderInTree() {


### PR DESCRIPTION
This is stacked on top of some commits cherry-picked from #1041:
* action_sheet [nfc]: Use a generalized name for the cancel button
* action_sheet [nfc]: Extract ActionSheetMenuItemButton

See also: [CZO discussion](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Buttons.20on.20the.20bottom.20tabs.20and.20main.20menu)

<details>
<summary>Screenshots</summary>

| light | dark |
| - | - |
|  ![1000015700](https://github.com/user-attachments/assets/2025dbbb-b4b5-4069-b7c5-0881e853297e) | ![1000015702](https://github.com/user-attachments/assets/7fedf362-ec97-4e05-bcd6-93482a8e3b02) |
| ![1000015701](https://github.com/user-attachments/assets/e0473062-3e27-4058-b967-1713dd2e72cc) | ![1000015703](https://github.com/user-attachments/assets/c94976ba-9aff-4dc6-bf6a-e8d663ad59a6) |

</details>

Fixes: #1035