### PR TITLE
Mark as resolved/unresolved prep 2

### DIFF
--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -110,11 +110,10 @@ void main() {
   group('topic action sheet', () {
     final someChannel = eg.stream();
     const someTopic = 'my topic';
+    final someMessage = eg.streamMessage(
+      stream: someChannel, topic: someTopic, sender: eg.otherUser);
 
     group('showTopicActionSheet', () {
-      final message = eg.streamMessage(
-        stream: someChannel, topic: someTopic, sender: eg.otherUser);
-
       Future<void> prepare({
         ZulipStream? channel,
         String topic = someTopic,
@@ -151,7 +150,7 @@ void main() {
           channels: [eg.unreadChannelMsgs(
             streamId: someChannel.streamId,
             topic: someTopic,
-            unreadMessageIds: [message.id],
+            unreadMessageIds: [someMessage.id],
           )]));
         await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
           child: const HomePage()));
@@ -167,7 +166,7 @@ void main() {
       testWidgets('show from app bar', (tester) async {
         await prepare();
         connection.prepare(json: eg.newestGetMessagesResult(
-          foundOldest: true, messages: [message]).toJson());
+          foundOldest: true, messages: [someMessage]).toJson());
         await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
           child: MessageListPage(
             initNarrow: eg.topicNarrow(someChannel.streamId, someTopic))));
@@ -186,7 +185,7 @@ void main() {
       testWidgets('show from recipient header', (tester) async {
         await prepare();
         connection.prepare(json: eg.newestGetMessagesResult(
-          foundOldest: true, messages: [message]).toJson());
+          foundOldest: true, messages: [someMessage]).toJson());
         await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
           child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
         // global store, per-account store, and message list get loaded

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -238,7 +238,7 @@ void main() {
         final subscriptions = isChannelMuted == null ? <Subscription>[]
           : [eg.subscription(channel, isMuted: isChannelMuted)];
         await testBinding.globalStore.add(account, eg.initialSnapshot(
-          realmUsers: [eg.selfUser],
+          realmUsers: [eg.selfUser, eg.otherUser],
           streams: [channel],
           subscriptions: subscriptions,
           userTopics: [eg.userTopicItem(channel, topic, visibilityPolicy)],
@@ -246,9 +246,10 @@ void main() {
         store = await testBinding.globalStore.perAccount(account.id);
         connection = store.connection as FakeApiConnection;
 
+        final message = eg.streamMessage(
+          stream: channel, topic: topic, sender: eg.otherUser);
         connection.prepare(json: eg.newestGetMessagesResult(
-          foundOldest: true, messages: [
-            eg.streamMessage(stream: channel, topic: topic)]).toJson());
+          foundOldest: true, messages: [message]).toJson());
         await tester.pumpWidget(TestZulipApp(accountId: account.id,
           child: MessageListPage(
             initNarrow: eg.topicNarrow(channel.streamId, topic))));

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -173,14 +173,14 @@ void main() {
     Future<void> showFromAppBar(WidgetTester tester, {
       ZulipStream? channel,
       String topic = someTopic,
-      StreamMessage? message,
+      List<StreamMessage>? messages,
     }) async {
       final effectiveChannel = channel ?? someChannel;
-      final effectiveMessage = message ?? someMessage;
-      assert(effectiveMessage.topic.apiName == topic);
+      final effectiveMessages = messages ?? [someMessage];
+      assert(effectiveMessages.every((m) => m.topic.apiName == topic));
 
       connection.prepare(json: eg.newestGetMessagesResult(
-        foundOldest: true, messages: [effectiveMessage]).toJson());
+        foundOldest: true, messages: effectiveMessages).toJson());
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
         child: MessageListPage(
           initNarrow: eg.topicNarrow(effectiveChannel.streamId, topic))));
@@ -284,7 +284,8 @@ void main() {
 
         final message = eg.streamMessage(
           stream: someChannel, topic: topic, sender: eg.otherUser);
-        await showFromAppBar(tester, channel: someChannel, topic: topic, message: message);
+        await showFromAppBar(tester,
+          channel: someChannel, topic: topic, messages: [message]);
       }
 
       void checkButtons(List<Finder> expectedButtonFinders) {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -149,7 +149,8 @@ void main() {
       // global store, per-account store, and message list get loaded
       await tester.pumpAndSettle();
 
-      await tester.longPress(find.byType(ZulipAppBar));
+      final topicRow = find.descendant(of: find.byType(ZulipAppBar), matching: find.text(topic));
+      await tester.longPress(topicRow);
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
       check(find.byType(BottomSheet)).findsOne();

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -214,15 +214,16 @@ void main() {
       await tester.pump(const Duration(milliseconds: 250));
     }
 
+    final actionSheetFinder = find.byType(BottomSheet);
+    Finder findButtonForLabel(String label) =>
+      find.descendant(of: actionSheetFinder, matching: find.text(label));
+
     group('showTopicActionSheet', () {
       void checkButtons() {
-        final actionSheetFinder = find.byType(BottomSheet);
         check(actionSheetFinder).findsOne();
 
         void checkButton(String label) {
-          check(
-            find.descendant(of: actionSheetFinder, matching: find.text(label))
-          ).findsOne();
+          check(findButtonForLabel(label)).findsOne();
         }
 
         checkButton('Follow topic');
@@ -255,10 +256,10 @@ void main() {
     group('UserTopicUpdateButton', () {
       late String topic;
 
-      final mute =     find.text('Mute topic');
-      final unmute =   find.text('Unmute topic');
-      final follow =   find.text('Follow topic');
-      final unfollow = find.text('Unfollow topic');
+      final mute =     findButtonForLabel('Mute topic');
+      final unmute =   findButtonForLabel('Unmute topic');
+      final follow =   findButtonForLabel('Follow topic');
+      final unfollow = findButtonForLabel('Unfollow topic');
 
       /// Prepare store and bring up a topic action sheet.
       ///
@@ -288,10 +289,10 @@ void main() {
 
       void checkButtons(List<Finder> expectedButtonFinders) {
         if (expectedButtonFinders.isEmpty) {
-          check(find.byType(BottomSheet)).findsNothing();
+          check(actionSheetFinder).findsNothing();
           return;
         }
-        check(find.byType(BottomSheet)).findsOne();
+        check(actionSheetFinder).findsOne();
 
         for (final buttonFinder in expectedButtonFinders) {
           check(buttonFinder).findsOne();

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -118,16 +118,19 @@ void main() {
         ZulipStream? channel,
         String topic = someTopic,
         UnreadMessagesSnapshot? unreadMsgs,
+        int? zulipFeatureLevel,
       }) async {
         final effectiveChannel = channel ?? someChannel;
 
         addTearDown(testBinding.reset);
 
-        await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+        final account = eg.selfAccount.copyWith(zulipFeatureLevel: zulipFeatureLevel);
+        await testBinding.globalStore.add(account, eg.initialSnapshot(
           realmUsers: [eg.selfUser, eg.otherUser],
           streams: [effectiveChannel],
           subscriptions: [eg.subscription(effectiveChannel)],
-          unreadMsgs: unreadMsgs));
+          unreadMsgs: unreadMsgs,
+          zulipFeatureLevel: zulipFeatureLevel));
         store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
         connection = store.connection as FakeApiConnection;
       }

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -106,311 +106,388 @@ void main() {
     connection.prepare(httpStatus: 400, json: fakeResponseJson);
   }
 
-  group('showTopicActionSheet', () {
-    final channel = eg.stream();
-    const topic = 'my topic';
-    final message = eg.streamMessage(
-      stream: channel, topic: topic, sender: eg.otherUser);
+  group('topic action sheet', () {
+    group('showTopicActionSheet', () {
+      final channel = eg.stream();
+      const topic = 'my topic';
+      final message = eg.streamMessage(
+        stream: channel, topic: topic, sender: eg.otherUser);
 
-    Future<void> prepare() async {
-      addTearDown(testBinding.reset);
+      Future<void> prepare() async {
+        addTearDown(testBinding.reset);
 
-      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
-        realmUsers: [eg.selfUser, eg.otherUser],
-        streams: [channel],
-        subscriptions: [eg.subscription(channel)]));
-      store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-      connection = store.connection as FakeApiConnection;
+        await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+          realmUsers: [eg.selfUser, eg.otherUser],
+          streams: [channel],
+          subscriptions: [eg.subscription(channel)]));
+        store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+        connection = store.connection as FakeApiConnection;
 
-      await store.addMessage(message);
-    }
-
-    void checkButtons() {
-      final actionSheetFinder = find.byType(BottomSheet);
-      check(actionSheetFinder).findsOne();
-
-      void checkButton(String label) {
-        check(
-          find.descendant(of: actionSheetFinder, matching: find.text(label))
-        ).findsOne();
+        await store.addMessage(message);
       }
 
-      checkButton('Follow topic');
-    }
+      void checkButtons() {
+        final actionSheetFinder = find.byType(BottomSheet);
+        check(actionSheetFinder).findsOne();
 
-    testWidgets('show from inbox', (tester) async {
-      await prepare();
-      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-        child: const HomePage()));
-      await tester.pump();
-      check(find.byType(InboxPageBody)).findsOne();
+        void checkButton(String label) {
+          check(
+            find.descendant(of: actionSheetFinder, matching: find.text(label))
+          ).findsOne();
+        }
 
-      await tester.longPress(find.text(topic));
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
-      checkButtons();
+        checkButton('Follow topic');
+      }
+
+      testWidgets('show from inbox', (tester) async {
+        await prepare();
+        await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+          child: const HomePage()));
+        await tester.pump();
+        check(find.byType(InboxPageBody)).findsOne();
+
+        await tester.longPress(find.text(topic));
+        // sheet appears onscreen; default duration of bottom-sheet enter animation
+        await tester.pump(const Duration(milliseconds: 250));
+        checkButtons();
+      });
+
+      testWidgets('show from app bar', (tester) async {
+        await prepare();
+        connection.prepare(json: eg.newestGetMessagesResult(
+          foundOldest: true, messages: [message]).toJson());
+        await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+          child: MessageListPage(
+            initNarrow: eg.topicNarrow(channel.streamId, topic))));
+        // global store, per-account store, and message list get loaded
+        await tester.pumpAndSettle();
+
+        final topicRow = find.descendant(of: find.byType(ZulipAppBar), matching: find.text(topic));
+        await tester.longPress(topicRow);
+        // sheet appears onscreen; default duration of bottom-sheet enter animation
+        await tester.pump(const Duration(milliseconds: 250));
+        checkButtons();
+      });
+
+      testWidgets('show from recipient header', (tester) async {
+        await prepare();
+        connection.prepare(json: eg.newestGetMessagesResult(
+          foundOldest: true, messages: [message]).toJson());
+        await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+          child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
+        // global store, per-account store, and message list get loaded
+        await tester.pumpAndSettle();
+
+        await tester.longPress(find.descendant(
+          of: find.byType(RecipientHeader), matching: find.text(topic)));
+        // sheet appears onscreen; default duration of bottom-sheet enter animation
+        await tester.pump(const Duration(milliseconds: 250));
+        checkButtons();
+      });
     });
 
-    testWidgets('show from app bar', (tester) async {
-      await prepare();
-      connection.prepare(json: eg.newestGetMessagesResult(
-        foundOldest: true, messages: [message]).toJson());
-      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-        child: MessageListPage(
-          initNarrow: eg.topicNarrow(channel.streamId, topic))));
-      // global store, per-account store, and message list get loaded
-      await tester.pumpAndSettle();
+    group('UserTopicUpdateButton', () {
+      late ZulipStream channel;
+      late String topic;
 
-      final topicRow = find.descendant(of: find.byType(ZulipAppBar), matching: find.text(topic));
-      await tester.longPress(topicRow);
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
-      checkButtons();
-    });
+      final mute =     find.text('Mute topic');
+      final unmute =   find.text('Unmute topic');
+      final follow =   find.text('Follow topic');
+      final unfollow = find.text('Unfollow topic');
 
-    testWidgets('show from recipient header', (tester) async {
-      await prepare();
-      connection.prepare(json: eg.newestGetMessagesResult(
-        foundOldest: true, messages: [message]).toJson());
-      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-        child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
-      // global store, per-account store, and message list get loaded
-      await tester.pumpAndSettle();
+      /// Prepare store and bring up a topic action sheet.
+      ///
+      /// If `isChannelMuted` is `null`, the user is not subscribed to the
+      /// channel.
+      Future<void> setupToTopicActionSheet(WidgetTester tester, {
+        required bool? isChannelMuted,
+        required UserTopicVisibilityPolicy visibilityPolicy,
+        int? zulipFeatureLevel,
+      }) async {
+        addTearDown(testBinding.reset);
 
-      await tester.longPress(find.descendant(
-        of: find.byType(RecipientHeader), matching: find.text(topic)));
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
-      checkButtons();
+        channel = eg.stream();
+        topic = 'isChannelMuted: $isChannelMuted, policy: $visibilityPolicy';
+
+        final account = eg.selfAccount.copyWith(zulipFeatureLevel: zulipFeatureLevel);
+        final subscriptions = isChannelMuted == null ? <Subscription>[]
+          : [eg.subscription(channel, isMuted: isChannelMuted)];
+        await testBinding.globalStore.add(account, eg.initialSnapshot(
+          realmUsers: [eg.selfUser],
+          streams: [channel],
+          subscriptions: subscriptions,
+          userTopics: [eg.userTopicItem(channel, topic, visibilityPolicy)],
+          zulipFeatureLevel: zulipFeatureLevel));
+        store = await testBinding.globalStore.perAccount(account.id);
+        connection = store.connection as FakeApiConnection;
+
+        connection.prepare(json: eg.newestGetMessagesResult(
+          foundOldest: true, messages: [
+            eg.streamMessage(stream: channel, topic: topic)]).toJson());
+        await tester.pumpWidget(TestZulipApp(accountId: account.id,
+          child: MessageListPage(
+            initNarrow: eg.topicNarrow(channel.streamId, topic))));
+        await tester.pumpAndSettle();
+
+        await tester.longPress(find.descendant(
+          of: find.byType(RecipientHeader), matching: find.text(topic)));
+        // sheet appears onscreen; default duration of bottom-sheet enter animation
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      void checkButtons(List<Finder> expectedButtonFinders) {
+        if (expectedButtonFinders.isEmpty) {
+          check(find.byType(BottomSheet)).findsNothing();
+          return;
+        }
+        check(find.byType(BottomSheet)).findsOne();
+
+        for (final buttonFinder in expectedButtonFinders) {
+          check(buttonFinder).findsOne();
+        }
+        check(find.bySubtype<UserTopicUpdateButton>())
+          .findsExactly(expectedButtonFinders.length);
+      }
+
+      void checkUpdateUserTopicRequest(UserTopicVisibilityPolicy expectedPolicy) async {
+        check(connection.lastRequest).isA<http.Request>()
+          ..url.path.equals('/api/v1/user_topics')
+          ..bodyFields.deepEquals({
+            'stream_id': '${channel.streamId}',
+            'topic': topic,
+            'visibility_policy': jsonEncode(expectedPolicy),
+          });
+      }
+
+      testWidgets('unmuteInMutedChannel', (tester) async {
+        await setupToTopicActionSheet(tester,
+          isChannelMuted: true,
+          visibilityPolicy: UserTopicVisibilityPolicy.none);
+        await tester.tap(unmute);
+        await tester.pump();
+        checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.unmuted);
+      });
+
+      testWidgets('unmute', (tester) async {
+        await setupToTopicActionSheet(tester,
+          isChannelMuted: false,
+          visibilityPolicy: UserTopicVisibilityPolicy.muted);
+        await tester.tap(unmute);
+        await tester.pump();
+        checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.none);
+      });
+
+      testWidgets('mute', (tester) async {
+        await setupToTopicActionSheet(tester,
+          isChannelMuted: false,
+          visibilityPolicy: UserTopicVisibilityPolicy.none);
+        await tester.tap(mute);
+        await tester.pump();
+        checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.muted);
+      });
+
+      testWidgets('follow', (tester) async {
+        await setupToTopicActionSheet(tester,
+          isChannelMuted: false,
+          visibilityPolicy: UserTopicVisibilityPolicy.none);
+        await tester.tap(follow);
+        await tester.pump();
+        checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.followed);
+      });
+
+      testWidgets('unfollow', (tester) async {
+        await setupToTopicActionSheet(tester,
+          isChannelMuted: false,
+          visibilityPolicy: UserTopicVisibilityPolicy.followed);
+        await tester.tap(unfollow);
+        await tester.pump();
+        checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.none);
+      });
+
+      testWidgets('request fails with an error dialog', (tester) async {
+        await setupToTopicActionSheet(tester,
+          isChannelMuted: false,
+          visibilityPolicy: UserTopicVisibilityPolicy.followed);
+
+        connection.prepare(httpStatus: 400, json: {
+          'result': 'error', 'code': 'BAD_REQUEST', 'msg': ''});
+        await tester.tap(unfollow);
+        await tester.pumpAndSettle();
+
+        checkErrorDialog(tester, expectedTitle: 'Failed to unfollow topic');
+      });
+
+      group('check expected buttons', () {
+        final testCases = [
+          (false, UserTopicVisibilityPolicy.muted,    [unmute, follow]),
+          (false, UserTopicVisibilityPolicy.none,     [mute, follow]),
+          (false, UserTopicVisibilityPolicy.unmuted,  [mute, follow]),
+          (false, UserTopicVisibilityPolicy.followed, [mute, unfollow]),
+
+          (true,  UserTopicVisibilityPolicy.muted,    [unmute, follow]),
+          (true,  UserTopicVisibilityPolicy.none,     [unmute, follow]),
+          (true,  UserTopicVisibilityPolicy.unmuted,  [mute, follow]),
+          (true,  UserTopicVisibilityPolicy.followed, [mute, unfollow]),
+
+          (null,  UserTopicVisibilityPolicy.none,     <Finder>[]),
+        ];
+
+        for (final (isChannelMuted, visibilityPolicy, buttons) in testCases) {
+          final description = 'isChannelMuted: ${isChannelMuted ?? "(not subscribed)"}, $visibilityPolicy';
+          testWidgets(description, (tester) async {
+            await setupToTopicActionSheet(tester,
+              isChannelMuted: isChannelMuted,
+              visibilityPolicy: visibilityPolicy);
+            checkButtons(buttons);
+          });
+        }
+      });
+
+      group('legacy: follow is unsupported when FL < 219', () {
+        final testCases = [
+          (false, UserTopicVisibilityPolicy.muted,    [unmute]),
+          (false, UserTopicVisibilityPolicy.none,     [mute]),
+          (false, UserTopicVisibilityPolicy.unmuted,  [mute]),
+          (false, UserTopicVisibilityPolicy.followed, [mute]),
+
+          (true,  UserTopicVisibilityPolicy.muted,    [unmute]),
+          (true,  UserTopicVisibilityPolicy.none,     [unmute]),
+          (true,  UserTopicVisibilityPolicy.unmuted,  [mute]),
+          (true,  UserTopicVisibilityPolicy.followed, [mute]),
+
+          (null,  UserTopicVisibilityPolicy.none,     <Finder>[]),
+        ];
+
+        for (final (isChannelMuted, visibilityPolicy, buttons) in testCases) {
+          final description = 'isChannelMuted: ${isChannelMuted ?? "(not subscribed)"}, $visibilityPolicy';
+          testWidgets(description, (tester) async {
+            await setupToTopicActionSheet(tester,
+              isChannelMuted: isChannelMuted,
+              visibilityPolicy: visibilityPolicy,
+              zulipFeatureLevel: 218);
+            checkButtons(buttons);
+          });
+        }
+      });
+
+      group('legacy: unmute is unsupported when FL < 170', () {
+        final testCases = [
+          (false, UserTopicVisibilityPolicy.muted,    [unmute]),
+          (false, UserTopicVisibilityPolicy.none,     [mute]),
+          (false, UserTopicVisibilityPolicy.unmuted,  [mute]),
+          (false, UserTopicVisibilityPolicy.followed, [mute]),
+
+          (true,  UserTopicVisibilityPolicy.muted,    <Finder>[]),
+          (true,  UserTopicVisibilityPolicy.none,     <Finder>[]),
+          (true,  UserTopicVisibilityPolicy.unmuted,  <Finder>[]),
+          (true,  UserTopicVisibilityPolicy.followed, <Finder>[]),
+
+          (null,  UserTopicVisibilityPolicy.none,     <Finder>[]),
+        ];
+
+        for (final (isChannelMuted, visibilityPolicy, buttons) in testCases) {
+          final description = 'isChannelMuted: ${isChannelMuted ?? "(not subscribed)"}, $visibilityPolicy';
+          testWidgets(description, (tester) async {
+            await setupToTopicActionSheet(tester,
+              isChannelMuted: isChannelMuted,
+              visibilityPolicy: visibilityPolicy,
+              zulipFeatureLevel: 169);
+            checkButtons(buttons);
+          });
+        }
+      });
     });
   });
 
-  group('UserTopicUpdateButton', () {
-    late ZulipStream channel;
-    late String topic;
+  group('message action sheet', () {
+    group('ReactionButtons', () {
+      final popularCandidates = EmojiStore.popularEmojiCandidates;
 
-    final mute =     find.text('Mute topic');
-    final unmute =   find.text('Unmute topic');
-    final follow =   find.text('Follow topic');
-    final unfollow = find.text('Unfollow topic');
+      for (final emoji in popularCandidates) {
+        final emojiDisplay = emoji.emojiDisplay as UnicodeEmojiDisplay;
 
-    /// Prepare store and bring up a topic action sheet.
-    ///
-    /// If `isChannelMuted` is `null`, the user is not subscribed to the
-    /// channel.
-    Future<void> setupToTopicActionSheet(WidgetTester tester, {
-      required bool? isChannelMuted,
-      required UserTopicVisibilityPolicy visibilityPolicy,
-      int? zulipFeatureLevel,
-    }) async {
-      addTearDown(testBinding.reset);
+        Future<void> tapButton(WidgetTester tester) async {
+          await tester.tap(find.descendant(
+            of: find.byType(BottomSheet),
+            matching: find.text(emojiDisplay.emojiUnicode)));
+        }
 
-      channel = eg.stream();
-      topic = 'isChannelMuted: $isChannelMuted, policy: $visibilityPolicy';
+        testWidgets('${emoji.emojiName} adding success', (tester) async {
+          final message = eg.streamMessage();
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-      final account = eg.selfAccount.copyWith(zulipFeatureLevel: zulipFeatureLevel);
-      final subscriptions = isChannelMuted == null ? <Subscription>[]
-        : [eg.subscription(channel, isMuted: isChannelMuted)];
-      await testBinding.globalStore.add(account, eg.initialSnapshot(
-        realmUsers: [eg.selfUser],
-        streams: [channel],
-        subscriptions: subscriptions,
-        userTopics: [eg.userTopicItem(channel, topic, visibilityPolicy)],
-        zulipFeatureLevel: zulipFeatureLevel));
-      store = await testBinding.globalStore.perAccount(account.id);
-      connection = store.connection as FakeApiConnection;
+          connection.prepare(json: {});
+          await tapButton(tester);
+          await tester.pump(Duration.zero);
 
-      connection.prepare(json: eg.newestGetMessagesResult(
-        foundOldest: true, messages: [
-          eg.streamMessage(stream: channel, topic: topic)]).toJson());
-      await tester.pumpWidget(TestZulipApp(accountId: account.id,
-        child: MessageListPage(
-          initNarrow: eg.topicNarrow(channel.streamId, topic))));
-      await tester.pumpAndSettle();
-
-      await tester.longPress(find.descendant(
-        of: find.byType(RecipientHeader), matching: find.text(topic)));
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
-    }
-
-    void checkButtons(List<Finder> expectedButtonFinders) {
-      if (expectedButtonFinders.isEmpty) {
-        check(find.byType(BottomSheet)).findsNothing();
-        return;
-      }
-      check(find.byType(BottomSheet)).findsOne();
-
-      for (final buttonFinder in expectedButtonFinders) {
-        check(buttonFinder).findsOne();
-      }
-      check(find.bySubtype<UserTopicUpdateButton>())
-        .findsExactly(expectedButtonFinders.length);
-    }
-
-    void checkUpdateUserTopicRequest(UserTopicVisibilityPolicy expectedPolicy) async {
-      check(connection.lastRequest).isA<http.Request>()
-        ..url.path.equals('/api/v1/user_topics')
-        ..bodyFields.deepEquals({
-          'stream_id': '${channel.streamId}',
-          'topic': topic,
-          'visibility_policy': jsonEncode(expectedPolicy),
+          check(connection.lastRequest).isA<http.Request>()
+            ..method.equals('POST')
+            ..url.path.equals('/api/v1/messages/${message.id}/reactions')
+            ..bodyFields.deepEquals({
+                'reaction_type': 'unicode_emoji',
+                'emoji_code': emoji.emojiCode,
+                'emoji_name': emoji.emojiName,
+              });
         });
-    }
 
-    testWidgets('unmuteInMutedChannel', (tester) async {
-      await setupToTopicActionSheet(tester,
-        isChannelMuted: true,
-        visibilityPolicy: UserTopicVisibilityPolicy.none);
-      await tester.tap(unmute);
-      await tester.pump();
-      checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.unmuted);
-    });
+        testWidgets('${emoji.emojiName} removing success', (tester) async {
+          final message = eg.streamMessage(
+            reactions: [Reaction(
+              emojiName: emoji.emojiName,
+              emojiCode: emoji.emojiCode,
+              reactionType: ReactionType.unicodeEmoji,
+              userId: eg.selfAccount.userId)]
+          );
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-    testWidgets('unmute', (tester) async {
-      await setupToTopicActionSheet(tester,
-        isChannelMuted: false,
-        visibilityPolicy: UserTopicVisibilityPolicy.muted);
-      await tester.tap(unmute);
-      await tester.pump();
-      checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.none);
-    });
+          connection.prepare(json: {});
+          await tapButton(tester);
+          await tester.pump(Duration.zero);
 
-    testWidgets('mute', (tester) async {
-      await setupToTopicActionSheet(tester,
-        isChannelMuted: false,
-        visibilityPolicy: UserTopicVisibilityPolicy.none);
-      await tester.tap(mute);
-      await tester.pump();
-      checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.muted);
-    });
+          check(connection.lastRequest).isA<http.Request>()
+            ..method.equals('DELETE')
+            ..url.path.equals('/api/v1/messages/${message.id}/reactions')
+            ..bodyFields.deepEquals({
+                'reaction_type': 'unicode_emoji',
+                'emoji_code': emoji.emojiCode,
+                'emoji_name': emoji.emojiName,
+              });
+        });
 
-    testWidgets('follow', (tester) async {
-      await setupToTopicActionSheet(tester,
-        isChannelMuted: false,
-        visibilityPolicy: UserTopicVisibilityPolicy.none);
-      await tester.tap(follow);
-      await tester.pump();
-      checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.followed);
-    });
+        testWidgets('${emoji.emojiName} request has an error', (tester) async {
+          final message = eg.streamMessage();
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-    testWidgets('unfollow', (tester) async {
-      await setupToTopicActionSheet(tester,
-        isChannelMuted: false,
-        visibilityPolicy: UserTopicVisibilityPolicy.followed);
-      await tester.tap(unfollow);
-      await tester.pump();
-      checkUpdateUserTopicRequest(UserTopicVisibilityPolicy.none);
-    });
+          connection.prepare(httpStatus: 400, json: {
+            'code': 'BAD_REQUEST',
+            'msg': 'Invalid message(s)',
+            'result': 'error',
+          });
+          await tapButton(tester);
+          await tester.pump(Duration.zero); // error arrives; error dialog shows
 
-    testWidgets('request fails with an error dialog', (tester) async {
-      await setupToTopicActionSheet(tester,
-        isChannelMuted: false,
-        visibilityPolicy: UserTopicVisibilityPolicy.followed);
-
-      connection.prepare(httpStatus: 400, json: {
-        'result': 'error', 'code': 'BAD_REQUEST', 'msg': ''});
-      await tester.tap(unfollow);
-      await tester.pumpAndSettle();
-
-      checkErrorDialog(tester, expectedTitle: 'Failed to unfollow topic');
-    });
-
-    group('check expected buttons', () {
-      final testCases = [
-        (false, UserTopicVisibilityPolicy.muted,    [unmute, follow]),
-        (false, UserTopicVisibilityPolicy.none,     [mute, follow]),
-        (false, UserTopicVisibilityPolicy.unmuted,  [mute, follow]),
-        (false, UserTopicVisibilityPolicy.followed, [mute, unfollow]),
-
-        (true,  UserTopicVisibilityPolicy.muted,    [unmute, follow]),
-        (true,  UserTopicVisibilityPolicy.none,     [unmute, follow]),
-        (true,  UserTopicVisibilityPolicy.unmuted,  [mute, follow]),
-        (true,  UserTopicVisibilityPolicy.followed, [mute, unfollow]),
-
-        (null,  UserTopicVisibilityPolicy.none,     <Finder>[]),
-      ];
-
-      for (final (isChannelMuted, visibilityPolicy, buttons) in testCases) {
-        final description = 'isChannelMuted: ${isChannelMuted ?? "(not subscribed)"}, $visibilityPolicy';
-        testWidgets(description, (tester) async {
-          await setupToTopicActionSheet(tester,
-            isChannelMuted: isChannelMuted,
-            visibilityPolicy: visibilityPolicy);
-          checkButtons(buttons);
+          await tester.tap(find.byWidget(checkErrorDialog(tester,
+            expectedTitle: 'Adding reaction failed',
+            expectedMessage: 'Invalid message(s)')));
         });
       }
     });
 
-    group('legacy: follow is unsupported when FL < 219', () {
-      final testCases = [
-        (false, UserTopicVisibilityPolicy.muted,    [unmute]),
-        (false, UserTopicVisibilityPolicy.none,     [mute]),
-        (false, UserTopicVisibilityPolicy.unmuted,  [mute]),
-        (false, UserTopicVisibilityPolicy.followed, [mute]),
-
-        (true,  UserTopicVisibilityPolicy.muted,    [unmute]),
-        (true,  UserTopicVisibilityPolicy.none,     [unmute]),
-        (true,  UserTopicVisibilityPolicy.unmuted,  [mute]),
-        (true,  UserTopicVisibilityPolicy.followed, [mute]),
-
-        (null,  UserTopicVisibilityPolicy.none,     <Finder>[]),
-      ];
-
-      for (final (isChannelMuted, visibilityPolicy, buttons) in testCases) {
-        final description = 'isChannelMuted: ${isChannelMuted ?? "(not subscribed)"}, $visibilityPolicy';
-        testWidgets(description, (tester) async {
-          await setupToTopicActionSheet(tester,
-            isChannelMuted: isChannelMuted,
-            visibilityPolicy: visibilityPolicy,
-            zulipFeatureLevel: 218);
-          checkButtons(buttons);
-        });
-      }
-    });
-
-    group('legacy: unmute is unsupported when FL < 170', () {
-      final testCases = [
-        (false, UserTopicVisibilityPolicy.muted,    [unmute]),
-        (false, UserTopicVisibilityPolicy.none,     [mute]),
-        (false, UserTopicVisibilityPolicy.unmuted,  [mute]),
-        (false, UserTopicVisibilityPolicy.followed, [mute]),
-
-        (true,  UserTopicVisibilityPolicy.muted,    <Finder>[]),
-        (true,  UserTopicVisibilityPolicy.none,     <Finder>[]),
-        (true,  UserTopicVisibilityPolicy.unmuted,  <Finder>[]),
-        (true,  UserTopicVisibilityPolicy.followed, <Finder>[]),
-
-        (null,  UserTopicVisibilityPolicy.none,     <Finder>[]),
-      ];
-
-      for (final (isChannelMuted, visibilityPolicy, buttons) in testCases) {
-        final description = 'isChannelMuted: ${isChannelMuted ?? "(not subscribed)"}, $visibilityPolicy';
-        testWidgets(description, (tester) async {
-          await setupToTopicActionSheet(tester,
-            isChannelMuted: isChannelMuted,
-            visibilityPolicy: visibilityPolicy,
-            zulipFeatureLevel: 169);
-          checkButtons(buttons);
-        });
-      }
-    });
-  });
-
-  group('ReactionButtons', () {
-    final popularCandidates = EmojiStore.popularEmojiCandidates;
-
-    for (final emoji in popularCandidates) {
-      final emojiDisplay = emoji.emojiDisplay as UnicodeEmojiDisplay;
-
-      Future<void> tapButton(WidgetTester tester) async {
+    group('StarButton', () {
+      Future<void> tapButton(WidgetTester tester, {bool starred = false}) async {
+        // Starred messages include the same icon so we need to
+        // match only by descendants of [BottomSheet].
+        await tester.ensureVisible(find.descendant(
+          of: find.byType(BottomSheet),
+          matching: find.byIcon(starred ? ZulipIcons.star_filled : ZulipIcons.star, skipOffstage: false)));
         await tester.tap(find.descendant(
           of: find.byType(BottomSheet),
-          matching: find.text(emojiDisplay.emojiUnicode)));
+          matching: find.byIcon(starred ? ZulipIcons.star_filled : ZulipIcons.star)));
+        await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
       }
 
-      testWidgets('${emoji.emojiName} adding success', (tester) async {
-        final message = eg.streamMessage();
+      testWidgets('star success', (tester) async {
+        final message = eg.streamMessage(flags: []);
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
         connection.prepare(json: {});
@@ -419,41 +496,36 @@ void main() {
 
         check(connection.lastRequest).isA<http.Request>()
           ..method.equals('POST')
-          ..url.path.equals('/api/v1/messages/${message.id}/reactions')
+          ..url.path.equals('/api/v1/messages/flags')
           ..bodyFields.deepEquals({
-              'reaction_type': 'unicode_emoji',
-              'emoji_code': emoji.emojiCode,
-              'emoji_name': emoji.emojiName,
-            });
+            'messages': jsonEncode([message.id]),
+            'op': 'add',
+            'flag': 'starred',
+          });
       });
 
-      testWidgets('${emoji.emojiName} removing success', (tester) async {
-        final message = eg.streamMessage(
-          reactions: [Reaction(
-            emojiName: emoji.emojiName,
-            emojiCode: emoji.emojiCode,
-            reactionType: ReactionType.unicodeEmoji,
-            userId: eg.selfAccount.userId)]
-        );
+      testWidgets('unstar success', (tester) async {
+        final message = eg.streamMessage(flags: [MessageFlag.starred]);
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
         connection.prepare(json: {});
-        await tapButton(tester);
+        await tapButton(tester, starred: true);
         await tester.pump(Duration.zero);
 
         check(connection.lastRequest).isA<http.Request>()
-          ..method.equals('DELETE')
-          ..url.path.equals('/api/v1/messages/${message.id}/reactions')
+          ..method.equals('POST')
+          ..url.path.equals('/api/v1/messages/flags')
           ..bodyFields.deepEquals({
-              'reaction_type': 'unicode_emoji',
-              'emoji_code': emoji.emojiCode,
-              'emoji_name': emoji.emojiName,
-            });
+            'messages': jsonEncode([message.id]),
+            'op': 'remove',
+            'flag': 'starred',
+          });
       });
 
-      testWidgets('${emoji.emojiName} request has an error', (tester) async {
-        final message = eg.streamMessage();
+      testWidgets('star request has an error', (tester) async {
+        final message = eg.streamMessage(flags: []);
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
 
         connection.prepare(httpStatus: 400, json: {
           'code': 'BAD_REQUEST',
@@ -464,567 +536,499 @@ void main() {
         await tester.pump(Duration.zero); // error arrives; error dialog shows
 
         await tester.tap(find.byWidget(checkErrorDialog(tester,
-          expectedTitle: 'Adding reaction failed',
+          expectedTitle: zulipLocalizations.errorStarMessageFailedTitle,
           expectedMessage: 'Invalid message(s)')));
       });
-    }
-  });
 
-  group('StarButton', () {
-    Future<void> tapButton(WidgetTester tester, {bool starred = false}) async {
-      // Starred messages include the same icon so we need to
-      // match only by descendants of [BottomSheet].
-      await tester.ensureVisible(find.descendant(
-        of: find.byType(BottomSheet),
-        matching: find.byIcon(starred ? ZulipIcons.star_filled : ZulipIcons.star, skipOffstage: false)));
-      await tester.tap(find.descendant(
-        of: find.byType(BottomSheet),
-        matching: find.byIcon(starred ? ZulipIcons.star_filled : ZulipIcons.star)));
-      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
-    }
+      testWidgets('unstar request has an error', (tester) async {
+        final message = eg.streamMessage(flags: [MessageFlag.starred]);
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
 
-    testWidgets('star success', (tester) async {
-      final message = eg.streamMessage(flags: []);
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-
-      connection.prepare(json: {});
-      await tapButton(tester);
-      await tester.pump(Duration.zero);
-
-      check(connection.lastRequest).isA<http.Request>()
-        ..method.equals('POST')
-        ..url.path.equals('/api/v1/messages/flags')
-        ..bodyFields.deepEquals({
-          'messages': jsonEncode([message.id]),
-          'op': 'add',
-          'flag': 'starred',
+        connection.prepare(httpStatus: 400, json: {
+          'code': 'BAD_REQUEST',
+          'msg': 'Invalid message(s)',
+          'result': 'error',
         });
-    });
+        await tapButton(tester, starred: true);
+        await tester.pump(Duration.zero); // error arrives; error dialog shows
 
-    testWidgets('unstar success', (tester) async {
-      final message = eg.streamMessage(flags: [MessageFlag.starred]);
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-
-      connection.prepare(json: {});
-      await tapButton(tester, starred: true);
-      await tester.pump(Duration.zero);
-
-      check(connection.lastRequest).isA<http.Request>()
-        ..method.equals('POST')
-        ..url.path.equals('/api/v1/messages/flags')
-        ..bodyFields.deepEquals({
-          'messages': jsonEncode([message.id]),
-          'op': 'remove',
-          'flag': 'starred',
-        });
-    });
-
-    testWidgets('star request has an error', (tester) async {
-      final message = eg.streamMessage(flags: []);
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-
-      connection.prepare(httpStatus: 400, json: {
-        'code': 'BAD_REQUEST',
-        'msg': 'Invalid message(s)',
-        'result': 'error',
+        await tester.tap(find.byWidget(checkErrorDialog(tester,
+          expectedTitle: zulipLocalizations.errorUnstarMessageFailedTitle,
+          expectedMessage: 'Invalid message(s)')));
       });
-      await tapButton(tester);
-      await tester.pump(Duration.zero); // error arrives; error dialog shows
-
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: zulipLocalizations.errorStarMessageFailedTitle,
-        expectedMessage: 'Invalid message(s)')));
     });
 
-    testWidgets('unstar request has an error', (tester) async {
-      final message = eg.streamMessage(flags: [MessageFlag.starred]);
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-
-      connection.prepare(httpStatus: 400, json: {
-        'code': 'BAD_REQUEST',
-        'msg': 'Invalid message(s)',
-        'result': 'error',
-      });
-      await tapButton(tester, starred: true);
-      await tester.pump(Duration.zero); // error arrives; error dialog shows
-
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: zulipLocalizations.errorUnstarMessageFailedTitle,
-        expectedMessage: 'Invalid message(s)')));
-    });
-  });
-
-  group('QuoteAndReplyButton', () {
-    ComposeBoxController? findComposeBoxController(WidgetTester tester) {
-      return tester.stateList<ComposeBoxState>(find.byType(ComposeBox))
-        .singleOrNull?.controller;
-    }
-
-    Widget? findQuoteAndReplyButton(WidgetTester tester) {
-      return tester.widgetList(find.byIcon(ZulipIcons.format_quote)).singleOrNull;
-    }
-
-    /// Simulates tapping the quote-and-reply button in the message action sheet.
-    ///
-    /// Checks that there is a quote-and-reply button.
-    Future<void> tapQuoteAndReplyButton(WidgetTester tester) async {
-      await tester.ensureVisible(find.byIcon(ZulipIcons.format_quote, skipOffstage: false));
-      final quoteAndReplyButton = findQuoteAndReplyButton(tester);
-      check(quoteAndReplyButton).isNotNull();
-      TypingNotifier.debugEnable = false;
-      addTearDown(TypingNotifier.debugReset);
-      await tester.tap(find.byWidget(quoteAndReplyButton!));
-      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
-    }
-
-    void checkLoadingState(PerAccountStore store, ComposeContentController contentController, {
-      required TextEditingValue valueBefore,
-      required Message message,
-    }) {
-      check(contentController).value.equals((ComposeContentController()
-        ..value = valueBefore
-        ..insertPadded(quoteAndReplyPlaceholder(store, message: message))
-      ).value);
-      check(contentController).validationErrors.contains(ContentValidationError.quoteAndReplyInProgress);
-    }
-
-    void checkSuccessState(PerAccountStore store, ComposeContentController contentController, {
-      required TextEditingValue valueBefore,
-      required Message message,
-      required String rawContent,
-    }) {
-      final builder = ComposeContentController()
-        ..value = valueBefore
-        ..insertPadded(quoteAndReply(store, message: message, rawContent: rawContent));
-      if (!valueBefore.selection.isValid) {
-        // (At the end of the process, we focus the input, which puts a cursor
-        // at text's end, if there was no cursor at the time.)
-        builder.selection = TextSelection.collapsed(offset: builder.text.length);
+    group('QuoteAndReplyButton', () {
+      ComposeBoxController? findComposeBoxController(WidgetTester tester) {
+        return tester.stateList<ComposeBoxState>(find.byType(ComposeBox))
+          .singleOrNull?.controller;
       }
-      check(contentController).value.equals(builder.value);
-      check(contentController).not((it) => it.validationErrors.contains(ContentValidationError.quoteAndReplyInProgress));
-    }
 
-    testWidgets('in channel narrow', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: ChannelNarrow(message.streamId));
+      Widget? findQuoteAndReplyButton(WidgetTester tester) {
+        return tester.widgetList(find.byIcon(ZulipIcons.format_quote)).singleOrNull;
+      }
 
-      final composeBoxController = findComposeBoxController(tester) as StreamComposeBoxController;
-      final contentController = composeBoxController.content;
+      /// Simulates tapping the quote-and-reply button in the message action sheet.
+      ///
+      /// Checks that there is a quote-and-reply button.
+      Future<void> tapQuoteAndReplyButton(WidgetTester tester) async {
+        await tester.ensureVisible(find.byIcon(ZulipIcons.format_quote, skipOffstage: false));
+        final quoteAndReplyButton = findQuoteAndReplyButton(tester);
+        check(quoteAndReplyButton).isNotNull();
+        TypingNotifier.debugEnable = false;
+        addTearDown(TypingNotifier.debugReset);
+        await tester.tap(find.byWidget(quoteAndReplyButton!));
+        await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+      }
 
-      // Ensure channel-topics are loaded before testing quote & reply behavior
-      connection.prepare(body:
-        jsonEncode(GetStreamTopicsResult(topics: [eg.getStreamTopicsEntry()]).toJson()));
-      final topicController = composeBoxController.topic;
-      topicController.value = const TextEditingValue(text: kNoTopicTopic);
+      void checkLoadingState(PerAccountStore store, ComposeContentController contentController, {
+        required TextEditingValue valueBefore,
+        required Message message,
+      }) {
+        check(contentController).value.equals((ComposeContentController()
+          ..value = valueBefore
+          ..insertPadded(quoteAndReplyPlaceholder(store, message: message))
+        ).value);
+        check(contentController).validationErrors.contains(ContentValidationError.quoteAndReplyInProgress);
+      }
 
-      final valueBefore = contentController.value;
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-      await tapQuoteAndReplyButton(tester);
-      checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
-      await tester.pump(Duration.zero); // message is fetched; compose box updates
-      check(composeBoxController.contentFocusNode.hasFocus).isTrue();
-      checkSuccessState(store, contentController,
-        valueBefore: valueBefore, message: message, rawContent: 'Hello world');
-    });
+      void checkSuccessState(PerAccountStore store, ComposeContentController contentController, {
+        required TextEditingValue valueBefore,
+        required Message message,
+        required String rawContent,
+      }) {
+        final builder = ComposeContentController()
+          ..value = valueBefore
+          ..insertPadded(quoteAndReply(store, message: message, rawContent: rawContent));
+        if (!valueBefore.selection.isValid) {
+          // (At the end of the process, we focus the input, which puts a cursor
+          // at text's end, if there was no cursor at the time.)
+          builder.selection = TextSelection.collapsed(offset: builder.text.length);
+        }
+        check(contentController).value.equals(builder.value);
+        check(contentController).not((it) => it.validationErrors.contains(ContentValidationError.quoteAndReplyInProgress));
+      }
 
-    group('in topic narrow', () {
-      testWidgets('smoke', (tester) async {
+      testWidgets('in channel narrow', (tester) async {
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: ChannelNarrow(message.streamId));
+
+        final composeBoxController = findComposeBoxController(tester) as StreamComposeBoxController;
+        final contentController = composeBoxController.content;
+
+        // Ensure channel-topics are loaded before testing quote & reply behavior
+        connection.prepare(body:
+          jsonEncode(GetStreamTopicsResult(topics: [eg.getStreamTopicsEntry()]).toJson()));
+        final topicController = composeBoxController.topic;
+        topicController.value = const TextEditingValue(text: kNoTopicTopic);
+
+        final valueBefore = contentController.value;
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        await tapQuoteAndReplyButton(tester);
+        checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
+        await tester.pump(Duration.zero); // message is fetched; compose box updates
+        check(composeBoxController.contentFocusNode.hasFocus).isTrue();
+        checkSuccessState(store, contentController,
+          valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+      });
+
+      group('in topic narrow', () {
+        testWidgets('smoke', (tester) async {
+          final message = eg.streamMessage();
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+          final composeBoxController = findComposeBoxController(tester)!;
+          final contentController = composeBoxController.content;
+
+          final valueBefore = contentController.value;
+          prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+          await tapQuoteAndReplyButton(tester);
+          checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
+          await tester.pump(Duration.zero); // message is fetched; compose box updates
+          check(composeBoxController.contentFocusNode.hasFocus).isTrue();
+          checkSuccessState(store, contentController,
+            valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+        });
+
+        testWidgets('no error if user lost posting permission after action sheet opened', (tester) async {
+          final stream = eg.stream();
+          final message = eg.streamMessage(stream: stream);
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+          await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId,
+            role: UserRole.guest));
+          await store.handleEvent(eg.channelUpdateEvent(stream,
+            property: ChannelPropertyName.channelPostPolicy,
+            value: ChannelPostPolicy.administrators));
+          await tester.pump();
+
+          await tapQuoteAndReplyButton(tester);
+          // no error
+        });
+      });
+
+      group('in DM narrow', () {
+        testWidgets('smoke', (tester) async {
+          final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
+          await setupToMessageActionSheet(tester,
+            message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
+
+          final composeBoxController = findComposeBoxController(tester)!;
+          final contentController = composeBoxController.content;
+
+          final valueBefore = contentController.value;
+          prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+          await tapQuoteAndReplyButton(tester);
+          checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
+          await tester.pump(Duration.zero); // message is fetched; compose box updates
+          check(composeBoxController.contentFocusNode.hasFocus).isTrue();
+          checkSuccessState(store, contentController,
+            valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+        });
+
+        testWidgets('no error if recipient was deactivated while raw-content request in progress', (tester) async {
+          final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
+          await setupToMessageActionSheet(tester,
+            message: message,
+            narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
+
+          prepareRawContentResponseSuccess(
+            message: message,
+            rawContent: 'Hello world',
+            delay: const Duration(seconds: 5),
+          );
+          await tapQuoteAndReplyButton(tester);
+          await tester.pump(const Duration(seconds: 1)); // message not yet fetched
+
+          await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.otherUser.userId,
+            isActive: false));
+          await tester.pump();
+          // no error
+          await tester.pump(const Duration(seconds: 4));
+        });
+      });
+
+      testWidgets('request has an error', (tester) async {
         final message = eg.streamMessage();
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
         final composeBoxController = findComposeBoxController(tester)!;
         final contentController = composeBoxController.content;
 
-        final valueBefore = contentController.value;
-        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        final valueBefore = contentController.value = TextEditingValue.empty;
+        prepareRawContentResponseError();
         await tapQuoteAndReplyButton(tester);
         checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
-        await tester.pump(Duration.zero); // message is fetched; compose box updates
-        check(composeBoxController.contentFocusNode.hasFocus).isTrue();
-        checkSuccessState(store, contentController,
-          valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+        await tester.pump(Duration.zero); // error arrives; error dialog shows
+
+        await tester.tap(find.byWidget(checkErrorDialog(tester,
+          expectedTitle: 'Quotation failed',
+          expectedMessage: 'That message does not seem to exist.',
+        )));
+
+        check(contentController.value).equals(const TextEditingValue(
+          // The placeholder was removed. (A newline from the placeholder's
+          // insertPadded remains; I guess ideally we'd try to prevent that.)
+          text: '\n',
+
+          // (At the end of the process, we focus the input.)
+          selection: TextSelection.collapsed(offset: 1), //
+        ));
       });
 
-      testWidgets('no error if user lost posting permission after action sheet opened', (tester) async {
-        final stream = eg.stream();
-        final message = eg.streamMessage(stream: stream);
-        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      testWidgets('not offered in CombinedFeedNarrow (composing to reply is not yet supported)', (tester) async {
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: const CombinedFeedNarrow());
+        check(findQuoteAndReplyButton(tester)).isNull();
+      });
 
-        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId,
-          role: UserRole.guest));
-        await store.handleEvent(eg.channelUpdateEvent(stream,
-          property: ChannelPropertyName.channelPostPolicy,
-          value: ChannelPostPolicy.administrators));
-        await tester.pump();
+      testWidgets('not offered in MentionsNarrow (composing to reply is not yet supported)', (tester) async {
+        final message = eg.streamMessage(flags: [MessageFlag.mentioned]);
+        await setupToMessageActionSheet(tester, message: message, narrow: const MentionsNarrow());
+        check(findQuoteAndReplyButton(tester)).isNull();
+      });
 
-        await tapQuoteAndReplyButton(tester);
-        // no error
+      testWidgets('not offered in StarredMessagesNarrow (composing to reply is not yet supported)', (tester) async {
+        final message = eg.streamMessage(flags: [MessageFlag.starred]);
+        await setupToMessageActionSheet(tester, message: message, narrow: const StarredMessagesNarrow());
+        check(findQuoteAndReplyButton(tester)).isNull();
       });
     });
 
-    group('in DM narrow', () {
-      testWidgets('smoke', (tester) async {
-        final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
-        await setupToMessageActionSheet(tester,
-          message: message, narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
+    group('MarkAsUnread', () {
+      testWidgets('not visible if message is not read', (tester) async {
+        final unreadMessage = eg.streamMessage(flags: []);
+        await setupToMessageActionSheet(tester, message: unreadMessage, narrow: TopicNarrow.ofMessage(unreadMessage));
 
-        final composeBoxController = findComposeBoxController(tester)!;
-        final contentController = composeBoxController.content;
-
-        final valueBefore = contentController.value;
-        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-        await tapQuoteAndReplyButton(tester);
-        checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
-        await tester.pump(Duration.zero); // message is fetched; compose box updates
-        check(composeBoxController.contentFocusNode.hasFocus).isTrue();
-        checkSuccessState(store, contentController,
-          valueBefore: valueBefore, message: message, rawContent: 'Hello world');
+        check(find.byIcon(Icons.mark_chat_unread_outlined).evaluate()).isEmpty();
       });
 
-      testWidgets('no error if recipient was deactivated while raw-content request in progress', (tester) async {
-        final message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
-        await setupToMessageActionSheet(tester,
-          message: message,
-          narrow: DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
+      testWidgets('visible if message is read', (tester) async {
+        final readMessage = eg.streamMessage(flags: [MessageFlag.read]);
+        await setupToMessageActionSheet(tester, message: readMessage, narrow: TopicNarrow.ofMessage(readMessage));
 
-        prepareRawContentResponseSuccess(
-          message: message,
-          rawContent: 'Hello world',
-          delay: const Duration(seconds: 5),
+        check(find.byIcon(Icons.mark_chat_unread_outlined).evaluate()).single;
+      });
+
+      group('onPressed', () {
+        testWidgets('smoke test', (tester) async {
+          final message = eg.streamMessage(flags: [MessageFlag.read]);
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+          connection.prepare(json: UpdateMessageFlagsForNarrowResult(
+            processedCount: 11, updatedCount: 3,
+            firstProcessedId: 1, lastProcessedId: 1980,
+            foundOldest: true, foundNewest: true).toJson());
+
+          await tester.ensureVisible(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
+          await tester.tap(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
+          await tester.pumpAndSettle();
+          check(connection.lastRequest).isA<http.Request>()
+            ..method.equals('POST')
+            ..url.path.equals('/api/v1/messages/flags/narrow')
+            ..bodyFields.deepEquals({
+                'anchor': '${message.id}',
+                'include_anchor': 'true',
+                'num_before': '0',
+                'num_after': '1000',
+                'narrow': jsonEncode(TopicNarrow.ofMessage(message).apiEncode()),
+                'op': 'remove',
+                'flag': 'read',
+              });
+        });
+
+        testWidgets('on topic move, acts on new topic', (tester) async {
+          final stream = eg.stream();
+          const topic = 'old topic';
+          final message = eg.streamMessage(flags: [MessageFlag.read],
+            stream: stream, topic: topic);
+          await setupToMessageActionSheet(tester, message: message,
+            narrow: TopicNarrow.ofMessage(message));
+
+          // Get the action sheet fully deployed while the old narrow applies.
+          // (This way we maximize the range of potential bugs this test can catch,
+          // by giving the code maximum opportunity to latch onto the old topic.)
+          await tester.pumpAndSettle();
+
+          final newStream = eg.stream();
+          const newTopic = 'other topic';
+          // This result isn't quite realistic for this request: it should get
+          // the updated channel/stream ID and topic, because we don't even
+          // start the request until after we get the move event.
+          // But constructing the right result is annoying at the moment, and
+          // it doesn't matter anyway: [MessageStoreImpl.reconcileMessages] will
+          // keep the version updated by the event.  If that somehow changes in
+          // some future refactor, it'll cause this test to fail.
+          connection.prepare(json: eg.newestGetMessagesResult(
+            foundOldest: true, messages: [message]).toJson());
+          await store.handleEvent(eg.updateMessageEventMoveFrom(
+            newStreamId: newStream.streamId, newTopicStr: newTopic,
+            propagateMode: PropagateMode.changeAll,
+            origMessages: [message]));
+
+          connection.prepare(json: UpdateMessageFlagsForNarrowResult(
+            processedCount: 11, updatedCount: 3,
+            firstProcessedId: 1, lastProcessedId: 1980,
+            foundOldest: true, foundNewest: true).toJson());
+          await tester.tap(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
+          await tester.pumpAndSettle();
+          check(connection.lastRequest).isA<http.Request>()
+            ..method.equals('POST')
+            ..url.path.equals('/api/v1/messages/flags/narrow')
+            ..bodyFields['narrow'].equals(
+                jsonEncode(eg.topicNarrow(newStream.streamId, newTopic).apiEncode()));
+        });
+
+        testWidgets('shows error when fails', (tester) async {
+          final message = eg.streamMessage(flags: [MessageFlag.read]);
+          await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+          connection.prepare(exception: http.ClientException('Oops'));
+          final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+
+          await tester.ensureVisible(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
+          await tester.tap(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
+          await tester.pumpAndSettle();
+          checkErrorDialog(tester,
+            expectedTitle: zulipLocalizations.errorMarkAsUnreadFailedTitle,
+            expectedMessage: 'NetworkException: Oops (ClientException: Oops)');
+        });
+      });
+    });
+
+    group('CopyMessageTextButton', () {
+      setUp(() async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          MockClipboard().handleMethodCall,
         );
-        await tapQuoteAndReplyButton(tester);
-        await tester.pump(const Duration(seconds: 1)); // message not yet fetched
-
-        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.otherUser.userId,
-          isActive: false));
-        await tester.pump();
-        // no error
-        await tester.pump(const Duration(seconds: 4));
       });
-    });
 
-    testWidgets('request has an error', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      Future<void> tapCopyMessageTextButton(WidgetTester tester) async {
+        await tester.ensureVisible(find.byIcon(ZulipIcons.copy, skipOffstage: false));
+        await tester.tap(find.byIcon(ZulipIcons.copy));
+        await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+      }
 
-      final composeBoxController = findComposeBoxController(tester)!;
-      final contentController = composeBoxController.content;
-
-      final valueBefore = contentController.value = TextEditingValue.empty;
-      prepareRawContentResponseError();
-      await tapQuoteAndReplyButton(tester);
-      checkLoadingState(store, contentController, valueBefore: valueBefore, message: message);
-      await tester.pump(Duration.zero); // error arrives; error dialog shows
-
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: 'Quotation failed',
-        expectedMessage: 'That message does not seem to exist.',
-      )));
-
-      check(contentController.value).equals(const TextEditingValue(
-        // The placeholder was removed. (A newline from the placeholder's
-        // insertPadded remains; I guess ideally we'd try to prevent that.)
-        text: '\n',
-
-        // (At the end of the process, we focus the input.)
-        selection: TextSelection.collapsed(offset: 1), //
-      ));
-    });
-
-    testWidgets('not offered in CombinedFeedNarrow (composing to reply is not yet supported)', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: const CombinedFeedNarrow());
-      check(findQuoteAndReplyButton(tester)).isNull();
-    });
-
-    testWidgets('not offered in MentionsNarrow (composing to reply is not yet supported)', (tester) async {
-      final message = eg.streamMessage(flags: [MessageFlag.mentioned]);
-      await setupToMessageActionSheet(tester, message: message, narrow: const MentionsNarrow());
-      check(findQuoteAndReplyButton(tester)).isNull();
-    });
-
-    testWidgets('not offered in StarredMessagesNarrow (composing to reply is not yet supported)', (tester) async {
-      final message = eg.streamMessage(flags: [MessageFlag.starred]);
-      await setupToMessageActionSheet(tester, message: message, narrow: const StarredMessagesNarrow());
-      check(findQuoteAndReplyButton(tester)).isNull();
-    });
-  });
-
-  group('MarkAsUnread', () {
-    testWidgets('not visible if message is not read', (tester) async {
-      final unreadMessage = eg.streamMessage(flags: []);
-      await setupToMessageActionSheet(tester, message: unreadMessage, narrow: TopicNarrow.ofMessage(unreadMessage));
-
-      check(find.byIcon(Icons.mark_chat_unread_outlined).evaluate()).isEmpty();
-    });
-
-    testWidgets('visible if message is read', (tester) async {
-      final readMessage = eg.streamMessage(flags: [MessageFlag.read]);
-      await setupToMessageActionSheet(tester, message: readMessage, narrow: TopicNarrow.ofMessage(readMessage));
-
-      check(find.byIcon(Icons.mark_chat_unread_outlined).evaluate()).single;
-    });
-
-    group('onPressed', () {
-      testWidgets('smoke test', (tester) async {
-        final message = eg.streamMessage(flags: [MessageFlag.read]);
+      testWidgets('success', (tester) async {
+        final message = eg.streamMessage();
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-        connection.prepare(json: UpdateMessageFlagsForNarrowResult(
-          processedCount: 11, updatedCount: 3,
-          firstProcessedId: 1, lastProcessedId: 1980,
-          foundOldest: true, foundNewest: true).toJson());
-
-        await tester.ensureVisible(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
-        await tester.tap(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
-        await tester.pumpAndSettle();
-        check(connection.lastRequest).isA<http.Request>()
-          ..method.equals('POST')
-          ..url.path.equals('/api/v1/messages/flags/narrow')
-          ..bodyFields.deepEquals({
-              'anchor': '${message.id}',
-              'include_anchor': 'true',
-              'num_before': '0',
-              'num_after': '1000',
-              'narrow': jsonEncode(TopicNarrow.ofMessage(message).apiEncode()),
-              'op': 'remove',
-              'flag': 'read',
-            });
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        await tapCopyMessageTextButton(tester);
+        await tester.pump(Duration.zero);
+        check(await Clipboard.getData('text/plain')).isNotNull().text.equals('Hello world');
       });
 
-      testWidgets('on topic move, acts on new topic', (tester) async {
-        final stream = eg.stream();
-        const topic = 'old topic';
-        final message = eg.streamMessage(flags: [MessageFlag.read],
-          stream: stream, topic: topic);
-        await setupToMessageActionSheet(tester, message: message,
-          narrow: TopicNarrow.ofMessage(message));
+      testWidgets('can show snackbar on success', (tester) async {
+        // Regression test for: https://github.com/zulip/zulip-flutter/issues/732
+        testBinding.deviceInfoResult = const IosDeviceInfo(systemVersion: '16.0');
 
-        // Get the action sheet fully deployed while the old narrow applies.
-        // (This way we maximize the range of potential bugs this test can catch,
-        // by giving the code maximum opportunity to latch onto the old topic.)
-        await tester.pumpAndSettle();
-
-        final newStream = eg.stream();
-        const newTopic = 'other topic';
-        // This result isn't quite realistic for this request: it should get
-        // the updated channel/stream ID and topic, because we don't even
-        // start the request until after we get the move event.
-        // But constructing the right result is annoying at the moment, and
-        // it doesn't matter anyway: [MessageStoreImpl.reconcileMessages] will
-        // keep the version updated by the event.  If that somehow changes in
-        // some future refactor, it'll cause this test to fail.
-        connection.prepare(json: eg.newestGetMessagesResult(
-          foundOldest: true, messages: [message]).toJson());
-        await store.handleEvent(eg.updateMessageEventMoveFrom(
-          newStreamId: newStream.streamId, newTopicStr: newTopic,
-          propagateMode: PropagateMode.changeAll,
-          origMessages: [message]));
-
-        connection.prepare(json: UpdateMessageFlagsForNarrowResult(
-          processedCount: 11, updatedCount: 3,
-          firstProcessedId: 1, lastProcessedId: 1980,
-          foundOldest: true, foundNewest: true).toJson());
-        await tester.tap(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
-        await tester.pumpAndSettle();
-        check(connection.lastRequest).isA<http.Request>()
-          ..method.equals('POST')
-          ..url.path.equals('/api/v1/messages/flags/narrow')
-          ..bodyFields['narrow'].equals(
-              jsonEncode(eg.topicNarrow(newStream.streamId, newTopic).apiEncode()));
-      });
-
-      testWidgets('shows error when fails', (tester) async {
-        final message = eg.streamMessage(flags: [MessageFlag.read]);
+        final message = eg.streamMessage();
         await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
 
-        connection.prepare(exception: http.ClientException('Oops'));
+        // Make the request take a bit of time to complete…
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world',
+          delay: const Duration(milliseconds: 500));
+        await tapCopyMessageTextButton(tester);
+        // … and pump a frame to finish the NavigationState.pop animation…
+        await tester.pump(const Duration(milliseconds: 250));
+        // … before the request finishes.  This is the repro condition for #732.
+        await tester.pump(const Duration(milliseconds: 250));
+
+        final snackbar = tester.widget<SnackBar>(find.byType(SnackBar));
+        check(snackbar.behavior).equals(SnackBarBehavior.floating);
         final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        tester.widget(find.descendant(matchRoot: true,
+          of: find.byWidget(snackbar.content),
+          matching: find.text(zulipLocalizations.successMessageTextCopied)));
+      });
 
-        await tester.ensureVisible(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
-        await tester.tap(find.byIcon(Icons.mark_chat_unread_outlined, skipOffstage: false));
-        await tester.pumpAndSettle();
-        checkErrorDialog(tester,
-          expectedTitle: zulipLocalizations.errorMarkAsUnreadFailedTitle,
-          expectedMessage: 'NetworkException: Oops (ClientException: Oops)');
+      testWidgets('request has an error', (tester) async {
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+        prepareRawContentResponseError();
+        await tapCopyMessageTextButton(tester);
+        await tester.pump(Duration.zero); // error arrives; error dialog shows
+
+        await tester.tap(find.byWidget(checkErrorDialog(tester,
+          expectedTitle: 'Copying failed',
+          expectedMessage: 'That message does not seem to exist.',
+        )));
+        check(await Clipboard.getData('text/plain')).isNull();
       });
     });
-  });
 
-  group('CopyMessageTextButton', () {
-    setUp(() async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-        SystemChannels.platform,
-        MockClipboard().handleMethodCall,
-      );
+    group('CopyMessageLinkButton', () {
+      setUp(() async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          MockClipboard().handleMethodCall,
+        );
+      });
+
+      Future<void> tapCopyMessageLinkButton(WidgetTester tester) async {
+        await tester.ensureVisible(find.byIcon(Icons.link, skipOffstage: false));
+        await tester.tap(find.byIcon(Icons.link));
+        await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+      }
+
+      testWidgets('copies message link to clipboard', (tester) async {
+        final message = eg.streamMessage();
+        final narrow = TopicNarrow.ofMessage(message);
+        await setupToMessageActionSheet(tester, message: message, narrow: narrow);
+
+        await tapCopyMessageLinkButton(tester);
+        await tester.pump(Duration.zero);
+        final expectedLink = narrowLink(store, narrow, nearMessageId: message.id).toString();
+        check(await Clipboard.getData('text/plain')).isNotNull().text.equals(expectedLink);
+      });
     });
 
-    Future<void> tapCopyMessageTextButton(WidgetTester tester) async {
-      await tester.ensureVisible(find.byIcon(ZulipIcons.copy, skipOffstage: false));
-      await tester.tap(find.byIcon(ZulipIcons.copy));
-      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
-    }
+    group('ShareButton', () {
+      // Tests should call this.
+      MockSharePlus setupMockSharePlus() {
+        final mock = MockSharePlus();
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+          MethodChannelShare.channel,
+          mock.handleMethodCall,
+        );
+        return mock;
+      }
 
-    testWidgets('success', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      Future<void> tapShareButton(WidgetTester tester) async {
+        await tester.ensureVisible(find.byIcon(ZulipIcons.share, skipOffstage: false));
+        await tester.tap(find.byIcon(ZulipIcons.share));
+        await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+      }
 
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-      await tapCopyMessageTextButton(tester);
-      await tester.pump(Duration.zero);
-      check(await Clipboard.getData('text/plain')).isNotNull().text.equals('Hello world');
+      testWidgets('request succeeds; sharing succeeds', (tester) async {
+        final mockSharePlus = setupMockSharePlus();
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        await tapShareButton(tester);
+        await tester.pump(Duration.zero);
+        check(mockSharePlus.sharedString).equals('Hello world');
+      });
+
+      testWidgets('request succeeds; sharing fails', (tester) async {
+        final mockSharePlus = setupMockSharePlus();
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+        prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
+        mockSharePlus.resultString = 'dev.fluttercommunity.plus/share/unavailable';
+        await tapShareButton(tester);
+        await tester.pump(Duration.zero);
+        check(mockSharePlus.sharedString).equals('Hello world');
+        await tester.pump();
+        await tester.tap(find.byWidget(checkErrorDialog(tester,
+          expectedTitle: 'Sharing failed')));
+      });
+
+      testWidgets('request has an error', (tester) async {
+        final mockSharePlus = setupMockSharePlus();
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+
+        prepareRawContentResponseError();
+        await tapShareButton(tester);
+        await tester.pump(Duration.zero); // error arrives; error dialog shows
+
+        await tester.tap(find.byWidget(checkErrorDialog(tester,
+          expectedTitle: 'Sharing failed',
+          expectedMessage: 'That message does not seem to exist.',
+        )));
+
+        check(mockSharePlus.sharedString).isNull();
+      });
     });
 
-    testWidgets('can show snackbar on success', (tester) async {
-      // Regression test for: https://github.com/zulip/zulip-flutter/issues/732
-      testBinding.deviceInfoResult = const IosDeviceInfo(systemVersion: '16.0');
-
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-
-      // Make the request take a bit of time to complete…
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world',
-        delay: const Duration(milliseconds: 500));
-      await tapCopyMessageTextButton(tester);
-      // … and pump a frame to finish the NavigationState.pop animation…
-      await tester.pump(const Duration(milliseconds: 250));
-      // … before the request finishes.  This is the repro condition for #732.
-      await tester.pump(const Duration(milliseconds: 250));
-
-      final snackbar = tester.widget<SnackBar>(find.byType(SnackBar));
-      check(snackbar.behavior).equals(SnackBarBehavior.floating);
+    group('MessageActionSheetCancelButton', () {
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-      tester.widget(find.descendant(matchRoot: true,
-        of: find.byWidget(snackbar.content),
-        matching: find.text(zulipLocalizations.successMessageTextCopied)));
-    });
 
-    testWidgets('request has an error', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+      void checkActionSheet(WidgetTester tester, {required bool isShown}) {
+        check(find.text(zulipLocalizations.actionSheetOptionStarMessage)
+          .evaluate().length).equals(isShown ? 1 : 0);
 
-      prepareRawContentResponseError();
-      await tapCopyMessageTextButton(tester);
-      await tester.pump(Duration.zero); // error arrives; error dialog shows
+        final findCancelButton = find.text(zulipLocalizations.dialogCancel);
+        check(findCancelButton.evaluate().length).equals(isShown ? 1 : 0);
+      }
 
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: 'Copying failed',
-        expectedMessage: 'That message does not seem to exist.',
-      )));
-      check(await Clipboard.getData('text/plain')).isNull();
-    });
-  });
+      testWidgets('pressing the button dismisses the action sheet', (tester) async {
+        final message = eg.streamMessage();
+        await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
+        checkActionSheet(tester, isShown: true);
 
-  group('CopyMessageLinkButton', () {
-    setUp(() async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-        SystemChannels.platform,
-        MockClipboard().handleMethodCall,
-      );
-    });
-
-    Future<void> tapCopyMessageLinkButton(WidgetTester tester) async {
-      await tester.ensureVisible(find.byIcon(Icons.link, skipOffstage: false));
-      await tester.tap(find.byIcon(Icons.link));
-      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
-    }
-
-    testWidgets('copies message link to clipboard', (tester) async {
-      final message = eg.streamMessage();
-      final narrow = TopicNarrow.ofMessage(message);
-      await setupToMessageActionSheet(tester, message: message, narrow: narrow);
-
-      await tapCopyMessageLinkButton(tester);
-      await tester.pump(Duration.zero);
-      final expectedLink = narrowLink(store, narrow, nearMessageId: message.id).toString();
-      check(await Clipboard.getData('text/plain')).isNotNull().text.equals(expectedLink);
-    });
-  });
-
-  group('ShareButton', () {
-    // Tests should call this.
-    MockSharePlus setupMockSharePlus() {
-      final mock = MockSharePlus();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-        MethodChannelShare.channel,
-        mock.handleMethodCall,
-      );
-      return mock;
-    }
-
-    Future<void> tapShareButton(WidgetTester tester) async {
-      await tester.ensureVisible(find.byIcon(ZulipIcons.share, skipOffstage: false));
-      await tester.tap(find.byIcon(ZulipIcons.share));
-      await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
-    }
-
-    testWidgets('request succeeds; sharing succeeds', (tester) async {
-      final mockSharePlus = setupMockSharePlus();
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-      await tapShareButton(tester);
-      await tester.pump(Duration.zero);
-      check(mockSharePlus.sharedString).equals('Hello world');
-    });
-
-    testWidgets('request succeeds; sharing fails', (tester) async {
-      final mockSharePlus = setupMockSharePlus();
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-
-      prepareRawContentResponseSuccess(message: message, rawContent: 'Hello world');
-      mockSharePlus.resultString = 'dev.fluttercommunity.plus/share/unavailable';
-      await tapShareButton(tester);
-      await tester.pump(Duration.zero);
-      check(mockSharePlus.sharedString).equals('Hello world');
-      await tester.pump();
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: 'Sharing failed')));
-    });
-
-    testWidgets('request has an error', (tester) async {
-      final mockSharePlus = setupMockSharePlus();
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-
-      prepareRawContentResponseError();
-      await tapShareButton(tester);
-      await tester.pump(Duration.zero); // error arrives; error dialog shows
-
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: 'Sharing failed',
-        expectedMessage: 'That message does not seem to exist.',
-      )));
-
-      check(mockSharePlus.sharedString).isNull();
-    });
-  });
-
-  group('MessageActionSheetCancelButton', () {
-    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-
-    void checkActionSheet(WidgetTester tester, {required bool isShown}) {
-      check(find.text(zulipLocalizations.actionSheetOptionStarMessage)
-        .evaluate().length).equals(isShown ? 1 : 0);
-
-      final findCancelButton = find.text(zulipLocalizations.dialogCancel);
-      check(findCancelButton.evaluate().length).equals(isShown ? 1 : 0);
-    }
-
-    testWidgets('pressing the button dismisses the action sheet', (tester) async {
-      final message = eg.streamMessage();
-      await setupToMessageActionSheet(tester, message: message, narrow: TopicNarrow.ofMessage(message));
-      checkActionSheet(tester, isShown: true);
-
-      final findCancelButton = find.text(zulipLocalizations.dialogCancel);
-      await tester.tap(findCancelButton);
-      await tester.pumpAndSettle();
-      checkActionSheet(tester, isShown: false);
+        final findCancelButton = find.text(zulipLocalizations.dialogCancel);
+        await tester.tap(findCancelButton);
+        await tester.pumpAndSettle();
+        checkActionSheet(tester, isShown: false);
+      });
     });
   });
 }

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -125,6 +125,19 @@ void main() {
       await store.addMessage(message);
     }
 
+    void checkButtons() {
+      final actionSheetFinder = find.byType(BottomSheet);
+      check(actionSheetFinder).findsOne();
+
+      void checkButton(String label) {
+        check(
+          find.descendant(of: actionSheetFinder, matching: find.text(label))
+        ).findsOne();
+      }
+
+      checkButton('Follow topic');
+    }
+
     testWidgets('show from inbox', (tester) async {
       await prepare();
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
@@ -135,8 +148,7 @@ void main() {
       await tester.longPress(find.text(topic));
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
-      check(find.byType(BottomSheet)).findsOne();
-      check(find.text('Follow topic')).findsOne();
+      checkButtons();
     });
 
     testWidgets('show from app bar', (tester) async {
@@ -153,8 +165,7 @@ void main() {
       await tester.longPress(topicRow);
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
-      check(find.byType(BottomSheet)).findsOne();
-      check(find.text('Follow topic')).findsOne();
+      checkButtons();
     });
 
     testWidgets('show from recipient header', (tester) async {
@@ -170,8 +181,7 @@ void main() {
         of: find.byType(RecipientHeader), matching: find.text(topic)));
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
-      check(find.byType(BottomSheet)).findsOne();
-      check(find.text('Follow topic')).findsOne();
+      checkButtons();
     });
   });
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -195,6 +195,25 @@ void main() {
       await tester.pump(const Duration(milliseconds: 250));
     }
 
+    Future<void> showFromRecipientHeader(WidgetTester tester, {
+      StreamMessage? message,
+    }) async {
+      final effectiveMessage = message ?? someMessage;
+
+      connection.prepare(json: eg.newestGetMessagesResult(
+        foundOldest: true, messages: [effectiveMessage]).toJson());
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
+      // global store, per-account store, and message list get loaded
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.descendant(
+        of: find.byType(RecipientHeader),
+        matching: find.text(effectiveMessage.topic.displayName)));
+      // sheet appears onscreen; default duration of bottom-sheet enter animation
+      await tester.pump(const Duration(milliseconds: 250));
+    }
+
     group('showTopicActionSheet', () {
       void checkButtons() {
         final actionSheetFinder = find.byType(BottomSheet);
@@ -228,17 +247,7 @@ void main() {
 
       testWidgets('show from recipient header', (tester) async {
         await prepare();
-        connection.prepare(json: eg.newestGetMessagesResult(
-          foundOldest: true, messages: [someMessage]).toJson());
-        await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-          child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
-        // global store, per-account store, and message list get loaded
-        await tester.pumpAndSettle();
-
-        await tester.longPress(find.descendant(
-          of: find.byType(RecipientHeader), matching: find.text(someTopic)));
-        // sheet appears onscreen; default duration of bottom-sheet enter animation
-        await tester.pump(const Duration(milliseconds: 250));
+        await showFromRecipientHeader(tester);
         checkButtons();
       });
     });

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -119,6 +119,7 @@ void main() {
         String topic = someTopic,
         bool isChannelSubscribed = true,
         bool? isChannelMuted,
+        UserTopicVisibilityPolicy? visibilityPolicy,
         UnreadMessagesSnapshot? unreadMsgs,
         int? zulipFeatureLevel,
       }) async {
@@ -133,6 +134,9 @@ void main() {
           streams: [effectiveChannel],
           subscriptions: isChannelSubscribed
             ? [eg.subscription(effectiveChannel, isMuted: isChannelMuted ?? false)]
+            : null,
+          userTopics: visibilityPolicy != null
+            ? [eg.userTopicItem(effectiveChannel, topic, visibilityPolicy)]
             : null,
           unreadMsgs: unreadMsgs,
           zulipFeatureLevel: zulipFeatureLevel));

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -212,7 +212,6 @@ void main() {
     });
 
     group('UserTopicUpdateButton', () {
-      late ZulipStream channel;
       late String topic;
 
       final mute =     find.text('Mute topic');
@@ -231,10 +230,9 @@ void main() {
       }) async {
         addTearDown(testBinding.reset);
 
-        channel = eg.stream();
         topic = 'isChannelMuted: $isChannelMuted, policy: $visibilityPolicy';
         await prepare(
-          channel: channel,
+          channel: someChannel,
           topic: topic,
           isChannelSubscribed: isChannelMuted != null, // shorthand; see dartdoc
           isChannelMuted: isChannelMuted,
@@ -243,12 +241,12 @@ void main() {
         );
 
         final message = eg.streamMessage(
-          stream: channel, topic: topic, sender: eg.otherUser);
+          stream: someChannel, topic: topic, sender: eg.otherUser);
         connection.prepare(json: eg.newestGetMessagesResult(
           foundOldest: true, messages: [message]).toJson());
         await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
           child: MessageListPage(
-            initNarrow: eg.topicNarrow(channel.streamId, topic))));
+            initNarrow: eg.topicNarrow(someChannel.streamId, topic))));
         await tester.pumpAndSettle();
 
         await tester.longPress(find.descendant(
@@ -275,7 +273,7 @@ void main() {
         check(connection.lastRequest).isA<http.Request>()
           ..url.path.equals('/api/v1/user_topics')
           ..bodyFields.deepEquals({
-            'stream_id': '${channel.streamId}',
+            'stream_id': '${someChannel.streamId}',
             'topic': topic,
             'visibility_policy': jsonEncode(expectedPolicy),
           });

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -274,17 +274,7 @@ void main() {
 
         final message = eg.streamMessage(
           stream: someChannel, topic: topic, sender: eg.otherUser);
-        connection.prepare(json: eg.newestGetMessagesResult(
-          foundOldest: true, messages: [message]).toJson());
-        await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
-          child: MessageListPage(
-            initNarrow: eg.topicNarrow(someChannel.streamId, topic))));
-        await tester.pumpAndSettle();
-
-        await tester.longPress(find.descendant(
-          of: find.byType(RecipientHeader), matching: find.text(topic)));
-        // sheet appears onscreen; default duration of bottom-sheet enter animation
-        await tester.pump(const Duration(milliseconds: 250));
+        await showFromAppBar(tester, channel: someChannel, topic: topic, message: message);
       }
 
       void checkButtons(List<Finder> expectedButtonFinders) {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -117,10 +117,13 @@ void main() {
       Future<void> prepare({
         ZulipStream? channel,
         String topic = someTopic,
+        bool isChannelSubscribed = true,
+        bool? isChannelMuted,
         UnreadMessagesSnapshot? unreadMsgs,
         int? zulipFeatureLevel,
       }) async {
         final effectiveChannel = channel ?? someChannel;
+        assert(isChannelSubscribed || isChannelMuted == null);
 
         addTearDown(testBinding.reset);
 
@@ -128,7 +131,9 @@ void main() {
         await testBinding.globalStore.add(account, eg.initialSnapshot(
           realmUsers: [eg.selfUser, eg.otherUser],
           streams: [effectiveChannel],
-          subscriptions: [eg.subscription(effectiveChannel)],
+          subscriptions: isChannelSubscribed
+            ? [eg.subscription(effectiveChannel, isMuted: isChannelMuted ?? false)]
+            : null,
           unreadMsgs: unreadMsgs,
           zulipFeatureLevel: zulipFeatureLevel));
         store = await testBinding.globalStore.perAccount(eg.selfAccount.id);

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -206,6 +206,8 @@ void main() {
     // TODO test that tapping a conversation row opens the message list
     //   for the conversation
 
+    // Tests for the topic action sheet are in test/widgets/action_sheet_test.dart.
+
     group('muting', () { // aka topic visibility
       testWidgets('baseline', (tester) async {
         final stream = eg.stream();

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -133,6 +133,8 @@ void main() {
   });
 
   group('app bar', () {
+    // Tests for the topic action sheet are in test/widgets/action_sheet_test.dart.
+
     testWidgets('has channel-feed action for topic narrows', (tester) async {
       final pushedRoutes = <Route<void>>[];
       final navObserver = TestNavigatorObserver()
@@ -748,6 +750,8 @@ void main() {
 
   group('recipient headers', () {
     group('StreamMessageRecipientHeader', () {
+      // Tests for the topic action sheet are in test/widgets/action_sheet_test.dart.
+
       final stream = eg.stream(name: 'stream name');
       const topic = 'topic name';
       final message = eg.streamMessage(stream: stream, topic: topic);


### PR DESCRIPTION
Here are the commits from #1301 that are just about refactoring the action-sheet tests. I've revised them for Zixuan's review https://github.com/zulip/zulip-flutter/pull/1301#pullrequestreview-2573663606 ; in particular by just removing an `assert(() {}())` wrapper (which isn't needed because it's only running in tests).