### PR TITLE
Rank emoji results in autocomplete

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -758,9 +758,14 @@ sealed class ComposeAutocompleteResult extends AutocompleteResult {}
 
 /// An emoji chosen in an autocomplete interaction, via [EmojiAutocompleteView].
 class EmojiAutocompleteResult extends ComposeAutocompleteResult {
-  EmojiAutocompleteResult(this.candidate);
+  EmojiAutocompleteResult(this.candidate, this.rank);
 
   final EmojiCandidate candidate;
+
+  /// A measure of the result's quality in the context of the query.
+  ///
+  /// Used internally by [EmojiAutocompleteView] for ranking the results.
+  final int rank;
 
   @override
   String toString() {

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -364,6 +364,7 @@ class EmojiAutocompleteQuery extends ComposeAutocompleteQuery {
 
   // Compare get_emoji_matcher in Zulip web:shared/src/typeahead.ts .
   bool matches(EmojiCandidate candidate) {
+    if (_adjusted == '') return true;
     if (candidate.emojiDisplay case UnicodeEmojiDisplay(:var emojiUnicode)) {
       if (_adjusted == emojiUnicode) return true;
     }

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -343,7 +343,7 @@ class EmojiAutocompleteView extends AutocompleteView<EmojiAutocompleteQuery, Emo
   }
 
   static EmojiAutocompleteResult? _testCandidate(EmojiAutocompleteQuery query, EmojiCandidate candidate) {
-    return query._testCandidate(candidate);
+    return query.testCandidate(candidate);
   }
 }
 
@@ -375,7 +375,8 @@ class EmojiAutocompleteQuery extends ComposeAutocompleteQuery {
     return EmojiAutocompleteView.init(store: store, query: this);
   }
 
-  EmojiAutocompleteResult? _testCandidate(EmojiCandidate candidate) {
+  @visibleForTesting
+  EmojiAutocompleteResult? testCandidate(EmojiCandidate candidate) {
     return matches(candidate) ? EmojiAutocompleteResult(candidate) : null;
   }
 

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -295,7 +295,7 @@ class EmojiStoreImpl with EmojiStore {
     //    but then ranks them first, after only the six "popular" emoji,
     //    once there's a non-empty query.
     //  * Web gives the six "popular" emoji a set order amongst themselves,
-    //    like we do after #1112; but in web, this order appears only in the
+    //    like we do here; but in web, this order appears only in the
     //    emoji picker on an empty query, and is otherwise lost even when the
     //    emoji are taken out of their home categories and shown instead
     //    together at the front.
@@ -307,12 +307,18 @@ class EmojiStoreImpl with EmojiStore {
 
     final results = <EmojiCandidate>[];
 
+    // Include the "popular" emoji, in their canonical order
+    // relative to each other.
+    results.addAll(_popularCandidates);
+
     final namesOverridden = {
       for (final emoji in activeRealmEmoji) emoji.name,
       'zulip',
     };
     // TODO(log) if _serverEmojiData missing
     for (final entry in (_serverEmojiData ?? {}).entries) {
+      if (_popularEmojiCodes.contains(entry.key)) continue;
+
       final allNames = entry.value;
       final String emojiName;
       final List<String>? aliases;

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -380,6 +380,7 @@ class EmojiAutocompleteQuery extends ComposeAutocompleteQuery {
   }
 
   // Compare get_emoji_matcher in Zulip web:shared/src/typeahead.ts .
+  @visibleForTesting
   bool matches(EmojiCandidate candidate) {
     if (_adjusted == '') return true;
     if (candidate.emojiDisplay case UnicodeEmojiDisplay(:var emojiUnicode)) {

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -342,8 +342,8 @@ class EmojiAutocompleteView extends AutocompleteView<EmojiAutocompleteQuery, Emo
     return results;
   }
 
-  EmojiAutocompleteResult? _testCandidate(EmojiAutocompleteQuery query, EmojiCandidate candidate) {
-    return query.matches(candidate) ? EmojiAutocompleteResult(candidate) : null;
+  static EmojiAutocompleteResult? _testCandidate(EmojiAutocompleteQuery query, EmojiCandidate candidate) {
+    return query._testCandidate(candidate);
   }
 }
 
@@ -373,6 +373,10 @@ class EmojiAutocompleteQuery extends ComposeAutocompleteQuery {
   @override
   EmojiAutocompleteView initViewModel(PerAccountStore store, Narrow narrow) {
     return EmojiAutocompleteView.init(store: store, query: this);
+  }
+
+  EmojiAutocompleteResult? _testCandidate(EmojiCandidate candidate) {
+    return matches(candidate) ? EmojiAutocompleteResult(candidate) : null;
   }
 
   // Compare get_emoji_matcher in Zulip web:shared/src/typeahead.ts .

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -292,7 +292,7 @@ void main() {
       final store = prepare(
         realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f642': ['smile']});
       final view = EmojiAutocompleteView.init(store: store,
-        query: EmojiAutocompleteQuery('h'));
+        query: EmojiAutocompleteQuery('hap'));
       bool done = false;
       view.addListener(() { done = true; });
       await Future(() {});
@@ -301,7 +301,7 @@ void main() {
         isRealmResult(emojiName: 'happy'));
 
       done = false;
-      view.query = EmojiAutocompleteQuery('s');
+      view.query = EmojiAutocompleteQuery('sm');
       await Future(() {});
       check(done).isTrue();
       check(view.results).single.which(

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -324,98 +324,99 @@ void main() {
       return EmojiAutocompleteQuery(query).match(candidate);
     }
 
-    bool matchesNames(String query, List<String> names) {
-      return matchOf(query, unicode(names)) != null;
+    EmojiMatchQuality? matchOfNames(String query, List<String> names) {
+      return matchOf(query, unicode(names));
     }
 
-    bool matchesName(String query, String emojiName) {
-      return matchesNames(query, [emojiName]);
+    EmojiMatchQuality? matchOfName(String query, String emojiName) {
+      return matchOfNames(query, [emojiName]);
     }
 
     test('one-word query matches anywhere in name', () {
-      check(matchesName('', 'smile')).isTrue();
-      check(matchesName('s', 'smile')).isTrue();
-      check(matchesName('sm', 'smile')).isTrue();
-      check(matchesName('smile', 'smile')).isTrue();
-      check(matchesName('m', 'smile')).isTrue();
-      check(matchesName('mile', 'smile')).isTrue();
-      check(matchesName('e', 'smile')).isTrue();
+      check(matchOfName('', 'smile')).match;
+      check(matchOfName('s', 'smile')).match;
+      check(matchOfName('sm', 'smile')).match;
+      check(matchOfName('smile', 'smile')).match;
+      check(matchOfName('m', 'smile')).match;
+      check(matchOfName('mile', 'smile')).match;
+      check(matchOfName('e', 'smile')).match;
 
-      check(matchesName('smiley', 'smile')).isFalse();
-      check(matchesName('a', 'smile')).isFalse();
+      check(matchOfName('smiley', 'smile')).none;
+      check(matchOfName('a', 'smile')).none;
 
-      check(matchesName('o', 'open_book')).isTrue();
-      check(matchesName('open', 'open_book')).isTrue();
-      check(matchesName('pe', 'open_book')).isTrue();
-      check(matchesName('boo', 'open_book')).isTrue();
-      check(matchesName('ok', 'open_book')).isTrue();
+      check(matchOfName('o', 'open_book')).match;
+      check(matchOfName('open', 'open_book')).match;
+      check(matchOfName('pe', 'open_book')).match;
+      check(matchOfName('boo', 'open_book')).match;
+      check(matchOfName('ok', 'open_book')).match;
     });
 
     test('multi-word query matches from start of a word', () {
-      check(matchesName('open_', 'open_book')).isTrue();
-      check(matchesName('open_b', 'open_book')).isTrue();
-      check(matchesName('open_book', 'open_book')).isTrue();
+      check(matchOfName('open_', 'open_book')).match;
+      check(matchOfName('open_b', 'open_book')).match;
+      check(matchOfName('open_book', 'open_book')).match;
 
-      check(matchesName('pen_', 'open_book')).isFalse();
-      check(matchesName('n_b', 'open_book')).isFalse();
+      check(matchOfName('pen_', 'open_book')).none;
+      check(matchOfName('n_b', 'open_book')).none;
 
-      check(matchesName('blue_dia', 'large_blue_diamond')).isTrue();
+      check(matchOfName('blue_dia', 'large_blue_diamond')).match;
     });
 
     test('spaces in query behave as underscores', () {
-      check(matchesName('open ', 'open_book')).isTrue();
-      check(matchesName('open b', 'open_book')).isTrue();
-      check(matchesName('open book', 'open_book')).isTrue();
+      check(matchOfName('open ', 'open_book')).match;
+      check(matchOfName('open b', 'open_book')).match;
+      check(matchOfName('open book', 'open_book')).match;
 
-      check(matchesName('pen ', 'open_book')).isFalse();
-      check(matchesName('n b', 'open_book')).isFalse();
+      check(matchOfName('pen ', 'open_book')).none;
+      check(matchOfName('n b', 'open_book')).none;
 
-      check(matchesName('blue dia', 'large_blue_diamond')).isTrue();
+      check(matchOfName('blue dia', 'large_blue_diamond')).match;
     });
 
     test('query is lower-cased', () {
-      check(matchesName('Smi', 'smile')).isTrue();
+      check(matchOfName('Smi', 'smile')).match;
     });
 
     test('query matches aliases same way as primary name', () {
-      check(matchesNames('a', ['a', 'b'])).isTrue();
-      check(matchesNames('b', ['a', 'b'])).isTrue();
-      check(matchesNames('c', ['a', 'b'])).isFalse();
+      check(matchOfNames('a', ['a', 'b'])).match;
+      check(matchOfNames('b', ['a', 'b'])).match;
+      check(matchOfNames('c', ['a', 'b'])).none;
 
-      check(matchesNames('pe', ['x', 'open_book'])).isTrue();
-      check(matchesNames('ok', ['x', 'open_book'])).isTrue();
+      check(matchOfNames('pe', ['x', 'open_book'])).match;
+      check(matchOfNames('ok', ['x', 'open_book'])).match;
 
-      check(matchesNames('open_', ['x', 'open_book'])).isTrue();
-      check(matchesNames('open b', ['x', 'open_book'])).isTrue();
-      check(matchesNames('pen_', ['x', 'open_book'])).isFalse();
+      check(matchOfNames('open_', ['x', 'open_book'])).match;
+      check(matchOfNames('open b', ['x', 'open_book'])).match;
+      check(matchOfNames('pen_', ['x', 'open_book'])).none;
 
-      check(matchesNames('Smi', ['x', 'smile'])).isTrue();
+      check(matchOfNames('Smi', ['x', 'smile'])).match;
     });
 
     test('query matches literal Unicode value', () {
-      bool matchesLiteral(String query, String emojiCode, {required String aka}) {
+      EmojiMatchQuality? matchOfLiteral(String query, String emojiCode, {
+          required String aka}) {
         assert(aka == query);
-        return matchOf(query, unicode(['asdf'], emojiCode: emojiCode)) != null;
+        return matchOf(query, unicode(['asdf'], emojiCode: emojiCode));
       }
 
       // Matching the code, in hex, doesn't count.
-      check(matchesLiteral('1f642', aka: '1f642', '1f642')).isFalse();
+      check(matchOfLiteral('1f642', aka: '1f642', '1f642')).none;
 
       // Matching the Unicode value the code describes does count…
-      check(matchesLiteral('🙂', aka: '\u{1f642}', '1f642')).isTrue();
+      check(matchOfLiteral('🙂', aka: '\u{1f642}', '1f642')).match;
       // … and failing to match it doesn't make a match.
-      check(matchesLiteral('🙁', aka: '\u{1f641}', '1f642')).isFalse();
+      check(matchOfLiteral('🙁', aka: '\u{1f641}', '1f642')).none;
 
       // Multi-code-point emoji work fine.
-      check(matchesLiteral('🏳‍🌈', aka: '\u{1f3f3}\u{200d}\u{1f308}',
-        '1f3f3-200d-1f308')).isTrue();
+      check(matchOfLiteral('🏳‍🌈', aka: '\u{1f3f3}\u{200d}\u{1f308}',
+        '1f3f3-200d-1f308')).match;
       // Only exact matches count; no partial matches.
-      check(matchesLiteral('🏳', aka: '\u{1f3f3}',
-        '1f3f3-200d-1f308')).isFalse();
-      check(matchesLiteral('‍🌈', aka: '\u{200d}\u{1f308}',
-        '1f3f3-200d-1f308')).isFalse();
-      check(matchesLiteral('🏳‍🌈', aka: '\u{1f3f3}\u{200d}\u{1f308}',
-        '1f3f3')).isFalse();
+      check(matchOfLiteral('🏳', aka: '\u{1f3f3}',
+        '1f3f3-200d-1f308')).none;
+      check(matchOfLiteral('‍🌈', aka: '\u{200d}\u{1f308}',
+        '1f3f3-200d-1f308')).none;
+      check(matchOfLiteral('🏳‍🌈', aka: '\u{1f3f3}\u{200d}\u{1f308}',
+        '1f3f3')).none;
     });
 
     test('can match realm emoji', () {
@@ -429,11 +430,11 @@ void main() {
             resolvedStillUrl: eg.realmUrl.resolve('/emoji/1-still.png')));
       }
 
-      check(matchOf('eqeq', realmCandidate('eqeq'))).isNotNull();
-      check(matchOf('open_', realmCandidate('open_book'))).isNotNull();
-      check(matchOf('n_b', realmCandidate('open_book'))).isNull();
-      check(matchOf('blue dia', realmCandidate('large_blue_diamond'))).isNotNull();
-      check(matchOf('Smi', realmCandidate('smile'))).isNotNull();
+      check(matchOf('eqeq', realmCandidate('eqeq'))).match;
+      check(matchOf('open_', realmCandidate('open_book'))).match;
+      check(matchOf('n_b', realmCandidate('open_book'))).none;
+      check(matchOf('blue dia', realmCandidate('large_blue_diamond'))).match;
+      check(matchOf('Smi', realmCandidate('smile'))).match;
     });
 
     test('can match Zulip extra emoji', () {
@@ -445,10 +446,10 @@ void main() {
           emojiType: ReactionType.zulipExtraEmoji,
           emojiCode: 'zulip', emojiName: 'zulip'));
 
-      check(matchOf('z', zulipCandidate)).isNotNull();
-      check(matchOf('Zulip', zulipCandidate)).isNotNull();
-      check(matchOf('p', zulipCandidate)).isNotNull();
-      check(matchOf('x', zulipCandidate)).isNull();
+      check(matchOf('z', zulipCandidate)).match;
+      check(matchOf('Zulip', zulipCandidate)).match;
+      check(matchOf('p', zulipCandidate)).match;
+      check(matchOf('x', zulipCandidate)).none;
     });
   });
 }
@@ -472,6 +473,11 @@ extension EmojiCandidateChecks on Subject<EmojiCandidate> {
   Subject<String> get emojiName => has((x) => x.emojiName, 'emojiName');
   Subject<Iterable<String>> get aliases => has((x) => x.aliases, 'aliases');
   Subject<EmojiDisplay> get emojiDisplay => has((x) => x.emojiDisplay, 'emojiDisplay');
+}
+
+extension EmojiMatchQualityChecks on Subject<EmojiMatchQuality?> {
+  void get match => equals(EmojiMatchQuality.match);
+  void get none => isNull();
 }
 
 extension EmojiAutocompleteResultChecks on Subject<EmojiAutocompleteResult> {

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -309,7 +309,7 @@ void main() {
     });
   });
 
-  group('EmojiAutocompleteQuery.matches', () {
+  group('EmojiAutocompleteQuery.match', () {
     EmojiCandidate unicode(List<String> names, {String? emojiCode}) {
       emojiCode ??= '10ffff';
       return EmojiCandidate(emojiType: ReactionType.unicodeEmoji,
@@ -320,12 +320,12 @@ void main() {
           emojiUnicode: tryParseEmojiCodeToUnicode(emojiCode)!));
     }
 
-    bool matches(String query, EmojiCandidate candidate) {
-      return EmojiAutocompleteQuery(query).matches(candidate);
+    EmojiMatchQuality? matchOf(String query, EmojiCandidate candidate) {
+      return EmojiAutocompleteQuery(query).match(candidate);
     }
 
     bool matchesNames(String query, List<String> names) {
-      return matches(query, unicode(names));
+      return matchOf(query, unicode(names)) != null;
     }
 
     bool matchesName(String query, String emojiName) {
@@ -395,7 +395,7 @@ void main() {
     test('query matches literal Unicode value', () {
       bool matchesLiteral(String query, String emojiCode, {required String aka}) {
         assert(aka == query);
-        return matches(query, unicode(['asdf'], emojiCode: emojiCode));
+        return matchOf(query, unicode(['asdf'], emojiCode: emojiCode)) != null;
       }
 
       // Matching the code, in hex, doesn't count.
@@ -429,11 +429,11 @@ void main() {
             resolvedStillUrl: eg.realmUrl.resolve('/emoji/1-still.png')));
       }
 
-      check(matches('eqeq', realmCandidate('eqeq'))).isTrue();
-      check(matches('open_', realmCandidate('open_book'))).isTrue();
-      check(matches('n_b', realmCandidate('open_book'))).isFalse();
-      check(matches('blue dia', realmCandidate('large_blue_diamond'))).isTrue();
-      check(matches('Smi', realmCandidate('smile'))).isTrue();
+      check(matchOf('eqeq', realmCandidate('eqeq'))).isNotNull();
+      check(matchOf('open_', realmCandidate('open_book'))).isNotNull();
+      check(matchOf('n_b', realmCandidate('open_book'))).isNull();
+      check(matchOf('blue dia', realmCandidate('large_blue_diamond'))).isNotNull();
+      check(matchOf('Smi', realmCandidate('smile'))).isNotNull();
     });
 
     test('can match Zulip extra emoji', () {
@@ -445,10 +445,10 @@ void main() {
           emojiType: ReactionType.zulipExtraEmoji,
           emojiCode: 'zulip', emojiName: 'zulip'));
 
-      check(matches('z', zulipCandidate)).isTrue();
-      check(matches('Zulip', zulipCandidate)).isTrue();
-      check(matches('p', zulipCandidate)).isTrue();
-      check(matches('x', zulipCandidate)).isFalse();
+      check(matchOf('z', zulipCandidate)).isNotNull();
+      check(matchOf('Zulip', zulipCandidate)).isNotNull();
+      check(matchOf('p', zulipCandidate)).isNotNull();
+      check(matchOf('x', zulipCandidate)).isNull();
     });
   });
 }

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -320,8 +320,12 @@ void main() {
           emojiUnicode: tryParseEmojiCodeToUnicode(emojiCode)!));
     }
 
+    bool matchesNames(String query, List<String> names) {
+      return EmojiAutocompleteQuery(query).matches(unicode(names));
+    }
+
     bool matchesName(String query, String emojiName) {
-      return EmojiAutocompleteQuery(query).matches(unicode([emojiName]));
+      return matchesNames(query, [emojiName]);
     }
 
     test('one-word query matches anywhere in name', () {
@@ -370,10 +374,6 @@ void main() {
     });
 
     test('query matches aliases same way as primary name', () {
-      bool matchesNames(String query, List<String> names) {
-        return EmojiAutocompleteQuery(query).matches(unicode(names));
-      }
-
       check(matchesNames('a', ['a', 'b'])).isTrue();
       check(matchesNames('b', ['a', 'b'])).isTrue();
       check(matchesNames('c', ['a', 'b'])).isFalse();

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -152,11 +152,11 @@ void main() {
       final store = prepare(realmEmoji: {
         '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'smiley'),
       }, unicodeEmoji: {
-        '1f642': ['smile'],
+        '1f516': ['bookmark'],
         '1f603': ['smiley'],
       });
       check(store.allEmojiCandidates()).deepEquals([
-        isUnicodeCandidate('1f642', ['smile']),
+        isUnicodeCandidate('1f516', ['bookmark']),
         isRealmCandidate(emojiCode: '1', emojiName: 'smiley'),
         isZulipCandidate(),
       ]);
@@ -207,10 +207,10 @@ void main() {
       ]);
 
       store.setServerEmojiData(ServerEmojiData(codeToNames: {
-        '1f642': ['smile'],
+        '1f516': ['bookmark'],
       }));
       check(store.allEmojiCandidates()).deepEquals([
-        isUnicodeCandidate('1f642', ['smile']),
+        isUnicodeCandidate('1f516', ['bookmark']),
         isZulipCandidate(),
       ]);
     });
@@ -234,7 +234,7 @@ void main() {
       final store = prepare(realmEmoji: {
         '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'happy'),
       }, unicodeEmoji: {
-        '1f642': ['smile'],
+        '1f516': ['bookmark'],
       });
       final candidates = store.allEmojiCandidates();
       check(store.allEmojiCandidates()).identicalTo(candidates);
@@ -274,7 +274,7 @@ void main() {
 
     test('results can include all three emoji types', () async {
       final store = prepare(
-        realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f642': ['smile']});
+        realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f516': ['bookmark']});
       final view = EmojiAutocompleteView.init(store: store,
         query: EmojiAutocompleteQuery(''));
       bool done = false;
@@ -282,7 +282,7 @@ void main() {
       await Future(() {});
       check(done).isTrue();
       check(view.results).deepEquals([
-        isUnicodeResult(names: ['smile']),
+        isUnicodeResult(names: ['bookmark']),
         isRealmResult(emojiName: 'happy'),
         isZulipResult(),
       ]);

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -462,17 +462,17 @@ void main() {
         '1f3f3')).none;
     });
 
-    test('can match realm emoji', () {
-      EmojiCandidate realmCandidate(String emojiName) {
-        return EmojiCandidate(
-          emojiType: ReactionType.realmEmoji,
-          emojiCode: '1', emojiName: emojiName, aliases: null,
-          emojiDisplay: ImageEmojiDisplay(
-            emojiName: emojiName,
-            resolvedUrl: eg.realmUrl.resolve('/emoji/1.png'),
-            resolvedStillUrl: eg.realmUrl.resolve('/emoji/1-still.png')));
-      }
+    EmojiCandidate realmCandidate(String emojiName) {
+      return EmojiCandidate(
+        emojiType: ReactionType.realmEmoji,
+        emojiCode: '1', emojiName: emojiName, aliases: null,
+        emojiDisplay: ImageEmojiDisplay(
+          emojiName: emojiName,
+          resolvedUrl: eg.realmUrl.resolve('/emoji/1.png'),
+          resolvedStillUrl: eg.realmUrl.resolve('/emoji/1-still.png')));
+    }
 
+    test('can match realm emoji', () {
       check(matchOf('eqeq', realmCandidate('eqeq'))).exact;
       check(matchOf('open_', realmCandidate('open_book'))).prefix;
       check(matchOf('n_b', realmCandidate('open_book'))).none;
@@ -480,19 +480,21 @@ void main() {
       check(matchOf('Smi', realmCandidate('smile'))).prefix;
     });
 
-    test('can match Zulip extra emoji', () {
+    EmojiCandidate zulipCandidate() {
       final store = eg.store();
-      final zulipCandidate = EmojiCandidate(
+      return EmojiCandidate(
         emojiType: ReactionType.zulipExtraEmoji,
         emojiCode: 'zulip', emojiName: 'zulip', aliases: null,
         emojiDisplay: store.emojiDisplayFor(
           emojiType: ReactionType.zulipExtraEmoji,
           emojiCode: 'zulip', emojiName: 'zulip'));
+    }
 
-      check(matchOf('z', zulipCandidate)).prefix;
-      check(matchOf('Zulip', zulipCandidate)).exact;
-      check(matchOf('p', zulipCandidate)).other;
-      check(matchOf('x', zulipCandidate)).none;
+    test('can match Zulip extra emoji', () {
+      check(matchOf('z', zulipCandidate())).prefix;
+      check(matchOf('Zulip', zulipCandidate())).exact;
+      check(matchOf('p', zulipCandidate())).other;
+      check(matchOf('x', zulipCandidate())).none;
     });
 
     int? rankOf(String query, EmojiCandidate candidate) {

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -320,8 +320,12 @@ void main() {
           emojiUnicode: tryParseEmojiCodeToUnicode(emojiCode)!));
     }
 
+    bool matches(String query, EmojiCandidate candidate) {
+      return EmojiAutocompleteQuery(query).matches(candidate);
+    }
+
     bool matchesNames(String query, List<String> names) {
-      return EmojiAutocompleteQuery(query).matches(unicode(names));
+      return matches(query, unicode(names));
     }
 
     bool matchesName(String query, String emojiName) {
@@ -391,8 +395,7 @@ void main() {
     test('query matches literal Unicode value', () {
       bool matchesLiteral(String query, String emojiCode, {required String aka}) {
         assert(aka == query);
-        return EmojiAutocompleteQuery(query)
-          .matches(unicode(['asdf'], emojiCode: emojiCode));
+        return matches(query, unicode(['asdf'], emojiCode: emojiCode));
       }
 
       // Matching the code, in hex, doesn't count.
@@ -426,16 +429,11 @@ void main() {
             resolvedStillUrl: eg.realmUrl.resolve('/emoji/1-still.png')));
       }
 
-      check(EmojiAutocompleteQuery('eqeq')
-        .matches(realmCandidate('eqeq'))).isTrue();
-      check(EmojiAutocompleteQuery('open_')
-        .matches(realmCandidate('open_book'))).isTrue();
-      check(EmojiAutocompleteQuery('n_b')
-        .matches(realmCandidate('open_book'))).isFalse();
-      check(EmojiAutocompleteQuery('blue dia')
-        .matches(realmCandidate('large_blue_diamond'))).isTrue();
-      check(EmojiAutocompleteQuery('Smi')
-        .matches(realmCandidate('smile'))).isTrue();
+      check(matches('eqeq', realmCandidate('eqeq'))).isTrue();
+      check(matches('open_', realmCandidate('open_book'))).isTrue();
+      check(matches('n_b', realmCandidate('open_book'))).isFalse();
+      check(matches('blue dia', realmCandidate('large_blue_diamond'))).isTrue();
+      check(matches('Smi', realmCandidate('smile'))).isTrue();
     });
 
     test('can match Zulip extra emoji', () {
@@ -447,10 +445,10 @@ void main() {
           emojiType: ReactionType.zulipExtraEmoji,
           emojiCode: 'zulip', emojiName: 'zulip'));
 
-      check(EmojiAutocompleteQuery('z').matches(zulipCandidate)).isTrue();
-      check(EmojiAutocompleteQuery('Zulip').matches(zulipCandidate)).isTrue();
-      check(EmojiAutocompleteQuery('p').matches(zulipCandidate)).isTrue();
-      check(EmojiAutocompleteQuery('x').matches(zulipCandidate)).isFalse();
+      check(matches('z', zulipCandidate)).isTrue();
+      check(matches('Zulip', zulipCandidate)).isTrue();
+      check(matches('p', zulipCandidate)).isTrue();
+      check(matches('x', zulipCandidate)).isFalse();
     });
   });
 }


### PR DESCRIPTION
Fixes #1068.

As is, this PR applies to the results of autocomplete in the compose box (when you type a colon `:`). In combination with #1103 adding an emoji picker, it applies to the results in the emoji picker too, because that PR reuses the same autocomplete machinery.

This mimics the ranking in the web client (from [shared/src/typeahead.ts](https://github.com/zulip/zulip/blob/83a121c7e4f365d8253db251b072d0a034b87d4d/web/shared/src/typeahead.ts)) with a handful of small discrepancies. Almost all are (minor) bugs in web:
```dart
    // Behavior differences we might copy, TODO:
    //  * Web ranks each name of a Unicode emoji separately.
    //  * Web recognizes a word-aligned match starting after [ /-] as well as [_].
    //
    // Behavior differences that web should probably fix, TODO(web):
    //  * Among popular emoji with non-exact matches,
    //    web doesn't prioritize prefix over word-aligned; we do.
    //    (This affects just one case: for query "o",
    //    we put :octopus: before :working_on_it:.)
    //  * Web only counts an emoji as "popular" for ranking if the query
    //    is a prefix of a single word in the name; so "thumbs_" or "working_on_i"
    //    lose the ranking boost for :thumbs_up: and :working_on_it: respectively.
    //  * Web starts with only case-sensitive exact matches ("perfect matches"),
    //    and puts case-insensitive exact matches just ahead of prefix matches;
    //    it also distinguishes prefix matches by case-sensitive vs. not.
    //    We use case-insensitive matches throughout;
    //    case seems unhelpful for emoji search.
    //  * Web suppresses Unicode emoji names shadowed by a realm emoji
    //    only if the latter is also a match for the query.  That mostly works,
    //    because emoji with the same name will mostly both match or both not;
    //    but it breaks if the Unicode emoji was a literal match.
```

(There may also be differences in the base ordering within custom emoji or within Unicode emoji, seen when they match a given query equally well; I haven't yet studied those to pin them down.)

The details of this implementation work a bit differently from those in web. I think this one is easier to follow, and it's certainly more efficient. Rather than iterate through the list of candidates again and again to evaluate various criteria, partitioning into sub-lists and sub-sub-lists, for each query we
* give each result a single ranking score once, based on all the criteria;
* then sort by rank, using a stable sort.

Similarly, rather than check for different kinds of matches [once](https://github.com/zulip/zulip/blob/83a121c7e4f365d8253db251b072d0a034b87d4d/web/shared/src/typeahead.ts#L97-L119) to decide if the emoji matches the query at all, and [separately later](https://github.com/zulip/zulip/blob/83a121c7e4f365d8253db251b072d0a034b87d4d/web/shared/src/typeahead.ts#L225-L280) to help decide how to rank it among matching results, we check for matches just once and return an EmojiMatchQuality enum rather than just a boolean, which records the information we need for ranking too.

I think the duplication of logic within the web implementation, in each of those areas, is the root cause of the bugs listed above — they're discrepancies between one part of web's logic and another, as tends to naturally arise once the same logic is repeated in multiple places in different ways.

# Selected commit messages

algorithms: Add bucketSort, for stable, linear-time sorting

Specifically the sort takes linear time so long as there aren't
more than linearly-many buckets.  For our immediate use case of
ranking emoji-autocomplete results, we'll in fact stick to a
constant number of buckets.

---

emoji [nfc]: Add ranking framework for emoji autocomplete results

---

emoji test [nfc]: Make the EmojiMatchQuality values explicit

This actually has a pretty nice effect on the readability of these
tests, even at this stage where the enum isn't doing anything!

Separate from the parent commit just because this one is a
bigger, and almost entirely mechanical and boring, diff.

---

emoji: Rank by quality of match (exact, prefix, other)

Fixes part of #1068.

---

emoji: Add list of the "popular" emoji

---

emoji: Rank "popular" > custom > other emoji

Fixes part of #1068.

---

emoji: Recognize word-aligned matches in ranking

Fixes #1068.

---

emoji: Order "popular" emoji canonically amongst themselves

As a bonus, this provides the popular emoji as candidates
even when we haven't yet fetched the server's emoji data.



