### PR TITLE
content [nfc]: Pull out parseUserMention, give regexp less to do

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -878,12 +878,24 @@ class _ZulipContentParser {
     final classes = element.className.split(' ')..sort();
     assert(classes.contains('user-mention')
         || classes.contains('user-group-mention'));
-    switch (classes) {
-      case ['user-mention' || 'user-group-mention']:
-      case ['silent', 'user-mention' || 'user-group-mention']:
-        break;
-      default:
-        return null;
+    int i = 0;
+
+    if (i >= classes.length) return null;
+    if (classes[i] == 'silent') {
+      // A silent @-mention.  We ignore this flag; see [UserMentionNode].
+      i++;
+    }
+
+    if (i >= classes.length) return null;
+    if (classes[i] == 'user-mention' || classes[i] == 'user-group-mention') {
+      // The class we already knew we'd find before we called this function.
+      // We ignore the distinction between these; see [UserMentionNode].
+      i++;
+    }
+
+    if (i != classes.length) {
+      // There was some class we didn't expect.
+      return null;
     }
 
     // TODO assert UserMentionNode can't contain LinkNode;

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -706,17 +706,15 @@ class UserMentionNode extends InlineContainerNode {
   const UserMentionNode({
     super.debugHtmlNode,
     required super.nodes,
-    // required this.mentionType,
-    // required this.isSilent,
   });
 
-  // We don't currently seem to need this information in code.  Instead,
+  // For the legacy design, we don't need this information in code; instead,
   // the inner text already shows how to communicate it to the user
   // (e.g., silent mentions' text lacks a leading "@"),
   // and we show that text in the same style for all types of @-mention.
-  // If we need this information in the future, go ahead and add it here.
-  //   final UserMentionType mentionType;
-  //   final bool isSilent;
+  // We'll need these for implementing the post-2023 Zulip design, though.
+  //   final UserMentionType mentionType; // TODO(#646)
+  //   final bool isSilent; // TODO(#647)
 }
 
 sealed class EmojiNode extends InlineContentNode {


### PR DESCRIPTION
This gives us more breathing room for making this handling more
complicated, as we'll need for the new "channel-wildcard-mention"
class (#1064) and for distinguishing different types of mentions (#646, #647).

Prompted by:
https://github.com/zulip/zulip-flutter/pull/1073#discussion_r1857421404
(/cc @sm-sayedi, @PIG208).