### PR TITLE
unreads: Fix false positives in a debug check; log in another case when helpful

### DIFF
--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -265,9 +265,14 @@ class Unreads extends ChangeNotifier {
     //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/mark-as-read.20events.20with.20message.20moves.3F/near/1639957
     final bool isRead = event.flags.contains(MessageFlag.read);
     assert(() {
-      final isUnreadLocally = _slowIsPresentInDms(messageId) || _slowIsPresentInStreams(messageId);
+      final isUnreadLocally = isUnread(messageId);
       final isUnreadInEvent = !isRead;
-      if (!oldUnreadsMissing && isUnreadLocally != isUnreadInEvent) {
+
+      // Unread state unknown because of [oldUnreadsMissing].
+      // We were going to check something but can't; shrug.
+      if (isUnreadLocally == null) return true;
+
+      if (isUnreadLocally != isUnreadInEvent) {
         // If this happens, then either:
         // - the server and client have been out of sync about the message's
         //   unread state since before this event, or

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -253,14 +253,13 @@ class Unreads extends ChangeNotifier {
     //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/mark-as-read.20events.20with.20message.20moves.3F/near/1639957
     final bool isRead = event.flags.contains(MessageFlag.read);
     assert(() {
-      if (!oldUnreadsMissing && !event.messageIds.every((messageId) {
-        final isUnreadLocally = _slowIsPresentInDms(messageId) || _slowIsPresentInStreams(messageId);
-        return isUnreadLocally == !isRead;
-      })) {
+      final isUnreadLocally = _slowIsPresentInDms(messageId) || _slowIsPresentInStreams(messageId);
+      final isUnreadInEvent = !isRead;
+      if (!oldUnreadsMissing && isUnreadLocally != isUnreadInEvent) {
         // If this happens, then either:
-        // - the server and client have been out of sync about a message's
+        // - the server and client have been out of sync about the message's
         //   unread state since before this event, or
-        // - this event was unexpectedly used to announce a change in a
+        // - this event was unexpectedly used to announce a change in the
         //   message's 'read' flag.
         debugLog('Unreads warning: got surprising UpdateMessageEvent');
       }

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -240,6 +240,49 @@ void main() {
     });
   });
 
+  group('isUnread', () {
+    final unreadDmMessage = eg.dmMessage(
+      from: eg.otherUser, to: [eg.selfUser], flags: []);
+    final readDmMessage = eg.dmMessage(
+      from: eg.otherUser, to: [eg.selfUser], flags: [MessageFlag.read]);
+    final unreadChannelMessage = eg.streamMessage(flags: []);
+    final readChannelMessage = eg.streamMessage(flags: [MessageFlag.read]);
+
+    final allMessages = [
+      unreadDmMessage, unreadChannelMessage,
+      readDmMessage,   readChannelMessage,
+    ];
+
+    void doTestCommon(String description, int messageId, {required bool expected}) {
+      test(description, () {
+        prepare();
+        model.oldUnreadsMissing = false;
+        fillWithMessages(allMessages);
+        check(model.isUnread(messageId)).equals(expected);
+      });
+    }
+
+    void doTestOldUnreadsMissing(String description, int messageId, {required bool? expected}) {
+      assert(expected == true || expected == null);
+      test('oldUnreadsMissing; $description', () {
+        prepare();
+        model.oldUnreadsMissing = true;
+        fillWithMessages(allMessages);
+        check(model.isUnread(messageId)).equals(expected);
+      });
+    }
+
+    doTestCommon('unread DM message',      unreadDmMessage.id,      expected: true);
+    doTestCommon('read DM message',        readDmMessage.id,        expected: false);
+    doTestCommon('unread channel message', unreadChannelMessage.id, expected: true);
+    doTestCommon('read channel message',   readChannelMessage.id,   expected: false);
+
+    doTestOldUnreadsMissing('unread DM message',      unreadDmMessage.id,      expected: true);
+    doTestOldUnreadsMissing('read DM message',        readDmMessage.id,        expected: null);
+    doTestOldUnreadsMissing('unread channel message', unreadChannelMessage.id, expected: true);
+    doTestOldUnreadsMissing('read channel message',   readChannelMessage.id,   expected: null);
+  });
+
   group('handleMessageEvent', () {
     for (final (isUnread, isStream, isDirectMentioned, isWildcardMentioned) in [
       (true,  true,  true,  true ),


### PR DESCRIPTION
In manual testing for my work on resolve/unresolve #744, I noticed some surprising debug-log lines that turned out to be false positives, so this fixes those.

It also makes the debug check run in a helpful case where it wasn't running before.