### PR TITLE
Use emoji font to show explicit emoji

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -54,6 +54,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
         debugLabel: 'ContentTheme.textStylePlainParagraph'),
+      textStyleEmoji: TextStyle(
+        fontFamily: emojiFontFamily, fontFamilyFallback: const []),
       codeBlockTextStyles: CodeBlockTextStyles.light(context),
       textStyleError: const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
         .merge(weightVariableTextStyle(context, wght: 700)),
@@ -85,6 +87,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.85).toColor(),
         debugLabel: 'ContentTheme.textStylePlainParagraph'),
+      textStyleEmoji: TextStyle(
+        fontFamily: emojiFontFamily, fontFamilyFallback: const []),
       codeBlockTextStyles: CodeBlockTextStyles.dark(context),
       textStyleError: const TextStyle(fontSize: kBaseFontSize, color: Colors.red)
         .merge(weightVariableTextStyle(context, wght: 700)),
@@ -113,6 +117,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.colorTableHeaderBackground,
     required this.colorThematicBreak,
     required this.textStylePlainParagraph,
+    required this.textStyleEmoji,
     required this.codeBlockTextStyles,
     required this.textStyleError,
     required this.textStyleErrorCode,
@@ -151,6 +156,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   /// This is the complete style for plain paragraphs. Plain-paragraph content
   /// should not need styles from other sources, such as Material defaults.
   final TextStyle textStylePlainParagraph;
+
+  /// The [TextStyle] to use for Unicode emoji.
+  final TextStyle textStyleEmoji;
 
   final CodeBlockTextStyles codeBlockTextStyles;
   final TextStyle textStyleError;
@@ -201,6 +209,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     Color? colorTableHeaderBackground,
     Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
+    TextStyle? textStyleEmoji,
     CodeBlockTextStyles? codeBlockTextStyles,
     TextStyle? textStyleError,
     TextStyle? textStyleErrorCode,
@@ -222,6 +231,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorTableHeaderBackground: colorTableHeaderBackground ?? this.colorTableHeaderBackground,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
+      textStyleEmoji: textStyleEmoji ?? this.textStyleEmoji,
       codeBlockTextStyles: codeBlockTextStyles ?? this.codeBlockTextStyles,
       textStyleError: textStyleError ?? this.textStyleError,
       textStyleErrorCode: textStyleErrorCode ?? this.textStyleErrorCode,
