### PR TITLE
l10n [nfc]: Treat Weblate-derived data as generated in Git diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,11 @@
 # Generated files for localizations.
 lib/generated/l10n/*.dart -diff
 
+# Data files for translations synced from Weblate:
+assets/l10n/app_*.arb -diff
+# though not the similar file that is the source for what to translate:
+assets/l10n/app_en.arb diff
+
 # Generated files for testing migrations:
 test/model/schemas/*.dart -diff
 test/model/schemas/*.json -diff


### PR DESCRIPTION
This way these don't produce giant diffs, by default, when comparing versions of the tree across a sync of translations from Weblate.