### PR TITLE
i18n [nfc]: Adjust "page title" string descriptions for clarity

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1,7 +1,7 @@
 {
   "aboutPageTitle": "About Zulip",
   "@aboutPageTitle": {
-    "description": "Title for About Zulip page"
+    "description": "Title for About Zulip page."
   },
   "aboutPageAppVersion": "App version",
   "@aboutPageAppVersion": {
@@ -17,7 +17,7 @@
   },
   "chooseAccountPageTitle": "Choose account",
   "@chooseAccountPageTitle": {
-    "description": "Title for ChooseAccountPage"
+    "description": "Title for the page to choose between Zulip accounts."
   },
   "chooseAccountPageLogOutButton": "Log out",
   "@chooseAccountPageLogOutButton": {
@@ -348,7 +348,7 @@
   },
   "loginPageTitle": "Log in",
   "@loginPageTitle": {
-    "description": "Page title for login page."
+    "description": "Title for login page."
   },
   "loginFormSubmitLabel": "Log in",
   "@loginFormSubmitLabel": {
@@ -367,7 +367,7 @@
   },
   "loginAddAnAccountPageTitle": "Add an account",
   "@loginAddAnAccountPageTitle": {
-    "description": "Page title for screen to add a Zulip account."
+    "description": "Title for page to add a Zulip account."
   },
   "loginServerUrlInputLabel": "Your Zulip server URL",
   "@loginServerUrlInputLabel": {
@@ -531,19 +531,19 @@
   },
   "recentDmConversationsPageTitle": "Direct messages",
   "@recentDmConversationsPageTitle": {
-    "description": "Title for the page of recent DM conversations"
+    "description": "Title for the page with a list of DM conversations."
   },
   "combinedFeedPageTitle": "Combined feed",
   "@combinedFeedPageTitle": {
-    "description": "Title for the page of combined feed."
+    "description": "Page title for the 'Combined feed' message view."
   },
   "mentionsPageTitle": "Mentions",
   "@mentionsPageTitle": {
-    "description": "Title for the page of @-mentions."
+    "description": "Page title for the 'Mentions' message view."
   },
   "starredMessagesPageTitle": "Starred messages",
   "@starredMessagesPageTitle": {
-    "description": "Title for the page of starred messages."
+    "description": "Page title for the 'Starred messages' message view."
   },
   "channelFeedButtonTooltip": "Channel feed",
   "@channelFeedButtonTooltip": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -97,7 +97,7 @@ abstract class ZulipLocalizations {
     Locale('ja')
   ];
 
-  /// Title for About Zulip page
+  /// Title for About Zulip page.
   ///
   /// In en, this message translates to:
   /// **'About Zulip'**
@@ -121,7 +121,7 @@ abstract class ZulipLocalizations {
   /// **'Tap to view'**
   String get aboutPageTapToView;
 
-  /// Title for ChooseAccountPage
+  /// Title for the page to choose between Zulip accounts.
   ///
   /// In en, this message translates to:
   /// **'Choose account'**
@@ -553,7 +553,7 @@ abstract class ZulipLocalizations {
   /// **'Copy link'**
   String get lightboxCopyLinkTooltip;
 
-  /// Page title for login page.
+  /// Title for login page.
   ///
   /// In en, this message translates to:
   /// **'Log in'**
@@ -577,7 +577,7 @@ abstract class ZulipLocalizations {
   /// **'Sign in with {method}'**
   String signInWithFoo(String method);
 
-  /// Page title for screen to add a Zulip account.
+  /// Title for page to add a Zulip account.
   ///
   /// In en, this message translates to:
   /// **'Add an account'**
@@ -799,25 +799,25 @@ abstract class ZulipLocalizations {
   /// **'Unknown'**
   String get userRoleUnknown;
 
-  /// Title for the page of recent DM conversations
+  /// Title for the page with a list of DM conversations.
   ///
   /// In en, this message translates to:
   /// **'Direct messages'**
   String get recentDmConversationsPageTitle;
 
-  /// Title for the page of combined feed.
+  /// Page title for the 'Combined feed' message view.
   ///
   /// In en, this message translates to:
   /// **'Combined feed'**
   String get combinedFeedPageTitle;
 
-  /// Title for the page of @-mentions.
+  /// Page title for the 'Mentions' message view.
   ///
   /// In en, this message translates to:
   /// **'Mentions'**
   String get mentionsPageTitle;
 
-  /// Title for the page of starred messages.
+  /// Page title for the 'Starred messages' message view.
   ///
   /// In en, this message translates to:
   /// **'Starred messages'**


### PR DESCRIPTION
Some of these were a bit hard to parse.

Also make them somewhat more parallel to each other.

Prompted by: https://github.com/zulip/zulip-flutter/pull/1076#discussion_r1874151721