### PR TITLE
Started working #83

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -487,7 +487,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   // Anchor message ID is used to fetch messages from a specific point in the list.
   // It is set when the user navigates to a message list page with a specific anchor message.
   int? anchorMessageId;
-  int? get anchorIndex => anchorMessageId != null ? findItemWithMessageId(anchorMessageId!) : null;
+  int get anchorIndex => anchorMessageId != null ? findItemWithMessageId(anchorMessageId!) : 0;
   factory MessageListView.init(
       {required PerAccountStore store, required Narrow narrow, int? anchorMessageId}) {
     final view = MessageListView._(store: store, narrow: narrow, anchorMessageId: anchorMessageId);
@@ -591,7 +591,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         ? kMessageListFetchBatchSize ~/2 // Fetch messages before and after anchor
         : 0,                          // Don't fetch newer messages when no anchor
     );
-    anchorMessageId ??= result.messages.last.id;
+    if(result.messages.isNotEmpty){
+      anchorMessageId ??= result.messages.last.id;
+    }
 
     if (this.generation > generation) return;
     store.reconcileMessages(result.messages);

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -483,8 +483,8 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     model!.addListener(_modelChanged);
     await model!.fetchInitial();
     setState(() {
-      oldItems = model!.items.sublist(0, model!.anchorIndex!+1);
-      newItems = model!.items.sublist(model!.anchorIndex!+1, model!.items.length);
+      oldItems = model!.items.sublist(0, model!.anchorIndex+1);
+      newItems = model!.items.sublist(model!.anchorIndex+1, model!.items.length);
     });
   }
 
@@ -498,8 +498,8 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     final previousLength = oldItems.length + newItems.length;
 
     setState(() {
-      oldItems = model!.items.sublist(0, model!.anchorIndex!+1);
-      newItems = model!.items.sublist(model!.anchorIndex!+1, model!.items.length);
+      oldItems = model!.items.sublist(0, model!.anchorIndex+1);
+      newItems = model!.items.sublist(model!.anchorIndex+1, model!.items.length);
       // The actual state lives in the [MessageListView] model.
       // This method was called because that just changed.
     });

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -515,11 +515,13 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           return;
         }
 
+        // Might be used in the future
+        // ignore: unused_local_variable
         final viewportDimension = scrollController.position.viewportDimension;
         final currentScroll = scrollController.position.pixels;
 
         // If we're one viewportDimension from the bottomList, scroll to it
