### PR TITLE
compose: Skip failing test for windows.

### DIFF
--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:file_picker/file_picker.dart';
@@ -581,7 +582,13 @@ void main() {
       });
 
       // TODO test what happens when capturing/uploading fails
-    });
+    },
+    // This test fails on Windows because [XFile.name] splits on
+    // [Platform.pathSeparator], corresponding to the actual host platform
+    // the test is running on, instead of the path separator for the
+    // target platform the test is simulating.
+    // TODO(upstream): unskip after fix to https://github.com/flutter/flutter/issues/161073
+    skip: Platform.isWindows);
   });
 
   group('error banner', () {


### PR DESCRIPTION
The `attach from camera` test fails on
Windows due to the the path separator
used in the split function of the XFile.name
getter in `cross_file` being `\` instead of `/`.
This results in the getter returning the
entire path on Windows instead of the
last word present after the last '/' in the path.

Read this excellent explanation by
@chrisbobbe for better understanding:
https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/failing.20composebox.20test.20while.20running.20check.20script/near/2000301