### PR TITLE
lightbox: Add "download" button in bottom app bar

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
      open the android/ subtree as its own project
      and follow these instructions:
        https://developer.android.com/build/manage-manifests#inspect_the_merged_manifest_and_find_conflicts -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+   <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
    <uses-permission android:name="android.permission.INTERNET"/>
    <application
         android:label="Zulip beta"

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -680,5 +680,45 @@
   "emojiPickerSearchEmoji": "Search emoji",
   "@emojiPickerSearchEmoji": {
     "description": "Hint text for the emoji picker search text field."
+  },
+  "permissionDeniedTitle": "Permission Denied",
+  "@permissionDeniedTitle": {
+    "description": "Title for permission denied dialog"
+  },
+  "storagePermissionPermanentlyDenied": "Storage permission is permanently denied. Please enable it in system settings.",
+  "@storagePermissionPermanentlyDenied": {
+    "description": "Message when storage permission is permanently denied."
+  },
+  "cancel": "Cancel",
+  "@cancel": {
+    "description": "Text for cancelling the permanent permission denied dialog"
+  },
+  "openSettings": "Open Settings",
+  "@openSettings": {
+    "description": "Message for opening settings through permission denied dialog"
+  },
+  "storagePermissionRequired": "Storage permission is required to download images",
+  "@storagePermissionRequired": {
+    "description": "Message when storage permission is needed"
+  },
+  "imageDownloadFailed": "Server error while downloading image",
+  "@imageDownloadFailed": {
+    "description": "Message when image download fails due to server error"
+  },
+  "imageDownloadSuccess": "Image downloaded successfully",
+  "@imageDownloadSuccess": {
+    "description": "Message shown when image download is successful"
+  },
+  "imageDownloadError": "Failed to download image",
+  "@imageDownloadError": {
+    "description": "Error message when image download fails"
+  },
+  "downloadImageTooltip": "Download image",
+  "@downloadImageTooltip": {
+    "description": "Tooltip for download image button in lightbox"
+  },
+  "downloadTimeout": "Download timed out. Please try again.",
+  "@downloadTimeout": {
+    "description": "Message shown when the image download exceeds the timeout limit"
   }
 }

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1014,6 +1014,66 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Search emoji'**
   String get emojiPickerSearchEmoji;
