### PR TITLE
autocomplete: Put best matches near input field.

### DIFF
--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -134,6 +134,7 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
               constraints: const BoxConstraints(maxHeight: 300), // TODO not hard-coded
               child: ListView.builder(
                 padding: EdgeInsets.zero,
+                reverse: true,
                 shrinkWrap: true,
                 itemCount: _resultsToDisplay.length,
                 itemBuilder: _buildItem))));


### PR DESCRIPTION
This commit reverses the list that was originally
presented to the user while showing the typeahead
menu.

This makes sense since on mobile its easier to click on options closer to the input box, i.e. where your fingers are currently present, instead of pressing arrow keys to navigate through the options on a keyboard which is convenient on a desktop setup.

Hence we place the best matching options not at the top of the typeahead menu, but instead at the bottom for better reachability and convenience of the user.

[CZO](https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/Put.20best.20autocomplete.20matches.20at.20bottom.20of.20list.20.23F1121/near/1999427)

Fixes #1121.

Here is a demo:
[Screencast from 12-11-2024 12:38:19 PM.webm](https://github.com/user-attachments/assets/9a299840-9f9e-4f90-ae87-4ec9d2deb05d)


![image](https://github.com/user-attachments/assets/29a44892-f27f-40a1-a543-eb286d82e7de)
![image](https://github.com/user-attachments/assets/6187eb89-973b-4852-9148-03dda96b04c2)

