### PR TITLE
notif: Use associated account as initial account; if opened from background

### DIFF
--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -470,8 +470,9 @@ class NotificationDisplayManager {
     assert(url.scheme == 'zulip' && url.host == 'notification');
     final payload = NotificationOpenPayload.parseUrl(url);
 
-    final account = globalStore.accounts.firstWhereOrNull((account) =>
-      account.realmUrl == payload.realmUrl && account.userId == payload.userId);
+    final account = globalStore.accounts.firstWhereOrNull(
+      (account) => account.realmUrl.origin == payload.realmUrl.origin
+                && account.userId == payload.userId);
     if (account == null) { // TODO(log)
       final zulipLocalizations = ZulipLocalizations.of(context);
       showErrorDialog(context: context,

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -453,6 +453,39 @@ class NotificationDisplayManager {
 
   static String _personKey(Uri realmUrl, int userId) => "$realmUrl|$userId";
 
+  /// Provides the route and the account ID by parsing the notification URL.
+  ///
+  /// The URL must have been generated using [NotificationOpenPayload.buildUrl]
+  /// while creating the notification.
+  ///
+  /// Returns null and shows an error dialog if the associated account is not
+  /// found in the global store.
+  static AccountRoute<void>? routeForNotification({
+    required BuildContext context,
+    required Uri url,
+  }) {
+    final globalStore = GlobalStoreWidget.of(context);
+
+    assert(debugLog('got notif: url: $url'));
+    assert(url.scheme == 'zulip' && url.host == 'notification');
+    final payload = NotificationOpenPayload.parseUrl(url);
+
+    final account = globalStore.accounts.firstWhereOrNull((account) =>
+      account.realmUrl == payload.realmUrl && account.userId == payload.userId);
+    if (account == null) { // TODO(log)
+      final zulipLocalizations = ZulipLocalizations.of(context);
+      showErrorDialog(context: context,
+        title: zulipLocalizations.errorNotificationOpenTitle,
+        message: zulipLocalizations.errorNotificationOpenAccountMissing);
+      return null;
+    }
+
+    return MessageListPage.buildRoute(
+      accountId: account.id,
+      // TODO(#82): Open at specific message, not just conversation
+      narrow: payload.narrow);
+  }
+
   /// Navigates to the [MessageListPage] of the specific conversation
   /// given the `zulip://notification/…` Android intent data URL,
   /// generated with [NotificationOpenPayload.buildUrl] while creating
@@ -460,29 +493,16 @@ class NotificationDisplayManager {
   static Future<void> navigateForNotification(Uri url) async {
     assert(debugLog('opened notif: url: $url'));
 
-    assert(url.scheme == 'zulip' && url.host == 'notification');
-    final payload = NotificationOpenPayload.parseUrl(url);
-
     NavigatorState navigator = await ZulipApp.navigator;
     final context = navigator.context;
     assert(context.mounted);
     if (!context.mounted) return; // TODO(linter): this is impossible as there's no actual async gap, but the use_build_context_synchronously lint doesn't see that
 
-    final zulipLocalizations = ZulipLocalizations.of(context);
-    final globalStore = GlobalStoreWidget.of(context);
-    final account = globalStore.accounts.firstWhereOrNull((account) =>
-      account.realmUrl == payload.realmUrl && account.userId == payload.userId);
-    if (account == null) { // TODO(log)
-      showErrorDialog(context: context,
-        title: zulipLocalizations.errorNotificationOpenTitle,
-        message: zulipLocalizations.errorNotificationOpenAccountMissing);
-      return;
-    }
+    final route = routeForNotification(context: context, url: url);
+    if (route == null) return; // TODO(log)
 
     // TODO(nav): Better interact with existing nav stack on notif open
-    unawaited(navigator.push(MaterialAccountWidgetRoute<void>(accountId: account.id,
-      // TODO(#82): Open at specific message, not just conversation
-      page: MessageListPage(initNarrow: payload.narrow))));
+    unawaited(navigator.push(route));
   }
 
   static Future<Uint8List?> _fetchBitmap(Uri url) async {

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -178,8 +178,6 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
     return GlobalStoreWidget(
       child: Builder(builder: (context) {
         final globalStore = GlobalStoreWidget.of(context);
-        // TODO(#524) choose initial account as last one used
-        final initialAccountId = globalStore.accounts.firstOrNull?.id;
         return MaterialApp(
           onGenerateTitle: (BuildContext context) {
             return ZulipLocalizations.of(context).zulipAppTitle;
@@ -209,6 +207,8 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
           onGenerateRoute: (_) => null,
 
           onGenerateInitialRoutes: (_) {
+            // TODO(#524) choose initial account as last one used
+            final initialAccountId = globalStore.accounts.firstOrNull?.id;
             return [
               if (initialAccountId == null)
                 MaterialWidgetRoute(page: const ChooseAccountPage())

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -140,26 +140,6 @@ class ZulipApp extends StatefulWidget {
 
 class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
   @override
-  Future<bool> didPushRouteInformation(routeInformation) async {
-    switch (routeInformation.uri) {
-      case Uri(scheme: 'zulip', host: 'login') && var url:
-        await LoginPage.handleWebAuthUrl(url);
-        return true;
-      case Uri(scheme: 'zulip', host: 'notification') && var url:
-        await NotificationDisplayManager.navigateForNotification(url);
-        return true;
-    }
-    return super.didPushRouteInformation(routeInformation);
-  }
-
-  Future<void> _handleInitialRoute() async {
-    final initialRouteUrl = Uri.parse(WidgetsBinding.instance.platformDispatcher.defaultRouteName);
-    if (initialRouteUrl case Uri(scheme: 'zulip', host: 'notification')) {
-      await NotificationDisplayManager.navigateForNotification(initialRouteUrl);
-    }
-  }
-
-  @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
@@ -170,6 +150,26 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  Future<void> _handleInitialRoute() async {
+    final initialRouteUrl = Uri.parse(WidgetsBinding.instance.platformDispatcher.defaultRouteName);
+    if (initialRouteUrl case Uri(scheme: 'zulip', host: 'notification')) {
+      await NotificationDisplayManager.navigateForNotification(initialRouteUrl);
+    }
+  }
+
+  @override
+  Future<bool> didPushRouteInformation(routeInformation) async {
+    switch (routeInformation.uri) {
+      case Uri(scheme: 'zulip', host: 'login') && var url:
+        await LoginPage.handleWebAuthUrl(url);
+        return true;
+      case Uri(scheme: 'zulip', host: 'notification') && var url:
+        await NotificationDisplayManager.navigateForNotification(url);
+        return true;
+    }
+    return super.didPushRouteInformation(routeInformation);
   }
 
   @override

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -31,7 +31,7 @@ enum _HomePageTab {
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
-  static Route<void> buildRoute({required int accountId}) {
+  static AccountRoute<void> buildRoute({required int accountId}) {
     return MaterialAccountWidgetRoute(accountId: accountId,
       loadingPlaceholderPage: _LoadingPlaceholderPage(accountId: accountId),
       page: const HomePage());

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -188,7 +188,7 @@ abstract class MessageListPageState {
 class MessageListPage extends StatefulWidget {
   const MessageListPage({super.key, required this.initNarrow});
 
-  static Route<void> buildRoute({int? accountId, BuildContext? context,
+  static AccountRoute<void> buildRoute({int? accountId, BuildContext? context,
       required Narrow narrow}) {
     return MaterialAccountWidgetRoute(accountId: accountId, context: context,
       page: MessageListPage(initNarrow: narrow));

--- a/lib/widgets/page.dart
+++ b/lib/widgets/page.dart
@@ -35,6 +35,12 @@ abstract class WidgetRoute<T extends Object?> extends PageRoute<T> {
   Widget get page;
 }
 
+/// A page route that specifies a particular Zulip account to use, by ID.
+abstract class AccountRoute<T extends Object?> extends PageRoute<T> {
+  /// The [Account.id] of the account to use for this page.
+  int get accountId;
+}
+
 /// A [MaterialPageRoute] that always builds the same widget.
 ///
 /// This is useful for making the route more transparent for a test to inspect.
@@ -56,8 +62,10 @@ class MaterialWidgetRoute<T extends Object?> extends MaterialPageRoute<T> implem
 }
 
 /// A mixin for providing a given account's per-account store on a page route.
-mixin AccountPageRouteMixin<T extends Object?> on PageRoute<T> {
+mixin AccountPageRouteMixin<T extends Object?> on PageRoute<T> implements AccountRoute<T> {
+  @override
   int get accountId;
+
   Widget? get loadingPlaceholderPage;
 
   @override

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -30,7 +30,7 @@ class ProfilePage extends StatelessWidget {
 
   final int userId;
 
-  static Route<void> buildRoute({int? accountId, BuildContext? context,
+  static AccountRoute<void> buildRoute({int? accountId, BuildContext? context,
       required int userId}) {
     return MaterialAccountWidgetRoute(accountId: accountId, context: context,
       page: ProfilePage(userId: userId));

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -1112,11 +1112,12 @@ void main() {
         realmUrl: data.realmUrl,
         userId: data.userId,
         narrow: switch (data.recipient) {
-        FcmMessageChannelRecipient(:var streamId, :var topic) =>
-          TopicNarrow(streamId, topic),
-        FcmMessageDmRecipient(:var allRecipientIds) =>
-          DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
-      }).buildUrl();
+          FcmMessageChannelRecipient(:var streamId, :var topic) =>
+            TopicNarrow(streamId, topic),
+          FcmMessageDmRecipient(:var allRecipientIds) =>
+            DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
+        }).buildUrl();
+      addTearDown(tester.binding.platformDispatcher.clearDefaultRouteNameTestValue);
       tester.binding.platformDispatcher.defaultRouteNameTestValue = intentDataUrl.toString();
 
       // Now start the app.

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -1037,6 +1037,21 @@ void main() {
         eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]));
     });
 
+    testWidgets('account queried by realmUrl origin component', (tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(
+        eg.selfAccount.copyWith(realmUrl: Uri.parse('http://chat.example')),
+        eg.initialSnapshot());
+      await prepare(tester);
+
+      await checkOpenNotification(tester,
+        eg.selfAccount.copyWith(realmUrl: Uri.parse('http://chat.example/')),
+        eg.streamMessage());
+      await checkOpenNotification(tester,
+        eg.selfAccount.copyWith(realmUrl: Uri.parse('http://chat.example')),
+        eg.streamMessage());
+    });
+
     testWidgets('no accounts', (tester) async {
       await prepare(tester, withAccount: false);
       await openNotification(tester, eg.selfAccount, eg.streamMessage());

--- a/test/widgets/page_checks.dart
+++ b/test/widgets/page_checks.dart
@@ -6,6 +6,6 @@ extension WidgetRouteChecks<T> on Subject<WidgetRoute<T>> {
   Subject<Widget> get page => has((x) => x.page, 'page');
 }
 
-extension AccountPageRouteMixinChecks<T> on Subject<AccountPageRouteMixin<T>> {
+extension AccountRouteChecks<T> on Subject<AccountRoute<T>> {
   Subject<int> get accountId => has((x) => x.accountId, 'accountId');
 }


### PR DESCRIPTION
Previously, when two accounts (Account-1 and Account-2) were logged in, the app always defaulted to showing the home page of Account-1 on launch. If the app was closed and the user opened a notification from Account-2, the navigation stack would be:
  HomePage(Account-1) -> MessageListPage(Account-2)

This commit fixes that behaviour, now when a notification is opened while the app is closed, the home page will correspond to the account associated with the notification's conversation.

This addresses #1210 for background notifications.