### PR TITLE
action_sheet [nfc]: Remove an assumption that popular emoji are Unicode

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -484,7 +484,7 @@ class ReactionButtons extends StatelessWidget {
 
     bool hasSelfVote(EmojiCandidate emoji) {
       return message.reactions?.aggregated.any((reactionWithVotes) {
-        return reactionWithVotes.reactionType == ReactionType.unicodeEmoji
+        return reactionWithVotes.reactionType == emoji.emojiType
           && reactionWithVotes.emojiCode == emoji.emojiCode
           && reactionWithVotes.userIds.contains(store.selfUserId);
       }) ?? false;


### PR DESCRIPTION
Currently the popular emoji are all Unicode emoji. But in a possible future where they might not be (e.g. if done by "recently used") we won't want this to break.