### PR TITLE
anchors 2/n: Fix three sticky-header bugs

### DIFF
--- a/lib/example/sticky_header.dart
+++ b/lib/example/sticky_header.dart
@@ -1,0 +1,345 @@
+/// Example app for exercising the sticky_header library.
+///
+/// This is useful when developing changes to [StickyHeaderListView],
+/// [SliverStickyHeaderList], and [StickyHeaderItem],
+/// for experimenting visually with changes.
+///
+/// To use this example app, run the command:
+///     flutter run lib/example/sticky_header.dart
+/// or run this file from your IDE.
+///
+/// One inconvenience: this means the example app will use the same app ID
+/// as the actual Zulip app.  The app's data remains untouched, though, so
+/// a normal `flutter run` will put things back as they were.
+/// This inconvenience could be fixed with a bit more work: we'd use
+/// `flutter run --flavor`, and define an Android flavor in build.gradle
+/// and an Xcode scheme in the iOS build config
+/// so as to set the app ID differently.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../widgets/sticky_header.dart';
+
+/// Example page using [StickyHeaderListView] and [StickyHeaderItem] in a
+/// vertically-scrolling list.
+class ExampleVertical extends StatelessWidget {
+  ExampleVertical({
+    super.key,
+    required this.title,
+    this.reverse = false,
+    this.headerDirection = AxisDirection.down,
+  }) : assert(axisDirectionToAxis(headerDirection) == Axis.vertical);
+
+  final String title;
+  final bool reverse;
+  final AxisDirection headerDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    final headerAtBottom = axisDirectionIsReversed(headerDirection);
+
+    const numSections = 100;
+    const numPerSection = 10;
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+
+      // Invoke StickyHeaderListView the same way you'd invoke ListView.
+      // The constructor takes the same arguments.
+      body: StickyHeaderListView.separated(
+        reverse: reverse,
+        reverseHeader: headerAtBottom,
+        itemCount: numSections,
+        separatorBuilder: (context, i) => const SizedBox.shrink(),
+
+        // Use StickyHeaderItem as an item widget in the ListView.
+        // A header will float over the item as needed in order to
+        // "stick" at the edge of the viewport.
+        //
+        // You can also include non-StickyHeaderItem items in the list.
+        // They'll behave just like in a plain ListView.
+        //
+        // Each StickyHeaderItem needs to be an item directly in the list, not
+        // wrapped inside other widgets that affect layout, in order to get
+        // the sticky-header behavior.
+        itemBuilder: (context, i) => StickyHeaderItem(
+          header: WideHeader(i: i),
+          child: Column(
+            verticalDirection: headerAtBottom
+              ? VerticalDirection.up : VerticalDirection.down,
+            children: List.generate(
+              numPerSection + 1, (j) {
+                if (j == 0) return WideHeader(i: i);
+                return WideItem(i: i, j: j-1);
+              })))));
+  }
+}
+
+/// Example page using [StickyHeaderListView] and [StickyHeaderItem] in a
+/// horizontally-scrolling list.
+class ExampleHorizontal extends StatelessWidget {
+  ExampleHorizontal({
+    super.key,
+    required this.title,
+    this.reverse = false,
+    required this.headerDirection,
+  }) : assert(axisDirectionToAxis(headerDirection) == Axis.horizontal);
+
+  final String title;
+  final bool reverse;
+  final AxisDirection headerDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    final headerAtRight = axisDirectionIsReversed(headerDirection);
+    const numSections = 100;
+    const numPerSection = 10;
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: StickyHeaderListView.separated(
+
+        // StickyHeaderListView and StickyHeaderItem also work for horizontal
+        // scrolling.  Pass `scrollDirection: Axis.horizontal` to the
+        // StickyHeaderListView constructor, just like for ListView.
+        scrollDirection: Axis.horizontal,
+        reverse: reverse,
+        reverseHeader: headerAtRight,
+        itemCount: numSections,
+        separatorBuilder: (context, i) => const SizedBox.shrink(),
+        itemBuilder: (context, i) => StickyHeaderItem(
+          header: TallHeader(i: i),
+          child: Row(
+            textDirection: headerAtRight ? TextDirection.rtl : TextDirection.ltr,
+            children: List.generate(
+              numPerSection + 1,
+              (j) {
+                if (j == 0) return TallHeader(i: i);
+                return TallItem(i: i, j: j-1, numPerSection: numPerSection);
+              })))));
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// That's it!
+//
+// The rest of this file is boring infrastructure for navigating to the
+// different examples, and for having some content to put inside them.
+//
+////////////////////////////////////////////////////////////////////////////
+
+class WideHeader extends StatelessWidget {
+  const WideHeader({super.key, required this.i});
+
+  final int i;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colorScheme.primaryContainer,
+      child: ListTile(
+        title: Text("Section ${i + 1}",
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimaryContainer))));
+  }
+}
+
+class WideItem extends StatelessWidget {
+  const WideItem({super.key, required this.i, required this.j});
+
+  final int i;
+  final int j;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(title: Text("Item ${i + 1}.${j + 1}"));
+  }
+}
+
+class TallHeader extends StatelessWidget {
+  const TallHeader({super.key, required this.i});
+
+  final int i;
+
+  @override
+  Widget build(BuildContext context) {
+    final contents = Column(children: [
+      Text("Section ${i + 1}",
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.onPrimaryContainer)),
+      const SizedBox(height: 8),
+      const Expanded(child: SizedBox.shrink()),
+      const SizedBox(height: 8),
+      const Text("end"),
+    ]);
+
+    return Container(
+      alignment: Alignment.center,
+      child: Card(
+        color: Theme.of(context).colorScheme.primaryContainer,
+        child: Padding(padding: const EdgeInsets.all(8), child: contents)));
+  }
+}
+
+class TallItem extends StatelessWidget {
+  const TallItem({super.key,
+    required this.i,
+    required this.j,
+    required this.numPerSection,
+  });
+
+  final int i;
+  final int j;
+  final int numPerSection;
+
+  @override
+  Widget build(BuildContext context) {
+    final heightFactor = (1 + j) / numPerSection;
+
+    final contents = Column(children: [
+      Text("Item ${i + 1}.${j + 1}"),
+      const SizedBox(height: 8),
+      Expanded(
+        child: FractionallySizedBox(
+          heightFactor: heightFactor,
+          child: ColoredBox(
+            color: Theme.of(context).colorScheme.secondary,
+            child: const SizedBox(width: 4)))),
+      const SizedBox(height: 8),
+      const Text("end"),
+    ]);
+
+    return Container(
+      alignment: Alignment.center,
+      child: Card(
+        child: Padding(padding: const EdgeInsets.all(8), child: contents)));
+  }
+}
+
+enum _ExampleType { vertical, horizontal }
+
+class MainPage extends StatelessWidget {
+  const MainPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final verticalItems = [
+      _buildItem(context, _ExampleType.vertical,
+        primary: true,
+        title: 'Scroll down, headers at top (a standard list)',
+        headerDirection: AxisDirection.down),
+      _buildItem(context, _ExampleType.vertical,
+        title: 'Scroll up, headers at top',
+        reverse: true,
+        headerDirection: AxisDirection.down),
+      _buildItem(context, _ExampleType.vertical,
+        title: 'Scroll down, headers at bottom',
+        headerDirection: AxisDirection.up),
+      _buildItem(context, _ExampleType.vertical,
+        title: 'Scroll up, headers at bottom',
+        reverse: true,
+        headerDirection: AxisDirection.up),
+    ];
+    final horizontalItems = [
+      _buildItem(context, _ExampleType.horizontal,
+        title: 'Scroll right, headers at left',
+        headerDirection: AxisDirection.right),
+      _buildItem(context, _ExampleType.horizontal,
+        title: 'Scroll left, headers at left',
+        reverse: true,
+        headerDirection: AxisDirection.right),
+      _buildItem(context, _ExampleType.horizontal,
+        title: 'Scroll right, headers at right',
+        headerDirection: AxisDirection.left),
+      _buildItem(context, _ExampleType.horizontal,
+        title: 'Scroll left, headers at right',
+        reverse: true,
+        headerDirection: AxisDirection.left),
+    ];
+    return Scaffold(
+        appBar: AppBar(title: const Text('Sticky Headers example')),
+        body: CustomScrollView(slivers: [
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 24),
+              child: Center(
+                child: Text("Vertical lists",
+                  style: Theme.of(context).textTheme.headlineMedium)))),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            sliver: SliverGrid.count(
+              childAspectRatio: 2,
+              crossAxisCount: 2,
+              children: verticalItems)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 24),
+              child: Center(
+                child: Text("Horizontal lists",
+                  style: Theme.of(context).textTheme.headlineMedium)))),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            sliver: SliverGrid.count(
+              childAspectRatio: 2,
+              crossAxisCount: 2,
+              children: horizontalItems)),
+        ]));
+  }
+
+  Widget _buildItem(BuildContext context, _ExampleType exampleType, {
+    required String title,
+    bool reverse = false,
+    required AxisDirection headerDirection,
+    bool primary = false,
+  }) {
+    Widget page;
+    switch (exampleType) {
+      case _ExampleType.vertical:
+        page = ExampleVertical(
+          title: title, reverse: reverse, headerDirection: headerDirection);
+        break;
+      case _ExampleType.horizontal:
+        page = ExampleHorizontal(
+          title: title, reverse: reverse, headerDirection: headerDirection);
+        break;
+    }
+
+    var label = Text(title,
+      textAlign: TextAlign.center,
+      style: TextStyle(
+        inherit: true,
+        fontSize: Theme.of(context).textTheme.titleMedium?.fontSize));
+    var buttonStyle = primary
+      ? null
+      : ElevatedButton.styleFrom(
+          foregroundColor: Theme.of(context).colorScheme.onSecondary,
+          backgroundColor: Theme.of(context).colorScheme.secondary);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      child: ElevatedButton(
+        style: buttonStyle,
+        onPressed: () => Navigator.of(context)
+          .push(MaterialPageRoute<void>(builder: (_) => page)),
+        child: label));
+  }
+}
+
+class ExampleApp extends StatelessWidget {
+  const ExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Sticky Headers example',
+      theme: ThemeData(
+        colorScheme:
+          ColorScheme.fromSeed(seedColor: const Color(0xff3366cc))),
+      home: const MainPage(),
+    );
+  }
+}
+
+void main() {
+  runApp(const ExampleApp());
+}

