### PR TITLE
Split inline from block parser class, and other small refactors

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -815,6 +815,9 @@ enum _ParserContext {
   inline,
 }
 
+/// Parser for a complete piece of Zulip HTML content, a [ZulipContent].
+///
+/// The only entry point to this class is [parse].
 class _ZulipContentParser {
   /// The current state of what sort of nodes the parser is looking for.
   ///
@@ -1039,6 +1042,8 @@ class _ZulipContentParser {
     return nodes.map(parseInlineContent).toList(growable: false);
   }
 
+  /// Parse the children of a [BlockInlineContainerNode], making up a
+  /// complete subtree of inline content with no further inline ancestors.
   ({List<InlineContentNode> nodes, List<LinkNode>? links}) parseBlockInline(List<dom.Node> nodes) {
     assert(_debugParserContext == _ParserContext.block);
     assert(() {
@@ -1660,6 +1665,8 @@ class _ZulipContentParser {
   }
 }
 
+/// Parse a complete piece of Zulip HTML content,
+/// such as an entire value of [Message.content].
 ZulipContent parseContent(String html) {
   return _ZulipContentParser().parse(html);
 }


### PR DESCRIPTION
This series of commits has a few small refactors of the content-parsing code, prompted by #1156.

@rajveermalviya feel free to rebase #1156 atop this if it seems helpful — the last two commits in particular might simplify that PR a bit. If the conflict resolution seems more annoying than the refactor is helpful, no need, and I can resolve it after either PR is merged.

## Selected commit messages

content [nfc]: Split out _ZulipInlineContentParser class

This helps organize the parsing code a bit more cleanly -- not to
mention more statically, by making the dynamic _debugParserContext
assertions redundant.

---

content [nfc]: Encapsulate parsing math nodes a bit more

---

content [nfc]: Factor out consumeImageNodes in block-content parse loops

This hopefully makes the logic of these loops a bit more readable.
