### PR TITLE
test: Handle emails more realistically in example data

### DIFF
--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -24,8 +24,7 @@ void main() {
     Future<http.BaseRequest> makeRequest(String realmUrl, String requestUrl, {
       bool? useAuth,
     }) {
-      final account = eg.account(user: eg.selfUser, apiKey: eg.selfAccount.apiKey,
-        realmUrl: Uri.parse(realmUrl));
+      final account = eg.selfAccount.copyWith(realmUrl: Uri.parse(realmUrl));
       return FakeApiConnection.with_(account: account, (connection) async {
         connection.prepare(json: {});
         final request = http.Request('GET', Uri.parse(requestUrl));

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -106,9 +106,8 @@ int _lastEmailSuffix = 1000;
 /// other data in the test, or if the IDs need to increase in a different order
 /// from the calls to [user].
 ///
-/// If `deliveryEmail` is not given, it will be generated from a
-/// random sequence of distinct strings.
-/// If `email` is not given, it will be set to `deliveryEmail`.
+/// If `email` is not given, it defaults to `deliveryEmail` if given,
+/// or else to a value resembling the Zulip server's generated fake emails.
 User user({
   int? userId,
   String? deliveryEmail,
@@ -121,12 +120,12 @@ User user({
   String? avatarUrl,
   Map<int, ProfileFieldUserData>? profileData,
 }) {
-  var effectiveDeliveryEmail = deliveryEmail ?? _nextEmail();
   _checkPositive(userId, 'user ID');
+  final effectiveUserId = userId ?? _nextUserId();
   return User(
-    userId: userId ?? _nextUserId(),
-    deliveryEmail: effectiveDeliveryEmail,
-    email: email ?? effectiveDeliveryEmail,
+    userId: effectiveUserId,
+    deliveryEmail: deliveryEmail,
+    email: email ?? deliveryEmail ?? 'user$effectiveUserId@${realmUrl.host}',
     fullName: fullName ?? 'A user', // TODO generate example names
     dateJoined: dateJoined ?? '2024-02-24T11:18+00:00',
     isActive: isActive ?? true,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -171,23 +171,23 @@ Account account({
   );
 }
 
-final User selfUser = user(fullName: 'Self User', email: 'self@example');
+final User selfUser = user(fullName: 'Self User');
 final Account selfAccount = account(
   id: 1001,
   user: selfUser,
   apiKey: 'dQcEJWTq3LczosDkJnRTwf31zniGvMrO', // A Zulip API key is 32 digits of base64.
 );
 
-final User otherUser = user(fullName: 'Other User', email: 'other@example');
+final User otherUser = user(fullName: 'Other User');
 final Account otherAccount = account(
   id: 1002,
   user: otherUser,
   apiKey: '6dxT4b73BYpCTU+i4BB9LAKC5h/CufqY', // A Zulip API key is 32 digits of base64.
 );
 
-final User thirdUser = user(fullName: 'Third User', email: 'third@example');
+final User thirdUser = user(fullName: 'Third User');
 
-final User fourthUser  = user(fullName: 'Fourth User', email: 'fourth@example');
+final User fourthUser  = user(fullName: 'Fourth User');
 
 ////////////////////////////////////////////////////////////////
 // Streams and subscriptions.

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -154,10 +154,14 @@ Account account({
   String? ackedPushToken,
 }) {
   _checkPositive(id, 'account ID');
+  // When `user.deliveryEmail` is null, using `user.email`
+  // wouldn't be realistic: it's going to be a fake email address
+  // generated to serve as a "Zulip API email".
+  final email = user.deliveryEmail ?? _nextEmail();
   return Account(
     id: id ?? 1000, // TODO generate example IDs
     realmUrl: realmUrl ?? _realmUrl,
-    email: user.email,
+    email: email,
     apiKey: apiKey ?? 'aeouasdf',
     userId: user.userId,
     zulipFeatureLevel: zulipFeatureLevel ?? recentZulipFeatureLevel,


### PR DESCRIPTION
Prompted by chat thread:
https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/ComposeAutocomplete.20test.20emailAddressVisbility.20help/near/1988541
(/cc @fombalang)

## Commit messages

api test: Fix a test to use Account.copyWith when it means that

The "auth headers sent by default" test below assumes that the
request is made with the email and API key of `eg.selfAccount`.
It happens to be true that `eg.account(user: eg.selfUser, …)`
will get that email, but that's a bit of an accident about
how eg.account works and what data is on eg.selfUser.

Instead of `eg.account`, use `eg.selfAccount.copyWith`, to make
the intention more explicit.

---

test: In eg.account use deliveryEmail or generate one, not user.email

This way we avoid using a source that in real data would be guaranteed
to be a fake email address: namely `user.email` for a user where
`user.deliveryEmail` is null.

---

test: Cut specific emails in eg.selfUser, eg.otherUser, and friends

Most of our tests don't and shouldn't care what the specific email
address of the user objects is.

I think these were originally here because `eg.user` didn't generate
fresh emails, so the caller needed to invent them in order to keep
them distinct.  But since d1a253856 it does, and the caller needn't.

---

test: Make eg.user more realistic about email and delivery email

This better reflects the fact that a User object will often have
null `deliveryEmail`, and that when that's the case it will have
a server-generated fake email address in `email`.