--- a/lib/example/sticky_header.dart
+++ b/lib/example/sticky_header.dart
@@ -119,6 +119,65 @@ class ExampleHorizontal extends StatelessWidget {
   }
 }
 
+/// An experimental example approximating the Zulip message list.
+class ExampleVerticalDouble extends StatelessWidget {
+  const ExampleVerticalDouble({
+    super.key,
+    required this.title,
+    // this.reverse = false,
+    // this.headerDirection = AxisDirection.down,
+  }); // : assert(axisDirectionToAxis(headerDirection) == Axis.vertical);
+
+  final String title;
+  // final bool reverse;
+  // final AxisDirection headerDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    const centerSliverKey = ValueKey('center sliver');
+    const numSections = 100;
+    const numBottomSections = 2;
+    const numPerSection = 10;
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: CustomScrollView(
+        semanticChildCount: numSections,
+        anchor: 0.5,
+        center: centerSliverKey,
+        slivers: [
+          SliverStickyHeaderList(
+            headerPlacement: HeaderPlacement.scrollingStart,
+            delegate: SliverChildBuilderDelegate(
+              childCount: numSections - numBottomSections,
+              (context, i) {
+                final ii = i + numBottomSections;
+                return StickyHeaderItem(
+                  header: WideHeader(i: ii),
+                  child: Column(
+                    children: List.generate(numPerSection + 1, (j) {
+                      if (j == 0) return WideHeader(i: ii);
+                      return WideItem(i: ii, j: j-1);
+                    })));
+              })),
+          SliverStickyHeaderList(
+            key: centerSliverKey,
+            headerPlacement: HeaderPlacement.scrollingStart,
+            delegate: SliverChildBuilderDelegate(
+              childCount: numBottomSections,
+              (context, i) {
+                final ii = numBottomSections - 1 - i;
+                return StickyHeaderItem(
+                  header: WideHeader(i: ii),
+                  child: Column(
+                    children: List.generate(numPerSection + 1, (j) {
+                        if (j == 0) return WideHeader(i: ii);
+                        return WideItem(i: ii, j: j-1);
+                      })));
+              })),
+        ]));
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////
 //
 // That's it!