-        if (currentScroll + viewportDimension > 0) {
+        if (currentScroll + 300  > 0) {
 
         // Calculate initial scroll parameters
         final distanceToCenter = scrollController.position.pixels;
@@ -537,17 +539,18 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
         // Wait for the layout to settle so scrollController.position.pixels is updated properly
 
-
-        final distanceToBottom = scrollController.position.maxScrollExtent - scrollController.position.pixels;
-        final durationMsToBottom = math.min(1500, (1000 * distanceToBottom / 8000).ceil());
+        var distanceToBottom = scrollController.position.maxScrollExtent - scrollController.position.pixels;
+        final durationMsToBottom =  math.min(200, (1000 * distanceToBottom / 8000).ceil());
         // If we go too fast, we'll overscroll.as
 
         // After scroling to the bottom sliver, scroll to the bottom of the bottomSliver if we're not already there
-        if (distanceToBottom > 36) {
+        while (distanceToBottom > 36) {
           await scrollController.animateTo(
             scrollController.position.maxScrollExtent,
             duration:  Duration(milliseconds: durationMsToBottom),
             curve: Curves.ease);
+          distanceToBottom = scrollController.position.maxScrollExtent - scrollController.position.pixels;
+          await Future<void>.delayed(const Duration(milliseconds: 50));
         }
 
         }
@@ -783,7 +786,6 @@ class ScrollToBottomButton extends StatelessWidget {
     final distanceToCenter = scrollController.position.pixels;
     final durationMsAtSpeedLimit = (1000 * distanceToCenter / 8000).ceil();
     final durationMs = math.max(300, durationMsAtSpeedLimit);
-
     // If we're not at the bottomSliver,scroll to it
     if(distanceToCenter<36){
       await scrollController.animateTo(
@@ -796,18 +798,21 @@ class ScrollToBottomButton extends StatelessWidget {
     // Wait for the layout to settle so scrollController.position.pixels is updated properly
     await Future<void>.delayed(const Duration(milliseconds: 50));
 
-
-    final distanceToBottom = scrollController.position.maxScrollExtent - scrollController.position.pixels;
-    final durationMsToBottom = math.min(1000, (1000 * distanceToBottom / 8000).ceil());
+    var distanceToBottom = scrollController.position.maxScrollExtent - scrollController.position.pixels;
+    final durationMsToBottom = math.min(1000, (1200 * distanceToBottom / 8000).ceil());
     // If we go too fast, we'll overscroll.
-
     // After scroling to the bottom sliver, scroll to the bottom of the bottomSliver if we're not already there
-    if (distanceToBottom > 36) {
+    var count = 0;
+    while (distanceToBottom > 36) {
       await scrollController.animateTo(
         scrollController.position.maxScrollExtent,
         duration: Duration(milliseconds: durationMsToBottom),
         curve: Curves.easeOut);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      distanceToBottom = scrollController.position.maxScrollExtent - scrollController.position.pixels;
+      count++;
     }
+    print("count: $count");
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1044,10 +1044,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "4ac0537115a24d772c408a2520ecd0abb99bca2ea9c4e634ccbdbfae64fe17ec"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -366,7 +366,7 @@ void main() {
       await tester.tap(find.byType(ScrollToBottomButton));
       await tester.pumpAndSettle();
       check(isButtonVisible(tester)).equals(false);
-      check(scrollController.position.pixels).equals(0);
+      check(scrollController.position.maxScrollExtent - scrollController.position.pixels).isLessThan(36);
     });
   });
 
@@ -720,6 +720,10 @@ void main() {
       final existingMessage = eg.streamMessage(
         stream: eg.stream(), topic: 'new topic', content: 'Existing message');
       prepareGetMessageResponse([existingMessage, message]);
+      // Prepare response for fetchInitial after move
+      connection.prepare(json: eg.newestGetMessagesResult(
+        foundOldest: true,
+        messages: [existingMessage, message]).toJson());
       handleMessageMoveEvent([message], 'new topic');
       await tester.pump(const Duration(seconds: 1));
 
@@ -732,6 +736,10 @@ void main() {
       await setupMessageListPage(tester, narrow: narrow, messages: [message], streams: [channel]);
 
       prepareGetMessageResponse([message]);
+      // Prepare response for fetchInitial after move
+      connection.prepare(json: eg.newestGetMessagesResult(
+        foundOldest: true,
+        messages: [message]).toJson());
       handleMessageMoveEvent([message], 'new topic');
       await tester.pump(const Duration(seconds: 1));
 


### PR DESCRIPTION
 Closes #83

 Closes #82
 
 Started working on this.
 Here's what i did

- Added an optional parameter anchor to MessageList and started fetching newer Messages similar to how older messages were being fetched around the anchor(if one is given)

- Changed the single sliver to two slivers that grow in opposite directions. The center is after the anchor message with newer messages growing downward in the bottom sliver

- Handled the case of when user is looking at the latest messages by adding a condition that when the scroll is less than (viewport size + 300 px) away from the bottom it scrolls down to the bottom. This is required now as adding new messages doesn't cause the messages to jump up. Fetching newer messages causes no jump or scroll though

- The navigateToBottom button was initially set to scroll down to 0 which was after the changes was only scrolling down to the zero index of the toplist so i changed it to scrolldown to maxScrollExtent.

But still the navigate button works correctly when new messages are fetched as part of the scrolling process but when a single message is added to the list the maxScrollExtent does not scroll all the way down as it (for some reason) calculates the maxScrollExtent wrong. 

What I did to fix the above problem was to call the scrollDown function repeatedly until the end is reached. 


Videos:

https://github.com/user-attachments/assets/a379256e-3208-48b5-960c-7740a06fe497

https://github.com/user-attachments/assets/9feec67c-380e-4e92-9631-37a58ec8d8ab

Chat:

https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/Control.20scroll.20position.20on.20new.20and.20newly-fetched.20messages

