### PR TITLE
ci: Update workaround for broken ref for Flutter upstream main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
         TZ=UTC git --git-dir ~/flutter/.git log -1 --format='%h | %ci | %s' --date=iso8601-local
         echo ~/flutter/bin >> "$GITHUB_PATH"
 
-        # The Flutter tool assumes the tip of tree is "upstream/master":
-        #   https://github.com/flutter/flutter/issues/160558
+        # The Flutter tool assumes the tip of tree is "origin/master"
+        # (or "upstream/master"):
+        #   https://github.com/flutter/flutter/issues/160626
         # TODO(upstream): make workaround unneeded
-        git --git-dir ~/flutter/.git update-ref refs/remotes/upstream/master origin/main
+        git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
 
     - name: Download Flutter SDK artifacts (flutter precache)
       run: flutter precache --universal


### PR DESCRIPTION
Fixes #1177, take 2.

The original hacky workaround subsequently broke after the upstream change that fixed the "upstream" vs. "origin" part of the issue. We still need a version of this workaround, though, because we clone the repo with the branch `main`, which in the Flutter repo always points to the same commit as `master`.