### PR TITLE
Fix channel navigation when tapping recipient header areas

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1054,6 +1054,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
         ?? '(unknown channel)'; // TODO(log)
 
       streamWidget = GestureDetector(
+	behavior: HitTestBehavior.opaque,
         onTap: () => Navigator.push(context,
           MessageListPage.buildRoute(context: context,
             narrow: ChannelNarrow(message.streamId))),


### PR DESCRIPTION
This PR fixes the tap target behavior in the recipient header of channel messages. Previously, tapping above or below the channel name would navigate to the topic view instead of the channel view. 

The fix adds `behavior: HitTestBehavior.opaque` to the GestureDetector which makes the entire area (including padding spaces) respond to taps.

 The fix improves the header's usability by ensuring the entire channel section responds correctly to taps, making navigation more intuitive.

Issue: #1179 

Screencast:
<video src="https://github.com/user-attachments/assets/46cacd9c-3fe8-4030-8435-6f5b4dd82c3b" controls></video>