+
+  /// Title for permission denied dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Permission Denied'**
+  String get permissionDeniedTitle;
+
+  /// Message when storage permission is permanently denied.
+  ///
+  /// In en, this message translates to:
+  /// **'Storage permission is permanently denied. Please enable it in system settings.'**
+  String get storagePermissionPermanentlyDenied;
+
+  /// Text for cancelling the permanent permission denied dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancel;
+
+  /// Message for opening settings through permission denied dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Open Settings'**
+  String get openSettings;
+
+  /// Message when storage permission is needed
+  ///
+  /// In en, this message translates to:
+  /// **'Storage permission is required to download images'**
+  String get storagePermissionRequired;
+
+  /// Message when image download fails due to server error
+  ///
+  /// In en, this message translates to:
+  /// **'Server error while downloading image'**
+  String get imageDownloadFailed;
+
+  /// Message shown when image download is successful
+  ///
+  /// In en, this message translates to:
+  /// **'Image downloaded successfully'**
+  String get imageDownloadSuccess;
+
+  /// Error message when image download fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to download image'**
+  String get imageDownloadError;
+
+  /// Tooltip for download image button in lightbox
+  ///
+  /// In en, this message translates to:
+  /// **'Download image'**
+  String get downloadImageTooltip;
+
+  /// Message shown when the image download exceeds the timeout limit
+  ///
+  /// In en, this message translates to:
+  /// **'Download timed out. Please try again.'**
+  String get downloadTimeout;
 }
 
 class _ZulipLocalizationsDelegate extends LocalizationsDelegate<ZulipLocalizations> {

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -537,4 +537,34 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get permissionDeniedTitle => 'Permission Denied';
+
+  @override
+  String get storagePermissionPermanentlyDenied => 'Storage permission is permanently denied. Please enable it in system settings.';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get storagePermissionRequired => 'Storage permission is required to download images';
+
+  @override
+  String get imageDownloadFailed => 'Server error while downloading image';
+
+  @override
+  String get imageDownloadSuccess => 'Image downloaded successfully';
+
+  @override
+  String get imageDownloadError => 'Failed to download image';
+
+  @override
+  String get downloadImageTooltip => 'Download image';
+
+  @override
+  String get downloadTimeout => 'Download timed out. Please try again.';
 }

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -537,4 +537,34 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get permissionDeniedTitle => 'Permission Denied';
+
+  @override
+  String get storagePermissionPermanentlyDenied => 'Storage permission is permanently denied. Please enable it in system settings.';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get storagePermissionRequired => 'Storage permission is required to download images';
+
+  @override
+  String get imageDownloadFailed => 'Server error while downloading image';
+
+  @override
+  String get imageDownloadSuccess => 'Image downloaded successfully';
+
+  @override
+  String get imageDownloadError => 'Failed to download image';
+
+  @override
+  String get downloadImageTooltip => 'Download image';
+
+  @override
+  String get downloadTimeout => 'Download timed out. Please try again.';
 }

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -537,4 +537,34 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get permissionDeniedTitle => 'Permission Denied';
+
+  @override
+  String get storagePermissionPermanentlyDenied => 'Storage permission is permanently denied. Please enable it in system settings.';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get storagePermissionRequired => 'Storage permission is required to download images';
+
+  @override
+  String get imageDownloadFailed => 'Server error while downloading image';
+
+  @override
+  String get imageDownloadSuccess => 'Image downloaded successfully';
+
+  @override
+  String get imageDownloadError => 'Failed to download image';
+
+  @override
+  String get downloadImageTooltip => 'Download image';
+
+  @override
+  String get downloadTimeout => 'Download timed out. Please try again.';
 }

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -537,4 +537,34 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get permissionDeniedTitle => 'Permission Denied';
+
+  @override
+  String get storagePermissionPermanentlyDenied => 'Storage permission is permanently denied. Please enable it in system settings.';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get storagePermissionRequired => 'Storage permission is required to download images';
+
+  @override
+  String get imageDownloadFailed => 'Server error while downloading image';
+
+  @override
+  String get imageDownloadSuccess => 'Image downloaded successfully';
+
+  @override
+  String get imageDownloadError => 'Failed to download image';
+
+  @override
+  String get downloadImageTooltip => 'Download image';
+
+  @override
+  String get downloadTimeout => 'Download timed out. Please try again.';
 }

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -537,4 +537,34 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get permissionDeniedTitle => 'Permission Denied';
+
+  @override
+  String get storagePermissionPermanentlyDenied => 'Storage permission is permanently denied. Please enable it in system settings.';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get storagePermissionRequired => 'Storage permission is required to download images';
+
+  @override
+  String get imageDownloadFailed => 'Server error while downloading image';
+
+  @override
+  String get imageDownloadSuccess => 'Image downloaded successfully';
+
+  @override
+  String get imageDownloadError => 'Failed to download image';
+
+  @override
+  String get downloadImageTooltip => 'Download image';
+
+  @override
+  String get downloadTimeout => 'Download timed out. Please try again.';
 }

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -537,4 +537,34 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get permissionDeniedTitle => 'Permission Denied';
+
+  @override
+  String get storagePermissionPermanentlyDenied => 'Storage permission is permanently denied. Please enable it in system settings.';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get storagePermissionRequired => 'Storage permission is required to download images';
+
+  @override
+  String get imageDownloadFailed => 'Server error while downloading image';
+
+  @override
+  String get imageDownloadSuccess => 'Image downloaded successfully';
+
+  @override
+  String get imageDownloadError => 'Failed to download image';
+
+  @override
+  String get downloadImageTooltip => 'Download image';
+
+  @override
+  String get downloadTimeout => 'Download timed out. Please try again.';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -835,6 +835,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.3.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.13"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.5"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.3"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   wakelock_plus: ^1.2.8
   zulip_plugin:
     path: ./packages/zulip_plugin
+  permission_handler: ^11.3.1
   # Keep list sorted when adding dependencies; it helps prevent merge conflicts.
 
 dependency_overrides:

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -19,6 +19,7 @@ import '../model/binding.dart';
 import '../test_images.dart';
 import 'dialog_checks.dart';
 import 'test_app.dart';
+import 'package:http/http.dart' as http;
 
 const kTestVideoUrl = "https://a/video.mp4";
 const kTestUnsupportedVideoUrl = "https://a/unsupported.mp4";
@@ -194,8 +195,26 @@ class FakeVideoPlayerPlatform extends Fake
   }
 }
 
