### PR TITLE
compose: Enforce max topic/content length by code points, following API

### DIFF
--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -156,7 +156,7 @@ class GetMessagesResult {
 }
 
 // https://zulip.com/api/send-message#parameter-topic
-const int kMaxTopicLength = 60;
+const int kMaxTopicLengthCodePoints = 60;
 
 // https://zulip.com/api/send-message#parameter-content
 const int kMaxMessageLengthCodePoints = 10000;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -28,9 +28,30 @@ const double _composeButtonSize = 44;
 ///
 /// Subclasses must ensure that [_update] is called in all exposed constructors.
 abstract class ComposeController<ErrorT> extends TextEditingController {
+  int get maxLengthUnicodeCodePoints;
+
   String get textNormalized => _textNormalized;
   late String _textNormalized;
   String _computeTextNormalized();
+
+  /// Length of [textNormalized] in Unicode code points
+  /// if it might exceed [maxLengthUnicodeCodePoints], else null.
+  ///
+  /// Use this instead of [String.length]
+  /// to enforce a max length expressed in code points.
+  /// [String.length] is conservative and may cut the user off too short.
+  ///
+  /// Counting code points ([String.runes])
+  /// is more expensive than getting the number of UTF-16 code units
+  /// ([String.length]), so we avoid it when the result definitely won't exceed
+  /// [maxLengthUnicodeCodePoints].
+  late int? _lengthUnicodeCodePointsIfLong;
+  @visibleForTesting
+  int? get debugLengthUnicodeCodePointsIfLong => _lengthUnicodeCodePointsIfLong;
+  int? _computeLengthUnicodeCodePointsIfLong() =>
+    _textNormalized.length > maxLengthUnicodeCodePoints
+      ? _textNormalized.runes.length
+      : null;
 
   List<ErrorT> get validationErrors => _validationErrors;
   late List<ErrorT> _validationErrors;
@@ -40,6 +61,8 @@ abstract class ComposeController<ErrorT> extends TextEditingController {
 
   void _update() {
     _textNormalized = _computeTextNormalized();
+    // uses _textNormalized, so comes after _computeTextNormalized()
+    _lengthUnicodeCodePointsIfLong = _computeLengthUnicodeCodePointsIfLong();
     _validationErrors = _computeValidationErrors();
     hasValidationErrors.value = _validationErrors.isNotEmpty;
   }
@@ -74,6 +97,9 @@ class ComposeTopicController extends ComposeController<TopicValidationError> {
   //   https://zulip.com/help/require-topics
   final mandatory = true;
 
+  // TODO(#307) use `max_topic_length` instead of hardcoded limit
+  @override final maxLengthUnicodeCodePoints = kMaxTopicLengthCodePoints;
+
   @override
   String _computeTextNormalized() {
     String trimmed = text.trim();
@@ -86,11 +112,10 @@ class ComposeTopicController extends ComposeController<TopicValidationError> {
       if (mandatory && textNormalized == kNoTopicTopic)
         TopicValidationError.mandatoryButEmpty,
 
-      // textNormalized.length is the number of UTF-16 code units, while the server
-      // API expresses the max in Unicode code points. So this comparison will
-      // be conservative and may cut the user off shorter than necessary.
-      // TODO(#1238) stop cutting off shorter than necessary
-      if (textNormalized.length > kMaxTopicLengthCodePoints)
+      if (
+        _lengthUnicodeCodePointsIfLong != null
+        && _lengthUnicodeCodePointsIfLong! > maxLengthUnicodeCodePoints
+      )
         TopicValidationError.tooLong,
     ];
   }
@@ -124,6 +149,9 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   ComposeContentController() {
     _update();
   }
+
+  // TODO(#1237) use `max_message_length` instead of hardcoded limit
+  @override final maxLengthUnicodeCodePoints = kMaxMessageLengthCodePoints;
 
   int _nextQuoteAndReplyTag = 0;
   int _nextUploadTag = 0;
@@ -266,11 +294,10 @@ class ComposeContentController extends ComposeController<ContentValidationError>
       if (textNormalized.isEmpty)
         ContentValidationError.empty,
 
-      // normalized.length is the number of UTF-16 code units, while the server
-      // API expresses the max in Unicode code points. So this comparison will
-      // be conservative and may cut the user off shorter than necessary.
-      // TODO(#1238) stop cutting off shorter than necessary
-      if (textNormalized.length > kMaxMessageLengthCodePoints)
+      if (
+        _lengthUnicodeCodePointsIfLong != null
+        && _lengthUnicodeCodePointsIfLong! > maxLengthUnicodeCodePoints
+      )
         ContentValidationError.tooLong,
 
       if (_quoteAndReplies.isNotEmpty)

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -264,6 +264,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
       // normalized.length is the number of UTF-16 code units, while the server
       // API expresses the max in Unicode code points. So this comparison will
       // be conservative and may cut the user off shorter than necessary.
+      // TODO(#1238) stop cutting off shorter than necessary
       if (textNormalized.length > kMaxMessageLengthCodePoints)
         ContentValidationError.tooLong,
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -85,7 +85,12 @@ class ComposeTopicController extends ComposeController<TopicValidationError> {
     return [
       if (mandatory && textNormalized == kNoTopicTopic)
         TopicValidationError.mandatoryButEmpty,
-      if (textNormalized.length > kMaxTopicLength)
+
+      // textNormalized.length is the number of UTF-16 code units, while the server
+      // API expresses the max in Unicode code points. So this comparison will
+      // be conservative and may cut the user off shorter than necessary.
+      // TODO(#1238) stop cutting off shorter than necessary
+      if (textNormalized.length > kMaxTopicLengthCodePoints)
         TopicValidationError.tooLong,
     ];
   }

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -280,14 +280,14 @@ void main() {
       check(ZulipApp.ready).value.isFalse();
       await tester.pump();
       check(findSnackBarByText(message).evaluate()).isEmpty();
-      check(find.byType(AlertDialog).evaluate()).isEmpty();
+      checkNoErrorDialog(tester);
 
       check(ZulipApp.ready).value.isTrue();
       // After app startup, reportErrorToUserBriefly displays a SnackBar.
       reportErrorToUserBriefly(message, details: details);
       await tester.pumpAndSettle();
       check(findSnackBarByText(message).evaluate()).single;
-      check(find.byType(AlertDialog).evaluate()).isEmpty();
+      checkNoErrorDialog(tester);
 
       // Open the error details dialog.
       await tester.tap(find.text('Details'));

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -80,6 +80,7 @@ void main() {
     controller = tester.state<ComposeBoxState>(find.byType(ComposeBox)).controller;
   }
 
+  /// Set the topic input's text to [topic], using [WidgetTester.enterText].
   Future<void> enterTopic(WidgetTester tester, {
     required ChannelNarrow narrow,
     required String topic,

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -436,8 +436,7 @@ void main() {
       await setupAndTapSend(tester, prepareResponse: (int messageId) {
         connection.prepare(json: SendMessageResult(id: messageId).toJson());
       });
-      final errorDialogs = tester.widgetList(find.byType(AlertDialog));
-      check(errorDialogs).isEmpty();
+      checkNoErrorDialog(tester);
     });
 
     testWidgets('ZulipApiException', (tester) async {
@@ -506,8 +505,7 @@ void main() {
         check(call.allowMultiple).equals(true);
         check(call.type).equals(FileType.media);
 
-        final errorDialogs = tester.widgetList(find.byType(AlertDialog));
-        check(errorDialogs).isEmpty();
+        checkNoErrorDialog(tester);
 
         check(controller!.content.text)
           .equals('see image: [Uploading image.jpg…]()\n\n');
@@ -566,8 +564,7 @@ void main() {
         check(call.source).equals(ImageSource.camera);
         check(call.requestFullMetadata).equals(false);
 
-        final errorDialogs = tester.widgetList(find.byType(AlertDialog));
-        check(errorDialogs).isEmpty();
+        checkNoErrorDialog(tester);
 
         check(controller!.content.text)
           .equals('see image: [Uploading image.jpg…]()\n\n');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -41,9 +41,6 @@ void main() {
   late FakeApiConnection connection;
   late ComposeBoxController? controller;
 
-  final contentInputFinder = find.byWidgetPredicate(
-    (widget) => widget is TextField && widget.controller is ComposeContentController);
-
   Future<void> prepareComposeBox(WidgetTester tester, {
     required Narrow narrow,
     User? selfUser,
@@ -94,6 +91,17 @@ void main() {
     check(connection.takeRequests()).single
       ..method.equals('GET')
       ..url.path.equals('/api/v1/users/me/${narrow.streamId}/topics');
+  }
+
+  /// A [Finder] for the content input.
+  ///
+  /// To enter some text, use [enterContent].
+  final contentInputFinder = find.byWidgetPredicate(
+    (widget) => widget is TextField && widget.controller is ComposeContentController);
+
+  /// Set the content input's text to [content], using [WidgetTester.enterText].
+  Future<void> enterContent(WidgetTester tester, String content) async {
+    await tester.enterText(contentInputFinder, content);
   }
 
   group('ComposeContentController', () {
@@ -245,7 +253,7 @@ void main() {
 
     Future<void> checkStartTyping(WidgetTester tester, SendableNarrow narrow) async {
       connection.prepare(json: {});
-      await tester.enterText(contentInputFinder, 'hello world');
+      await enterContent(tester, 'hello world');
       checkTypingRequest(TypingOp.start, narrow);
     }
 
@@ -290,7 +298,7 @@ void main() {
       await checkStartTyping(tester, narrow);
 
       connection.prepare(json: {});
-      await tester.enterText(contentInputFinder, '');
+      await enterContent(tester, '');
       checkTypingRequest(TypingOp.stop, narrow);
     });
 
@@ -406,7 +414,7 @@ void main() {
       await prepareComposeBox(tester, narrow: eg.topicNarrow(123, 'some topic'),
         streams: [eg.stream(streamId: 123)]);
 
-      await tester.enterText(contentInputFinder, 'hello world');
+      await enterContent(tester, 'hello world');
 
       prepareResponse(456);
       await tester.tap(find.byTooltip(zulipLocalizations.composeBoxSendTooltip));
@@ -817,7 +825,7 @@ void main() {
       double? height;
       for (numLines = 2; numLines <= 1000; numLines++) {
         final content = List.generate(numLines, (_) => 'foo').join('\n');
-        await tester.enterText(contentInputFinder, content);
+        await enterContent(tester, content);
         await tester.pump();
         final newHeight = tester.getRect(contentInputFinder).height;
         if (newHeight == height) {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -256,19 +256,16 @@ void main() {
         await checkErrorResponse(tester);
       });
 
-      // TODO(#1238) unskip
-      // testWidgets('max-length content not rejected', (tester) async {
-      //   await prepareWithContent(tester,
-      //     makeStringWithCodePoints(kMaxMessageLengthCodePoints));
-      //   await tapSendButton(tester);
-      //   checkNoErrorDialog(tester);
-      // });
-
-      // TODO(#1238) replace with above commented-out test
-      testWidgets('some content not rejected', (tester) async {
-        await prepareWithContent(tester, 'a' * kMaxMessageLengthCodePoints);
+      testWidgets('max-length content not rejected', (tester) async {
+        await prepareWithContent(tester,
+          makeStringWithCodePoints(kMaxMessageLengthCodePoints));
         await tapSendButton(tester);
         checkNoErrorDialog(tester);
+      });
+
+      testWidgets('code points not counted unnecessarily', (tester) async {
+        await prepareWithContent(tester, 'a' * kMaxMessageLengthCodePoints);
+        check(controller!.content.debugLengthUnicodeCodePointsIfLong).isNull();
       });
     });
 
@@ -296,19 +293,17 @@ void main() {
         await checkErrorResponse(tester);
       });
 
-      // TODO(#1238) unskip
-      // testWidgets('max-length topic not rejected', (tester) async {
-      //   await prepareWithTopic(tester,
-      //     makeStringWithCodePoints(kMaxTopicLengthCodePoints));
-      //   await tapSendButton(tester);
-      //   checkNoErrorDialog(tester);
-      // });
-
-      // TODO(#1238) replace with above commented-out test
-      testWidgets('some topic not rejected', (tester) async {
-        await prepareWithTopic(tester, 'a' * kMaxTopicLengthCodePoints);
+      testWidgets('max-length topic not rejected', (tester) async {
+        await prepareWithTopic(tester,
+          makeStringWithCodePoints(kMaxTopicLengthCodePoints));
         await tapSendButton(tester);
         checkNoErrorDialog(tester);
+      });
+
+      testWidgets('code points not counted unnecessarily', (tester) async {
+        await prepareWithTopic(tester, 'a' * kMaxTopicLengthCodePoints);
+        check((controller as StreamComposeBoxController)
+          .topic.debugLengthUnicodeCodePointsIfLong).isNull();
       });
     });
   });

--- a/test/widgets/dialog_checks.dart
+++ b/test/widgets/dialog_checks.dart
@@ -1,4 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/widgets/dialog.dart';
 
@@ -24,6 +26,11 @@ Widget checkErrorDialog(WidgetTester tester, {
   return tester.widget(
     find.descendant(of: find.byWidget(dialog),
       matching: find.widgetWithText(TextButton, 'OK')));
+}
+
+// TODO(#996) update this to check for per-platform flavors of alert dialog
+void checkNoErrorDialog(WidgetTester tester) {
+  check(find.byType(AlertDialog)).findsNothing();
 }
 
 /// In a widget test, check that [showSuggestedActionDialog] was called


### PR DESCRIPTION
Fixes #1238.

Done by computing `String.runes` (the number of Unicode code points) unless we know that the result can't exceed the threshold number of code points. In particular, we don't compute it unless `String.length` (the number of UTF-16 code units) exceeds the threshold number of code points.