### PR TITLE
[IGNORE]lightbox: Use a friendlier format for the date

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -680,5 +680,29 @@
   "emojiPickerSearchEmoji": "Search emoji",
   "@emojiPickerSearchEmoji": {
     "description": "Hint text for the emoji picker search text field."
+  },
+  "aFewSecondsAgo": "A few seconds ago",
+  "@aFewSecondsAgo": {
+    "description": "Message displayed when the difference between the current time and the given time is less than 60 seconds."
+  },
+  "oneMinuteAgo": "1 minute ago",
+  "@oneMinuteAgo": {
+    "description": "Message displayed when the difference between the current time and the given time is exactly 1 minute."
+  },
+  "minutesAgo": "{minutes} minutes ago",
+  "@minutesAgo": {
+    "description": "Message displayed when the difference between the current time and the given time is in minutes. The placeholder {minutes} will be replaced with the actual number of minutes."
+  },
+  "todayAt": "Today at {time}",
+  "@todayAt": {
+    "description": "Message displayed when the given time is from today. The placeholder {time} will be replaced with the formatted time."
+  },
+  "yesterdayAt": "Yesterday at {time}",
+  "@yesterdayAt": {
+    "description": "Message displayed when the given time is from yesterday. The placeholder {time} will be replaced with the formatted time."
+  },
+  "dateAtTime": "{date} at {time}",
+  "@dateAtTime": {
+    "description": "Message displayed when the given time is older than yesterday. The placeholder {date} will be replaced with the formatted date and {time} with the formatted time."
   }
 }

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1016,6 +1016,42 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Search emoji'**
   String get emojiPickerSearchEmoji;
+
+  /// Message displayed when the difference between the current time and the given time is less than 60 seconds.
+  ///
+  /// In en, this message translates to:
+  /// **'A few seconds ago'**
+  String get aFewSecondsAgo;
+
+  /// Message displayed when the difference between the current time and the given time is exactly 1 minute.
+  ///
+  /// In en, this message translates to:
+  /// **'1 minute ago'**
+  String get oneMinuteAgo;
+
+  /// Message displayed when the difference between the current time and the given time is in minutes. The placeholder {minutes} will be replaced with the actual number of minutes.
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes} minutes ago'**
+  String minutesAgo(Object minutes);
+
+  /// Message displayed when the given time is from today. The placeholder {time} will be replaced with the formatted time.
+  ///
+  /// In en, this message translates to:
+  /// **'Today at {time}'**
+  String todayAt(Object time);
+
+  /// Message displayed when the given time is from yesterday. The placeholder {time} will be replaced with the formatted time.
+  ///
+  /// In en, this message translates to:
+  /// **'Yesterday at {time}'**
+  String yesterdayAt(Object time);
+
+  /// Message displayed when the given time is older than yesterday. The placeholder {date} will be replaced with the formatted date and {time} with the formatted time.
+  ///
+  /// In en, this message translates to:
+  /// **'{date} at {time}'**
+  String dateAtTime(Object date, Object time);
 }
 
 class _ZulipLocalizationsDelegate extends LocalizationsDelegate<ZulipLocalizations> {

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Search emoji';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Szukaj emoji';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Поиск эмодзи';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -537,4 +537,30 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get emojiPickerSearchEmoji => 'Hľadať emotikon';
+
+  @override
+  String get aFewSecondsAgo => 'A few seconds ago';
+
+  @override
+  String get oneMinuteAgo => '1 minute ago';
+
+  @override
+  String minutesAgo(Object minutes) {
+    return '$minutes minutes ago';
+  }
+
+  @override
+  String todayAt(Object time) {
+    return 'Today at $time';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Yesterday at $time';
+  }
+
+  @override
+  String dateAtTime(Object date, Object time) {
+    return '$date at $time';
+  }
 }

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -5,6 +5,7 @@ import 'package:clock/clock.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
 import 'package:video_player/video_player.dart';
@@ -249,7 +250,90 @@ void main() {
           matching: find.textContaining(findRichText: true,
             eg.otherUser.fullName)));
       check(labelTextWidget.text.toPlainText())