+class FakeHttpClient extends http.BaseClient {
+  final http.Response Function(http.Request) onRequest;
+
+  FakeHttpClient({required this.onRequest});
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final http.Response response = onRequest(request as http.Request);
+    return http.StreamedResponse(
+      Stream.fromIterable([response.bodyBytes]),
+      response.statusCode,
+      headers: response.headers,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+}
+
 void main() {
   TestZulipBinding.ensureInitialized();
+  late FakeHttpClient fakeHttpClient;
 
   group('_ImageLightboxPage', () {
     final src = Uri.parse('https://chat.example/lightbox-image.png');
@@ -287,6 +306,84 @@ void main() {
     //   https://github.com/zulip/zulip-flutter/pull/833#discussion_r1688762292
     //   https://github.com/zulip/zulip-flutter/pull/833#pullrequestreview-2200433626
     //   https://github.com/zulip/zulip-flutter/pull/833#issuecomment-2251782337
+  });
+
+  group('IconButton Download Test', () {
+    Future<void> buildTestWidget(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return IconButton(
+                  icon: const Icon(Icons.download_rounded),
+                  onPressed: () async {
+                    // Simulate download logic
+                    final response = await fakeHttpClient.get(Uri.parse('https://example.com/image.png'));
+
+                    if (response.statusCode == 200) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text("Image downloaded successfully")),
+                      );
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text("Failed to download image")),
+                      );
+                    }
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('should display download button and trigger download', (tester) async {
+      fakeHttpClient = FakeHttpClient(
+        onRequest: (request) {
+          return http.Response('Image Data', 200);
+        },
+      );
+
+      await buildTestWidget(tester);
+
+      // Verify download icon exists
+      final downloadIcon = find.byIcon(Icons.download_rounded);
+      expect(downloadIcon, findsOneWidget);
+
+      // Tap the download button
+      await tester.tap(downloadIcon);
+      await tester.pumpAndSettle(); // Wait for any resulting UI updates
+
+      // Verify success feedback, e.g., SnackBar
+      final snackBar = find.byType(SnackBar);
+      expect(snackBar, findsOneWidget, reason: 'SnackBar should appear after download');
+      expect(find.textContaining("Image downloaded successfully"), findsOneWidget);
+    });
+
+    testWidgets('should handle failed download', (tester) async {
+      fakeHttpClient = FakeHttpClient(
+        onRequest: (request) {
+          return http.Response('Error', 404);
+        },
+      );
+
+      await buildTestWidget(tester);
+
+      // Verify download icon exists
+      final downloadIcon = find.byIcon(Icons.download_rounded);
+      expect(downloadIcon, findsOneWidget);
+
+      // Tap the download button
+      await tester.tap(downloadIcon);
+      await tester.pumpAndSettle(); // Wait for any resulting UI updates
+
+      // Verify failure feedback
+      final snackBar = find.byType(SnackBar);
+      expect(snackBar, findsOneWidget, reason: 'SnackBar should appear on failure');
+      expect(find.textContaining("Failed to download image"), findsOneWidget);
+    });
   });
 
   group('VideoDurationLabel', () {

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -17,6 +18,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_core
+  permission_handler_windows
   share_plus
   sqlite3_flutter_libs
   url_launcher_windows


### PR DESCRIPTION
This PR enhances the bottom app bar in the  by adding a **download button** alongside the existing copy link button. The download button allows users to save the displayed image to local storage, offering a familiar and seamless experience consistent with platform norms.

**Related Issue:** #42 

### Key Changes:
**Download Button Added:**
A new IconButton with a download icon (Icons.download_rounded) is added to the bottom app bar.

**Download Functionality:**
When pressed, the button initiates a network request to download the image.
The image is saved to the local storage in the "Downloads" directory.

**User Feedback:**
A SnackBar is displayed to inform the user about the download status:
Success: "Image downloaded successfully."
Failure: "Failed to download image."
Timeout: "Download timed out."

**Testing:**
Comprehensive tests are added to verify the behavior of the download button:
Displays download button correctly.
Handles successful downloads.
Handles failed downloads (e.g., 404 errors).
Handles timeout scenarios gracefully.

| **Before**   | **After**           |
|-------------|--------------------------|
| ![Before](https://github.com/user-attachments/assets/26c85606-0c74-4fb1-90c6-e79f3d044677) | ![After](https://github.com/user-attachments/assets/c45bb138-4078-47b3-bb7f-a5c02f555ae9) |

**Video Demonstration:**

https://github.com/user-attachments/assets/55e9de1e-f0bc-4bf0-b88e-518261eeff28


