### PR TITLE
bump up minimum macOS deployment target to 10.15 from 10.14

### DIFF
--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
 https://github.com/zulip/zulip-flutter/issues/1116#issue-2726129973

changing the minimum deployment target inside the podfile is working as expected 

