### PR TITLE
tools: Make `ZulipIcons` results explicitly sorted

### DIFF
--- a/tools/icons/build-icon-font.js
+++ b/tools/icons/build-icon-font.js
@@ -34,7 +34,8 @@ async function main() {
   const iconFiles = fs
     .readdirSync(srcDir)
     .filter(name => name.endsWith('.svg'))
-    .map(name => path.join(srcDir, name));
+    .map(name => path.join(srcDir, name))
+    .sort(); // prevent inconsistent results across platforms
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'build-icon-font-'));
 


### PR DESCRIPTION
The custom icon entries in "ZulipIcons.dart" used to be generated/sorted based on the default OS order of the related ".svg" files in "assets\icons" directory. This default order behavior is different in different platforms (Windows vs. Linux or macOS) thus resulting in inconsistent output of "ZulipIcons.dart".
This PR adds an explicit sorting mechanism; so the output is consistent across different platforms.

Fixes: #1110