-        .contains('Jul 23, 2024 23:12:24');
+        .contains('Jul 23, 2024 at 11:12 PM');
+
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('app bar shows localized timestamp: a few seconds ago', (tester) async {
+      prepareBoringImageHttpClient();
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+      final timestamp = DateTime.now().subtract(const Duration(seconds: 30)).millisecondsSinceEpoch ~/ 1000;
+      final message = eg.streamMessage(sender: eg.otherUser, timestamp: timestamp);
+      await setupPage(tester, message: message, thumbnailUrl: null);
+
+      final labelTextWidget = tester.widget<RichText>(
+        find.descendant(of: find.byType(AppBar).last,
+          matching: find.textContaining(findRichText: true,
+            eg.otherUser.fullName)));
+
+      check(labelTextWidget.text.toPlainText())
+          .contains(zulipLocalizations.aFewSecondsAgo);
+
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('app bar shows localized timestamp: [mintues] minutes ago', (tester) async {
+      prepareBoringImageHttpClient();
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+      final timestamp = DateTime.now().subtract(const Duration(minutes: 5)).millisecondsSinceEpoch ~/ 1000;
+      final message = eg.streamMessage(sender: eg.otherUser, timestamp: timestamp);
+      await setupPage(tester, message: message, thumbnailUrl: null);
+
+      final labelTextWidget = tester.widget<RichText>(
+        find.descendant(of: find.byType(AppBar).last,
+          matching: find.textContaining(findRichText: true,
+            eg.otherUser.fullName)));
+
+      check(labelTextWidget.text.toPlainText())
+          .contains(zulipLocalizations.minutesAgo(5));
+
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('app bar shows localized timestamp: yesterday at [time]', (tester) async {
+      prepareBoringImageHttpClient();
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+      final now = DateTime.now();
+      final yesterday = now.subtract(const Duration(days: 1));
+      final timestamp = yesterday.millisecondsSinceEpoch ~/ 1000;
+      final message = eg.streamMessage(sender: eg.otherUser, timestamp: timestamp);
+      await setupPage(tester, message: message, thumbnailUrl: null);
+
+      final yesterdayAtTime = zulipLocalizations.yesterdayAt(
+        DateFormat.jm(zulipLocalizations.localeName).format(yesterday),
+      );
+
+      final labelTextWidget = tester.widget<RichText>(
+          find.descendant(of: find.byType(AppBar).last,
+            matching: find.textContaining(findRichText: true,
+              eg.otherUser.fullName)));
+
+      check(labelTextWidget.text.toPlainText())
+          .contains(yesterdayAtTime);
+
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('app bar shows localized timestamp: today at [time]', (tester) async {
+      prepareBoringImageHttpClient();
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+      final now = DateTime.now();
+      final localTimeToday = now.subtract(const Duration(hours: 1));
+      final timestamp = localTimeToday.millisecondsSinceEpoch ~/ 1000;
+      final message = eg.streamMessage(sender: eg.otherUser, timestamp: timestamp);
+      await setupPage(tester, message: message, thumbnailUrl: null);
+
+      final todayAtTime = zulipLocalizations.todayAt(
+        DateFormat.jm(zulipLocalizations.localeName).format(localTimeToday),
+      );
+
+      final labelTextWidget = tester.widget<RichText>(
+          find.descendant(of: find.byType(AppBar).last,
+            matching: find.textContaining(findRichText: true,
+              eg.otherUser.fullName)));
+
+      check(labelTextWidget.text.toPlainText()).contains(todayAtTime);
 
       debugNetworkImageHttpClientProvider = null;
     });


### PR DESCRIPTION
Changed the timestamp format from Mar 31, 2023 15:09:51 to a more readable Mar 31, 2023 at 3:09 PM.
Added proper localization support to adapt timestamps to the user's language and region preferences.
Optimized the timestamp logic to ensure accurate categorization into Today, Yesterday, or specific dates.

Fixes: #45