### PR TITLE
ci: Add setup script for running in Flutter "customer testing"

### DIFF
--- a/tools/customer-testing/setup.sh
+++ b/tools/customer-testing/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Setup script for running Zulip's tests as part of the Flutter
+# "customer testing" suite:
+#   https://github.com/flutter/tests
+
+set -euo pipefail
+
+# Flutter's "customer testing" suite runs in two environments:
+#  * GitHub Actions for changes to the flutter/tests tree itself
+#    (which is just a registry of downstream test suites to run);
+#  * LUCI, at ci.chromium.org, for changes in Flutter.
+#
+# For background, see:
+#   https://github.com/flutter/flutter/issues/162041#issuecomment-2611129958
+
+if ! sudo -v; then
+    # In the LUCI environment sudo isn't available,
+    # but also the setup below isn't needed.  Skip it.
+    exit 0
+fi
+
+# Otherwise, assume we're in the GitHub Actions environment.
+
+
+# Install libsqlite3-dev.
+#
+# A few Zulip tests use SQLite, and so need libsqlite3.so.
+# (The actual databases involved are tiny and in-memory.)
+#
+# Both older and newer GitHub Actions images have the SQLite shared
+# library, from the libsqlite3-0 package.  But newer images
+# (ubuntu-24.04, which the ubuntu-latest alias switched to around
+# 2025-01) no longer have a symlink "libsqlite3.so" pointing to it,
+# which is part of the libsqlite3-dev package.  Install that.
+sudo apt install -y libsqlite3-dev


### PR DESCRIPTION
Earlier I'd tried adding this "apt install" command directly in the test registry, as a "setup" line in the "zulip.test" file:
  https://github.com/flutter/tests/pull/441

But the Flutter "customer testing" suite gets run in two different environments; and it turns out that not only does the LUCI environment not need this step (the Zulip tests there were working fine right up until they were disabled last week due to the failures in GitHub Actions), but it also doesn't permit it: there's no access to `sudo`:
  https://discord.com/channels/608014603317936148/1290464157765865552/1331449169830871122
  https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20customer_testing/22301/overview

Error output (reformatted):

    Processing ./../../bin/cache/pkg/tests/registry/zulip.test...
    >> sudo apt install -y libsqlite3-dev
    | sudo: a terminal is required to read the password;
      either use the -S option to read from standard input
      or configure an askpass helper
    ERROR: Setup command failed: sudo apt install -y libsqlite3-dev

So we need this bit of conditional logic too.  That makes this a little more complex than fits in a "setup" line in the test registry. So instead let's make this script which we can invoke from there.