### PR TITLE
gitignore: Ignore CMake directory generated on Android build

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -6,6 +6,8 @@ gradle-wrapper.jar
 /local.properties
 GeneratedPluginRegistrant.java
 
+.cxx/
+
 *keystore.properties
 *.keystore
 *.keystore.pgp


### PR DESCRIPTION
Starting with our last Flutter update 273674f37 (#1184), a directory android/app/.cxx/ gets created whenever building or running the app for Android.  It has a lot of generated files in it.

See chat discussion:
  https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/Error.20in.20running.20the.20app/near/2017805
  https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/.2Ecxx.2F.20files.20created/near/2017819

There's an upstream issue for the need to add a gitignore line for these in the `flutter create` templates:
  https://github.com/flutter/flutter/issues/160372

Even when that's done, it won't affect existing apps like ours; we need to make a similar update in our own tree.  That's this commit.