### PR TITLE
Unify httpStatus field on ApiRequestException subclasses

### DIFF
--- a/lib/api/exception.dart
+++ b/lib/api/exception.dart
@@ -28,7 +28,10 @@ sealed class ApiRequestException implements Exception {
   String toString() => message;
 }
 
-/// A network-level error that prevented even getting an HTTP response.
+/// A network-level error that prevented even getting an HTTP response
+/// to some Zulip API network request.
+///
+/// This is the antonym of [HttpException].
 class NetworkException extends ApiRequestException {
   /// The exception describing the underlying error.
   ///
@@ -45,18 +48,25 @@ class NetworkException extends ApiRequestException {
   }
 }
 
-/// An error returned through the Zulip server API.
+/// Some kind of [ApiRequestException] that came as an HTTP response.
 ///
-/// See API docs: https://zulip.com/api/rest-error-handling
-class ZulipApiException extends ApiRequestException {
-
-  /// The Zulip API error code returned by the server.
-  final String code;
-
+/// This is the antonym of [NetworkException].
+sealed class HttpException extends ApiRequestException {
   /// The HTTP status code returned by the server.
   ///
-  /// This is always in the range 400..499.
+  /// On [ZulipApiException], this is always in the range 400..499.
   final int httpStatus;
+
+  HttpException({required super.routeName, required this.httpStatus, required super.message});
+}
+
+/// An error returned through the Zulip server API,
+/// and with a 4xx HTTP status code.
+///
+/// See API docs: https://zulip.com/api/rest-error-handling
+class ZulipApiException extends HttpException {
+  /// The Zulip API error code returned by the server.
+  final String code;
 
   /// The error's JSON data, if any, beyond the properties common to all errors.
   ///
@@ -67,8 +77,8 @@ class ZulipApiException extends ApiRequestException {
 
   ZulipApiException({
     required super.routeName,
+    required super.httpStatus,
     required this.code,
-    required this.httpStatus,
     required this.data,
     required super.message,
   }) : assert(400 <= httpStatus && httpStatus <= 499);
@@ -91,9 +101,7 @@ class ZulipApiException extends ApiRequestException {
 /// This should always represent either some kind of operational issue
 /// on the server, or a bug in the server where its responses don't
 /// agree with the documented API.
-sealed class ServerException extends ApiRequestException {
-  final int httpStatus;
-
+sealed class ServerException extends HttpException {
   /// The response body, decoded as a JSON object.
   ///
   /// This is null if the body could not be read, or was not a valid JSON object.
@@ -101,7 +109,7 @@ sealed class ServerException extends ApiRequestException {
 
   ServerException({
     required super.routeName,
-    required this.httpStatus,
+    required super.httpStatus,
     required this.data,
     required super.message,
   });

--- a/lib/api/exception.dart
+++ b/lib/api/exception.dart
@@ -28,6 +28,23 @@ sealed class ApiRequestException implements Exception {
   String toString() => message;
 }
 
+/// A network-level error that prevented even getting an HTTP response.
+class NetworkException extends ApiRequestException {
+  /// The exception describing the underlying error.
+  ///
+  /// This can be any exception value that [http.Client.send] throws.
+  /// Ideally that would always be an [http.ClientException],
+  /// but empirically it can be [TlsException] and possibly others.
+  final Object cause;
+
+  NetworkException({required super.routeName, required super.message, required this.cause});
+
+  @override
+  String toString() {
+    return 'NetworkException: $message ($cause)';
+  }
+}
+
 /// An error returned through the Zulip server API.
 ///
 /// See API docs: https://zulip.com/api/rest-error-handling
@@ -66,23 +83,6 @@ class ZulipApiException extends ApiRequestException {
     sb.write(" $routeName");
     sb.write(": $message");
     return sb.toString();
-  }
-}
-
-/// A network-level error that prevented even getting an HTTP response.
-class NetworkException extends ApiRequestException {
-  /// The exception describing the underlying error.
-  ///
-  /// This can be any exception value that [http.Client.send] throws.
-  /// Ideally that would always be an [http.ClientException],
-  /// but empirically it can be [TlsException] and possibly others.
-  final Object cause;
-
-  NetworkException({required super.routeName, required super.message, required this.cause});
-
-  @override
-  String toString() {
-    return 'NetworkException: $message ($cause)';
   }
 }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1128,8 +1128,7 @@ class UpdateMachine {
       case Server5xxException():
         shouldReportToUser = true;
 
-      case ServerException(httpStatus: 429):
-      case ZulipApiException(httpStatus: 429):
+      case HttpException(httpStatus: 429):
       case ZulipApiException(code: 'RATE_LIMIT_HIT'):
         // TODO(#946) handle rate-limit errors more generally, in ApiConnection
         shouldReportToUser = true;


### PR DESCRIPTION
Like #1187, this is a follow-up to #1063. It's a thought I had while working on those changes, but didn't pursue then because the PR was long and complex enough already.

## Commit messages

#### ab291ad06 api [nfc]: Reorder NetworkException to before sibling classes

We're about to group the others together under a new sibling of
this class, so it'll be cleanest if this one doesn't appear in the
midst of the others.


#### bdd625db1 api [nfc]: Add HttpException as base-class home for httpStatus field


#### 2eea63516 store [nfc]: Use HttpException to simplify error cases

This expresses more directly what we really mean here: if the
response had either the HTTP status code or the Zulip API error code
that mean a rate-limit error, treat it as a rate-limit error.