@@ -257,6 +316,11 @@ class MainPage extends StatelessWidget {
         reverse: true,
         headerDirection: AxisDirection.left),
     ];
+    final otherItems = [
+      _buildButton(context,
+        title: 'Double slivers',
+        page: ExampleVerticalDouble(title: 'Double slivers')),
+    ];
     return Scaffold(
         appBar: AppBar(title: const Text('Sticky Headers example')),
         body: CustomScrollView(slivers: [
@@ -284,6 +348,18 @@ class MainPage extends StatelessWidget {
               childAspectRatio: 2,
               crossAxisCount: 2,
               children: horizontalItems)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 24),
+              child: Center(
+                child: Text("Other examples",
+                  style: Theme.of(context).textTheme.headlineMedium)))),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            sliver: SliverGrid.count(
+              childAspectRatio: 2,
+              crossAxisCount: 2,
+              children: otherItems)),
         ]));
   }
 
@@ -304,7 +380,14 @@ class MainPage extends StatelessWidget {
           title: title, reverse: reverse, headerDirection: headerDirection);
         break;
     }
+    return _buildButton(context, title: title, page: page);
+  }
 
+  Widget _buildButton(BuildContext context, {
+    bool primary = false,
+    required String title,
+    required Widget page,
+  }) {
     var label = Text(title,
       textAlign: TextAlign.center,
       style: TextStyle(

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -566,8 +566,8 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
 
     if (header != null) {
       header!.layout(constraints.asBoxConstraints(), parentUsesSize: true);
-
       final headerExtent = header!.size.onAxis(constraints.axis);
+
       final double headerOffset;
       if (_headerEndBound == null) {
         // The header's item has [StickyHeaderItem.allowOverflow] true.
@@ -577,8 +577,6 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
 
         final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
         final cacheExtent = calculateCacheOffset(constraints, from: 0, to: headerExtent);
-
-        assert(0 <= paintedHeaderSize && paintedHeaderSize.isFinite);
 
         geometry = SliverGeometry( // TODO review interaction with other slivers
           scrollExtent: geometry.scrollExtent,

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -741,7 +741,10 @@ class _RenderSliverStickyHeaderListInner extends RenderSliverList {
   ///
   /// This means (child start) < (viewport end) <= (child end).
   RenderBox? _findChildAtEnd() {
-    final endOffset = constraints.scrollOffset + constraints.viewportMainAxisExtent;
+    /// The end of the visible area available to this sliver,
+    /// in this sliver's "scroll offset" coordinates.
+    final endOffset = constraints.scrollOffset
+      + constraints.remainingPaintExtent;
 
     RenderBox? child;
     for (child = lastChild; ; child = childBefore(child)) {

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -597,7 +597,6 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
           layoutExtent: geometry.layoutExtent,
           paintExtent: math.max(geometry.paintExtent, paintedHeaderSize),
           maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
-          hitTestExtent: math.max(geometry.hitTestExtent, paintedHeaderSize),
           hasVisualOverflow: geometry.hasVisualOverflow
             || headerExtent > constraints.remainingPaintExtent,
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -564,7 +564,10 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
     child!.layout(constraints, parentUsesSize: true);
     SliverGeometry geometry = child!.geometry!;
 
-    // TODO(#1309) handle the scrollOffsetCorrection case, passing it through
+    if (geometry.scrollOffsetCorrection != null) {
+      this.geometry = geometry;
+      return;
+    }
 
     // We assume [child]'s geometry is free of certain complications.
     // Probably most or all of these *could* be handled if necessary, just at

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -576,17 +576,21 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
         // and even if the whole child sliver is smaller than the header.
 
         final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
-        final cacheExtent = calculateCacheOffset(constraints, from: 0, to: headerExtent);
-
         geometry = SliverGeometry( // TODO review interaction with other slivers
           scrollExtent: geometry.scrollExtent,
           layoutExtent: geometry.layoutExtent,
           paintExtent: math.max(geometry.paintExtent, paintedHeaderSize),
-          cacheExtent: math.max(geometry.cacheExtent, cacheExtent),
           maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
           hitTestExtent: math.max(geometry.hitTestExtent, paintedHeaderSize),
           hasVisualOverflow: geometry.hasVisualOverflow
             || headerExtent > constraints.remainingPaintExtent,
+
+          // The cache extent is an extension of layout, not paint; it controls
+          // where the next sliver should start laying out content.  (See
+          // [SliverConstraints.remainingCacheExtent].)  The header isn't meant
+          // to affect where the next sliver gets laid out, so it shouldn't
+          // affect the cache extent.
+          cacheExtent: geometry.cacheExtent,
         );
 
         headerOffset = _headerAtCoordinateEnd()

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -570,6 +570,11 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
       final headerExtent = header!.size.onAxis(constraints.axis);
       final double headerOffset;
       if (_headerEndBound == null) {
+        // The header's item has [StickyHeaderItem.allowOverflow] true.
+        // Show the header in full, with one edge at the edge of the viewport,
+        // even if the (visible part of the) item is smaller than the header,
+        // and even if the whole child sliver is smaller than the header.
+
         final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
         final cacheExtent = calculateCacheOffset(constraints, from: 0, to: headerExtent);
 
@@ -590,6 +595,10 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
           ? geometry.layoutExtent - headerExtent
           : 0.0;
       } else {
+        // The header's item has [StickyHeaderItem.allowOverflow] false.
+        // Keep the header within the item, pushing the header partly out of
+        // the viewport if the item's visible part is smaller than the header.
+
         // The limiting edge of the header's item,
         // in the outer, non-scrolling coordinates.
         final endBoundAbsolute = axisDirectionIsReversed(constraints.growthAxisDirection)

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -564,6 +564,19 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
     child!.layout(constraints, parentUsesSize: true);
     SliverGeometry geometry = child!.geometry!;
 
+    // TODO(#1309) handle the scrollOffsetCorrection case, passing it through
+
+    // We assume [child]'s geometry is free of certain complications.
+    // Probably most or all of these *could* be handled if necessary, just at
+    // the cost of further complicating this code.  Fortunately they aren't,
+    // because [RenderSliverList.performLayout] never has these complications.
+    assert(geometry.paintOrigin == 0);
+    assert(geometry.layoutExtent == geometry.paintExtent);
+    assert(geometry.hitTestExtent == geometry.paintExtent);
+    assert(geometry.visible == (geometry.paintExtent > 0));
+    assert(geometry.maxScrollObstructionExtent == 0);
+    assert(geometry.crossAxisExtent == null);
+
     if (header != null) {
       header!.layout(constraints.asBoxConstraints(), parentUsesSize: true);
       final headerExtent = header!.size.onAxis(constraints.axis);

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -774,10 +774,23 @@ class _RenderSliverStickyHeaderListInner extends RenderSliverList {
 
     final RenderBox? child;
     switch (widget.headerPlacement._byGrowth(constraints.growthDirection)) {
-      case _HeaderGrowthPlacement.growthEnd:
-        child = _findChildAtEnd();
       case _HeaderGrowthPlacement.growthStart:
-        child = _findChildAtStart();
+        if (constraints.remainingPaintExtent < constraints.viewportMainAxisExtent) {
+          // Part of the viewport is occupied already by other slivers.  The way
+          // a RenderViewport does layout means that the already-occupied part is
+          // the part that's before this sliver in the growth direction.
+          // Which means that's the place where the header would go.
+          child = null;
+        } else {
+          child = _findChildAtStart();
+        }
+      case _HeaderGrowthPlacement.growthEnd:
+        // The edge this sliver wants to place a header at is the one where
+        // this sliver is free to run all the way to the viewport's edge; any
+        // further slivers in that direction will be laid out after this one.
+        // So if this sliver placed a child there, it's at the edge of the
+        // whole viewport and should determine a header.
+        child = _findChildAtEnd();
     }
 
     (parent! as _RenderSliverStickyHeaderList)._rebuildHeader(child);

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -579,6 +579,7 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
     assert(geometry.visible == (geometry.paintExtent > 0));
     assert(geometry.maxScrollObstructionExtent == 0);
     assert(geometry.crossAxisExtent == null);
+    final childExtent = geometry.layoutExtent;
 
     if (header != null) {
       header!.layout(constraints.asBoxConstraints(), parentUsesSize: true);
@@ -594,8 +595,8 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
         final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
         geometry = SliverGeometry( // TODO review interaction with other slivers
           scrollExtent: geometry.scrollExtent,
-          layoutExtent: geometry.layoutExtent,
-          paintExtent: math.max(geometry.paintExtent, paintedHeaderSize),
+          layoutExtent: childExtent,
+          paintExtent: math.max(childExtent, paintedHeaderSize),
           maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
           hasVisualOverflow: geometry.hasVisualOverflow
             || headerExtent > constraints.remainingPaintExtent,
@@ -609,7 +610,7 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
         );
 
         headerOffset = _headerAtCoordinateEnd()
-          ? geometry.layoutExtent - headerExtent
+          ? childExtent - headerExtent
           : 0.0;
       } else {
         // The header's item has [StickyHeaderItem.allowOverflow] false.
@@ -619,11 +620,11 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
         // The limiting edge of the header's item,
         // in the outer, non-scrolling coordinates.
         final endBoundAbsolute = axisDirectionIsReversed(constraints.growthAxisDirection)
-          ? geometry.layoutExtent - (_headerEndBound! - constraints.scrollOffset)
+          ? childExtent - (_headerEndBound! - constraints.scrollOffset)
           : _headerEndBound! - constraints.scrollOffset;
 
         headerOffset = _headerAtCoordinateEnd()
-          ? math.max(geometry.layoutExtent - headerExtent, endBoundAbsolute)
+          ? math.max(childExtent - headerExtent, endBoundAbsolute)
           : math.min(0.0, endBoundAbsolute - headerExtent);
       }
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -489,6 +489,11 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
     if (_header != null) adoptChild(_header!);
   }
 
+  /// This sliver's child sliver, a modified [RenderSliverList].
+  ///
+  /// The child manages the items in the list (deferring to [RenderSliverList]);
+  /// and identifies which list item, if any, should be consulted
+  /// for a sticky header.
   _RenderSliverStickyHeaderListInner? get child => _child;
   _RenderSliverStickyHeaderListInner? _child;
   set child(_RenderSliverStickyHeaderListInner? value) {
@@ -552,6 +557,9 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
 
   @override
   void performLayout() {
+    // First, lay out the child sliver.  This does all the normal work of
+    // [RenderSliverList], then calls [_rebuildHeader] on this sliver
+    // so that [header] and [_headerEndBound] are up to date.
     assert(child != null);
     child!.layout(constraints, parentUsesSize: true);
     SliverGeometry geometry = child!.geometry!;

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -174,7 +174,6 @@ Future<void> _checkSequence(
     final expectedHeaderIndex = first
       ? (scrollOffset / 100).floor()
       : (extent ~/ 100 - 1) + (scrollOffset / 100).ceil();
-    // print("$scrollOffset, $extent, $expectedHeaderIndex");
     check(tester.widget<_Item>(itemFinder).index).equals(expectedHeaderIndex);
     check(_headerIndex(tester)).equals(expectedHeaderIndex);
 

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -192,14 +192,10 @@ void main() {
       }));
       final itemWidget = itemElement.widget as _Item;
       check(itemWidget.index).equals(index);
-      // TODO the `.first` calls should be unnecessary; that's another bug
-      // check(_headerIndex(tester)).equals(index);
-      check(tester.widget<_Header>(find.byType(_Header).first).index)
-        .equals(index);
+      check(_headerIndex(tester)).equals(index);
       check((itemElement.renderObject as RenderBox).localToGlobal(Offset(0, 0)))
         .equals(Offset(0, item));
-      check(tester.getTopLeft(find.byType(_Header).first))
-        .equals(Offset(0, header));
+      check(tester.getTopLeft(find.byType(_Header))).equals(Offset(0, header));
     }
 
     check(controller.offset).equals(0);


### PR DESCRIPTION
Fixes #1309.
Fixes #725. (which is the same underlying bug)

In addition to that live bug in the app (involving scrollOffsetCorrection, which we previously weren't handling), the last two commits in this branch fix a couple of bugs in the `sticky_header` library that were latent bugs in the app — they can only trigger once we start having two slivers share space in the list. That's a scenario we'll need as part of #80 / #82, as seen for example in #1169 (fyi @rajveermalviya).

Specifically, when both slivers are visible, the version in main
* will fail to show the sticky header for the top sliver;
* and will show a sticky header for the bottom sliver.

After this PR, there's one remaining bug I'm aware of that affects sticky headers in the presence of multiple slivers: ~~if the top sliver should show a header, but the header doesn't fit within the sliver's share of the viewport, then the header will get pushed off screen even if it has `allowOverflow` true. Concretely for the message list, this means that the last message in the top sliver will fail to share its recipient header with the first message in the bottom sliver, even if they're meant to share a recipient header.~~

**edit:** @chrisbobbe showed me the current symptom is a bit different from this. Rather than get pushed off screen, the header will have its bottom part covered up by the bottom sliver. The fix doesn't change, though.

I have a draft fix for that bug too, and I believe it works, but it still needs tests and a bit of other polishing-up. So it'll come as a separate PR later.

This is the long-awaited followup to #496, from a year ago this week. The two fixes here involving multiple slivers, as well as the upcoming fix coming in another PR, were all in the draft branch I had then. The scrollOffsetCorrection fix (which fixes the two live bugs) is new today, after I took a fresh look last week at some of the underlying framework code as part of trying to really understand what this `performLayout` method needs to do clearly enough to get to an implementation I'm confident is correct.


# Selected commit messages

#### 4b290452b sticky_header: Add example app

This is adapted lightly from an example app I made back in the first
week of the zulip-flutter project, 2022-12-23, as part of developing
the sticky_header library.

The example app was extremely helpful then for experimenting with
changes and seeing the effects visually and interactively, as well as
for print-debugging such experiments.  So let's get it into the tree.

The main reason I didn't send the example app back then is that it
was a whole stand-alone app tree under example/, complete with all
the stuff in android/ and ios/ and so on that `flutter create` spits
out for setting up a Flutter app.  That's pretty voluminous: well
over 100 different files totalling about 1.1MB on disk.  I did't
want to permanently burden the repo with all that, nor have to
maintain it all over time.

Happily, I realized today that we can skip that, and still have a
perfectly good example app, by reusing that infrastructure from the
actual Zulip app.  That way all we need is a Dart file with a `main`
function, corresponding to the old example's `lib/main.dart` which
was the only not-from-the-template code in the whole example app.

So here it is.  Other than moving the Dart file and discarding the
rest, the code I wrote back then has been updated to our current
formatting style; adjusted slightly for changes in Flutter's
Material widgets; and updated for changes I made to the
sticky_header API after that first week.


#### 3de58fe3e sticky_header [nfc]: Add asserts from studying possible child geometry; note a bug

The logic below -- particularly in the allowOverflow true case,
where it constructs a new SliverGeometry from scratch -- has been
implicitly relying on several of these facts already.  These
wouldn't be true of an arbitrary sliver child; but this sliver knows
what type of child it actually has, and they are true of that one.
So write down the specific assumptions we can take from that.

Reading through [RenderSliverList.performLayout] to see what it can
produce as the child geometry also made clear there's another case
that this method isn't currently correctly handling at all: the case
where scrollOffsetCorrection is non-null.  Filed an issue for that;
add a todo-comment for it.


#### 075a8cd79 sticky_header: Handle scrollOffsetCorrection

Fixes #1309.
Fixes #725.

This is necessary when scrolling back to the origin over items that
grew taller while off screen (and beyond the 250px of near-on-screen
cached items).  For example that can happen because a message was
edited, or because new messages came in that were taller than those
previously present.


#### de2006098 sticky_header: Fix _findChildAtEnd when viewport partly consumed already

In particular this will affect the upper sliver (with older messages)
in the message list, when we start using two slivers there in earnest.


#### 7583bb4b0 sticky_header: Avoid header at sliver/sliver boundary