@@ -250,6 +260,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorTableHeaderBackground: Color.lerp(colorTableHeaderBackground, other.colorTableHeaderBackground, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
+      textStyleEmoji: TextStyle.lerp(textStyleEmoji, other.textStyleEmoji, t)!,
       codeBlockTextStyles: CodeBlockTextStyles.lerp(codeBlockTextStyles, other.codeBlockTextStyles, t),
       textStyleError: TextStyle.lerp(textStyleError, other.textStyleError, t)!,
       textStyleErrorCode: TextStyle.lerp(textStyleErrorCode, other.textStyleErrorCode, t)!,
@@ -1031,7 +1042,9 @@ class _InlineContentBuilder {
           child: UserMention(ambientTextStyle: widget.style, node: node));
 
       case UnicodeEmojiNode():
-        return TextSpan(text: node.emojiUnicode, recognizer: _recognizer);
+        return TextSpan(text: node.emojiUnicode, recognizer: _recognizer,
+          style: widget.style
+            .merge(ContentTheme.of(_context!).textStyleEmoji));
 
       case ImageEmojiNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -50,8 +50,8 @@ class UnicodeEmojiWidget extends StatelessWidget {
 
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        // We expect the font "Apple Color Emoji" to be used. There are some
-        // surprises in how Flutter ends up rendering emojis in this font:
+        // We use the font "Apple Color Emoji". There are some surprises in how
+        // Flutter ends up rendering emojis in this font:
         // - With a font size of 17px, the emoji visually seems to be about 17px
         //   square. (Unlike on Android, with Noto Color Emoji, where a 14.5px font
         //   size gives an emoji that looks 17px square.) See:
@@ -71,7 +71,9 @@ class UnicodeEmojiWidget extends StatelessWidget {
           SizedBox(height: boxSize, width: boxSize),
           PositionedDirectional(start: 0, child: Text(
             textScaler: textScaler,
-            style: TextStyle(fontSize: size),
+            style: TextStyle(
+              fontFamily: 'Apple Color Emoji',
+              fontSize: size),
             strutStyle: StrutStyle(fontSize: size, forceStrutHeight: true),
             emojiDisplay.emojiUnicode)),
         ]);

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -153,8 +153,12 @@ const kDefaultFontFamily = 'Source Sans 3';
 
 /// The [TextStyle.fontFamilyFallback] for use with [kDefaultFontFamily].
 List<String> get defaultFontFamilyFallback => [
-  _useAppleEmoji ? 'Apple Color Emoji' : 'Noto Color Emoji',
+  emojiFontFamily,
 ];
+
+String get emojiFontFamily {
+  return _useAppleEmoji ? 'Apple Color Emoji' : 'Noto Color Emoji';
+}
 
 /// Whether to use the Apple Color Emoji font for showing emoji.
 ///

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -153,19 +153,24 @@ const kDefaultFontFamily = 'Source Sans 3';
 
 /// The [TextStyle.fontFamilyFallback] for use with [kDefaultFontFamily].
 List<String> get defaultFontFamilyFallback => [
-  if (_useNotoEmoji) 'Noto Color Emoji',
+  _useAppleEmoji ? 'Apple Color Emoji' : 'Noto Color Emoji',
 ];
 
-/// Whether to use the Noto Color Emoji font for showing emoji.
-bool get _useNotoEmoji => switch (defaultTargetPlatform) {
+/// Whether to use the Apple Color Emoji font for showing emoji.
+///
+/// When false, we use Noto Color Emoji instead.
+bool get _useAppleEmoji => switch (defaultTargetPlatform) {
   // iOS doesn't support any of the formats Noto Color Emoji is available in.
   // If we use it on iOS, we'll get blank spaces where we could have had
   // Apple-style emojis.  We presume the same is true of macOS.
-  TargetPlatform.iOS || TargetPlatform.macOS => false,
-  // The font certainly works on Android.
+  // Conversely, both platforms provide Apple Color Emoji.  So we use that.
+  TargetPlatform.iOS || TargetPlatform.macOS => true,
+
+  // The Noto Color Emoji font works fine on Android.
   // We presume it works on the other platforms.
+  // Conversely Apple Color Emoji isn't an option on any of these.
   TargetPlatform.android || TargetPlatform.linux
-    || TargetPlatform.fuchsia || TargetPlatform.windows => true,
+    || TargetPlatform.fuchsia || TargetPlatform.windows => false,
 };
 
 /// A mergeable [TextStyle] with 'Source Code Pro' and platform-aware fallbacks.

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -21,7 +21,7 @@ import 'package:flutter/material.dart';
 /// For example, the base style for message content;
 /// see [ContentTheme.textStylePlainParagraph].
 ///
-/// Applies [kDefaultFontFamily] and [kDefaultFontFamilyFallback],
+/// Applies [kDefaultFontFamily] and [defaultFontFamilyFallback],
 /// being faithful to the Material-default font weights
 /// by running them through [weightVariableTextStyle].
 /// (That is needed because [kDefaultFontFamily] is a variable-weight font).

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -153,11 +153,20 @@ const kDefaultFontFamily = 'Source Sans 3';
 
 /// The [TextStyle.fontFamilyFallback] for use with [kDefaultFontFamily].
 List<String> get defaultFontFamilyFallback => [
-  // iOS doesn't support any of the formats this font is available in.
-  // If we use it on iOS, we'll get blank spaces where we could have had Apple-
-  // style emojis.
-  if (defaultTargetPlatform == TargetPlatform.android) 'Noto Color Emoji',
+  if (_useNotoEmoji) 'Noto Color Emoji',
 ];
+
+/// Whether to use the Noto Color Emoji font for showing emoji.
+bool get _useNotoEmoji => switch (defaultTargetPlatform) {
+  // iOS doesn't support any of the formats Noto Color Emoji is available in.
+  // If we use it on iOS, we'll get blank spaces where we could have had
+  // Apple-style emojis.  We presume the same is true of macOS.
+  TargetPlatform.iOS || TargetPlatform.macOS => false,
+  // The font certainly works on Android.
+  // We presume it works on the other platforms.
+  TargetPlatform.android || TargetPlatform.linux
+    || TargetPlatform.fuchsia || TargetPlatform.windows => true,
+};
 
 /// A mergeable [TextStyle] with 'Source Code Pro' and platform-aware fallbacks.
 ///

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -65,16 +65,17 @@ TextStyle? mergeSpanStylesOuterToInner(
   });
 }
 
