### PR TITLE
Use `ScrollViewKeyboardDismissBehavior.onDrag` on both platforms

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -552,13 +552,10 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       // TODO: Offer `ScrollViewKeyboardDismissBehavior.interactive` (or
       //   similar) if that is ever offered:
       //     https://github.com/flutter/flutter/issues/57609#issuecomment-1355340849
-      keyboardDismissBehavior: switch (Theme.of(context).platform) {
-        // This seems to offer the only built-in way to close the keyboard
-        // on iOS. It's not ideal; see TODO above.
-        TargetPlatform.iOS => ScrollViewKeyboardDismissBehavior.onDrag,
-        // The Android keyboard seems to have a built-in close button.
-        _ => ScrollViewKeyboardDismissBehavior.manual,
-      },
+      //   This seems to offer the only built-in way to close the keyboard
+      // on iOS. It's not ideal; see TODO above.
+      // For Android also users gets ability to dismiss the keyboard by dragging the message list.
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
 
       controller: scrollController,
       semanticChildCount: length + 2,


### PR DESCRIPTION
Enable keyboard dismissal by dragging the message list on both iOS and Android. This provides a consistent experience across platforms while preserving Android's built-in keyboard close button.

Previously we used `ScrollViewKeyboardDismissBehavior.manual` on Android which didn't work effectively for dismissing the keyboard. Now users on both platforms can dismiss the keyboard by dragging the message list, matching iOS's existing behavior.

The change is simple - we now use `ScrollViewKeyboardDismissBehavior.onDrag` unconditionally instead of switching based on platform.

Please refer - [comment - 897](https://github.com/zulip/zulip-flutter/pull/897#discussion_r1818188643) and [Topic discussion](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Dismiss.20keyboard.20and.20shift.20focus.20when.20tap.20background)