### PR TITLE
api: Cut ZulipStream.canRemoveSubscribersGroup as it changes format

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -439,9 +439,6 @@ class ChannelUpdateEvent extends ChannelEvent {
         return value as int?;
       case ChannelPropertyName.channelPostPolicy:
         return ChannelPostPolicy.fromApiValue(value as int);
-      case ChannelPropertyName.canRemoveSubscribersGroup:
-      case ChannelPropertyName.canRemoveSubscribersGroupId:
-        return value as int;
       case ChannelPropertyName.streamWeeklyTraffic:
         return value as int?;
       case null:

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -268,9 +268,6 @@ const _$ChannelPropertyNameEnumMap = {
   ChannelPropertyName.inviteOnly: 'invite_only',
   ChannelPropertyName.messageRetentionDays: 'message_retention_days',
   ChannelPropertyName.channelPostPolicy: 'stream_post_policy',
-  ChannelPropertyName.canRemoveSubscribersGroup: 'can_remove_subscribers_group',
-  ChannelPropertyName.canRemoveSubscribersGroupId:
-      'can_remove_subscribers_group_id',
   ChannelPropertyName.streamWeeklyTraffic: 'stream_weekly_traffic',
 };
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -342,18 +342,10 @@ class ZulipStream {
   ChannelPostPolicy channelPostPolicy;
   // final bool isAnnouncementOnly; // deprecated for `channelPostPolicy`; ignore
 
-  // TODO(server-6): `canRemoveSubscribersGroupId` added in FL 142
-  // TODO(server-8): in FL 197 renamed to `canRemoveSubscribersGroup`
-  @JsonKey(readValue: _readCanRemoveSubscribersGroup)
-  int? canRemoveSubscribersGroup;
+  // GroupSettingsValue canRemoveSubscribersGroup; // TODO(#814)
 
   // TODO(server-8): added in FL 199, was previously only on [Subscription] objects
   int? streamWeeklyTraffic;
-
-  static int? _readCanRemoveSubscribersGroup(Map<dynamic, dynamic> json, String key) {
-    return (json[key] as int?)
-      ?? (json['can_remove_subscribers_group_id'] as int?);
-  }
 
   ZulipStream({
     required this.streamId,
@@ -367,7 +359,6 @@ class ZulipStream {
     required this.historyPublicToSubscribers,
     required this.messageRetentionDays,
     required this.channelPostPolicy,
-    required this.canRemoveSubscribersGroup,
     required this.streamWeeklyTraffic,
   });
 
@@ -478,7 +469,6 @@ class Subscription extends ZulipStream {
     required super.historyPublicToSubscribers,
     required super.messageRetentionDays,
     required super.channelPostPolicy,
-    required super.canRemoveSubscribersGroup,
     required super.streamWeeklyTraffic,
     required this.desktopNotifications,
     required this.emailNotifications,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -388,8 +388,8 @@ enum ChannelPropertyName {
   messageRetentionDays,
   @JsonValue('stream_post_policy')
   channelPostPolicy,
-  canRemoveSubscribersGroup,
-  canRemoveSubscribersGroupId, // TODO(server-8): remove, replaced by canRemoveSubscribersGroup
+  // canRemoveSubscribersGroup, // TODO(#814)
+  // canRemoveSubscribersGroupId, // TODO(#814) handle // TODO(server-8) remove
   streamWeeklyTraffic;
 
   /// Get a [ChannelPropertyName] from a raw, snake-case string we recognize, else null.

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -400,9 +400,6 @@ const _$ChannelPropertyNameEnumMap = {
   ChannelPropertyName.inviteOnly: 'invite_only',
   ChannelPropertyName.messageRetentionDays: 'message_retention_days',
   ChannelPropertyName.channelPostPolicy: 'stream_post_policy',
-  ChannelPropertyName.canRemoveSubscribersGroup: 'can_remove_subscribers_group',
-  ChannelPropertyName.canRemoveSubscribersGroupId:
-      'can_remove_subscribers_group_id',
   ChannelPropertyName.streamWeeklyTraffic: 'stream_weekly_traffic',
 };
 

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -171,9 +171,6 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
       messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
       channelPostPolicy:
           $enumDecode(_$ChannelPostPolicyEnumMap, json['stream_post_policy']),
-      canRemoveSubscribersGroup: (ZulipStream._readCanRemoveSubscribersGroup(
-              json, 'can_remove_subscribers_group') as num?)
-          ?.toInt(),
       streamWeeklyTraffic: (json['stream_weekly_traffic'] as num?)?.toInt(),
     );
 
@@ -190,7 +187,6 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.channelPostPolicy,
-      'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
     };
 
@@ -215,9 +211,6 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
       channelPostPolicy:
           $enumDecode(_$ChannelPostPolicyEnumMap, json['stream_post_policy']),
-      canRemoveSubscribersGroup: (ZulipStream._readCanRemoveSubscribersGroup(
-              json, 'can_remove_subscribers_group') as num?)
-          ?.toInt(),
       streamWeeklyTraffic: (json['stream_weekly_traffic'] as num?)?.toInt(),
       desktopNotifications: json['desktop_notifications'] as bool?,
       emailNotifications: json['email_notifications'] as bool?,
@@ -242,7 +235,6 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.channelPostPolicy,
-      'can_remove_subscribers_group': instance.canRemoveSubscribersGroup,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
       'desktop_notifications': instance.desktopNotifications,
       'email_notifications': instance.emailNotifications,

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -279,9 +279,6 @@ class ChannelStoreImpl with ChannelStore {
             stream.messageRetentionDays = event.value as int?;
           case ChannelPropertyName.channelPostPolicy:
             stream.channelPostPolicy = event.value as ChannelPostPolicy;
-          case ChannelPropertyName.canRemoveSubscribersGroup:
-          case ChannelPropertyName.canRemoveSubscribersGroupId:
-            break; // not tracking this property
           case ChannelPropertyName.streamWeeklyTraffic:
             stream.streamWeeklyTraffic = event.value as int?;
         }

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -281,7 +281,7 @@ class ChannelStoreImpl with ChannelStore {
             stream.channelPostPolicy = event.value as ChannelPostPolicy;
           case ChannelPropertyName.canRemoveSubscribersGroup:
           case ChannelPropertyName.canRemoveSubscribersGroupId:
-            stream.canRemoveSubscribersGroup = event.value as int?;
+            break; // not tracking this property
           case ChannelPropertyName.streamWeeklyTraffic:
             stream.streamWeeklyTraffic = event.value as int?;
         }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -906,9 +906,12 @@ class UpdateMachine {
     while (true) {
       try {
         return await registerQueue(connection);
-      } catch (e) {
-        assert(debugLog('Error fetching initial snapshot: $e\n'
-          'Backing off, then will retry…'));
+      } catch (e, s) {
+        assert(debugLog('Error fetching initial snapshot: $e'));
+        // Print stack trace in its own log entry; log entries are truncated
+        // at 1 kiB (at least on Android), and stack can be longer than that.
+        assert(debugLog('Stack:\n$s'));
+        assert(debugLog('Backing off, then will retry…'));
         // TODO tell user if initial-fetch errors persist, or look non-transient
         await (backoffMachine ??= BackoffMachine()).wait();
         assert(debugLog('… Backoff wait complete, retrying initial fetch.'));

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -22,7 +22,6 @@ extension UserChecks on Subject<User> {
 }
 
 extension ZulipStreamChecks on Subject<ZulipStream> {
-  Subject<int?> get canRemoveSubscribersGroup => has((e) => e.canRemoveSubscribersGroup, 'canRemoveSubscribersGroup');
 }
 
 extension MessageChecks on Subject<Message> {

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -67,43 +67,6 @@ void main() {
     });
   });
 
-  group('ZulipStream.canRemoveSubscribersGroup', () {
-    final Map<String, dynamic> baseJson = Map.unmodifiable({
-      'stream_id': 123,
-      'name': 'A stream',
-      'description': 'A description',
-      'rendered_description': '<p>A description</p>',
-      'date_created': 1686774898,
-      'first_message_id': null,
-      'invite_only': false,
-      'is_web_public': false,
-      'history_public_to_subscribers': true,
-      'message_retention_days': null,
-      'stream_post_policy': ChannelPostPolicy.any.apiValue,
-      // 'can_remove_subscribers_group': null,
-      'stream_weekly_traffic': null,
-    });
-
-    test('smoke', () {
-      check(ZulipStream.fromJson({ ...baseJson,
-        'can_remove_subscribers_group': 123,
-      })).canRemoveSubscribersGroup.equals(123);
-    });
-
-    // TODO(server-8): field renamed in FL 197
-    test('support old can_remove_subscribers_group_id', () {
-      check(ZulipStream.fromJson({ ...baseJson,
-        'can_remove_subscribers_group_id': 456,
-      })).canRemoveSubscribersGroup.equals(456);
-    });
-
-    // TODO(server-6): field added in FL 142
-    test('support field missing', () {
-      check(ZulipStream.fromJson({ ...baseJson,
-      })).canRemoveSubscribersGroup.isNull();
-    });
-  });
-
   group('Subscription', () {
     test('converts color to int', () {
       Subscription subWithColor(String color) {

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -212,7 +212,6 @@ ZulipStream stream({
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
   ChannelPostPolicy? channelPostPolicy,
-  int? canRemoveSubscribersGroup,
   int? streamWeeklyTraffic,
 }) {
   _checkPositive(streamId, 'stream ID');
@@ -232,7 +231,6 @@ ZulipStream stream({
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
     channelPostPolicy: channelPostPolicy ?? ChannelPostPolicy.any,
-    canRemoveSubscribersGroup: canRemoveSubscribersGroup ?? 123,
     streamWeeklyTraffic: streamWeeklyTraffic,
   );
 }
@@ -270,7 +268,6 @@ Subscription subscription(
     historyPublicToSubscribers: stream.historyPublicToSubscribers,
     messageRetentionDays: stream.messageRetentionDays,
     channelPostPolicy: stream.channelPostPolicy,
-    canRemoveSubscribersGroup: stream.canRemoveSubscribersGroup,
     streamWeeklyTraffic: stream.streamWeeklyTraffic,
     desktopNotifications: desktopNotifications ?? false,
     emailNotifications: emailNotifications ?? false,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -786,8 +786,6 @@ ChannelUpdateEvent channelUpdateEvent(
       assert(value is int?);
     case ChannelPropertyName.channelPostPolicy:
       assert(value is ChannelPostPolicy);
-    case ChannelPropertyName.canRemoveSubscribersGroup:
-    case ChannelPropertyName.canRemoveSubscribersGroupId:
     case ChannelPropertyName.streamWeeklyTraffic:
       assert(value is int?);
   }


### PR DESCRIPTION
This field is becoming a group-setting value.  We haven't yet
implemented those (that's #814), so we can no longer handle this field
until we do that work.  Conveniently we weren't actually making any
use of this field, though -- so for now, just ignore it.

Fixes: #1082