-/// The "merged style" ([mergeSpanStylesOuterToInner]) of a nested span.
-TextStyle? mergedStyleOfSubstring(InlineSpan rootSpan, Pattern substringPattern) {
+/// The "merged style" ([mergeSpanStylesOuterToInner]) of a text span
+/// whose whole text matches the given pattern, under the given root span.
+TextStyle? mergedStyleOfSubstring(InlineSpan rootSpan, Pattern spanPattern) {
   return mergeSpanStylesOuterToInner(rootSpan,
     (span) {
       if (span is! TextSpan) return false;
       final text = span.text;
       if (text == null) return false;
-      return switch (substringPattern) {
-        String() => text == substringPattern,
-        _ => substringPattern.allMatches(text)
+      return switch (spanPattern) {
+        String() => text == spanPattern,
+        _ => spanPattern.allMatches(text)
           .any((match) => match.start == 0 && match.end == text.length),
       };
     });

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -877,6 +877,19 @@ void main() {
     testContentSmoke(ContentExample.emojiUnicode);
     testContentSmoke(ContentExample.emojiUnicodeMultiCodepoint);
     testContentSmoke(ContentExample.emojiUnicodeLiteral);
+
+    testWidgets('use emoji font', (tester) async {
+      // Compare [ContentExample.emojiUnicode].
+      const emojiHeartHtml =
+        '<p><span aria-label="heart" class="emoji emoji-2764" role="img" title="heart">:heart:</span></p>';
+      await prepareContent(tester, plainContent(emojiHeartHtml));
+      check(mergedStyleOf(tester, '\u{2764}')).isNotNull()
+        .fontFamily.equals(switch (defaultTargetPlatform) {
+          TargetPlatform.android => 'Noto Color Emoji',
+          TargetPlatform.iOS => 'Apple Color Emoji',
+          _ => throw StateError('unexpected platform in test'),
+        });
+    }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
   });
 
   group('inline math', () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -683,11 +683,8 @@ void main() {
     }
 
     TextStyle textStyleFromWidget(WidgetTester tester, UserMention widget, String mentionText) {
-      final fullNameSpan = tester.renderObject<RenderParagraph>(
-        find.descendant(
-          of: find.byWidget(widget), matching: find.text(mentionText))
-      ).text;
-      return mergedStyleOfSubstring(fullNameSpan, mentionText)!;
+      return mergedStyleOf(tester,
+        findAncestor: find.byWidget(widget), mentionText)!;
     }
 
     testWidgets('maintains font-size ratio with surrounding text', (tester) async {

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -18,6 +18,7 @@ import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/test_store.dart';
 import '../test_images.dart';
+import 'content_test.dart';
 import 'test_app.dart';
 import 'text_test.dart';
 
@@ -258,6 +259,23 @@ void main() {
     check(backgroundColor('tada')).isNotNull()
       .isSameColorAs(EmojiReactionTheme.dark().bgUnselected);
   });
+
+  testWidgets('use emoji font', (tester) async {
+    await prepare();
+    await store.addUser(eg.selfUser);
+    await setupChipsInBox(tester, reactions: [
+      Reaction.fromJson({
+        'user_id': eg.selfUser.userId,
+        'emoji_name': 'heart', 'emoji_code': '2764', 'reaction_type': 'unicode_emoji'}),
+    ]);
+
+    check(mergedStyleOf(tester, '\u{2764}')).isNotNull()
+      .fontFamily.equals(switch (defaultTargetPlatform) {
+        TargetPlatform.android => 'Noto Color Emoji',
+        TargetPlatform.iOS => 'Apple Color Emoji',
+        _ => throw StateError('unexpected platform in test'),
+      });
+  }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
   // TODO more tests:
   // - Tapping a chip does the right thing


### PR DESCRIPTION
One of the two main commits here I cherry-picked from @rajveermalviya's #1103, and then wrote a test for.

Fixes: #1104 

### Selected commit messages

emoji: Use "Apple Color Emoji" font on iOS/macOS for UnicodeEmojiWidget

Some unicode characters, like U+2764 (❤) or U+00AE (®) can
have glyphs in non-Emoji fonts, resulting in incorrect
rendering of such characters, where we specifically want an
emoji to be displayed.

So, explicitly mention "Apple Color Emoji" to be the font used on
iOS/macOS for displaying the unicode emoji.

This resolves part of #1104, namely for reaction chips
and autocomplete results.

[greg: wrote test]

Fixes-partly: #1104

---

content: Use emoji font to show emoji nodes

For emoji like ❤ U+2764 HEAVY BLACK HEART, this causes us to show a
colorful, larger glyph like ❤️ from the emoji font, instead of a glyph
like ❤︎ that comes from a plain-text font and has the color and size
of plain text.

Fixes: #1104
