### PR TITLE
Max message limit changed from static value to server value

### DIFF
--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -77,6 +77,7 @@ class InitialSnapshot {
   final int maxFileUploadSizeMib;
 
   final Uri? serverEmojiDataUrl; // TODO(server-6)
+  final int maxMessageLength;
 
   @JsonKey(readValue: _readUsersIsActiveFallbackTrue)
   final List<User> realmUsers;
@@ -132,6 +133,7 @@ class InitialSnapshot {
     required this.realmUsers,
     required this.realmNonActiveUsers,
     required this.crossRealmBots,
+    required this.maxMessageLength,
   });
 
   factory InitialSnapshot.fromJson(Map<String, dynamic> json) =>

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -82,6 +82,7 @@ InitialSnapshot _$InitialSnapshotFromJson(Map<String, dynamic> json) =>
               json, 'cross_realm_bots') as List<dynamic>)
           .map((e) => User.fromJson(e as Map<String, dynamic>))
           .toList(),
+      maxMessageLength: (json['max_message_length'] as num).toInt(),
     );
 
 Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
@@ -112,6 +113,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
       'realm_default_external_accounts': instance.realmDefaultExternalAccounts,
       'max_file_upload_size_mib': instance.maxFileUploadSizeMib,
       'server_emoji_data_url': instance.serverEmojiDataUrl?.toString(),
+      'max_message_length': instance.maxMessageLength,
       'realm_users': instance.realmUsers,
       'realm_non_active_users': instance.realmNonActiveUsers,
       'cross_realm_bots': instance.crossRealmBots,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -269,8 +269,8 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
       connection: connection,
       realmUrl: realmUrl,
       realmWaitingPeriodThreshold: initialSnapshot.realmWaitingPeriodThreshold,
-      maxFileUploadSizeMib: initialSnapshot.maxFileUploadSizeMib,
       maxMessageLength : initialSnapshot.maxMessageLength,
+      maxFileUploadSizeMib: initialSnapshot.maxFileUploadSizeMib,
       realmDefaultExternalAccounts: initialSnapshot.realmDefaultExternalAccounts,
       customProfileFields: _sortCustomProfileFields(initialSnapshot.customProfileFields),
       emailAddressVisibility: initialSnapshot.emailAddressVisibility,
@@ -349,6 +349,8 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, ChannelStore, Mess
 
   UpdateMachine? get updateMachine => _updateMachine;
   UpdateMachine? _updateMachine;
+
+
   set updateMachine(UpdateMachine? value) {
     assert(_updateMachine == null);
     assert(value != null);
@@ -861,7 +863,6 @@ class UpdateMachine {
 
     final stopwatch = Stopwatch()..start();
     final initialSnapshot = await _registerQueueWithRetry(connection);
-
     final t = (stopwatch..stop()).elapsed;
     assert(debugLog("initial fetch time: ${t.inMilliseconds}ms"));
 
@@ -999,48 +1000,22 @@ class UpdateMachine {
     }());
   }
 
