### PR TITLE
lightbox: Added user's avatar in the lightbox app bar

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -171,21 +171,24 @@ class _LightboxPageLayoutState extends State<_LightboxPageLayout> {
         backgroundColor: appBarBackgroundColor,
         shape: const Border(), // Remove bottom border from [AppBarTheme]
         elevation: appBarElevation,
+        title: Row(children: [
+          Avatar(size: 36, borderRadius: 36 / 8, userId: widget.message.senderId),
+          const SizedBox(width: 8),
+          Expanded(
+            child: RichText(
+              text: TextSpan(children: [
+                TextSpan(
+                  text: '${widget.message.senderFullName}\n',
 
-        // TODO(#41): Show message author's avatar
-        title: RichText(
-          text: TextSpan(children: [
-            TextSpan(
-              text: '${widget.message.senderFullName}\n',
+                  // Restate default
+                  style: themeData.textTheme.titleLarge!.copyWith(color: appBarForegroundColor)),
+                TextSpan(
+                  text: timestampText,
 
-              // Restate default
-              style: themeData.textTheme.titleLarge!.copyWith(color: appBarForegroundColor)),
-            TextSpan(
-              text: timestampText,
-
-              // Make smaller, like a subtitle
-              style: themeData.textTheme.titleSmall!.copyWith(color: appBarForegroundColor)),
-          ])),
+                  // Make smaller, like a subtitle
+                  style: themeData.textTheme.titleSmall!.copyWith(color: appBarForegroundColor)),
+              ]))),
+        ]),
         bottom: widget.buildAppBarBottom(context));
     }
 

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -254,6 +254,17 @@ void main() {
       debugNetworkImageHttpClientProvider = null;
     });
 
+    testWidgets('app bar shows sender avatar', (tester) async {
+      prepareBoringImageHttpClient();
+      final message = eg.streamMessage(sender: eg.otherUser);
+      await setupPage(tester, message: message, thumbnailUrl: null);
+
+      final avatar = tester.widget<Avatar>(find.byType(Avatar));
+      check(avatar.userId).equals(message.senderId);
+
+      debugNetworkImageHttpClientProvider = null;
+    });
+
     testWidgets('header and footer hidden and shown by tapping image', (tester) async {
       prepareBoringImageHttpClient();
       final message = eg.streamMessage(sender: eg.otherUser);


### PR DESCRIPTION
In the lightbox, the RN app shows the message author's avatar along with their name in the app bar. This change implements the same behavior in the Flutter app, positioning the avatar beside the name/date text in the "start" direction (left in LTR layouts, right in RTL layouts).

The changes:
- Add Avatar widget in the lightbox app bar next to the author's name and date
- Ensure the avatar is positioned correctly based on the text direction (LTR/RTL)
- Maintain consistent sizing and spacing (35px size, 8px right padding)
- Handle overflow gracefully for both avatars and names

Screenshot-

<img src="https://github.com/user-attachments/assets/b756b95f-53b4-4cb0-b3c3-2cef1b995563" width="400"/>

Fixes #41