### PR TITLE
notif: package info indirection

### DIFF
--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -303,10 +303,12 @@ class LinuxDeviceInfo implements BaseDeviceInfo {
 class PackageInfo {
   final String version;
   final String buildNumber;
+  final String packageName;
 
   const PackageInfo({
     required this.version,
     required this.buildNumber,
+    required this.packageName,
   });
 }
 
@@ -411,6 +413,7 @@ class LiveZulipBinding extends ZulipBinding {
       _syncPackageInfo = PackageInfo(
         version: info.version,
         buildNumber: info.buildNumber,
+        packageName: info.packageName,
       );
     } catch (e, st) {
       assert(debugLog('Failed to prefetch package info: $e\n$st')); // TODO(log)

--- a/lib/notifications/receive.dart
+++ b/lib/notifications/receive.dart
@@ -149,8 +149,7 @@ class NotificationService {
         await addFcmToken(connection, token: token);
 
       case TargetPlatform.iOS:
-        const appBundleId = 'com.zulip.flutter'; // TODO(#407) find actual value live
-        await addApnsToken(connection, token: token, appid: appBundleId);
+        await addApnsToken(connection, token: token, appid: (await ZulipBinding.instance.packageInfo)?.packageName?? 'com.zulip.flutter');
 
       case TargetPlatform.linux:
       case TargetPlatform.macOS:

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -460,7 +460,7 @@ void main() {
       });
     }
 
-    const packageInfo = PackageInfo(version: '0.0.1', buildNumber: '1');
+    const packageInfo = PackageInfo(version: '0.0.1', buildNumber: '1', packageName: 'com.zulip.flutter.test');
 
     const testCases = [
       ('ZulipFlutter/0.0.1+1 (Android 14)',             AndroidDeviceInfo(release: '14', sdkInt: 34),                      ),

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -228,8 +228,8 @@ class TestZulipBinding extends ZulipBinding {
   BaseDeviceInfo? get syncDeviceInfo => deviceInfoResult;
 
   /// The value that `ZulipBinding.instance.packageInfo` should return.
-  PackageInfo packageInfoResult = _defaultPackageInfo;
-  static const _defaultPackageInfo = PackageInfo(version: '0.0.1', buildNumber: '1');
+  PackageInfo? packageInfoResult = _defaultPackageInfo;
+  static const _defaultPackageInfo = PackageInfo(version: '0.0.1', buildNumber: '1', packageName: 'com.zulip.flutter.test');
 
   void _resetPackageInfo() {
     packageInfoResult = _defaultPackageInfo;

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -1032,7 +1032,7 @@ void main() {
       if (defaultTargetPlatform == TargetPlatform.android) {
         checkLastRequestFcm(token: '012abc');
       } else {
-        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
+        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter.test');
       }
 
       if (defaultTargetPlatform == TargetPlatform.android) {
@@ -1071,7 +1071,7 @@ void main() {
       if (defaultTargetPlatform == TargetPlatform.android) {
         checkLastRequestFcm(token: '012abc');
       } else {
-        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
+        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter.test');
       }
 
       if (defaultTargetPlatform == TargetPlatform.android) {
@@ -1082,6 +1082,22 @@ void main() {
         checkLastRequestFcm(token: '456def');
       }
     }));
+
+
+    test('fallback to default appBundleId in case packageInfo is null', ()async{
+      // This tests the case where packageInfo is null
+      // and default appBundleId gets passed to the [NotificationService.registerToken] method
+
+      prepareStore();
+      connection.prepare(json: {});
+
+      if(defaultTargetPlatform == TargetPlatform.iOS){
+        testBinding.packageInfoResult=null;
+        await NotificationService.registerToken(connection, token: '012abc');
+        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
+        addTearDown(testBinding.reset);
+      }
+    });
   });
 }
 


### PR DESCRIPTION
In this PR, I made the changes to indirect PackageInfo.fromPlatform through a method on ZulipBinding.

Steps I followed :

1. Update the ZulipBinding to provide package info: Add a method in ZulipBinding to return the package name. This method will wrap the call to PackageInfo.fromPlatform() and make it test-friendly.

2. Override the method in TestZulipBinding: In the TestZulipBinding, override getAppBundleId to return a mock or predefined value for testing.

3. Refactor the code to use getAppBundleId: Replace the direct calls with the indirection from Zulip Binding class.

4. Write a test for the above logic under a group called 'tokens'. The allow the grouping of all tests related to tokens, I created a separate group : tokens.

Fixes #407 