### PR TITLE
Fix failing tests for RawAutocomplete

### DIFF
--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -224,6 +224,9 @@ void main() {
       await tester.enterText(composeInputFinder, 'hi :');
       await tester.enterText(composeInputFinder, 'hi :z');
       await tester.pump();
+      // Add an extra pump to account for any potential frame delays introduced
+      // by the post frame callback in RawAutocomplete's implementation.
+      await tester.pump();
       checkEmojiShown(expected: true, zzzOption);
       checkEmojiShown(expected: true, buzzingOption);
       checkEmojiShown(expected: true, zulipOption);


### PR DESCRIPTION
The fixes to RawAutocomplete's options width in the flutter framework (https://github.com/flutter/flutter/pull/143249) introduces a frame delay, so this test requires an extra pump to account for that.