### PR TITLE
Factor error-handling out of poll method

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -996,17 +996,22 @@ class UpdateMachine {
     }());
   }
 
+  Future<void> _debugLoopWait() async {
+    await _debugLoopSignal!.future;
+    if (_disposed) return;
+    assert(() {
+      _debugLoopSignal = Completer();
+      return true;
+    }());
+  }
+
   void poll() async {
     assert(!_disposed);
     try {
       while (true) {
         if (_debugLoopSignal != null) {
-          await _debugLoopSignal!.future;
+          await _debugLoopWait();
           if (_disposed) return;
-          assert(() {
-            _debugLoopSignal = Completer();
-            return true;
-          }());
         }
 
         final GetEventsResult result;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1094,9 +1094,7 @@ class UpdateMachine {
         backoffMachine = null;
 
         store.isLoading = false;
-        // Dismiss existing errors, if any.
-        reportErrorToUserBriefly(null);
-        _accumulatedTransientFailureCount = 0;
+        _clearReportingErrorsToUser();
 
         final events = result.events;
         for (final event in events) {
@@ -1181,6 +1179,11 @@ class UpdateMachine {
   static const transientFailureCountNotifyThreshold = 5;
 
   int _accumulatedTransientFailureCount = 0;
+
+  void _clearReportingErrorsToUser() {
+    _accumulatedTransientFailureCount = 0;
+    reportErrorToUserBriefly(null);
+  }
 
   /// This only reports transient errors after reaching
   /// a pre-defined threshold of retries.


### PR DESCRIPTION
This is a follow-up to #1063 — it's very lightly revised from commits that were in my draft branch leading to that PR, and which I left out at the time because the PR was getting long and complex enough already.

In this PR, factoring this logic out of the [UpdateMachine.poll] method isn't for the sake of deduplicating anything: the methods the logic gets moved into are still private helpers tuned specifically for the needs of that method. But it allows that method to get quite a lot shorter, so its overall structure is more apparent. And it also allows each of the two phases of error-handling to be read in a bit more of a self-contained context, by having them in their own methods.
