### PR TITLE
store: Handle invalid API key on register-queue

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -523,6 +523,13 @@
   "@topicValidationErrorMandatoryButEmpty": {
     "description": "Topic validation error when topic is required but was empty."
   },
+  "errorInvalidApiKeyMessage": "Your account at {url} could not be authenticated. Please try logging in again or use another account.",
+  "@errorInvalidApiKeyMessage": {
+    "description": "Error message in the dialog for invalid API key.",
+    "placeholders": {
+      "url": {"type": "String", "example": "http://chat.example.com/"}
+    }
+  },
   "errorInvalidResponse": "The server sent an invalid response",
   "@errorInvalidResponse": {
     "description": "Error message when an API call returned an invalid response."

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -214,8 +214,8 @@
       "url": {"type": "String", "example": "http://example.com/"}
     }
   },
-  "errorLoginCouldNotConnectTitle": "Could not connect",
-  "@errorLoginCouldNotConnectTitle": {
+  "errorCouldNotConnectTitle": "Could not connect",
+  "@errorCouldNotConnectTitle": {
     "description": "Error title when the app could not connect to the server."
   },
   "errorMessageDoesNotSeemToExist": "That message does not seem to exist.",

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -801,6 +801,12 @@ abstract class ZulipLocalizations {
   /// **'Topics are required in this organization.'**
   String get topicValidationErrorMandatoryButEmpty;
 
+  /// Error message in the dialog for invalid API key.
+  ///
+  /// In en, this message translates to:
+  /// **'Your account at {url} could not be authenticated. Please try logging in again or use another account.'**
+  String errorInvalidApiKeyMessage(String url);
+
   /// Error message when an API call returned an invalid response.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -397,7 +397,7 @@ abstract class ZulipLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Could not connect'**
-  String get errorLoginCouldNotConnectTitle;
+  String get errorCouldNotConnectTitle;
 
   /// Error message when loading a message that does not exist.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'The server sent an invalid response';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'The server sent an invalid response';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'The server sent an invalid response';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Could not connect';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'That message does not seem to exist.';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'The server sent an invalid response';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Nie można połączyć';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'Taka wiadomość raczej nie istnieje.';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Wątki są wymagane przez tę organizację.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'Nieprawidłowa odpowiedź serwera';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Не удалось подключиться';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'Это сообщение, похоже, отсутствует.';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Темы обязательны в этой организации.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'Получен недопустимый ответ сервера';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -405,6 +405,11 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get topicValidationErrorMandatoryButEmpty => 'Topics are required in this organization.';
 
   @override
+  String errorInvalidApiKeyMessage(String url) {
+    return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
+  }
+
+  @override
   String get errorInvalidResponse => 'Server poslal nesprávnu odpoveď';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -179,7 +179,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   }
 
   @override
-  String get errorLoginCouldNotConnectTitle => 'Nepodarilo sa pripojiť';
+  String get errorCouldNotConnectTitle => 'Could not connect';
 
   @override
   String get errorMessageDoesNotSeemToExist => 'Správa zrejme neexistuje.';

--- a/lib/log.dart
+++ b/lib/log.dart
@@ -31,7 +31,10 @@ bool debugLog(String message) {
   return true;
 }
 
-typedef ReportErrorCallback = void Function(String? message, {String? details});
+// This should only be used for error reporting functions that allow the error
+// to be cancelled programmatically.  The implementation is expected to handle
+// `null` for the `message` parameter and promptly dismiss the reported errors.
+typedef ReportErrorCancellablyCallback = void Function(String? message, {String? details});
 
 /// Show the user an error message, without requiring them to interact with it.
 ///
@@ -48,7 +51,7 @@ typedef ReportErrorCallback = void Function(String? message, {String? details});
 // This gets set in [ZulipApp].  We need this indirection to keep `lib/log.dart`
 // from importing widget code, because the file is a dependency for the rest of
 // the app.
-ReportErrorCallback reportErrorToUserBriefly = defaultReportErrorToUserBriefly;
+ReportErrorCancellablyCallback reportErrorToUserBriefly = defaultReportErrorToUserBriefly;
 
 void defaultReportErrorToUserBriefly(String? message, {String? details}) {
   // Error dismissing is a no-op to the default handler.

--- a/lib/log.dart
+++ b/lib/log.dart
@@ -54,7 +54,11 @@ typedef ReportErrorCancellablyCallback = void Function(String? message, {String?
 ReportErrorCancellablyCallback reportErrorToUserBriefly = defaultReportErrorToUserBriefly;
 
 void defaultReportErrorToUserBriefly(String? message, {String? details}) {
-  // Error dismissing is a no-op to the default handler.
+  _reportErrorToConsole(message, details);
+}
+
+void _reportErrorToConsole(String? message, String? details) {
+  // Error dismissing is a no-op for the console.
   if (message == null) return;
   // If this callback is still in place, then the app's widget tree
   // hasn't mounted yet even as far as the [Navigator].

--- a/lib/log.dart
+++ b/lib/log.dart
@@ -36,6 +36,8 @@ bool debugLog(String message) {
 // `null` for the `message` parameter and promptly dismiss the reported errors.
 typedef ReportErrorCancellablyCallback = void Function(String? message, {String? details});
 
+typedef ReportErrorCallback = void Function(String title, {String? message});
+
 /// Show the user an error message, without requiring them to interact with it.
 ///
 /// Typically this shows a [SnackBar] containing the message.
@@ -53,8 +55,23 @@ typedef ReportErrorCancellablyCallback = void Function(String? message, {String?
 // the app.
 ReportErrorCancellablyCallback reportErrorToUserBriefly = defaultReportErrorToUserBriefly;
 
+/// Show the user a dismissable error message in a modal popup.
+///
+/// Typically this shows an [AlertDialog] with `title` as the title, `message`
+/// as the body.  If called before the app's widget tree is ready
+/// (see [ZulipApp.ready]), then we give up on showing the message to the user,
+/// and just log the message to the console.
+// This gets set in [ZulipApp].  We need this indirection to keep `lib/log.dart`
+// from importing widget code, because the file is a dependency for the rest of
+// the app.
+ReportErrorCallback reportErrorToUserModally = defaultReportErrorToUserModally;
+
 void defaultReportErrorToUserBriefly(String? message, {String? details}) {
   _reportErrorToConsole(message, details);
+}
+
+void defaultReportErrorToUserModally(String title, {String? message}) {
+  _reportErrorToConsole(title, message);
 }
 
 void _reportErrorToConsole(String? message, String? details) {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1220,8 +1220,14 @@ class UpdateMachine {
       if (_disposed) return;
     }
 
-    await store._globalStore._reloadPerAccount(store.accountId);
-    assert(_disposed);
+    try {
+      await store._globalStore._reloadPerAccount(store.accountId);
+    } on AccountNotFoundException {
+      assert(debugLog('… Event queue not replaced; account was logged out.'));
+      return;
+    } finally {
+      assert(_disposed);
+    }
     assert(debugLog('… Event queue replaced.'));
   }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -918,7 +918,7 @@ class UpdateMachine {
         // at 1 kiB (at least on Android), and stack can be longer than that.
         assert(debugLog('Stack:\n$s'));
         assert(debugLog('Backing off, then will retry…'));
-        // TODO tell user if initial-fetch errors persist, or look non-transient
+        // TODO(#890): tell user if initial-fetch errors persist, or look non-transient
         await (backoffMachine ??= BackoffMachine()).wait();
         assert(debugLog('… Backoff wait complete, retrying initial fetch.'));
       }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -19,6 +19,7 @@ import '../api/backoff.dart';
 import '../api/route/realm.dart';
 import '../log.dart';
 import '../notifications/receive.dart';
+import 'actions.dart';
 import 'autocomplete.dart';
 import 'database.dart';
 import 'emoji.dart';
@@ -149,7 +150,34 @@ abstract class GlobalStore extends ChangeNotifier {
   /// and/or [perAccountSync].
   Future<PerAccountStore> loadPerAccount(int accountId) async {
     assert(_accounts.containsKey(accountId));
-    final store = await doLoadPerAccount(accountId);
+    final PerAccountStore store;
+    try {
+      store = await doLoadPerAccount(accountId);
+    } catch (e) {
+      switch (e) {
+        case HttpException(httpStatus: 401):
+          // The API key is invalid and the store can never be loaded
+          // unless the user retries manually.
+          final account = getAccount(accountId);
+          if (account == null) {
+            // The account was logged out during `await doLoadPerAccount`.
+            // Here, that seems possible only by the user's own action;
+            // the logout can't have been done programmatically.
+            // Even if it were, it would have come with its own UI feedback.
+            // Anyway, skip showing feedback, to not be confusing or repetitive.
+            throw AccountNotFoundException();
+          }
+          final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+          reportErrorToUserModally(
+            zulipLocalizations.errorCouldNotConnectTitle,
+            message: zulipLocalizations.errorInvalidApiKeyMessage(
+              account.realmUrl.toString()));
+          await logOutAccount(this, accountId);
+          throw AccountNotFoundException();
+        default:
+          rethrow;
+      }
+    }
     if (!_accounts.containsKey(accountId)) {
       // TODO(#1354): handle this earlier
       // [removeAccount] was called during [doLoadPerAccount].
@@ -914,12 +942,19 @@ class UpdateMachine {
       try {
         return await registerQueue(connection);
       } catch (e, s) {
-        assert(debugLog('Error fetching initial snapshot: $e'));
-        // Print stack trace in its own log entry; log entries are truncated
-        // at 1 kiB (at least on Android), and stack can be longer than that.
-        assert(debugLog('Stack:\n$s'));
-        assert(debugLog('Backing off, then will retry…'));
         // TODO(#890): tell user if initial-fetch errors persist, or look non-transient
+        switch (e) {
+          case HttpException(httpStatus: 401):
+            // We cannot recover from this error through retrying.
+            // Leave it to [GlobalStore.loadPerAccount].
+            rethrow;
+          default:
+            assert(debugLog('Error fetching initial snapshot: $e'));
+            // Print stack trace in its own log entry; log entries are truncated
+            // at 1 kiB (at least on Android), and stack can be longer than that.
+            assert(debugLog('Stack:\n$s'));
+        }
+        assert(debugLog('Backing off, then will retry…'));
         await (backoffMachine ??= BackoffMachine()).wait();
         assert(debugLog('… Backoff wait complete, retrying initial fetch.'));
       }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1177,6 +1177,7 @@ class UpdateMachine {
     store.isLoading = true;
 
     bool isUnexpected;
+    // TODO(#1054): handle auth failure
     switch (error) {
       case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
         assert(debugLog('Lost event queue for $store.  Replacing…'));

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -151,6 +151,7 @@ abstract class GlobalStore extends ChangeNotifier {
     assert(_accounts.containsKey(accountId));
     final store = await doLoadPerAccount(accountId);
     if (!_accounts.containsKey(accountId)) {
+      // TODO(#1354): handle this earlier
       // [removeAccount] was called during [doLoadPerAccount].
       store.dispose();
       throw AccountNotFoundException();

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -85,6 +85,7 @@ class ZulipApp extends StatefulWidget {
   static void debugReset() {
     _snackBarCount = 0;
     reportErrorToUserBriefly = defaultReportErrorToUserBriefly;
+    reportErrorToUserModally = defaultReportErrorToUserModally;
     _ready.dispose();
     _ready = ValueNotifier(false);
   }
@@ -128,10 +129,21 @@ class ZulipApp extends StatefulWidget {
     newSnackBar.closed.whenComplete(() => _snackBarCount--);
   }
 
+  /// The callback we normally use as [reportErrorToUserModally].
+  static void _reportErrorToUserModally(String title, {String? message}) {
+    assert(_ready.value);
+
+    showErrorDialog(
+      context: navigatorKey.currentContext!,
+      title: title,
+      message: message);
+  }
+
   void _declareReady() {
     assert(navigatorKey.currentContext != null);
     _ready.value = true;
     reportErrorToUserBriefly = _reportErrorToUserBriefly;
+    reportErrorToUserModally = _reportErrorToUserModally;
   }
 
   @override

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -190,7 +190,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
         // TODO(#105) give more helpful feedback; see `fetchServerSettings`
         //   in zulip-mobile's src/message/fetchActions.js.
         showErrorDialog(context: context,
-          title: zulipLocalizations.errorLoginCouldNotConnectTitle,
+          title: zulipLocalizations.errorCouldNotConnectTitle,
           message: zulipLocalizations.errorLoginCouldNotConnect(url.toString()));
         return;
       }

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -39,6 +39,18 @@ ZulipApiException apiBadRequest({
     data: {}, message: message);
 }
 
+/// The error for the "events" route when the target event queue has been
+/// garbage collected.
+///
+/// https://zulip.com/api/get-events#bad_event_queue_id-errors
+ZulipApiException apiExceptionBadEventQueueId({
+  String queueId = 'fb67bf8a-c031-47cc-84cf-ed80accacda8',
+}) {
+  return ZulipApiException(
+    routeName: 'events', httpStatus: 400, code: 'BAD_EVENT_QUEUE_ID',
+    data: {'queue_id': queueId}, message: 'Bad event queue ID: $queueId');
+}
+
 /// The error the server gives when the client's credentials
 /// (API key together with email and realm URL) are no longer valid.
 ///

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -879,6 +879,7 @@ ChannelUpdateEvent channelUpdateEvent(
 TestGlobalStore globalStore({List<Account> accounts = const []}) {
   return TestGlobalStore(accounts: accounts);
 }
+const _globalStore = globalStore;
 
 InitialSnapshot initialSnapshot({
   String? queueId,
@@ -949,10 +950,14 @@ InitialSnapshot initialSnapshot({
 }
 const _initialSnapshot = initialSnapshot;
 
-PerAccountStore store({Account? account, InitialSnapshot? initialSnapshot}) {
+PerAccountStore store({
+  GlobalStore? globalStore,
+  Account? account,
+  InitialSnapshot? initialSnapshot,
+}) {
   final effectiveAccount = account ?? selfAccount;
   return PerAccountStore.fromInitialSnapshot(
-    globalStore: globalStore(accounts: [effectiveAccount]),
+    globalStore: globalStore ?? _globalStore(accounts: [effectiveAccount]),
     accountId: effectiveAccount.id,
     initialSnapshot: initialSnapshot ?? _initialSnapshot(),
   );

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -757,11 +757,8 @@ void main() {
     }
 
     void prepareExpiredEventQueue() {
-      connection.prepare(httpStatus: 400, json: {
-        'result': 'error', 'code': 'BAD_EVENT_QUEUE_ID',
-        'queue_id': updateMachine.queueId,
-        'msg': 'Bad event queue ID: ${updateMachine.queueId}',
-      });
+      connection.prepare(apiException: eg.apiExceptionBadEventQueueId(
+        queueId: updateMachine.queueId));
     }
 
     Future<void> prepareHandleEventError() async {

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -129,6 +129,7 @@ class TestGlobalStore extends GlobalStore {
 
   static const Duration removeAccountDuration = Duration(milliseconds: 1);
   Duration? loadPerAccountDuration;
+  Object? loadPerAccountException;
 
   /// Consume the log of calls made to [doRemoveAccount].
   List<int> takeDoRemoveAccountCalls() {
@@ -149,6 +150,9 @@ class TestGlobalStore extends GlobalStore {
   Future<PerAccountStore> doLoadPerAccount(int accountId) async {
     if (loadPerAccountDuration != null) {
       await Future<void>.delayed(loadPerAccountDuration!);
+    }
+    if (loadPerAccountException != null) {
+      throw loadPerAccountException!;
     }
     final initialSnapshot = _initialSnapshots[accountId]!;
     final store = PerAccountStore.fromInitialSnapshot(

--- a/test/stdlib_checks.dart
+++ b/test/stdlib_checks.dart
@@ -5,6 +5,7 @@
 /// part of the Dart standard library.
 library;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:checks/checks.dart';
@@ -72,6 +73,10 @@ Object? deepToJson(Object? object) {
       return (null, false);
   }
   return (result, true);
+}
+
+extension CompleterChecks<T> on Subject<Completer<T>> {
+  Subject<bool> get isCompleted => has((x) => x.isCompleted, 'isCompleted');
 }
 
 extension JsonChecks on Subject<Object?> {

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -245,7 +245,9 @@ void main() {
       check(ZulipApp.scaffoldMessenger).isNotNull();
       check(ZulipApp.ready).value.isTrue();
     });
+  });
 
+  group('error reporting', () {
     Finder findSnackBarByText(String text) => find.descendant(
       of: find.byType(SnackBar),
       matching: find.text(text));
@@ -307,7 +309,7 @@ void main() {
       check(findSnackBarByText(message).evaluate()).single;
     }
 
-    testWidgets('reportErrorToUser dismissing SnackBar', (tester) async {
+    testWidgets('reportErrorToUserBriefly dismissing SnackBar', (tester) async {
       const message = 'test error message';
       const details = 'error details';
       await prepareSnackBarWithDetails(tester, message, details);

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -363,5 +363,24 @@ void main() {
       await tester.pumpAndSettle();
       check(findSnackBarByText('unrelated').evaluate()).single;
     });
+
+    testWidgets('reportErrorToUserModally', (tester) async {
+      addTearDown(testBinding.reset);
+      await tester.pumpWidget(const ZulipApp());
+      const title = 'test title';
+      const message = 'test message';
+
+      // Prior to app startup, reportErrorToUserModally only logs.
+      reportErrorToUserModally(title, message: message);
+      check(ZulipApp.ready).value.isFalse();
+      await tester.pump();
+      checkNoErrorDialog(tester);
+
+      check(ZulipApp.ready).value.isTrue();
+      // After app startup, reportErrorToUserModally displays an [AlertDialog].
+      reportErrorToUserModally(title, message: message);
+      await tester.pump();
+      checkErrorDialog(tester, expectedTitle: title, expectedMessage: message);
+    });
   });
 }

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:zulip/api/exception.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
@@ -143,9 +142,8 @@ void main() {
       updateMachine.debugPauseLoop();
       updateMachine.poll();
 
-      updateMachine.debugPrepareLoopError(ZulipApiException(
-        routeName: 'events', httpStatus: 400, code: 'BAD_EVENT_QUEUE_ID',
-        data: {'queue_id': updateMachine.queueId}, message: 'Bad event queue ID.'));
+      updateMachine.debugPrepareLoopError(
+        eg.apiExceptionBadEventQueueId(queueId: updateMachine.queueId));
       updateMachine.debugAdvanceLoop();
       await tester.pump();
       // Event queue has been replaced; but the [MessageList] hasn't been

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -203,7 +203,7 @@ void main() {
 
     final pushedRoutes = <Route<dynamic>>[];
     testNavObserver.onPushed = (route, prevRoute) => pushedRoutes.add(route);
-    // TODO(#737): switch to a realistic setup:
+    // TODO: switch to a realistic setup:
     //   https://github.com/zulip/zulip-flutter/pull/1076#discussion_r1874124363
     final account1Route = MaterialAccountWidgetRoute(
       accountId: account1.id, page: const InboxPageBody());


### PR DESCRIPTION
~~This is near term fix for a user-reported issue:
  https://chat.zulip.org/#narrow/channel/48-mobile/topic/0.2E0.2E19.20Flutter.20.3A.20Cant.20connect.20to.20self.20hosted.20instance/near/2004042~~

~~It is not intended to be the full fix.  With a better UX, we would bring the user back to the choose-account page without them manually doing so.  That's covered by #737 but out-of-scope for this commit.~~

This cherry-picks https://github.com/zulip/zulip-flutter/pull/1235, and partially addresses #890, by handling `INVALID_API_KEY` errors from the `PerAccountStoreWidget`.

Fixes: #737