### PR TITLE
compose: Refactor some logic; implement redesigned error banner

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -334,15 +334,15 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     if (composeBoxController == null) return;
     if (
       composeBoxController is StreamComposeBoxController
-      && composeBoxController.topicController.textNormalized == kNoTopicTopic
+      && composeBoxController.topic.textNormalized == kNoTopicTopic
       && message is StreamMessage
     ) {
-      composeBoxController.topicController.value = TextEditingValue(text: message.topic);
+      composeBoxController.topic.value = TextEditingValue(text: message.topic);
     }
 
     // This inserts a "[Quoting…]" placeholder into the content input,
     // giving the user a form of progress feedback.
-    final tag = composeBoxController.contentController
+    final tag = composeBoxController.content
       .registerQuoteAndReplyStart(PerAccountStoreWidget.of(pageContext),
         message: message,
       );
@@ -360,7 +360,7 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     // posting permission or when a DM recipient becomes deactivated.
     composeBoxController = findMessageListPage().composeBoxController;
     if (composeBoxController == null) return;
-    composeBoxController.contentController
+    composeBoxController.content
       .registerQuoteAndReplyEnd(PerAccountStoreWidget.of(pageContext), tag,
         message: message,
         rawContent: rawContent,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -14,6 +14,7 @@ import '../model/narrow.dart';
 import 'actions.dart';
 import 'clipboard.dart';
 import 'color.dart';
+import 'compose_box.dart';
 import 'dialog.dart';
 import 'icons.dart';
 import 'inset_shadow.dart';
@@ -331,13 +332,12 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     // or when a DM recipient becomes deactivated.
     var composeBoxController = findMessageListPage().composeBoxController;
     if (composeBoxController == null) return;
-    final topicController = composeBoxController.topicController;
     if (
-      topicController != null
-      && topicController.textNormalized == kNoTopicTopic
+      composeBoxController is StreamComposeBoxController
+      && composeBoxController.topicController.textNormalized == kNoTopicTopic
       && message is StreamMessage
     ) {
-      topicController.value = TextEditingValue(text: message.topic);
+      composeBoxController.topicController.value = TextEditingValue(text: message.topic);
     }
 
     // This inserts a "[Quoting…]" placeholder into the content input,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -326,12 +326,11 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
   @override void onPressed() async {
     final zulipLocalizations = ZulipLocalizations.of(pageContext);
 
-    // This will be null only if the compose box disappeared after the
-    // message action sheet opened, and before "Quote and reply" was pressed.
-    // This is rare: it happens when the self-user loses posting permission
-    // or when a DM recipient becomes deactivated.
     var composeBoxController = findMessageListPage().composeBoxController;
-    if (composeBoxController == null) return;
+    // The compose box doesn't null out its controller; it's either always null
+    // (e.g. in Combined Feed) or always non-null; it can't have been nulled out
+    // after the action sheet opened.
+    composeBoxController!;
     if (
       composeBoxController is StreamComposeBoxController
       && composeBoxController.topic.textNormalized == kNoTopicTopic
@@ -355,12 +354,11 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
 
     if (!pageContext.mounted) return;
 
-    // This will be null only if the compose box disappeared during the
-    // quotation request. This is rare: it happens when the self-user loses
-    // posting permission or when a DM recipient becomes deactivated.
     composeBoxController = findMessageListPage().composeBoxController;
-    if (composeBoxController == null) return;
-    composeBoxController.content
+    // The compose box doesn't null out its controller; it's either always null
+    // (e.g. in Combined Feed) or always non-null; it can't have been nulled out
+    // during the raw-content request.
+    composeBoxController!.content
       .registerQuoteAndReplyEnd(PerAccountStoreWidget.of(pageContext), tag,
         message: message,
         rawContent: rawContent,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -327,8 +327,10 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
 
     // This will be null only if the compose box disappeared after the
     // message action sheet opened, and before "Quote and reply" was pressed.
-    // Currently a compose box can't ever disappear, so this is impossible.
-    var composeBoxController = findMessageListPage().composeBoxController!;
+    // This is rare: it happens when the self-user loses posting permission
+    // or when a DM recipient becomes deactivated.
+    var composeBoxController = findMessageListPage().composeBoxController;
+    if (composeBoxController == null) return;
     final topicController = composeBoxController.topicController;
     if (
       topicController != null
@@ -354,9 +356,10 @@ class QuoteAndReplyButton extends MessageActionSheetMenuItemButton {
     if (!pageContext.mounted) return;
 
     // This will be null only if the compose box disappeared during the
-    // quotation request. Currently a compose box can't ever disappear,
-    // so this is impossible.
-    composeBoxController = findMessageListPage().composeBoxController!;
+    // quotation request. This is rare: it happens when the self-user loses
+    // posting permission or when a DM recipient becomes deactivated.
+    composeBoxController = findMessageListPage().composeBoxController;
+    if (composeBoxController == null) return;
     composeBoxController.contentController
       .registerQuoteAndReplyEnd(PerAccountStoreWidget.of(pageContext), tag,
         message: message,

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1032,18 +1032,21 @@ class _ComposeBoxContainer extends StatelessWidget {
 
 class _ComposeBoxBody extends StatelessWidget {
   const _ComposeBoxBody({
+    required this.narrow,
+    required this.controller,
     required this.topicInput,
     required this.contentInput,
     required this.sendButton,
-    required this.contentController,
-    required this.contentFocusNode,
   });
+
+  /// The narrow on view in the message list.
+  final Narrow narrow;
+
+  final ComposeBoxController controller;
 
   final Widget? topicInput;
   final Widget contentInput;
   final Widget sendButton;
-  final ComposeContentController contentController;
-  final FocusNode contentFocusNode;
 
   @override
   Widget build(BuildContext context) {
@@ -1069,10 +1072,11 @@ class _ComposeBoxBody extends StatelessWidget {
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(4)))));
 
+    final ComposeBoxController(:content, :contentFocusNode) = controller;
     final composeButtons = [
-      _AttachFileButton(contentController: contentController, contentFocusNode: contentFocusNode),
-      _AttachMediaButton(contentController: contentController, contentFocusNode: contentFocusNode),
-      _AttachFromCameraButton(contentController: contentController, contentFocusNode: contentFocusNode),
+      _AttachFileButton(contentController: content, contentFocusNode: contentFocusNode),
+      _AttachMediaButton(contentController: content, contentFocusNode: contentFocusNode),
+      _AttachFromCameraButton(contentController: content, contentFocusNode: contentFocusNode),
     ];
 
     return _ComposeBoxContainer(
@@ -1149,8 +1153,8 @@ class _StreamComposeBoxBody extends StatelessWidget {
     ) = controller;
 
     return _ComposeBoxBody(
-      contentController: content,
-      contentFocusNode: contentFocusNode,
+      narrow: narrow,
+      controller: controller,
       topicInput: _TopicInput(
         streamId: narrow.streamId,
         controller: topic,
@@ -1207,8 +1211,8 @@ class _FixedDestinationComposeBoxBody extends StatelessWidget {
     ) = controller;
 
     return _ComposeBoxBody(
-      contentController: content,
-      contentFocusNode: contentFocusNode,
+      narrow: narrow,
+      controller: controller,
       topicInput: null,
       contentInput: _FixedDestinationContentInput(
         narrow: narrow,

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1178,30 +1178,24 @@ class _FixedDestinationComposeBoxBody extends _ComposeBoxBody {
 }
 
 sealed class ComposeBoxController {
-  ComposeContentController get content => _content;
-  final _content = ComposeContentController();
-
-  FocusNode get contentFocusNode => _contentFocusNode;
-  final _contentFocusNode = FocusNode();
+  final content = ComposeContentController();
+  final contentFocusNode = FocusNode();
 
   @mustCallSuper
   void dispose() {
-    _content.dispose();
-    _contentFocusNode.dispose();
+    content.dispose();
+    contentFocusNode.dispose();
   }
 }
 
 class StreamComposeBoxController extends ComposeBoxController {
-  ComposeTopicController get topic => _topic;
-  final _topic = ComposeTopicController();
-
-  FocusNode get topicFocusNode => _topicFocusNode;
-  final _topicFocusNode = FocusNode();
+  final topic = ComposeTopicController();
+  final topicFocusNode = FocusNode();
 
   @override
   void dispose() {
-    _topic.dispose();
-    _topicFocusNode.dispose();
+    topic.dispose();
+    topicFocusNode.dispose();
     super.dispose();
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1030,8 +1030,8 @@ class _ComposeBoxContainer extends StatelessWidget {
   }
 }
 
-class _ComposeBoxLayout extends StatelessWidget {
-  const _ComposeBoxLayout({
+class _ComposeBoxBody extends StatelessWidget {
+  const _ComposeBoxBody({
     required this.topicInput,
     required this.contentInput,
     required this.sendButton,
@@ -1134,8 +1134,8 @@ class FixedDestinationComposeBoxController extends ComposeBoxController {}
 ///
 /// This offers a text input for the topic to send to,
 /// in addition to a text input for the message content.
-class _StreamComposeBox extends StatelessWidget {
-  const _StreamComposeBox({required this.narrow, required this.controller});
+class _StreamComposeBoxBody extends StatelessWidget {
+  const _StreamComposeBoxBody({required this.narrow, required this.controller});
 
   /// The narrow on view in the message list.
   final ChannelNarrow narrow;
@@ -1148,7 +1148,7 @@ class _StreamComposeBox extends StatelessWidget {
       :topic, :content, :topicFocusNode, :contentFocusNode,
     ) = controller;
 
-    return _ComposeBoxLayout(
+    return _ComposeBoxBody(
       contentController: content,
       contentFocusNode: contentFocusNode,
       topicInput: _TopicInput(
@@ -1193,8 +1193,8 @@ class _ErrorBanner extends StatelessWidget {
   }
 }
 
-class _FixedDestinationComposeBox extends StatelessWidget {
-  const _FixedDestinationComposeBox({required this.narrow, required this.controller});
+class _FixedDestinationComposeBoxBody extends StatelessWidget {
+  const _FixedDestinationComposeBoxBody({required this.narrow, required this.controller});
 
   final SendableNarrow narrow;
 
@@ -1206,7 +1206,7 @@ class _FixedDestinationComposeBox extends StatelessWidget {
       :content, :contentFocusNode,
     ) = controller;
 
-    return _ComposeBoxLayout(
+    return _ComposeBoxBody(
       contentController: content,
       contentFocusNode: contentFocusNode,
       topicInput: null,
@@ -1316,13 +1316,13 @@ class _ComposeBoxState extends State<ComposeBox> implements ComposeBoxState {
     switch (narrow) {
       case ChannelNarrow():
         _controller as StreamComposeBoxController;
-        return _StreamComposeBox(controller: _controller, narrow: narrow);
+        return _StreamComposeBoxBody(controller: _controller, narrow: narrow);
       case TopicNarrow():
         _controller as FixedDestinationComposeBoxController;
-        return _FixedDestinationComposeBox(controller: _controller, narrow: narrow);
+        return _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
       case DmNarrow():
         _controller as FixedDestinationComposeBoxController;
-        return _FixedDestinationComposeBox(controller: _controller, narrow: narrow);
+        return _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
       case CombinedFeedNarrow():
       case MentionsNarrow():
       case StarredMessagesNarrow():

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -442,17 +442,10 @@ class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserve
 
 /// The content input for _StreamComposeBox.
 class _StreamContentInput extends StatefulWidget {
-  const _StreamContentInput({
-    required this.narrow,
-    required this.controller,
-    required this.topicController,
-    required this.focusNode,
-  });
+  const _StreamContentInput({required this.narrow, required this.controller});
 
   final ChannelNarrow narrow;
-  final ComposeContentController controller;
-  final ComposeTopicController topicController;
-  final FocusNode focusNode;
+  final StreamComposeBoxController controller;
 
   @override
   State<_StreamContentInput> createState() => _StreamContentInputState();
@@ -463,29 +456,29 @@ class _StreamContentInputState extends State<_StreamContentInput> {
 
   void _topicChanged() {
     setState(() {
-      _topicTextNormalized = widget.topicController.textNormalized;
+      _topicTextNormalized = widget.controller.topic.textNormalized;
     });
   }
 
   @override
   void initState() {
     super.initState();
-    _topicTextNormalized = widget.topicController.textNormalized;
-    widget.topicController.addListener(_topicChanged);
+    _topicTextNormalized = widget.controller.topic.textNormalized;
+    widget.controller.topic.addListener(_topicChanged);
   }
 
   @override
   void didUpdateWidget(covariant _StreamContentInput oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.topicController != oldWidget.topicController) {
-      oldWidget.topicController.removeListener(_topicChanged);
-      widget.topicController.addListener(_topicChanged);
+    if (widget.controller.topic != oldWidget.controller.topic) {
+      oldWidget.controller.topic.removeListener(_topicChanged);
+      widget.controller.topic.addListener(_topicChanged);
     }
   }
 
   @override
   void dispose() {
-    widget.topicController.removeListener(_topicChanged);
+    widget.controller.topic.removeListener(_topicChanged);
     super.dispose();
   }
 
@@ -498,8 +491,8 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     return _ContentInput(
       narrow: widget.narrow,
       destination: TopicNarrow(widget.narrow.streamId, _topicTextNormalized),
-      controller: widget.controller,
-      focusNode: widget.focusNode,
+      controller: widget.controller.content,
+      focusNode: widget.controller.contentFocusNode,
       hintText: zulipLocalizations.composeBoxChannelContentHint(streamName, _topicTextNormalized));
   }
 }
@@ -1156,9 +1149,7 @@ class _StreamComposeBoxBody extends _ComposeBoxBody {
 
   @override Widget buildContentInput() => _StreamContentInput(
     narrow: narrow,
-    topicController: controller.topic,
-    controller: controller.content,
-    focusNode: controller.contentFocusNode,
+    controller: controller,
   );
 
   @override Widget buildSendButton() => _SendButton(

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -493,16 +493,10 @@ class _StreamContentInputState extends State<_StreamContentInput> {
 }
 
 class _TopicInput extends StatelessWidget {
-  const _TopicInput({
-    required this.streamId,
-    required this.controller,
-    required this.focusNode,
-    required this.contentFocusNode});
+  const _TopicInput({required this.streamId, required this.controller});
 
   final int streamId;
-  final ComposeTopicController controller;
-  final FocusNode focusNode;
-  final FocusNode contentFocusNode;
+  final StreamComposeBoxController controller;
 
   @override
   Widget build(BuildContext context) {
@@ -516,17 +510,17 @@ class _TopicInput extends StatelessWidget {
 
     return TopicAutocomplete(
       streamId: streamId,
-      controller: controller,
-      focusNode: focusNode,
-      contentFocusNode: contentFocusNode,
+      controller: controller.topic,
+      focusNode: controller.topicFocusNode,
+      contentFocusNode: controller.contentFocusNode,
       fieldViewBuilder: (context) => Container(
         padding: const EdgeInsets.only(top: 10, bottom: 9),
         decoration: BoxDecoration(border: Border(bottom: BorderSide(
           width: 1,
           color: designVariables.foreground.withFadedAlpha(0.2)))),
         child: TextField(
-          controller: controller,
-          focusNode: focusNode,
+          controller: controller.topic,
+          focusNode: controller.topicFocusNode,
           textInputAction: TextInputAction.next,
           style: topicTextStyle,
           decoration: InputDecoration(
@@ -1134,9 +1128,7 @@ class _StreamComposeBoxBody extends _ComposeBoxBody {
 
   @override Widget buildTopicInput() => _TopicInput(
     streamId: narrow.streamId,
-    controller: controller.topic,
-    focusNode: controller.topicFocusNode,
-    contentFocusNode: controller.contentFocusNode,
+    controller: controller,
   );
 
   @override Widget buildContentInput() => _StreamContentInput(

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1232,7 +1232,8 @@ class _FixedDestinationComposeBoxState extends State<_FixedDestinationComposeBox
 }
 
 class ComposeBox extends StatelessWidget {
-  const ComposeBox({super.key, this.controllerKey, required this.narrow});
+  ComposeBox({super.key, this.controllerKey, required this.narrow})
+    : assert(ComposeBox.hasComposeBox(narrow));
 
   final GlobalKey<ComposeBoxController>? controllerKey;
   final Narrow narrow;
@@ -1296,6 +1297,7 @@ class ComposeBox extends StatelessWidget {
       case CombinedFeedNarrow():
       case MentionsNarrow():
       case StarredMessagesNarrow():
+        assert(false);
         return const SizedBox.shrink();
     }
   }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1100,29 +1100,29 @@ class _ComposeBoxLayout extends StatelessWidget {
 }
 
 sealed class ComposeBoxController {
-  ComposeContentController get contentController => _contentController;
-  final _contentController = ComposeContentController();
+  ComposeContentController get content => _content;
+  final _content = ComposeContentController();
 
   FocusNode get contentFocusNode => _contentFocusNode;
   final _contentFocusNode = FocusNode();
 
   @mustCallSuper
   void dispose() {
-    _contentController.dispose();
+    _content.dispose();
     _contentFocusNode.dispose();
   }
 }
 
 class StreamComposeBoxController extends ComposeBoxController {
-  ComposeTopicController get topicController => _topicController;
-  final _topicController = ComposeTopicController();
+  ComposeTopicController get topic => _topic;
+  final _topic = ComposeTopicController();
 
   FocusNode get topicFocusNode => _topicFocusNode;
   final _topicFocusNode = FocusNode();
 
   @override
   void dispose() {
-    _topicController.dispose();
+    _topic.dispose();
     _topicFocusNode.dispose();
     super.dispose();
   }
@@ -1157,29 +1157,29 @@ class _StreamComposeBoxState extends State<_StreamComposeBox> {
   @override
   Widget build(BuildContext context) {
     final StreamComposeBoxController(
-      :topicController, :contentController, :topicFocusNode, :contentFocusNode,
+      :topic, :content, :topicFocusNode, :contentFocusNode,
     ) = controller;
 
     return _ComposeBoxLayout(
-      contentController: contentController,
+      contentController: content,
       contentFocusNode: contentFocusNode,
       topicInput: _TopicInput(
         streamId: widget.narrow.streamId,
-        controller: topicController,
+        controller: topic,
         focusNode: topicFocusNode,
         contentFocusNode: contentFocusNode,
       ),
       contentInput: _StreamContentInput(
         narrow: widget.narrow,
-        topicController: topicController,
-        controller: contentController,
+        topicController: topic,
+        controller: content,
         focusNode: contentFocusNode,
       ),
       sendButton: _SendButton(
-        topicController: topicController,
-        contentController: contentController,
+        topicController: topic,
+        contentController: content,
         getDestination: () => StreamDestination(
-          widget.narrow.streamId, topicController.textNormalized),
+          widget.narrow.streamId, topic.textNormalized),
       ));
   }
 }
@@ -1227,21 +1227,21 @@ class _FixedDestinationComposeBoxState extends State<_FixedDestinationComposeBox
   @override
   Widget build(BuildContext context) {
     final FixedDestinationComposeBoxController(
-      :contentController, :contentFocusNode,
+      :content, :contentFocusNode,
     ) = controller;
 
     return _ComposeBoxLayout(
-      contentController: contentController,
+      contentController: content,
       contentFocusNode: contentFocusNode,
       topicInput: null,
       contentInput: _FixedDestinationContentInput(
         narrow: widget.narrow,
-        controller: contentController,
+        controller: content,
         focusNode: contentFocusNode,
       ),
       sendButton: _SendButton(
         topicController: null,
-        contentController: contentController,
+        contentController: content,
         getDestination: () => widget.narrow.destination,
       ));
   }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1351,21 +1351,15 @@ class _ComposeBoxState extends State<ComposeBox> implements ComposeBoxState {
     }
 
     final narrow = widget.narrow;
-    switch (narrow) {
-      case ChannelNarrow():
-        _controller as StreamComposeBoxController;
+    switch (_controller) {
+      case StreamComposeBoxController(): {
+        narrow as ChannelNarrow;
         body = _StreamComposeBoxBody(controller: _controller, narrow: narrow);
-      case TopicNarrow():
-        _controller as FixedDestinationComposeBoxController;
+      }
+      case FixedDestinationComposeBoxController(): {
+        narrow as SendableNarrow;
         body = _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
-      case DmNarrow():
-        _controller as FixedDestinationComposeBoxController;
-        body = _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
-      case CombinedFeedNarrow():
-      case MentionsNarrow():
-      case StarredMessagesNarrow():
-        assert(false);
-        body = null;
+      }
     }
 
     // TODO(#720) dismissable message-send error, maybe something like:

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -545,12 +545,10 @@ class _FixedDestinationContentInput extends StatelessWidget {
   const _FixedDestinationContentInput({
     required this.narrow,
     required this.controller,
-    required this.focusNode,
   });
 
   final SendableNarrow narrow;
-  final ComposeContentController controller;
-  final FocusNode focusNode;
+  final FixedDestinationComposeBoxController controller;
 
   String _hintText(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
@@ -580,8 +578,8 @@ class _FixedDestinationContentInput extends StatelessWidget {
     return _ContentInput(
       narrow: narrow,
       destination: narrow,
-      controller: controller,
-      focusNode: focusNode,
+      controller: controller.content,
+      focusNode: controller.contentFocusNode,
       hintText: _hintText(context));
   }
 }
@@ -1173,8 +1171,7 @@ class _FixedDestinationComposeBoxBody extends _ComposeBoxBody {
 
   @override Widget buildContentInput() => _FixedDestinationContentInput(
     narrow: narrow,
-    controller: controller.content,
-    focusNode: controller.contentFocusNode,
+    controller: controller,
   );
 
   @override Widget buildSendButton() => _SendButton(

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1060,6 +1060,7 @@ class _ComposeBoxContainer extends StatelessWidget {
     return Container(width: double.infinity,
       decoration: BoxDecoration(
         border: Border(top: BorderSide(color: designVariables.borderBar))),
+      // TODO(#720) try a Stack for the overlaid linear progress indicator
       child: Material(
         color: designVariables.composeBoxBg,
         child: Column(

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1137,6 +1137,7 @@ class _StreamComposeBoxState extends State<_StreamComposeBox> implements Compose
     _topicController.dispose();
     _contentController.dispose();
     _contentFocusNode.dispose();
+    _topicFocusNode.dispose();
     super.dispose();
   }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1097,37 +1097,6 @@ abstract class _ComposeBoxBody extends StatelessWidget {
   }
 }
 
-sealed class ComposeBoxController {
-  ComposeContentController get content => _content;
-  final _content = ComposeContentController();
-
-  FocusNode get contentFocusNode => _contentFocusNode;
-  final _contentFocusNode = FocusNode();
-
-  @mustCallSuper
-  void dispose() {
-    _content.dispose();
-    _contentFocusNode.dispose();
-  }
-}
-
-class StreamComposeBoxController extends ComposeBoxController {
-  ComposeTopicController get topic => _topic;
-  final _topic = ComposeTopicController();
-
-  FocusNode get topicFocusNode => _topicFocusNode;
-  final _topicFocusNode = FocusNode();
-
-  @override
-  void dispose() {
-    _topic.dispose();
-    _topicFocusNode.dispose();
-    super.dispose();
-  }
-}
-
-class FixedDestinationComposeBoxController extends ComposeBoxController {}
-
 /// A compose box for use in a channel narrow.
 ///
 /// This offers a text input for the topic to send to,
@@ -1163,27 +1132,6 @@ class _StreamComposeBoxBody extends _ComposeBoxBody {
   );
 }
 
-class _ErrorBanner extends StatelessWidget {
-  const _ErrorBanner({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final designVariables = DesignVariables.of(context);
-    return Container(
-      padding: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: designVariables.errorBannerBackground,
-        border: Border.all(color: designVariables.errorBannerBorder),
-        borderRadius: BorderRadius.circular(5)),
-      child: Text(label,
-        style: TextStyle(fontSize: 18, color: designVariables.errorBannerLabel),
-      ),
-    );
-  }
-}
-
 class _FixedDestinationComposeBoxBody extends _ComposeBoxBody {
   _FixedDestinationComposeBoxBody({required this.narrow, required this.controller});
 
@@ -1206,6 +1154,58 @@ class _FixedDestinationComposeBoxBody extends _ComposeBoxBody {
     contentController: controller.content,
     getDestination: () => narrow.destination,
   );
+}
+
+sealed class ComposeBoxController {
+  ComposeContentController get content => _content;
+  final _content = ComposeContentController();
+
+  FocusNode get contentFocusNode => _contentFocusNode;
+  final _contentFocusNode = FocusNode();
+
+  @mustCallSuper
+  void dispose() {
+    _content.dispose();
+    _contentFocusNode.dispose();
+  }
+}
+
+class StreamComposeBoxController extends ComposeBoxController {
+  ComposeTopicController get topic => _topic;
+  final _topic = ComposeTopicController();
+
+  FocusNode get topicFocusNode => _topicFocusNode;
+  final _topicFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _topic.dispose();
+    _topicFocusNode.dispose();
+    super.dispose();
+  }
+}
+
+class FixedDestinationComposeBoxController extends ComposeBoxController {}
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: designVariables.errorBannerBackground,
+        border: Border.all(color: designVariables.errorBannerBorder),
+        borderRadius: BorderRadius.circular(5)),
+      child: Text(label,
+        style: TextStyle(fontSize: 18, color: designVariables.errorBannerLabel),
+      ),
+    );
+  }
 }
 
 class ComposeBox extends StatefulWidget {

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1073,27 +1073,26 @@ abstract class _ComposeBoxBody extends StatelessWidget {
     ];
 
     final topicInput = buildTopicInput();
-    return _ComposeBoxContainer(
-      child: Column(children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8),
-          child: Theme(
-            data: inputThemeData,
-            child: Column(children: [
-              if (topicInput != null) topicInput,
-              buildContentInput(),
+    return Column(children: [
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Theme(
+          data: inputThemeData,
+          child: Column(children: [
+            if (topicInput != null) topicInput,
+            buildContentInput(),
+          ]))),
+      SizedBox(
+        height: _composeButtonSize,
+        child: IconButtonTheme(
+          data: iconButtonThemeData,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(children: composeButtons),
+              buildSendButton(),
             ]))),
-        SizedBox(
-          height: _composeButtonSize,
-          child: IconButtonTheme(
-            data: iconButtonThemeData,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(children: composeButtons),
-                buildSendButton(),
-              ]))),
-      ]));
+    ]);
   }
 }
 
@@ -1298,21 +1297,24 @@ class _ComposeBoxState extends State<ComposeBox> implements ComposeBoxState {
     }
 
     final narrow = widget.narrow;
+    final Widget body;
     switch (narrow) {
       case ChannelNarrow():
         _controller as StreamComposeBoxController;
-        return _StreamComposeBoxBody(controller: _controller, narrow: narrow);
+        body = _StreamComposeBoxBody(controller: _controller, narrow: narrow);
       case TopicNarrow():
         _controller as FixedDestinationComposeBoxController;
-        return _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
+        body = _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
       case DmNarrow():
         _controller as FixedDestinationComposeBoxController;
-        return _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
+        body = _FixedDestinationComposeBoxBody(controller: _controller, narrow: narrow);
       case CombinedFeedNarrow():
       case MentionsNarrow():
       case StarredMessagesNarrow():
         assert(false);
-        return const SizedBox.shrink();
+        body = const SizedBox.shrink();
     }
+
+    return _ComposeBoxContainer(child: body);
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -658,10 +658,9 @@ Future<void> _uploadFiles({
 }
 
 abstract class _AttachUploadsButton extends StatelessWidget {
-  const _AttachUploadsButton({required this.contentController, required this.contentFocusNode});
+  const _AttachUploadsButton({required this.controller});
 
-  final ComposeContentController contentController;
-  final FocusNode contentFocusNode;
+  final ComposeBoxController controller;
 
   IconData get icon;
   String tooltip(ZulipLocalizations zulipLocalizations);
@@ -689,8 +688,8 @@ abstract class _AttachUploadsButton extends StatelessWidget {
 
     await _uploadFiles(
       context: context,
-      contentController: contentController,
-      contentFocusNode: contentFocusNode,
+      contentController: controller.content,
+      contentFocusNode: controller.contentFocusNode,
       files: files);
   }
 
@@ -762,7 +761,7 @@ Future<Iterable<_File>> _getFilePickerFiles(BuildContext context, FileType type)
 }
 
 class _AttachFileButton extends _AttachUploadsButton {
-  const _AttachFileButton({required super.contentController, required super.contentFocusNode});
+  const _AttachFileButton({required super.controller});
 
   @override
   IconData get icon => ZulipIcons.attach_file;
@@ -778,7 +777,7 @@ class _AttachFileButton extends _AttachUploadsButton {
 }
 
 class _AttachMediaButton extends _AttachUploadsButton {
-  const _AttachMediaButton({required super.contentController, required super.contentFocusNode});
+  const _AttachMediaButton({required super.controller});
 
   @override
   IconData get icon => ZulipIcons.image;
@@ -795,7 +794,7 @@ class _AttachMediaButton extends _AttachUploadsButton {
 }
 
 class _AttachFromCameraButton extends _AttachUploadsButton {
-  const _AttachFromCameraButton({required super.contentController, required super.contentFocusNode});
+  const _AttachFromCameraButton({required super.controller});
 
   @override
   IconData get icon => ZulipIcons.camera;
@@ -1096,11 +1095,10 @@ abstract class _ComposeBoxBody extends StatelessWidget {
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(4)))));
 
-    final ComposeBoxController(:content, :contentFocusNode) = controller;
     final composeButtons = [
-      _AttachFileButton(contentController: content, contentFocusNode: contentFocusNode),
-      _AttachMediaButton(contentController: content, contentFocusNode: contentFocusNode),
-      _AttachFromCameraButton(contentController: content, contentFocusNode: contentFocusNode),
+      _AttachFileButton(controller: controller),
+      _AttachMediaButton(controller: controller),
+      _AttachFromCameraButton(controller: controller),
     ];
 
     final topicInput = buildTopicInput();

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -301,7 +301,9 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
 
               child: Expanded(
                 child: MessageList(narrow: narrow, onNarrowChanged: _narrowChanged))),
-            ComposeBox(controllerKey: _composeBoxKey, narrow: narrow),
+            if (ComposeBox.hasComposeBox(narrow))
+              ComposeBox(controllerKey: _composeBoxKey, narrow: narrow)
+            else const SizedBox.shrink(),
           ]))));
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -303,7 +303,6 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
                 child: MessageList(narrow: narrow, onNarrowChanged: _narrowChanged))),
             if (ComposeBox.hasComposeBox(narrow))
               ComposeBox(controllerKey: _composeBoxKey, narrow: narrow)
-            else const SizedBox.shrink(),
           ]))));
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -213,9 +213,9 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
   late Narrow narrow;
 
   @override
-  ComposeBoxController? get composeBoxController => _composeBoxKey.currentState;
+  ComposeBoxController? get composeBoxController => _composeBoxKey.currentState?.controller;
 
-  final GlobalKey<ComposeBoxController> _composeBoxKey = GlobalKey();
+  final GlobalKey<ComposeBoxState> _composeBoxKey = GlobalKey();
 
   @override
   void initState() {
@@ -302,7 +302,7 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
               child: Expanded(
                 child: MessageList(narrow: narrow, onNarrowChanged: _narrowChanged))),
             if (ComposeBox.hasComposeBox(narrow))
-              ComposeBox(controllerKey: _composeBoxKey, narrow: narrow)
+              ComposeBox(key: _composeBoxKey, narrow: narrow)
           ]))));
   }
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -114,10 +114,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   DesignVariables.light() :
     this._(
       background: const Color(0xffffffff),
+      bannerBgIntDanger: const Color(0xfff2e4e4),
       bgContextMenu: const Color(0xfff2f2f2),
       bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.15),
       bgTopBar: const Color(0xfff5f5f5),
       borderBar: Colors.black.withValues(alpha: 0.2),
+      btnLabelAttLowIntDanger: const Color(0xffc0070a),
+      btnLabelAttMediumIntDanger: const Color(0xffac0508),
       composeBoxBg: const Color(0xffffffff),
       contextMenuCancelText: const Color(0xff222222),
       contextMenuItemBg: const Color(0xff6159e1),
@@ -135,9 +138,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       atMentionMarker: const HSLColor.fromAHSL(0.5, 0, 0, 0.2).toColor(),
       contextMenuCancelBg: const Color(0xff797986),
       dmHeaderBg: const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor(),
-      errorBannerBackground: const HSLColor.fromAHSL(1, 4, 0.33, 0.90).toColor(),
-      errorBannerBorder: const HSLColor.fromAHSL(0.4, 3, 0.57, 0.33).toColor(),
-      errorBannerLabel: const HSLColor.fromAHSL(1, 4, 0.58, 0.33).toColor(),
       groupDmConversationIcon: Colors.black.withValues(alpha: 0.5),
       groupDmConversationIconBg: const Color(0x33808080),
       loginOrDivider: const Color(0xffdedede),
@@ -154,10 +154,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   DesignVariables.dark() :
     this._(
       background: const Color(0xff000000),
+      bannerBgIntDanger: const Color(0xff461616),
       bgContextMenu: const Color(0xff262626),
       bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
       bgTopBar: const Color(0xff242424),
       borderBar: Colors.black.withValues(alpha: 0.5),
+      btnLabelAttLowIntDanger: const Color(0xffff8b7c),
+      btnLabelAttMediumIntDanger: const Color(0xffff8b7c),
       composeBoxBg: const Color(0xff0f0f0f),
       contextMenuCancelText: const Color(0xffffffff).withValues(alpha: 0.75),
       contextMenuItemBg: const Color(0xff7977fe),
@@ -176,9 +179,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       // TODO(design-dark) need proper dark-theme color (this is ad hoc)
       atMentionMarker: const HSLColor.fromAHSL(0.4, 0, 0, 1).toColor(),
       dmHeaderBg: const HSLColor.fromAHSL(1, 46, 0.15, 0.2).toColor(),
-      errorBannerBackground: const HSLColor.fromAHSL(1, 0, 0.61, 0.19).toColor(),
-      errorBannerBorder: const HSLColor.fromAHSL(0.4, 3, 0.73, 0.74).toColor(),
-      errorBannerLabel: const HSLColor.fromAHSL(1, 2, 0.73, 0.80).toColor(),
       // TODO(design-dark) need proper dark-theme color (this is ad hoc)
       groupDmConversationIcon: Colors.white.withValues(alpha: 0.5),
       // TODO(design-dark) need proper dark-theme color (this is ad hoc)
@@ -201,10 +201,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
 
   DesignVariables._({
     required this.background,
+    required this.bannerBgIntDanger,
     required this.bgContextMenu,
     required this.bgCounterUnread,
     required this.bgTopBar,
     required this.borderBar,
+    required this.btnLabelAttLowIntDanger,
+    required this.btnLabelAttMediumIntDanger,
     required this.composeBoxBg,
     required this.contextMenuCancelText,
     required this.contextMenuItemBg,
@@ -222,9 +225,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.atMentionMarker,
     required this.contextMenuCancelBg,
     required this.dmHeaderBg,
-    required this.errorBannerBackground,
-    required this.errorBannerBorder,
-    required this.errorBannerLabel,
     required this.groupDmConversationIcon,
     required this.groupDmConversationIconBg,
     required this.loginOrDivider,
@@ -249,10 +249,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   }
 
   final Color background;
+  final Color bannerBgIntDanger;
   final Color bgContextMenu;
   final Color bgCounterUnread;
   final Color bgTopBar;
   final Color borderBar;
+  final Color btnLabelAttLowIntDanger;
+  final Color btnLabelAttMediumIntDanger;
   final Color composeBoxBg;
   final Color contextMenuCancelText;
   final Color contextMenuItemBg;
@@ -274,9 +277,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color atMentionMarker;
   final Color contextMenuCancelBg; // In Figma, but unnamed.
   final Color dmHeaderBg;
-  final Color errorBannerBackground;
-  final Color errorBannerBorder;
-  final Color errorBannerLabel;
   final Color groupDmConversationIcon;
   final Color groupDmConversationIconBg;
   final Color loginOrDivider; // TODO(design-dark) need proper dark-theme color (this is ad hoc)
@@ -292,10 +292,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   @override
   DesignVariables copyWith({
     Color? background,
+    Color? bannerBgIntDanger,
     Color? bgContextMenu,
     Color? bgCounterUnread,
     Color? bgTopBar,
     Color? borderBar,
+    Color? btnLabelAttLowIntDanger,
+    Color? btnLabelAttMediumIntDanger,
     Color? composeBoxBg,
     Color? contextMenuCancelText,
     Color? contextMenuItemBg,
@@ -313,9 +316,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? atMentionMarker,
     Color? contextMenuCancelBg,
     Color? dmHeaderBg,
-    Color? errorBannerBackground,
-    Color? errorBannerBorder,
-    Color? errorBannerLabel,
     Color? groupDmConversationIcon,
     Color? groupDmConversationIconBg,
     Color? loginOrDivider,
@@ -330,10 +330,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   }) {
     return DesignVariables._(
       background: background ?? this.background,
+      bannerBgIntDanger: bannerBgIntDanger ?? this.bannerBgIntDanger,
       bgContextMenu: bgContextMenu ?? this.bgContextMenu,
       bgCounterUnread: bgCounterUnread ?? this.bgCounterUnread,
       bgTopBar: bgTopBar ?? this.bgTopBar,
       borderBar: borderBar ?? this.borderBar,
+      btnLabelAttLowIntDanger: btnLabelAttLowIntDanger ?? this.btnLabelAttLowIntDanger,
+      btnLabelAttMediumIntDanger: btnLabelAttMediumIntDanger ?? this.btnLabelAttMediumIntDanger,
       composeBoxBg: composeBoxBg ?? this.composeBoxBg,
       contextMenuCancelText: contextMenuCancelText ?? this.contextMenuCancelText,
       contextMenuItemBg: contextMenuItemBg ?? this.contextMenuItemBg,
@@ -351,9 +354,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       atMentionMarker: atMentionMarker ?? this.atMentionMarker,
       contextMenuCancelBg: contextMenuCancelBg ?? this.contextMenuCancelBg,
       dmHeaderBg: dmHeaderBg ?? this.dmHeaderBg,
-      errorBannerBackground: errorBannerBackground ?? this.errorBannerBackground,
-      errorBannerBorder: errorBannerBorder ?? this.errorBannerBorder,
-      errorBannerLabel: errorBannerLabel ?? this.errorBannerLabel,
       groupDmConversationIcon: groupDmConversationIcon ?? this.groupDmConversationIcon,
       groupDmConversationIconBg: groupDmConversationIconBg ?? this.groupDmConversationIconBg,
       loginOrDivider: loginOrDivider ?? this.loginOrDivider,
@@ -375,10 +375,13 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     }
     return DesignVariables._(
       background: Color.lerp(background, other.background, t)!,
+      bannerBgIntDanger: Color.lerp(bannerBgIntDanger, other.bannerBgIntDanger, t)!,
       bgContextMenu: Color.lerp(bgContextMenu, other.bgContextMenu, t)!,
       bgCounterUnread: Color.lerp(bgCounterUnread, other.bgCounterUnread, t)!,
       bgTopBar: Color.lerp(bgTopBar, other.bgTopBar, t)!,
       borderBar: Color.lerp(borderBar, other.borderBar, t)!,
+      btnLabelAttLowIntDanger: Color.lerp(btnLabelAttLowIntDanger, other.btnLabelAttLowIntDanger, t)!,
+      btnLabelAttMediumIntDanger: Color.lerp(btnLabelAttMediumIntDanger, other.btnLabelAttMediumIntDanger, t)!,
       composeBoxBg: Color.lerp(composeBoxBg, other.composeBoxBg, t)!,
       contextMenuCancelText: Color.lerp(contextMenuCancelText, other.contextMenuCancelText, t)!,
       contextMenuItemBg: Color.lerp(contextMenuItemBg, other.contextMenuItemBg, t)!,
@@ -396,9 +399,6 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       atMentionMarker: Color.lerp(atMentionMarker, other.atMentionMarker, t)!,
       contextMenuCancelBg: Color.lerp(contextMenuCancelBg, other.contextMenuCancelBg, t)!,
       dmHeaderBg: Color.lerp(dmHeaderBg, other.dmHeaderBg, t)!,
-      errorBannerBackground: Color.lerp(errorBannerBackground, other.errorBannerBackground, t)!,
-      errorBannerBorder: Color.lerp(errorBannerBorder, other.errorBannerBorder, t)!,
-      errorBannerLabel: Color.lerp(errorBannerLabel, other.errorBannerLabel, t)!,
       groupDmConversationIcon: Color.lerp(groupDmConversationIcon, other.groupDmConversationIcon, t)!,
       groupDmConversationIconBg: Color.lerp(groupDmConversationIconBg, other.groupDmConversationIconBg, t)!,
       loginOrDivider: Color.lerp(loginOrDivider, other.loginOrDivider, t)!,

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -230,8 +230,8 @@ void main() {
 
   group('QuoteAndReplyButton', () {
     ComposeBoxController? findComposeBoxController(WidgetTester tester) {
-      return tester.widgetList<ComposeBox>(find.byType(ComposeBox))
-        .singleOrNull?.controllerKey?.currentState;
+      return tester.stateList<ComposeBoxState>(find.byType(ComposeBox))
+        .singleOrNull?.controller;
     }
 
     Widget? findQuoteAndReplyButton(WidgetTester tester) {
@@ -283,14 +283,14 @@ void main() {
       final message = eg.streamMessage();
       await setupToMessageActionSheet(tester, message: message, narrow: ChannelNarrow(message.streamId));
 
-      final composeBoxController = findComposeBoxController(tester)!;
+      final composeBoxController = findComposeBoxController(tester) as StreamComposeBoxController;
       final contentController = composeBoxController.contentController;
 
       // Ensure channel-topics are loaded before testing quote & reply behavior
       connection.prepare(body:
         jsonEncode(GetStreamTopicsResult(topics: [eg.getStreamTopicsEntry()]).toJson()));
       final topicController = composeBoxController.topicController;
-      topicController?.value = const TextEditingValue(text: kNoTopicTopic);
+      topicController.value = const TextEditingValue(text: kNoTopicTopic);
 
       final valueBefore = contentController.value;
       prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -284,12 +284,12 @@ void main() {
       await setupToMessageActionSheet(tester, message: message, narrow: ChannelNarrow(message.streamId));
 
       final composeBoxController = findComposeBoxController(tester) as StreamComposeBoxController;
-      final contentController = composeBoxController.contentController;
+      final contentController = composeBoxController.content;
 
       // Ensure channel-topics are loaded before testing quote & reply behavior
       connection.prepare(body:
         jsonEncode(GetStreamTopicsResult(topics: [eg.getStreamTopicsEntry()]).toJson()));
-      final topicController = composeBoxController.topicController;
+      final topicController = composeBoxController.topic;
       topicController.value = const TextEditingValue(text: kNoTopicTopic);
 
       final valueBefore = contentController.value;
@@ -308,7 +308,7 @@ void main() {
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
         final composeBoxController = findComposeBoxController(tester)!;
-        final contentController = composeBoxController.contentController;
+        final contentController = composeBoxController.content;
 
         final valueBefore = contentController.value;
         prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
@@ -344,7 +344,7 @@ void main() {
           message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
 
         final composeBoxController = findComposeBoxController(tester)!;
-        final contentController = composeBoxController.contentController;
+        final contentController = composeBoxController.content;
 
         final valueBefore = contentController.value;
         prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
@@ -383,7 +383,7 @@ void main() {
       await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
       final composeBoxController = findComposeBoxController(tester)!;
-      final contentController = composeBoxController.contentController;
+      final contentController = composeBoxController.content;
 
       final valueBefore = contentController.value = TextEditingValue.empty;
       prepareRawContentResponseError();

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -224,8 +224,8 @@ void main() {
 
   group('QuoteAndReplyButton', () {
     ComposeBoxController? findComposeBoxController(WidgetTester tester) {
-      return tester.widget<ComposeBox>(find.byType(ComposeBox))
-        .controllerKey?.currentState;
+      return tester.widgetList<ComposeBox>(find.byType(ComposeBox))
+        .singleOrNull?.controllerKey?.currentState;
     }
 
     Widget? findQuoteAndReplyButton(WidgetTester tester) {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -296,39 +296,43 @@ void main() {
         valueBefore: valueBefore, message: message, rawContent: 'Hello world');
     });
 
-    testWidgets('in topic narrow', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+    group('in topic narrow', () {
+      testWidgets('smoke', (tester) async {
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      final composeBoxController = findComposeBoxController(tester)!;
-      final contentController = composeBoxController.contentController;
+        final composeBoxController = findComposeBoxController(tester)!;
+        final contentController = composeBoxController.contentController;
 
-      final valueBefore = contentController.value;
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-      await tapQuoteAndReplyButton(tester);
-      checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
-      await tester.pump(Duration.zero); // message is fetched; compose box updates
-      check(composeBoxController.contentFocusNode.hasFocus).isTrue();
-      checkSuccessState(store, contentController,
-        valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+        final valueBefore = contentController.value;
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        await tapQuoteAndReplyButton(tester);
+        checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
+        await tester.pump(Duration.zero); // message is fetched; compose box updates
+        check(composeBoxController.contentFocusNode.hasFocus).isTrue();
+        checkSuccessState(store, contentController,
+          valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+      });
     });
 
-    testWidgets('in DM narrow', (tester) async {
-      final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
-      await setupToMessageActionSheet(tester,
-        message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
+    group('in DM narrow', () {
+      testWidgets('smoke', (tester) async {
+        final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
+        await setupToMessageActionSheet(tester,
+          message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
 
-      final composeBoxController = findComposeBoxController(tester)!;
-      final contentController = composeBoxController.contentController;
+        final composeBoxController = findComposeBoxController(tester)!;
+        final contentController = composeBoxController.contentController;
 
-      final valueBefore = contentController.value;
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-      await tapQuoteAndReplyButton(tester);
-      checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
-      await tester.pump(Duration.zero); // message is fetched; compose box updates
-      check(composeBoxController.contentFocusNode.hasFocus).isTrue();
-      checkSuccessState(store, contentController,
-        valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+        final valueBefore = contentController.value;
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        await tapQuoteAndReplyButton(tester);
+        checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
+        await tester.pump(Duration.zero); // message is fetched; compose box updates
+        check(composeBoxController.contentFocusNode.hasFocus).isTrue();
+        checkSuccessState(store, contentController,
+          valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+      });
     });
 
     testWidgets('request has an error', (tester) async {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -38,11 +38,12 @@ void main() {
 
   late PerAccountStore store;
   late FakeApiConnection connection;
+  late GlobalKey<ComposeBoxController> controllerKey;
 
   final contentInputFinder = find.byWidgetPredicate(
     (widget) => widget is TextField && widget.controller is ComposeContentController);
 
-  Future<GlobalKey<ComposeBoxController>> prepareComposeBox(WidgetTester tester, {
+  Future<void> prepareComposeBox(WidgetTester tester, {
     required Narrow narrow,
     User? selfUser,
     int? realmWaitingPeriodThreshold,
@@ -65,7 +66,7 @@ void main() {
     await store.addStreams(streams);
     connection = store.connection as FakeApiConnection;
 
-    final controllerKey = GlobalKey<ComposeBoxController>();
+    controllerKey = GlobalKey<ComposeBoxController>();
     await tester.pumpWidget(TestZulipApp(accountId: selfAccount.id,
       child: Column(
         // This positions the compose box at the bottom of the screen,
@@ -75,8 +76,6 @@ void main() {
           ComposeBox(controllerKey: controllerKey, narrow: narrow),
         ])));
     await tester.pumpAndSettle();
-
-    return controllerKey;
   }
 
   Future<void> enterTopic(WidgetTester tester, {
@@ -198,7 +197,6 @@ void main() {
 
   group('ComposeBox textCapitalization', () {
     void checkComposeBoxTextFields(WidgetTester tester, {
-      required GlobalKey<ComposeBoxController> controllerKey,
       required bool expectTopicTextField,
     }) {
       final composeBoxController = controllerKey.currentState!;
@@ -222,18 +220,16 @@ void main() {
 
     testWidgets('_StreamComposeBox', (tester) async {
       final channel = eg.stream();
-      final key = await prepareComposeBox(tester,
+      await prepareComposeBox(tester,
         narrow: ChannelNarrow(channel.streamId), streams: [channel]);
-      checkComposeBoxTextFields(tester, controllerKey: key,
-        expectTopicTextField: true);
+      checkComposeBoxTextFields(tester, expectTopicTextField: true);
     });
 
     testWidgets('_FixedDestinationComposeBox', (tester) async {
       final channel = eg.stream();
-      final key = await prepareComposeBox(tester,
+      await prepareComposeBox(tester,
         narrow: TopicNarrow(channel.streamId, 'topic'), streams: [channel]);
-      checkComposeBoxTextFields(tester, controllerKey: key,
-        expectTopicTextField: false);
+      checkComposeBoxTextFields(tester, expectTopicTextField: false);
     });
   });
 
@@ -354,7 +350,7 @@ void main() {
     });
 
     testWidgets('selection change sends a "typing started" notice', (tester) async {
-      final controllerKey = await prepareComposeBox(tester, narrow: narrow, streams: [channel]);
+      await prepareComposeBox(tester, narrow: narrow, streams: [channel]);
       final composeBoxController = controllerKey.currentState!;
 
       await checkStartTyping(tester, narrow);
@@ -474,8 +470,7 @@ void main() {
 
         final channel = eg.stream();
         final narrow = ChannelNarrow(channel.streamId);
-        final controllerKey = await prepareComposeBox(tester,
-          narrow: narrow, streams: [channel]);
+        await prepareComposeBox(tester, narrow: narrow, streams: [channel]);
         final composeBoxController = controllerKey.currentState!;
 
         // (When we check that the send button looks disabled, it should be because
@@ -536,8 +531,7 @@ void main() {
 
         final channel = eg.stream();
         final narrow = ChannelNarrow(channel.streamId);
-        final controllerKey = await prepareComposeBox(tester,
-          narrow: narrow, streams: [channel]);
+        await prepareComposeBox(tester, narrow: narrow, streams: [channel]);
         final composeBoxController = controllerKey.currentState!;
 
         // (When we check that the send button looks disabled, it should be because

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -201,7 +201,7 @@ void main() {
       required bool expectTopicTextField,
     }) {
       if (expectTopicTextField) {
-        final topicController = (controller as StreamComposeBoxController).topicController;
+        final topicController = (controller as StreamComposeBoxController).topic;
         final topicTextField = tester.widgetList<TextField>(find.byWidgetPredicate(
           (widget) => widget is TextField && widget.controller == topicController
         )).singleOrNull;
@@ -214,7 +214,7 @@ void main() {
 
       final contentTextField = tester.widget<TextField>(find.byWidgetPredicate(
         (widget) => widget is TextField
-          && widget.controller == controller!.contentController));
+          && widget.controller == controller!.content));
       check(contentTextField)
         .textCapitalization.equals(TextCapitalization.sentences);
     }
@@ -360,7 +360,7 @@ void main() {
       checkTypingRequest(TypingOp.stop, narrow);
 
       connection.prepare(json: {});
-      controller!.contentController.selection =
+      controller!.content.selection =
         const TextSelection(baseOffset: 0, extentOffset: 2);
       checkTypingRequest(TypingOp.start, narrow);
 
@@ -475,7 +475,7 @@ void main() {
         // (When we check that the send button looks disabled, it should be because
         // the file is uploading, not a pre-existing reason.)
         await enterTopic(tester, narrow: narrow, topic: 'some topic');
-        controller!.contentController.value = const TextEditingValue(text: 'see image: ');
+        controller!.content.value = const TextEditingValue(text: 'see image: ');
         await tester.pump();
         checkAppearsLoading(tester, false);
 
@@ -499,7 +499,7 @@ void main() {
         final errorDialogs = tester.widgetList(find.byType(AlertDialog));
         check(errorDialogs).isEmpty();
 
-        check(controller!.contentController.text)
+        check(controller!.content.text)
           .equals('see image: [Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
@@ -515,7 +515,7 @@ void main() {
         checkAppearsLoading(tester, true);
 
         await tester.pump(const Duration(seconds: 1));
-        check(controller!.contentController.text)
+        check(controller!.content.text)
           .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         checkAppearsLoading(tester, false);
       });
@@ -535,7 +535,7 @@ void main() {
         // (When we check that the send button looks disabled, it should be because
         // the file is uploading, not a pre-existing reason.)
         await enterTopic(tester, narrow: narrow, topic: 'some topic');
-        controller!.contentController.value = const TextEditingValue(text: 'see image: ');
+        controller!.content.value = const TextEditingValue(text: 'see image: ');
         await tester.pump();
         checkAppearsLoading(tester, false);
 
@@ -559,7 +559,7 @@ void main() {
         final errorDialogs = tester.widgetList(find.byType(AlertDialog));
         check(errorDialogs).isEmpty();
 
-        check(controller!.contentController.text)
+        check(controller!.content.text)
           .equals('see image: [Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
@@ -575,7 +575,7 @@ void main() {
         checkAppearsLoading(tester, true);
 
         await tester.pump(const Duration(seconds: 1));
-        check(controller!.contentController.text)
+        check(controller!.content.text)
           .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         checkAppearsLoading(tester, false);
       });


### PR DESCRIPTION
Prompted by reviewing Zixuan's #924, this is meant to make the compose-box code better prepared for that work than it is in `main`; details at https://github.com/zulip/zulip-flutter/pull/924#pullrequestreview-2450028109 and in the commits.

Please let me know as soon as anything doesn't look clear. I'm tired (it's almost bedtime 🙂) but I've spent a while on this and I wanted to get it in today if possible. Since this makes a UI change, screenshots coming soon.

Fixes: #1089