### PR TITLE
Exclude deactivated realm emoji from autocomplete

### DIFF
--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -115,7 +115,8 @@ class CustomProfileFieldExternalAccountData {
 /// in <https://zulip.com/api/register-queue>.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class RealmEmojiItem {
-  final String id;
+  @JsonKey(name: 'id')
+  final String emojiCode;
   final String name;
   final String sourceUrl;
   final String? stillUrl;
@@ -123,7 +124,7 @@ class RealmEmojiItem {
   final int? authorId;
 
   RealmEmojiItem({
-    required this.id,
+    required this.emojiCode,
     required this.name,
     required this.sourceUrl,
     required this.stillUrl,
@@ -136,7 +137,6 @@ class RealmEmojiItem {
 
   Map<String, dynamic> toJson() => _$RealmEmojiItemToJson(this);
 }
-
 
 /// The name of a user setting that has a property in [UserSettings].
 ///

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -72,7 +72,7 @@ Map<String, dynamic> _$CustomProfileFieldExternalAccountDataToJson(
 
 RealmEmojiItem _$RealmEmojiItemFromJson(Map<String, dynamic> json) =>
     RealmEmojiItem(
-      id: json['id'] as String,
+      emojiCode: json['id'] as String,
       name: json['name'] as String,
       sourceUrl: json['source_url'] as String,
       stillUrl: json['still_url'] as String?,
@@ -82,7 +82,7 @@ RealmEmojiItem _$RealmEmojiItemFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$RealmEmojiItemToJson(RealmEmojiItem instance) =>
     <String, dynamic>{
-      'id': instance.id,
+      'id': instance.emojiCode,
       'name': instance.name,
       'source_url': instance.sourceUrl,
       'still_url': instance.stillUrl,

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -761,6 +761,11 @@ class EmojiAutocompleteResult extends ComposeAutocompleteResult {
   EmojiAutocompleteResult(this.candidate);
 
   final EmojiCandidate candidate;
+
+  @override
+  String toString() {
+    return 'EmojiAutocompleteResult(${candidate.description()})';
+  }
 }
 
 /// A result from an @-mention autocomplete interaction,

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -86,6 +86,18 @@ final class EmojiCandidate {
     required List<String>? aliases,
     required this.emojiDisplay,
   }) : _aliases = aliases;
+
+  /// Used for implementing [toString] and [EmojiAutocompleteResult.toString].
+  String description() {
+    final typeLabel = emojiType.name.replaceFirst(RegExp(r'Emoji$'), '');
+    return '$typeLabel $emojiCode $emojiName'
+      '${aliases.isNotEmpty ? ' $aliases' : ''}';
+  }
+
+  @override
+  String toString() {
+    return 'EmojiCandidate(${description()})';
+  }
 }
 
 /// The portion of [PerAccountStore] describing what emoji exist.

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -102,10 +102,6 @@ final class EmojiCandidate {
 
 /// The portion of [PerAccountStore] describing what emoji exist.
 mixin EmojiStore {
-  /// The realm's custom emoji (for [ReactionType.realmEmoji],
-  /// indexed by [Reaction.emojiCode].
-  Map<String, RealmEmojiItem> get realmEmoji;
-
   EmojiDisplay emojiDisplayFor({
     required ReactionType emojiType,
     required String emojiCode,
@@ -135,7 +131,8 @@ class EmojiStoreImpl with EmojiStore {
   /// The same as [PerAccountStore.realmUrl].
   final Uri realmUrl;
 
-  @override
+  /// The realm's custom emoji (for [ReactionType.realmEmoji],
+  /// indexed by [Reaction.emojiCode].
   Map<String, RealmEmojiItem> realmEmoji;
 
   /// The realm-relative URL of the unique "Zulip extra emoji", :zulip:.

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -131,7 +131,7 @@ class EmojiStoreImpl with EmojiStore {
   /// The same as [PerAccountStore.realmUrl].
   final Uri realmUrl;
 
-  /// The realm's custom emoji, indexed by [Reaction.emojiCode],
+  /// The realm's custom emoji, indexed by their [RealmEmojiItem.emojiCode],
   /// including deactivated emoji not available for new uses.
   ///
   /// These are the emoji that can have [ReactionType.realmEmoji].

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -135,8 +135,15 @@ class EmojiStoreImpl with EmojiStore {
   /// including deactivated emoji not available for new uses.
   ///
   /// These are the emoji that can have [ReactionType.realmEmoji].
-  // TODO(#1113) limit to active realm emoji where appropriate
+  ///
+  /// For emoji available to be newly used, see [activeRealmEmoji].
   Map<String, RealmEmojiItem> allRealmEmoji;
+
+  /// The realm's custom emoji that are available for new uses
+  /// in messages and reactions.
+  Iterable<RealmEmojiItem> get activeRealmEmoji {
+    return allRealmEmoji.values.where((emoji) => !emoji.deactivated);
+  }
 
   /// The realm-relative URL of the unique "Zulip extra emoji", :zulip:.
   static const kZulipEmojiUrl = '/static/generated/emoji/images/emoji/unicode/zulip.png';
@@ -218,7 +225,7 @@ class EmojiStoreImpl with EmojiStore {
     final results = <EmojiCandidate>[];
 
     final namesOverridden = {
-      for (final emoji in allRealmEmoji.values) emoji.name,
+      for (final emoji in activeRealmEmoji) emoji.name,
       'zulip',
     };
     // TODO(log) if _serverEmojiData missing
@@ -242,8 +249,8 @@ class EmojiStoreImpl with EmojiStore {
         aliases: aliases));
     }
 
-    for (final entry in allRealmEmoji.entries) {
-      final emojiName = entry.value.name;
+    for (final emoji in activeRealmEmoji) {
+      final emojiName = emoji.name;
       if (emojiName == 'zulip') {
         // TODO does 'zulip' really override realm emoji?
         //   (This is copied from zulip-mobile's behavior.)
@@ -251,7 +258,7 @@ class EmojiStoreImpl with EmojiStore {
       }
       results.add(_emojiCandidateFor(
         emojiType: ReactionType.realmEmoji,
-        emojiCode: entry.key, emojiName: emojiName,
+        emojiCode: emoji.emojiCode, emojiName: emojiName,
         aliases: null));
     }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -387,9 +387,6 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
   // The realm's repertoire of available emoji.
 
   @override
-  Map<String, RealmEmojiItem> get realmEmoji => _emoji.realmEmoji;
-
-  @override
   EmojiDisplay emojiDisplayFor({
     required ReactionType emojiType,
     required String emojiCode,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -274,7 +274,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
       customProfileFields: _sortCustomProfileFields(initialSnapshot.customProfileFields),
       emailAddressVisibility: initialSnapshot.emailAddressVisibility,
       emoji: EmojiStoreImpl(
-        realmUrl: realmUrl, realmEmoji: initialSnapshot.realmEmoji),
+        realmUrl: realmUrl, allRealmEmoji: initialSnapshot.realmEmoji),
       accountId: accountId,
       selfUserId: account.userId,
       userSettings: initialSnapshot.userSettings,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -77,7 +77,7 @@ RealmEmojiItem realmEmojiItem({
 }) {
   assert(RegExp(r'^[1-9][0-9]*$').hasMatch(emojiCode));
   return RealmEmojiItem(
-    id: emojiCode,
+    emojiCode: emojiCode,
     name: emojiName,
     sourceUrl: sourceUrl ?? '/emoji/$emojiCode.png',
     stillUrl: stillUrl,

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -123,6 +123,31 @@ void main() {
       return store;
     }
 
+    test('realm emoji included only when active', () {
+      final store = prepare(realmEmoji: {
+        '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'abc', deactivated: true),
+        '2': eg.realmEmojiItem(emojiCode: '2', emojiName: 'abcd'),
+      });
+      check(store.allEmojiCandidates()).deepEquals([
+        isRealmCandidate(emojiCode: '2', emojiName: 'abcd'),
+        isZulipCandidate(),
+      ]);
+    });
+
+    test('realm emoji tolerate name collisions', () {
+      final store = prepare(realmEmoji: {
+        '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'test', deactivated: true),
+        '2': eg.realmEmojiItem(emojiCode: '2', emojiName: 'try', deactivated: true),
+        '3': eg.realmEmojiItem(emojiCode: '3', emojiName: 'try', deactivated: true),
+        '4': eg.realmEmojiItem(emojiCode: '4', emojiName: 'try'),
+        '5': eg.realmEmojiItem(emojiCode: '5', emojiName: 'test', deactivated: true),
+      });
+      check(store.allEmojiCandidates()).deepEquals([
+        isRealmCandidate(emojiCode: '4', emojiName: 'try'),
+        isZulipCandidate(),
+      ]);
+    });
+
     test('realm emoji overrides Unicode emoji', () {
       final store = prepare(realmEmoji: {
         '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'smiley'),
@@ -133,6 +158,18 @@ void main() {
       check(store.allEmojiCandidates()).deepEquals([
         isUnicodeCandidate('1f642', ['smile']),
         isRealmCandidate(emojiCode: '1', emojiName: 'smiley'),
+        isZulipCandidate(),
+      ]);
+    });
+
+    test('deactivated realm emoji cause no override of Unicode emoji', () {
+      final store = prepare(realmEmoji: {
+        '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'ant', deactivated: true),
+      }, unicodeEmoji: {
+        '1f41c': ['ant'],
+      });
+      check(store.allEmojiCandidates()).deepEquals([
+        isUnicodeCandidate('1f41c', ['ant']),
         isZulipCandidate(),
       ]);
     });

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -33,7 +33,6 @@ extension PerAccountStoreChecks on Subject<PerAccountStore> {
   Subject<String> get zulipVersion => has((x) => x.zulipVersion, 'zulipVersion');
   Subject<int> get maxFileUploadSizeMib => has((x) => x.maxFileUploadSizeMib, 'maxFileUploadSizeMib');
   Subject<Map<String, RealmDefaultExternalAccount>> get realmDefaultExternalAccounts => has((x) => x.realmDefaultExternalAccounts, 'realmDefaultExternalAccounts');
-  Subject<Map<String, RealmEmojiItem>> get realmEmoji => has((x) => x.realmEmoji, 'realmEmoji');
   Subject<List<CustomProfileField>> get customProfileFields => has((x) => x.customProfileFields, 'customProfileFields');
   Subject<int> get accountId => has((x) => x.accountId, 'accountId');
   Subject<Account> get account => has((x) => x.account, 'account');


### PR DESCRIPTION
Fixes #1113.

The first commit (toString on some emoji-related data classes) is shared with #1112.

When combining with #1112, the three new test cases will each need a tweak like this one:
```diff
       check(store.allEmojiCandidates()).deepEquals([
+        ...arePopularCandidates,
```
just like #1112 itself does (in its last commit) for several existing test cases.


# Selected commit messages

#### 2c276b8cb emoji [nfc]: Make realmEmoji internal to EmojiStoreImpl

It's a bit of a trap for the unwary (... like me last month, in
ecd2cb5d4, causing #1113), because it includes deactivated realm emoji
as well as active ones.

#### e56480648 api [nfc]: Rename RealmEmojiItem.id to emojiCode

This way the binding encapsulates an important fact about this
bit of the API -- namely that these values are the same as the
"emoji code" values seen elsewhere in the API -- so that we don't
have to re-verify it when working elsewhere in the codebase and
using this class.

Also edit a doc comment in the model code to take advantage of
that understanding.

#### f09aab1a3 emoji: Exclude deactivated realm emoji from autocomplete

Fixes #1113.
