### PR TITLE
Make topic headers case-insensitive

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -352,7 +352,7 @@ mixin _MessageSequence {
 bool haveSameRecipient(Message prevMessage, Message message) {
   if (prevMessage is StreamMessage && message is StreamMessage) {
     if (prevMessage.streamId != message.streamId) return false;
-    if (prevMessage.topic != message.topic) return false;
+    if (prevMessage.topic.toLowerCase() != message.topic.toLowerCase()) return false;
   } else if (prevMessage is DmMessage && message is DmMessage) {
     if (!_equalIdSequences(prevMessage.allRecipientIds, message.allRecipientIds)) {
       return false;

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1803,6 +1803,26 @@ void main() {
         }
       }
     });
+
+    group('topics compared case-insensitively', () {
+      void doTest(String description, String topicA, String topicB, bool expected) {
+        test(description, () {
+          final stream = eg.stream();
+          final messageA = eg.streamMessage(stream: stream, topic: topicA);
+          final messageB = eg.streamMessage(stream: stream, topic: topicB);
+          check(haveSameRecipient(messageA, messageB)).equals(expected);
+        });
+      }
+
+      doTest('same case, all lower',               'abc',  'abc',  true);
+      doTest('same case, all upper',               'ABC',  'ABC',  true);
+      doTest('same case, mixed',                   'AbC',  'AbC',  true);
+      doTest('same non-cased chars',               '嗎',    '嗎',    true);
+      doTest('different case',                     'aBc',  'ABC',  true);
+      doTest('different case, same diacritics',    'AbÇ',  'aBç',  true);
+      doTest('same letters, different diacritics', 'ma',   'mǎ',   false);
+      doTest('having different CJK characters',    '嗎', '馬', false);
+    });
   });
 
   test('messagesSameDay', () {


### PR DESCRIPTION
Topics in Zulip are case-insensitive. This change makes the message list's topic headers match that behavior, so messages whose topics differ only in case (like "missing string" and "Missing string") share a single header.  This brings the behavior in line with Zulip web.

### What is the change?

The change modifies the topic comparison logic in `haveSameRecipient()` to use case-insensitive comparison when determining whether to show a new recipient header.

### Screenshots

| Before                                                                                       | After                                                                                        |
|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
| <img src="https://github.com/user-attachments/assets/fdc22a9b-bf28-42ec-aa74-0ea94dde20ff" width="400"/> | <img src="https://github.com/user-attachments/assets/7732218a-d42f-4421-8a30-d89a85e60389" width="400"/> |




Fixes #739