### PR TITLE
Issue#930 Hero animation for images should run only to/from lightbox, not between message lists

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -178,25 +178,19 @@ class _LightboxPageLayoutState extends State<_LightboxPageLayout> {
         elevation: appBarElevation,
 
         // TODO(#41): Show message author's avatar
-        title: Row(
-          children: [
-            Avatar(size: 32, borderRadius: 3,userId: widget.message.senderId),
-            const SizedBox(width: 8),
-            RichText(
-              text: TextSpan(children: [
-                TextSpan(
-                  text: '${widget.message.senderFullName}\n',
+        title: RichText(
+          text: TextSpan(children: [
+            TextSpan(
+              text: '${widget.message.senderFullName}\n',
 
-                  // Restate default
-                  style: themeData.textTheme.titleLarge!.copyWith(color: appBarForegroundColor)),
-                TextSpan(
-                  text: timestampText,
+              // Restate default
+              style: themeData.textTheme.titleLarge!.copyWith(color: appBarForegroundColor)),
+            TextSpan(
+              text: timestampText,
 
-                  // Make smaller, like a subtitle
-                  style: themeData.textTheme.titleSmall!.copyWith(color: appBarForegroundColor)),
-              ])),
-          ],
-        ),
+              // Make smaller, like a subtitle
+              style: themeData.textTheme.titleSmall!.copyWith(color: appBarForegroundColor)),
+          ])),
         bottom: widget.buildAppBarBottom(context));
     }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -602,6 +602,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         return MessageItem(
           key: ValueKey(data.message.id),
           header: header,
+          narrow: widget.narrow,
           trailingWhitespace: i == 1 ? 8 : 11,
           item: data);
     }
@@ -892,8 +893,9 @@ class MessageItem extends StatelessWidget {
     required this.item,
     required this.header,
     this.trailingWhitespace,
+    required this.narrow
   });
-
+  final Narrow narrow;
   final MessageListMessageItem item;
   final Widget header;
   final double? trailingWhitespace;
@@ -910,7 +912,7 @@ class MessageItem extends StatelessWidget {
         child: ColoredBox(
           color: messageListTheme.streamMessageBgDefault,
           child: Column(children: [
-            MessageWithPossibleSender(item: item),
+            MessageWithPossibleSender(item: item,narrow:narrow),
             if (trailingWhitespace != null && item.isLastInBlock) SizedBox(height: trailingWhitespace!),
           ]))));
   }
@@ -1201,9 +1203,10 @@ String formatHeaderDate(
 //   - https://github.com/zulip/zulip-mobile/issues/5511
 //   - https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=538%3A20849&mode=dev
 class MessageWithPossibleSender extends StatelessWidget {
-  const MessageWithPossibleSender({super.key, required this.item});
+  const MessageWithPossibleSender({super.key, required this.item, required this.narrow});
 
   final MessageListMessageItem item;
+  final Narrow narrow;
 
   @override
   Widget build(BuildContext context) {
@@ -1288,7 +1291,7 @@ class MessageWithPossibleSender extends StatelessWidget {
               Expanded(child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  MessageContent(message: message, content: item.content),
+                  MessageContent(message: message, content: item.content,narrow:narrow),
                   if ((message.reactions?.total ?? 0) > 0)
                     ReactionChipsList(messageId: message.id, reactions: message.reactions!),
                   if (editStateText != null)

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -119,14 +119,17 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   Widget plainContent(String html) {
+    final narrow = TopicNarrow.ofMessage(eg.streamMessage());
     return Builder(builder: (context) =>
       DefaultTextStyle(
         style: ContentTheme.of(context).textStylePlainParagraph,
-        child: BlockContentList(nodes: parseContent(html).nodes)));
+        child: BlockContentList(nodes: parseContent(html).nodes,narrow:narrow)));
   }
 
   Widget messageContent(String html) {
+    final narrow = TopicNarrow.ofMessage(eg.streamMessage());
     return MessageContent(message: eg.streamMessage(content: html),
+       narrow:narrow,
        content: parseContent(html));
   }
 

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -10,6 +10,7 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 import 'package:video_player/video_player.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/localizations.dart';
+import 'package:zulip/model/narrow.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/lightbox.dart';
@@ -199,7 +200,7 @@ void main() {
 
   group('_ImageLightboxPage', () {
     final src = Uri.parse('https://chat.example/lightbox-image.png');
-
+    final narrow = TopicNarrow.ofMessage(eg.streamMessage());
     Future<void> setupPage(WidgetTester tester, {
       Message? message,
       required Uri? thumbnailUrl,
@@ -220,6 +221,7 @@ void main() {
         thumbnailUrl: thumbnailUrl,
         originalHeight: null,
         originalWidth: null,
+        narrow:narrow
       )));
       await tester.pump(); // per-account store
       await tester.pump(const Duration(milliseconds: 301)); // nav transition


### PR DESCRIPTION
Inside ` _LightBoxHeroTag` added `narrow` to identify the message list 