### PR TITLE
Message List from Same User is now Distinguishable via Surface Tint on Long Press

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -31,6 +31,7 @@ import 'theme.dart';
 void _showActionSheet(
   BuildContext context, {
   required List<Widget> optionButtons,
+  VoidCallback? onDismiss
 }) {
   showModalBottomSheet<void>(
     context: context,
@@ -61,7 +62,7 @@ void _showActionSheet(
                       children: optionButtons))))),
               const ActionSheetCancelButton(),
             ])));
-    });
+    }).whenComplete(onDismiss ?? () {});
 }
 
 abstract class ActionSheetMenuItemButton extends StatelessWidget {
@@ -372,7 +373,7 @@ class UserTopicUpdateButton extends ActionSheetMenuItemButton {
 /// Show a sheet of actions you can take on a message in the message list.
 ///
 /// Must have a [MessageListPage] ancestor.
-void showMessageActionSheet({required BuildContext context, required Message message}) {
+void showMessageActionSheet({required BuildContext context, required Message message, VoidCallback? onDismiss}) {
   final store = PerAccountStoreWidget.of(context);
 
   // The UI that's conditioned on this won't live-update during this appearance
@@ -399,7 +400,7 @@ void showMessageActionSheet({required BuildContext context, required Message mes
     ShareButton(message: message, pageContext: context),
   ];
 
-  _showActionSheet(context, optionButtons: optionButtons);
+  _showActionSheet(context, optionButtons: optionButtons, onDismiss: onDismiss);
 }
 
 abstract class MessageActionSheetMenuItemButton extends ActionSheetMenuItemButton {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1274,10 +1274,18 @@ String formatHeaderDate(
 // Design referenced from:
 //   - https://github.com/zulip/zulip-mobile/issues/5511
 //   - https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=538%3A20849&mode=dev
-class MessageWithPossibleSender extends StatelessWidget {
+class MessageWithPossibleSender extends StatefulWidget {
   const MessageWithPossibleSender({super.key, required this.item});
 
   final MessageListMessageItem item;
+
+  @override
+  State<MessageWithPossibleSender> createState() => _MessageWithPossibleSenderState();
+}
+
+class _MessageWithPossibleSenderState extends State<MessageWithPossibleSender> {
+  bool isMessageActionSheetOpen = false;
+  Color pressedTint = const Color.fromRGBO(0, 0, 0, 0.2);
 
   @override
   Widget build(BuildContext context) {
@@ -1285,11 +1293,11 @@ class MessageWithPossibleSender extends StatelessWidget {
     final messageListTheme = MessageListTheme.of(context);
     final designVariables = DesignVariables.of(context);
 
-    final message = item.message;
+    final message = widget.item.message;
     final sender = store.users[message.senderId];
 
     Widget? senderRow;
-    if (item.showSender) {
+    if (widget.item.showSender) {
       final time = _kMessageTimestampFormat
         .format(DateTime.fromMillisecondsSinceEpoch(1000 * message.timestamp));
       senderRow = Row(
@@ -1347,40 +1355,61 @@ class MessageWithPossibleSender extends StatelessWidget {
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
-      onLongPress: () => showMessageActionSheet(context: context, message: message),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Column(children: [
-          if (senderRow != null)
-            Padding(padding: const EdgeInsets.fromLTRB(16, 2, 16, 0),
-              child: senderRow),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: localizedTextBaseline(context),
-            children: [
-              const SizedBox(width: 16),
-              Expanded(child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  MessageContent(message: message, content: item.content),
-                  if ((message.reactions?.total ?? 0) > 0)
-                    ReactionChipsList(messageId: message.id, reactions: message.reactions!),
-                  if (editStateText != null)
-                    Text(editStateText,
-                      textAlign: TextAlign.end,
-                      style: TextStyle(
-                        color: designVariables.labelEdited,
-                        fontSize: 12,
-                        height: (12 / 12),
-                        letterSpacing: proportionalLetterSpacing(
-                          context, 0.05, baseFontSize: 12))),
-                ])),
-              SizedBox(width: 16,
-                child: message.flags.contains(MessageFlag.starred)
-                  ? Icon(ZulipIcons.star_filled, size: 16, color: designVariables.star)
-                  : null),
-            ]),
-        ])));
+      onLongPress: () async {
+        setState(() {
+          isMessageActionSheetOpen = true;
+        });
+
+        await Future.delayed(const Duration(milliseconds: 100), () {
+          if (context.mounted) {return showMessageActionSheet(
+            context: context,
+            message: message,
+            onDismiss: () {
+              if (context.mounted) {
+                setState(() {
+                  isMessageActionSheetOpen = false;
+                });
+              }
+            },
+          );}
+        });
+      },
+      child: Container(
+        color: isMessageActionSheetOpen ? pressedTint : Colors.transparent,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Column(children: [
+            if (senderRow != null)
+              Padding(padding: const EdgeInsets.fromLTRB(16, 2, 16, 0),
+                child: senderRow),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: localizedTextBaseline(context),
+              children: [
+                const SizedBox(width: 16),
+                Expanded(child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    MessageContent(message: message, content: widget.item.content),
+                    if ((message.reactions?.total ?? 0) > 0)
+                      ReactionChipsList(messageId: message.id, reactions: message.reactions!),
+                    if (editStateText != null)
+                      Text(editStateText,
+                        textAlign: TextAlign.end,
+                        style: TextStyle(
+                          color: designVariables.labelEdited,
+                          fontSize: 12,
+                          height: (12 / 12),
+                          letterSpacing: proportionalLetterSpacing(
+                            context, 0.05, baseFontSize: 12))),
+                  ])),
+                SizedBox(width: 16,
+                  child: message.flags.contains(MessageFlag.starred)
+                    ? Icon(ZulipIcons.star_filled, size: 16, color: designVariables.star)
+                    : null),
+              ]),
+          ])),
+      ));
   }
 }
 


### PR DESCRIPTION
## Changes Made

This issue resolved by:
- Wrapping the `MessageWithPossibleSender` with a `Container` 
- Then, giving it a color property on a condition that when `isMessageActionSheetOpen` is `true` show the surface tint, else remain `Colors.transparent`.

For this,
- I shifted the `MessageWithPossibleSender` from `StatelessWidget` to `StatefulWidget`.
- Added a nullable `VoidCallback? onDismiss` method in parameters of `showMessageActionSheet` or BottomSheet for updating the Surface Tint of message.

## Fixes #1142 

## Screenshots

| Light Theme | Dark Theme |
| -----------------| -------------------|
|             <video src="https://github.com/user-attachments/assets/717d5f1d-0368-4647-b570-dfa3359bfd1e" width=60%>                 |           <video src="https://github.com/user-attachments/assets/c2c6fb8a-5bbe-4280-a88e-c0de52e1fe62" width=60%> | 

