### PR TITLE
github: Fix weblate action's rights, and update generated code.

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,4 +1,7 @@
 name: Update translations from Weblate
+permissions:
+  contents: write
+  pull-requests: write
 on:
   schedule:
     - cron: "0 10 * * 1"

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -6,17 +6,44 @@ on:
   schedule:
     - cron: "0 10 * * 1"
   workflow_dispatch:
+
 jobs:
   update-translations:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Fetch and merge from Weblate
         # The commit message is generated in Weblate; see https://hosted.weblate.org/addon/17163/
         run: |
           git remote add weblate https://hosted.weblate.org/git/zulip/zulip-flutter/
           git fetch weblate
           git merge --ff-only weblate/main
+
+      - name: Clone Flutter SDK
+        # We can't do a depth-1 clone, because we need the most recent tag
+        # so that Flutter knows its version and sees the constraint in our
+        # pubspec is satisfied.  It's uncommon for flutter/flutter to go
+        # more than 100 commits between tags.  Fetch 1000 for good measure.
+        run: |
+          git clone --depth=1000 -b main https://github.com/flutter/flutter ~/flutter
+          TZ=UTC git --git-dir ~/flutter/.git log -1 --format='%h | %ci | %s' --date=iso8601-local
+          echo ~/flutter/bin >> "$GITHUB_PATH"
+
+          # The Flutter tool assumes the tip of tree is "origin/master"
+          # (or "upstream/master"):
+          #   https://github.com/flutter/flutter/issues/160626
+          # TODO(upstream): make workaround unneeded
+          git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
+
+      - name: Update generated code
+        run: |
+          mkdir -p build
+          tools/check l10n --fix
+          git add lib/generated/l10n/
+          GIT_COMMITTER_NAME="Hosted Weblate" GIT_COMMITTER_EMAIL="hosted@weblate.org" \
+            git commit --amend -C HEAD
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -18,7 +18,11 @@ jobs:
         run: |
           git remote add weblate https://hosted.weblate.org/git/zulip/zulip-flutter/
           git fetch weblate
-          git merge --ff-only weblate/main
+          # This may lag behind `main` if weblate is backlogged; this can
+          # theoretically cause the PR to not be able to auto-merged, though
+          # re-running the action once weblate has caught up should be
+          # sufficient to fix that.
+          git reset --hard weblate/main
 
       - name: Clone Flutter SDK
         # We can't do a depth-1 clone, because we need the most recent tag


### PR DESCRIPTION
This replaces #1192, with the branch pushed to `zulip/zulip-flutter` so that it can possibly be tested before merging.