-  // This is static so that it persists through new UpdateMachine instances
-  // as we attempt to fix things by reloading data from scratch.  In principle
-  // it could also be per-account (or per-realm or per-server); but currently
-  // we skip that complication, as well as attempting to reset backoff on
-  // later success.  After all, these unexpected errors should be uncommon;
-  // ideally they'd never happen.
-  static BackoffMachine get _unexpectedErrorBackoffMachine {
-    return __unexpectedErrorBackoffMachine
-      ??= BackoffMachine(maxBound: const Duration(seconds: 60));
+  Future<void> _debugLoopWait() async {
+    await _debugLoopSignal!.future;
+    if (_disposed) return;
+    assert(() {
+      _debugLoopSignal = Completer();
+      return true;
+    }());
   }
-  static BackoffMachine? __unexpectedErrorBackoffMachine;
-
-  /// This controls when we start to report transient errors to the user when
-  /// polling.
-  ///
-  /// At the 6th failure, the expected time elapsed since the first failure
-  /// will be 1.55 seocnds.
-  static const transientFailureCountNotifyThreshold = 5;
 
   void poll() async {
     assert(!_disposed);
     try {
-      BackoffMachine? backoffMachine;
-      int accumulatedTransientFailureCount = 0;
-
-      /// This only reports transient errors after reaching
-      /// a pre-defined threshold of retries.
-      void maybeReportToUserTransientError(Object error) {
-        accumulatedTransientFailureCount++;
-        if (accumulatedTransientFailureCount > transientFailureCountNotifyThreshold) {
-          _reportToUserErrorConnectingToServer(error);
-        }
-      }
-
       while (true) {
         if (_debugLoopSignal != null) {
-          await _debugLoopSignal!.future;
+          await _debugLoopWait();
           if (_disposed) return;
-          assert(() {
-            _debugLoopSignal = Completer();
-            return true;
-          }());
         }
 
         final GetEventsResult result;
@@ -1048,76 +1023,13 @@ class UpdateMachine {
           result = await getEvents(store.connection,
             queueId: queueId, lastEventId: lastEventId);
           if (_disposed) return;
-        } catch (e) {
+        } catch (e, stackTrace) {
           if (_disposed) return;
-          store.isLoading = true;
-
-          if (e is! ApiRequestException) {
-            // Some unexpected error, outside even making the HTTP request.
-            // Definitely a bug in our code.
-            rethrow;
-          }
-
-          bool shouldReportToUser;
-          switch (e) {
-            case NetworkException(cause: SocketException()):
-              // A [SocketException] is common when the app returns from sleep.
-              shouldReportToUser = false;
-
-            case NetworkException():
-            case Server5xxException():
-              shouldReportToUser = true;
-
-            case ServerException(httpStatus: 429):
-            case ZulipApiException(httpStatus: 429):
-            case ZulipApiException(code: 'RATE_LIMIT_HIT'):
-              // TODO(#946) handle rate-limit errors more generally, in ApiConnection
-              shouldReportToUser = true;
-
-            case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
-              rethrow;
-
-            case ZulipApiException():
-            case MalformedServerResponseException():
-              // Either a 4xx we didn't expect, or a malformed response;
-              // in either case, a mismatch of the client's expectations to the
-              // server's behavior, and therefore a bug in one or the other.
-              // TODO(#1054) handle auth failures specifically
-              rethrow;
-          }
-
-          assert(debugLog('Transient error polling event queue for $store: $e\n'
-              'Backing off, then will retry…'));
-          if (shouldReportToUser) {
-            maybeReportToUserTransientError(e);
-          }
-          await (backoffMachine ??= BackoffMachine()).wait();
+          await _handlePollRequestError(e, stackTrace); // may rethrow
           if (_disposed) return;
-          assert(debugLog('… Backoff wait complete, retrying poll.'));
           continue;
         }
-
-        // After one successful request, we reset backoff to its initial state.
-        // That way if the user is off the network and comes back on, the app
-        // doesn't wind up in a state where it's slow to recover the next time
-        // one request fails.
-        //
-        // This does mean that if the server is having trouble and handling some
-        // but not all of its requests, we'll end up doing a lot more retries than
-        // if we stayed at the max backoff interval; partway toward what would
-        // happen if we weren't backing off at all.
-        //
-        // But at least for [getEvents] requests, as here, it should be OK,
-        // because this is a long-poll.  That means a typical successful request
-        // takes a long time to come back; in fact longer than our max backoff
-        // duration (which is 10 seconds).  So if we're getting a mix of successes
-        // and failures, the successes themselves should space out the requests.
-        backoffMachine = null;
-
-        store.isLoading = false;
-        // Dismiss existing errors, if any.
-        reportErrorToUserBriefly(null);
-        accumulatedTransientFailureCount = 0;
+        _clearPollErrors();
 
         final events = result.events;
         for (final event in events) {
@@ -1136,61 +1048,186 @@ class UpdateMachine {
       }
     } catch (e) {
       if (_disposed) return;
-
-      // An error occurred, other than the transient request errors we retry on.
-      // This means either a lost/expired event queue on the server (which is
-      // normal after the app is offline for a period like 10 minutes),
-      // or an unexpected exception representing a bug in our code or the server.
-      // Either way, the show must go on.  So reload server data from scratch.
-
-      // First, log what happened.
-      store.isLoading = true;
-      bool isUnexpected;
-      switch (e) {
-        case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
-          assert(debugLog('Lost event queue for $store.  Replacing…'));
-          // The old event queue is gone, so we need a new one.  This is normal.
-          isUnexpected = false;
-
-        case _EventHandlingException(:final cause, :final event):
-          assert(debugLog('BUG: Error handling an event: $cause\n' // TODO(log)
-            '  event: $event\n'
-            'Replacing event queue…'));
-          reportErrorToUserBriefly(
-            GlobalLocalizations.zulipLocalizations.errorHandlingEventTitle,
-            details: GlobalLocalizations.zulipLocalizations.errorHandlingEventDetails(
-              store.realmUrl.toString(), cause.toString(), event.toString()));
-          // We can't just continue with the next event, because our state
-          // may be garbled due to failing to apply this one (and worse,
-          // any invariants that were left in a broken state from where
-          // the exception was thrown).  So reload from scratch.
-          // Hopefully (probably?) the bug only affects our implementation of
-          // the *change* in state represented by the event, and when we get the
-          // new state in a fresh InitialSnapshot we'll handle that just fine.
-          isUnexpected = true;
-
-        default:
-          assert(debugLog('BUG: Unexpected error in event polling: $e\n' // TODO(log)
-            'Replacing event queue…'));
-          _reportToUserErrorConnectingToServer(e);
-          // Similar story to the _EventHandlingException case;
-          // separate only so that that other case can print more context.
-          // The bug here could be in the server if it's an ApiRequestException,
-          // but our remedy is the same either way.
-          isUnexpected = true;
-      }
-
-      if (isUnexpected) {
-        // We don't know the cause of the failure; it might well keep happening.
-        // Avoid creating a retry storm.
-        await _unexpectedErrorBackoffMachine.wait();
-        if (_disposed) return;
-      }
-
-      // This disposes the store, which disposes this update machine.
-      await store._globalStore._reloadPerAccount(store.accountId);
-      assert(debugLog('… Event queue replaced.'));
+      await _handlePollError(e);
+      assert(_disposed);
       return;
+    }
+  }
+
+  // This is static so that it persists through new UpdateMachine instances
+  // as we attempt to fix things by reloading data from scratch.  In principle
+  // it could also be per-account (or per-realm or per-server); but currently
+  // we skip that complication, as well as attempting to reset backoff on
+  // later success.  After all, these unexpected errors should be uncommon;
+  // ideally they'd never happen.
+  static BackoffMachine get _unexpectedErrorBackoffMachine {
+    return __unexpectedErrorBackoffMachine
+      ??= BackoffMachine(maxBound: const Duration(seconds: 60));
+  }
+  static BackoffMachine? __unexpectedErrorBackoffMachine;
+
+  BackoffMachine? _pollBackoffMachine;
+
+  /// This controls when we start to report transient errors to the user when
+  /// polling.
+  ///
+  /// At the 6th failure, the expected time elapsed since the first failure
+  /// will be 1.55 seocnds.
+  static const transientFailureCountNotifyThreshold = 5;
+
+  int _accumulatedTransientFailureCount = 0;
+
+  void _clearPollErrors() {
+    // After one successful request, we reset backoff to its initial state.
+    // That way if the user is off the network and comes back on, the app
+    // doesn't wind up in a state where it's slow to recover the next time
+    // one request fails.
+    //
+    // This does mean that if the server is having trouble and handling some
+    // but not all of its requests, we'll end up doing a lot more retries than
+    // if we stayed at the max backoff interval; partway toward what would
+    // happen if we weren't backing off at all.
+    //
+    // But at least for [getEvents] requests, as here, it should be OK,
+    // because this is a long-poll.  That means a typical successful request
+    // takes a long time to come back; in fact longer than our max backoff
+    // duration (which is 10 seconds).  So if we're getting a mix of successes
+    // and failures, the successes themselves should space out the requests.
+    _pollBackoffMachine = null;
+
+    store.isLoading = false;
+    _accumulatedTransientFailureCount = 0;
+    reportErrorToUserBriefly(null);
+  }
+
+  /// Sort out an error from the network request in [poll]:
+  /// either wait for a backoff duration (and possibly report the error),
+  /// or rethrow.
+  ///
+  /// If the request should be retried, this method uses [_pollBackoffMachine]
+  /// to wait an appropriate backoff duration for that retry,
+  /// after reporting the error if appropriate to the user and/or developer.
+  ///
+  /// Otherwise this method rethrows the error, with no other side effects.
+  ///
+  /// See also:
+  ///  * [_handlePollError], which handles errors from the rest of [poll]
+  ///    and errors this method rethrows.
+  Future<void> _handlePollRequestError(Object error, StackTrace stackTrace) async {
+    store.isLoading = true;
+
+    if (error is! ApiRequestException) {
+      // Some unexpected error, outside even making the HTTP request.
+      // Definitely a bug in our code.
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    bool shouldReportToUser;
+    switch (error) {
+      case NetworkException(cause: SocketException()):
+        // A [SocketException] is common when the app returns from sleep.
+        shouldReportToUser = false;
+
+      case NetworkException():
+      case Server5xxException():
+        shouldReportToUser = true;
+
+      case ServerException(httpStatus: 429):
+      case ZulipApiException(httpStatus: 429):
+      case ZulipApiException(code: 'RATE_LIMIT_HIT'):
+        // TODO(#946) handle rate-limit errors more generally, in ApiConnection
+        shouldReportToUser = true;
+
+      case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
+        Error.throwWithStackTrace(error, stackTrace);
+
+      case ZulipApiException():
+      case MalformedServerResponseException():
+        // Either a 4xx we didn't expect, or a malformed response;
+        // in either case, a mismatch of the client's expectations to the
+        // server's behavior, and therefore a bug in one or the other.
+        // TODO(#1054) handle auth failures specifically
+        Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    assert(debugLog('Transient error polling event queue for $store: $error\n'
+        'Backing off, then will retry…'));
+    if (shouldReportToUser) {
+      _maybeReportToUserTransientError(error);
+    }
+    await (_pollBackoffMachine ??= BackoffMachine()).wait();
+    if (_disposed) return;
+    assert(debugLog('… Backoff wait complete, retrying poll.'));
+  }
+
+  /// Deal with an error in [poll]: reload server data to replace the store,
+  /// after reporting the error as appropriate to the user and/or developer.
+  ///
+  /// See also:
+  ///  * [_handlePollRequestError], which handles certain errors
+  ///    and causes them not to reach this method.
+  Future<void> _handlePollError(Object error) async {
+    // An error occurred, other than the transient request errors we retry on.
+    // This means either a lost/expired event queue on the server (which is
+    // normal after the app is offline for a period like 10 minutes),
+    // or an unexpected exception representing a bug in our code or the server.
+    // Either way, the show must go on.  So reload server data from scratch.
+
+    store.isLoading = true;
+
+    bool isUnexpected;
+    switch (error) {
+      case ZulipApiException(code: 'BAD_EVENT_QUEUE_ID'):
+        assert(debugLog('Lost event queue for $store.  Replacing…'));
+        // The old event queue is gone, so we need a new one.  This is normal.
+        isUnexpected = false;
+
+      case _EventHandlingException(:final cause, :final event):
+        assert(debugLog('BUG: Error handling an event: $cause\n' // TODO(log)
+          '  event: $event\n'
+          'Replacing event queue…'));
+        reportErrorToUserBriefly(
+          GlobalLocalizations.zulipLocalizations.errorHandlingEventTitle,
+          details: GlobalLocalizations.zulipLocalizations.errorHandlingEventDetails(
+            store.realmUrl.toString(), cause.toString(), event.toString()));
+        // We can't just continue with the next event, because our state
+        // may be garbled due to failing to apply this one (and worse,
+        // any invariants that were left in a broken state from where
+        // the exception was thrown).  So reload from scratch.
+        // Hopefully (probably?) the bug only affects our implementation of
+        // the *change* in state represented by the event, and when we get the
+        // new state in a fresh InitialSnapshot we'll handle that just fine.
+        isUnexpected = true;
+
+      default:
+        assert(debugLog('BUG: Unexpected error in event polling: $error\n' // TODO(log)
+          'Replacing event queue…'));
+        _reportToUserErrorConnectingToServer(error);
+        // Similar story to the _EventHandlingException case;
+        // separate only so that that other case can print more context.
+        // The bug here could be in the server if it's an ApiRequestException,
+        // but our remedy is the same either way.
+        isUnexpected = true;
+    }
+
+    if (isUnexpected) {
+      // We don't know the cause of the failure; it might well keep happening.
+      // Avoid creating a retry storm.
+      await _unexpectedErrorBackoffMachine.wait();
+      if (_disposed) return;
+    }
+
+    await store._globalStore._reloadPerAccount(store.accountId);
+    assert(_disposed);
+    assert(debugLog('… Event queue replaced.'));
+  }
+
+  /// This only reports transient errors after reaching
+  /// a pre-defined threshold of retries.
+  void _maybeReportToUserTransientError(Object error) {
+    _accumulatedTransientFailureCount++;
+    if (_accumulatedTransientFailureCount > transientFailureCountNotifyThreshold) {
+      _reportToUserErrorConnectingToServer(error);
     }
   }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -118,6 +118,17 @@ class ComposeContentController extends ComposeController<ContentValidationError>
 
   int _nextQuoteAndReplyTag = 0;
   int _nextUploadTag = 0;
+  num _maxMessageLimit = 0;
+
+   num get maxMessageLimit => _maxMessageLimit;
+
+  // Setter for maxMessageLimit
+  set maxMessageLimit(num value) {
+    if (value < 0) {
+      throw ArgumentError("maxMessageLimit cannot be negative.");
+    }
+    _maxMessageLimit = value;
+  }
 
   final Map<int, ({int messageId, String placeholder})> _quoteAndReplies = {};
   final Map<int, ({String filename, String placeholder})> _uploads = {};
@@ -260,7 +271,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
       // normalized.length is the number of UTF-16 code units, while the server
       // API expresses the max in Unicode code points. So this comparison will
       // be conservative and may cut the user off shorter than necessary.
-      if (textNormalized.length > kMaxMessageLengthCodePoints)
+      if (textNormalized.length > _maxMessageLimit)
         ContentValidationError.tooLong,
 
       if (_quoteAndReplies.isNotEmpty)
@@ -1322,7 +1333,8 @@ class _ComposeBoxState extends State<ComposeBox> implements ComposeBoxState {
   @override
   Widget build(BuildContext context) {
     final Widget? body;
-
+    final perAccountStore = PerAccountStoreWidget.of(context);
+    _controller.content.maxMessageLimit = perAccountStore.maxMessageLength;
     final errorBanner = _errorBanner(context);
     if (errorBanner != null) {
       return _ComposeBoxContainer(body: null, errorBanner: errorBanner);

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -831,6 +831,7 @@ InitialSnapshot initialSnapshot({
   int? realmWaitingPeriodThreshold,
   Map<String, RealmDefaultExternalAccount>? realmDefaultExternalAccounts,
   int? maxFileUploadSizeMib,
+  int? maxMessageLength,
   Uri? serverEmojiDataUrl,
   List<User>? realmUsers,
   List<User>? realmNonActiveUsers,
@@ -865,6 +866,7 @@ InitialSnapshot initialSnapshot({
     realmWaitingPeriodThreshold: realmWaitingPeriodThreshold ?? 0,
     realmDefaultExternalAccounts: realmDefaultExternalAccounts ?? {},
     maxFileUploadSizeMib: maxFileUploadSizeMib ?? 25,
+    maxMessageLength: maxMessageLength ?? 10000,
     serverEmojiDataUrl: serverEmojiDataUrl
       ?? realmUrl.replace(path: '/static/emoji.json'),
     realmUsers: realmUsers ?? [],


### PR DESCRIPTION
1. Extracted max_message_limit from the register-queue API endpoint response
2. Added the max_message_limit property in the initial_snapshot model
3. Created a maxMessageLimit variable in the compose_box widget and set the value of it to the value fetched from the api endpoint while rendering the sendButton. 
4. Added dummy value for maxMessageLimit in example_data.dart file. 
5. Generated a new .g file for initial_snapshot as I made a new addition to the model. 