### PR TITLE
general chat #1: add support at most places

### DIFF
--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -85,6 +85,8 @@ class InitialSnapshot {
 
   final Uri? serverEmojiDataUrl; // TODO(server-6)
 
+  final String? realmEmptyTopicDisplayName; // TODO(server-10)
+
   @JsonKey(readValue: _readUsersIsActiveFallbackTrue)
   final List<User> realmUsers;
   @JsonKey(readValue: _readUsersIsActiveFallbackFalse)
@@ -138,6 +140,7 @@ class InitialSnapshot {
     required this.realmDefaultExternalAccounts,
     required this.maxFileUploadSizeMib,
     required this.serverEmojiDataUrl,
+    required this.realmEmptyTopicDisplayName,
     required this.realmUsers,
     required this.realmNonActiveUsers,
     required this.crossRealmBots,

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -85,6 +85,7 @@ InitialSnapshot _$InitialSnapshotFromJson(
       json['server_emoji_data_url'] == null
           ? null
           : Uri.parse(json['server_emoji_data_url'] as String),
+  realmEmptyTopicDisplayName: json['realm_empty_topic_display_name'] as String?,
   realmUsers:
       (InitialSnapshot._readUsersIsActiveFallbackTrue(json, 'realm_users')
               as List<dynamic>)
@@ -135,6 +136,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
       'realm_default_external_accounts': instance.realmDefaultExternalAccounts,
       'max_file_upload_size_mib': instance.maxFileUploadSizeMib,
       'server_emoji_data_url': instance.serverEmojiDataUrl?.toString(),
+      'realm_empty_topic_display_name': instance.realmEmptyTopicDisplayName,
       'realm_users': instance.realmUsers,
       'realm_non_active_users': instance.realmNonActiveUsers,
       'cross_realm_bots': instance.crossRealmBots,

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -921,7 +921,7 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
   }
 
   TopicAutocompleteResult? _testTopic(TopicAutocompleteQuery query, TopicName topic) {
-    if (query.testTopic(topic)) {
+    if (query.testTopic(topic, store)) {
       return TopicAutocompleteResult(topic: topic);
     }
     return null;
@@ -939,10 +939,17 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
 class TopicAutocompleteQuery extends AutocompleteQuery {
   TopicAutocompleteQuery(super.raw);
 
-  bool testTopic(TopicName topic) {
+  bool testTopic(TopicName topic, PerAccountStore store) {
     // TODO(#881): Sort by match relevance, like web does.
+
+    // ignore: unnecessary_null_comparison // null topic names soon to be enabled
+    if (topic.displayName == null) {
+      return store.realmEmptyTopicDisplayName.toLowerCase()
+        .contains(raw.toLowerCase());
+    }
     return topic.displayName != raw
-      && topic.displayName.toLowerCase().contains(raw.toLowerCase());
+      // ignore: unnecessary_non_null_assertion // null topic names soon to be enabled
+      && topic.displayName!.toLowerCase().contains(raw.toLowerCase());
   }
 
   @override

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -302,6 +302,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
       realmMandatoryTopics: initialSnapshot.realmMandatoryTopics,
       realmWaitingPeriodThreshold: initialSnapshot.realmWaitingPeriodThreshold,
       maxFileUploadSizeMib: initialSnapshot.maxFileUploadSizeMib,
+      realmEmptyTopicDisplayName: initialSnapshot.realmEmptyTopicDisplayName,
       realmDefaultExternalAccounts: initialSnapshot.realmDefaultExternalAccounts,
       customProfileFields: _sortCustomProfileFields(initialSnapshot.customProfileFields),
       emailAddressVisibility: initialSnapshot.emailAddressVisibility,
@@ -344,6 +345,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
     required this.realmMandatoryTopics,
     required this.realmWaitingPeriodThreshold,
     required this.maxFileUploadSizeMib,
+    required String? realmEmptyTopicDisplayName,
     required this.realmDefaultExternalAccounts,
     required this.customProfileFields,
     required this.emailAddressVisibility,
@@ -362,6 +364,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
        assert(realmUrl == connection.realmUrl),
        assert(emoji.realmUrl == realmUrl),
        _globalStore = globalStore,
+       _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
        _emoji = emoji,
        _users = users,
        _channels = channels,
@@ -414,6 +417,18 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
   /// For docs, please see [InitialSnapshot.realmWaitingPeriodThreshold].
   final int realmWaitingPeriodThreshold;  // TODO(#668): update this realm setting
   final int maxFileUploadSizeMib; // No event for this.
+
+  /// The display name to use for empty topics.
+  ///
+  /// This should only be accessed when FL >= 334, since topics cannot
+  /// be empty otherwise.
+  // TODO(server-10) simplify this
+  String get realmEmptyTopicDisplayName {
+    assert(_realmEmptyTopicDisplayName != null); // TODO(log)
+    return _realmEmptyTopicDisplayName ?? 'general chat';
+  }
+  final String? _realmEmptyTopicDisplayName; // TODO(#668): update this realm setting
+
   final Map<String, RealmDefaultExternalAccount> realmDefaultExternalAccounts;
   List<CustomProfileField> customProfileFields;
   /// For docs, please see [InitialSnapshot.emailAddressVisibility].

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -415,12 +415,23 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
 
   @override
   Widget buildItem(BuildContext context, int index, TopicAutocompleteResult option) {
+    final Widget child;
+    // ignore: unnecessary_null_comparison // null topic names soon to be enabled
+    if (option.topic.displayName == null) {
+      final store = PerAccountStoreWidget.of(context);
+      child = Text(store.realmEmptyTopicDisplayName,
+        style: const TextStyle(fontStyle: FontStyle.italic));
+    } else {
+      // ignore: unnecessary_non_null_assertion // null topic names soon to be enabled
+      child = Text(option.topic.displayName!);
+    }
+
     return InkWell(
       onTap: () {
         _onTapOption(context, option);
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-        child: Text(option.topic.displayName)));
+        child: child));
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -182,7 +182,8 @@ class ComposeTopicController extends ComposeController<TopicValidationError> {
   }
 
   void setTopic(TopicName newTopic) {
-    value = TextEditingValue(text: newTopic.displayName);
+    // ignore: dead_null_aware_expression // null topic names soon to be enabled
+    value = TextEditingValue(text: newTopic.displayName ?? '');
   }
 }
 

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -532,12 +532,15 @@ class _TopicItem extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 17,
                   height: (20 / 17),
+                  // ignore: unnecessary_null_comparison // null topic names soon to be enabled
+                  fontStyle: topic.displayName == null ? FontStyle.italic : null,
                   // TODO(design) check if this is the right variable
                   color: designVariables.labelMenuButton,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                topic.displayName))),
+                // ignore: dead_null_aware_expression // null topic names soon to be enabled
+                topic.displayName ?? store.realmEmptyTopicDisplayName))),
             const SizedBox(width: 12),
             if (hasMention) const _IconMarker(icon: ZulipIcons.at_sign),
             // TODO(design) copies the "@" marker color; is there a better color?

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -339,8 +339,11 @@ class MessageListAppBarTitle extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Flexible(child: Text(topic.displayName, style: const TextStyle(
+        // ignore: dead_null_aware_expression // null topic names soon to be enabled
+        Flexible(child: Text(topic.displayName ?? store.realmEmptyTopicDisplayName, style: TextStyle(
           fontSize: 13,
+          // ignore: unnecessary_null_comparison // null topic names soon to be enabled
+          fontStyle: topic.displayName == null ? FontStyle.italic : null,
         ).merge(weightVariableTextStyle(context)))),
         if (icon != null)
           Padding(
@@ -1092,11 +1095,15 @@ class StreamMessageRecipientHeader extends StatelessWidget {
       child: Row(
         children: [
           Flexible(
-            child: Text(topic.displayName,
+            // ignore: dead_null_aware_expression // null topic names soon to be enabled
+            child: Text(topic.displayName ?? store.realmEmptyTopicDisplayName,
               // TODO: Give a way to see the whole topic (maybe a
               //   long-press interaction?)
               overflow: TextOverflow.ellipsis,
-              style: recipientHeaderTextStyle(context))),
+              style: recipientHeaderTextStyle(context,
+                // ignore: unnecessary_null_comparison // null topic names soon to be enabled
+                fontStyle: topic.displayName == null ? FontStyle.italic : null,
+              ))),
           const SizedBox(width: 4),
           Icon(size: 14, color: designVariables.title.withFadedAlpha(0.5),
             // A null [Icon.icon] makes a blank space.
@@ -1191,12 +1198,13 @@ class DmRecipientHeader extends StatelessWidget {
   }
 }
 
-TextStyle recipientHeaderTextStyle(BuildContext context) {
+TextStyle recipientHeaderTextStyle(BuildContext context, {FontStyle? fontStyle}) {
   return TextStyle(
     color: DesignVariables.of(context).title,
     fontSize: 16,
     letterSpacing: proportionalLetterSpacing(context, 0.02, baseFontSize: 16),
     height: (18 / 16),
+    fontStyle: fontStyle,
   ).merge(weightVariableTextStyle(context, wght: 600));
 }
 

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -881,6 +881,8 @@ TestGlobalStore globalStore({List<Account> accounts = const []}) {
 }
 const _globalStore = globalStore;
 
+const String defaultRealmEmptyTopicDisplayName = 'test general chat';
+
 InitialSnapshot initialSnapshot({
   String? queueId,
   int? lastEventId,
@@ -906,6 +908,7 @@ InitialSnapshot initialSnapshot({
   Map<String, RealmDefaultExternalAccount>? realmDefaultExternalAccounts,
   int? maxFileUploadSizeMib,
   Uri? serverEmojiDataUrl,
+  String? realmEmptyTopicDisplayName,
   List<User>? realmUsers,
   List<User>? realmNonActiveUsers,
   List<User>? crossRealmBots,
@@ -943,6 +946,7 @@ InitialSnapshot initialSnapshot({
     maxFileUploadSizeMib: maxFileUploadSizeMib ?? 25,
     serverEmojiDataUrl: serverEmojiDataUrl
       ?? realmUrl.replace(path: '/static/emoji.json'),
+    realmEmptyTopicDisplayName: realmEmptyTopicDisplayName ?? defaultRealmEmptyTopicDisplayName,
     realmUsers: realmUsers ?? [],
     realmNonActiveUsers: realmNonActiveUsers ?? [],
     crossRealmBots: crossRealmBots ?? [],

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -1027,8 +1027,9 @@ void main() {
   });
 
   group('TopicAutocompleteQuery.testTopic', () {
+    final store = eg.store();
     void doCheck(String rawQuery, String topic, bool expected) {
-      final result = TopicAutocompleteQuery(rawQuery).testTopic(eg.t(topic));
+      final result = TopicAutocompleteQuery(rawQuery).testTopic(eg.t(topic), store);
       expected ? check(result).isTrue() : check(result).isFalse();
     }
 

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -392,8 +392,8 @@ void main() {
   });
 
   group('TopicAutocomplete', () {
-    void checkTopicShown(GetStreamTopicsEntry topic, PerAccountStore store, {required bool expected}) {
-      check(find.text(topic.name.displayName).evaluate().length).equals(expected ? 1 : 0);
+    void checkTopicShown(String topic, PerAccountStore store, {required bool expected}) {
+      check(find.text(topic).evaluate().length).equals(expected ? 1 : 0);
     }
 
     testWidgets('options appear, disappear, and change correctly', (WidgetTester tester) async {
@@ -410,24 +410,24 @@ void main() {
       await tester.pumpAndSettle();
 
       // "topic three" and "topic two" appear, but not "topic one"
-      checkTopicShown(topic1, store, expected: false);
-      checkTopicShown(topic2, store, expected: true);
-      checkTopicShown(topic3, store, expected: true);
+      checkTopicShown('Topic one',   store, expected: false);
+      checkTopicShown('Topic two',   store, expected: true);
+      checkTopicShown('Topic three', store, expected: true);
 
       // Finishing autocomplete updates topic box; causes options to disappear
       await tester.tap(find.text('Topic three'));
       await tester.pumpAndSettle();
       check(tester.widget<TextField>(topicInputFinder).controller!.text)
         .equals(topic3.name.displayName);
-      checkTopicShown(topic1, store, expected: false);
-      checkTopicShown(topic2, store, expected: false);
-      checkTopicShown(topic3, store, expected: true); // shown in `_TopicInput` once
+      checkTopicShown('Topic one',   store, expected: false);
+      checkTopicShown('Topic two',   store, expected: false);
+      checkTopicShown('Topic three', store, expected: true); // shown in `_TopicInput` once
 
       // Then a new autocomplete intent brings up options again
       await tester.enterText(topicInputFinder, 'Topic');
       await tester.enterText(topicInputFinder, 'Topic T');
       await tester.pumpAndSettle();
-      checkTopicShown(topic2, store, expected: true);
+      checkTopicShown('Topic two', store, expected: true);
     });
 
     testWidgets('text selection is reset on choosing an option', (tester) async {

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -392,16 +392,11 @@ void main() {
   });
 
   group('TopicAutocomplete', () {
-    void checkTopicShown(String topic, PerAccountStore store, {required bool expected}) {
-      check(find.text(topic).evaluate().length).equals(expected ? 1 : 0);
-    }
-
     testWidgets('options appear, disappear, and change correctly', (WidgetTester tester) async {
       final topic1 = eg.getStreamTopicsEntry(maxId: 1, name: 'Topic one');
       final topic2 = eg.getStreamTopicsEntry(maxId: 2, name: 'Topic two');
       final topic3 = eg.getStreamTopicsEntry(maxId: 3, name: 'Topic three');
       final topicInputFinder = await setupToTopicInput(tester, topics: [topic1, topic2, topic3]);
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
       // Options are filtered correctly for query
       // TODO(#226): Remove this extra edit when this bug is fixed.
@@ -410,24 +405,24 @@ void main() {
       await tester.pumpAndSettle();
 
       // "topic three" and "topic two" appear, but not "topic one"
-      checkTopicShown('Topic one',   store, expected: false);
-      checkTopicShown('Topic two',   store, expected: true);
-      checkTopicShown('Topic three', store, expected: true);
+      check(find.text('Topic one'  )).findsNothing();
+      check(find.text('Topic two'  )).findsOne();
+      check(find.text('Topic three')).findsOne();
 
       // Finishing autocomplete updates topic box; causes options to disappear
       await tester.tap(find.text('Topic three'));
       await tester.pumpAndSettle();
       check(tester.widget<TextField>(topicInputFinder).controller!.text)
         .equals(topic3.name.displayName);
-      checkTopicShown('Topic one',   store, expected: false);
-      checkTopicShown('Topic two',   store, expected: false);
-      checkTopicShown('Topic three', store, expected: true); // shown in `_TopicInput` once
+      check(find.text('Topic one'  )).findsNothing();
+      check(find.text('Topic two'  )).findsNothing();
+      check(find.text('Topic three')).findsOne(); // shown in `_TopicInput` once
 
       // Then a new autocomplete intent brings up options again
       await tester.enterText(topicInputFinder, 'Topic');
       await tester.enterText(topicInputFinder, 'Topic T');
       await tester.pumpAndSettle();
-      checkTopicShown('Topic two', store, expected: true);
+      check(find.text('Topic two')).findsOne();
     });
 
     testWidgets('text selection is reset on choosing an option', (tester) async {

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -307,6 +307,15 @@ void main() {
       });
     });
 
+    testWidgets('empty topic', (tester) async {
+      final channel = eg.stream();
+      await setupPage(tester,
+        streams: [channel],
+        subscriptions: [(eg.subscription(channel))],
+        unreadMessages: [eg.streamMessage(stream: channel, topic: '')]);
+      check(find.text(eg.defaultRealmEmptyTopicDisplayName)).findsOne();
+    }, skip: true); // null topic names soon to be enabled
+
     group('topic visibility', () {
       final channel = eg.stream();
       const topic = 'topic';

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -194,6 +194,16 @@ void main() {
   group('app bar', () {
     // Tests for the topic action sheet are in test/widgets/action_sheet_test.dart.
 
+    testWidgets('handle empty topics', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: eg.topicNarrow(channel.streamId, ''),
+        streams: [channel],
+        messageCount: 1);
+      checkAppBarChannelTopic(
+        channel.name, eg.defaultRealmEmptyTopicDisplayName);
+    }, skip: true); // null topic names soon to be enabled
+
     testWidgets('has channel-feed action for topic narrows', (tester) async {
       final pushedRoutes = <Route<void>>[];
       final navObserver = TestNavigatorObserver()
@@ -933,6 +943,26 @@ void main() {
         check(findInMessageList('stream name')).length.equals(0);
         check(findInMessageList('topic name')).length.equals(1);
       });
+
+      final messageEmptyTopic = eg.streamMessage(stream: stream, topic: '');
+
+      testWidgets('show general chat for empty topics with channel name', (tester) async {
+        await setupMessageListPage(tester,
+          narrow: const CombinedFeedNarrow(),
+          messages: [messageEmptyTopic], subscriptions: [eg.subscription(stream)]);
+        await tester.pump();
+        check(findInMessageList('stream name')).single;
+        check(findInMessageList(eg.defaultRealmEmptyTopicDisplayName)).single;
+      }, skip: true); // null topic names soon to be enabled
+
+      testWidgets('show general chat for empty topics without channel name', (tester) async {
+        await setupMessageListPage(tester,
+          narrow: TopicNarrow.ofMessage(messageEmptyTopic),
+          messages: [messageEmptyTopic]);
+        await tester.pump();
+        check(findInMessageList('stream name')).isEmpty();
+        check(findInMessageList(eg.defaultRealmEmptyTopicDisplayName)).single;
+      }, skip: true); // null topic names soon to be enabled
 
       testWidgets('show topic visibility icon when followed', (tester) async {
         await setupMessageListPage(tester,


### PR DESCRIPTION
~~Stacked on top of #1342.~~

This addresses part of #1250.

This is the bare minimum needed for making `TopicName.displayName` nullable before we can work on the more intricate details on how parts like sending from compose box or live hint text updates work.

The last three commits enable support for empty topics for testing. When merging, we leave those three commits out because we haven't yet finished working other other parts mentioned above. This allows us to review and merge related changes without interrupting beta releases with user-visible changes.

See the [screenshots](https://github.com/zulip/zulip-flutter/pull/1297#issuecomment-2644408826) for what changes are included here.