### PR TITLE
anchors 3/n: Fix hit-testing when header overflows sliver

### DIFF
--- a/lib/example/sticky_header.dart
+++ b/lib/example/sticky_header.dart
@@ -152,6 +152,7 @@ class ExampleVerticalDouble extends StatelessWidget {
               (context, i) {
                 final ii = i + numBottomSections;
                 return StickyHeaderItem(
+                  allowOverflow: true,
                   header: WideHeader(i: ii),
                   child: Column(
                     children: List.generate(numPerSection + 1, (j) {
@@ -167,6 +168,7 @@ class ExampleVerticalDouble extends StatelessWidget {
               (context, i) {
                 final ii = numBottomSections - 1 - i;
                 return StickyHeaderItem(
+                  allowOverflow: true,
                   header: WideHeader(i: ii),
                   child: Column(
                     children: List.generate(numPerSection + 1, (j) {

--- a/lib/example/sticky_header.dart
+++ b/lib/example/sticky_header.dart
@@ -134,23 +134,20 @@ class ExampleVerticalDouble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const centerSliverKey = ValueKey('center sliver');
-    const numSections = 100;
+    const numSections = 4;
     const numBottomSections = 2;
     const numPerSection = 10;
     return Scaffold(
       appBar: AppBar(title: Text(title)),
       body: CustomScrollView(
         semanticChildCount: numSections,
-        anchor: 0.5,
-        center: centerSliverKey,
         slivers: [
           SliverStickyHeaderList(
             headerPlacement: HeaderPlacement.scrollingStart,
             delegate: SliverChildBuilderDelegate(
               childCount: numSections - numBottomSections,
               (context, i) {
-                final ii = i + numBottomSections;
+                final ii = numSections - 1 - i;
                 return StickyHeaderItem(
                   allowOverflow: true,
                   header: WideHeader(i: ii),
@@ -161,7 +158,6 @@ class ExampleVerticalDouble extends StatelessWidget {
                     })));
               })),
           SliverStickyHeaderList(
-            key: centerSliverKey,
             headerPlacement: HeaderPlacement.scrollingStart,
             delegate: SliverChildBuilderDelegate(
               childCount: numBottomSections,

--- a/lib/example/sticky_header.dart
+++ b/lib/example/sticky_header.dart
@@ -197,6 +197,7 @@ class WideHeader extends StatelessWidget {
     return Material(
       color: Theme.of(context).colorScheme.primaryContainer,
       child: ListTile(
+        onTap: () {}, // nop, but non-null so the ink splash appears
         title: Text("Section ${i + 1}",
           style: TextStyle(
             color: Theme.of(context).colorScheme.onPrimaryContainer))));
@@ -211,7 +212,9 @@ class WideItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(title: Text("Item ${i + 1}.${j + 1}"));
+    return ListTile(
+      onTap: () {}, // nop, but non-null so the ink splash appears
+      title: Text("Item ${i + 1}.${j + 1}"));
   }
 }
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -99,6 +99,18 @@ class RenderStickyHeaderItem extends RenderProxyBox {
 /// or if [scrollDirection] is horizontal then to the start in the
 /// reading direction of the ambient [Directionality].
 /// It can be controlled with [reverseHeader].
+///
+/// Much like [ListView], a [StickyHeaderListView] is basically
+/// a [CustomScrollView] with a single sliver in its [CustomScrollView.slivers]
+/// property.
+/// For a [StickyHeaderListView], that sliver is a [SliverStickyHeaderList].
+///
+/// If more than one sliver is needed, any code using [StickyHeaderListView]
+/// can be ported to use [CustomScrollView] directly, in much the same way
+/// as for code using [ListView].  See [ListView] for details.
+///
+/// See also:
+///  * [SliverStickyHeaderList], which provides the sticky-header behavior.
 class StickyHeaderListView extends BoxScrollView {
   // Like ListView, but with sticky headers.
   StickyHeaderListView({
@@ -296,6 +308,10 @@ enum _HeaderGrowthPlacement {
   growthEnd
 }
 
+/// A list sliver with sticky headers.
+///
+/// This widget takes most of its behavior from [SliverList],
+/// but adds sticky headers as described at [StickyHeaderListView].
 class SliverStickyHeaderList extends RenderObjectWidget {
   SliverStickyHeaderList({
     super.key,
@@ -306,7 +322,16 @@ class SliverStickyHeaderList extends RenderObjectWidget {
     delegate: delegate,
   );
 
+  /// Whether the sticky header appears at the start or the end
+  /// in the scrolling direction.
+  ///
+  /// For example, if the enclosing [Viewport] has [Viewport.axisDirection]
+  /// of [AxisDirection.down], then
+  /// [HeaderPlacement.scrollingStart] means the header appears at
+  /// the top of the viewport, and
+  /// [HeaderPlacement.scrollingEnd] means it appears at the bottom.
   final HeaderPlacement headerPlacement;
+
   final _SliverStickyHeaderListInner _child;
 
   @override

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -630,22 +630,30 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
 
           // This sliver's paint region consists entirely of the header.
           final paintExtent = headerExtent;
-          headerOffset = _headerAtCoordinateEnd()
-            ? childExtent - headerExtent // TODO buggy, should be zero
-            : 0.0;
+          headerOffset = 0.0;
 
           // Its layout region (affecting where the next sliver begins layout)
           // is that given by the child sliver.
           final layoutExtent = childExtent;
 
           // The paint origin places this sliver's paint region relative to its
-          // layout region.
-          final paintOrigin = 0.0; // TODO buggy
+          // layout region so that they share the edge the header appears at
+          // (which should be the edge of the viewport).
+          final headerGrowthPlacement =
+            _widget.headerPlacement._byGrowth(constraints.growthDirection);
+          final paintOrigin = switch (headerGrowthPlacement) {
+            _HeaderGrowthPlacement.growthStart => 0.0,
+            _HeaderGrowthPlacement.growthEnd => layoutExtent - paintExtent,
+          };
+          // TODO the child sliver should be painted at offset -paintOrigin
+          //   (This bug doesn't matter so long as the header is opaque,
+          //   because the header covers the child in that case.
+          //   For that reason the Zulip message list isn't affected.)
 
           geometry = SliverGeometry( // TODO review interaction with other slivers
             scrollExtent: geometry.scrollExtent,
             layoutExtent: layoutExtent,
-            paintExtent: childExtent, // TODO buggy
+            paintExtent: paintExtent,
             paintOrigin: paintOrigin,
             maxPaintExtent: math.max(geometry.maxPaintExtent, paintExtent),
             hasVisualOverflow: geometry.hasVisualOverflow

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -312,6 +312,27 @@ enum _HeaderGrowthPlacement {
 ///
 /// This widget takes most of its behavior from [SliverList],
 /// but adds sticky headers as described at [StickyHeaderListView].
+///
+/// ## Overflow across slivers
+///
+/// When the list item that controls the sticky header has
+/// [StickyHeaderItem.allowOverflow] true, the header will be permitted
+/// to overflow not only the item but this whole sliver.
+///
+/// The caller is responsible for arranging the paint order between slivers
+/// so that this works correctly: a sliver that might overflow must be painted
+/// after any sliver it might overflow onto.
+/// For example if [headerPlacement] puts headers at the left of the viewport
+/// (and any items with [StickyHeaderItem.allowOverflow] true are present),
+/// then this [SliverStickyHeaderList] must paint after any slivers that appear
+/// to the right of this sliver.
+///
+/// At present there's no off-the-shelf way to fully control the paint order
+/// between slivers.
+/// See the implementation of [RenderViewport.childrenInPaintOrder] for the
+/// paint order provided by [CustomScrollView]; it meets the above needs
+/// for some arrangements of slivers and values of [headerPlacement],
+/// but not others.
 class SliverStickyHeaderList extends RenderObjectWidget {
   SliverStickyHeaderList({
     super.key,

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -691,16 +691,21 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
   double childMainAxisPosition(RenderObject child) {
     if (child == this.child) return 0.0;
     assert(child == header);
+
+    final headerParentData = (header!.parentData as SliverPhysicalParentData);
+    final paintOffset = headerParentData.paintOffset;
+
     // We use Sliver*Physical*ParentData, so the header's position is stored in
     // physical coordinates.  To meet the spec of `childMainAxisPosition`, we
     // need to convert to the sliver's coordinate system.
-    final headerParentData = (header!.parentData as SliverPhysicalParentData);
-    final paintOffset = headerParentData.paintOffset;
+    // This is all a bit silly because callers like [hitTestBoxChild] are just
+    // going to do the same things in reverse to get physical coordinates.
+    // Ah well; that's the API.
     return switch (constraints.growthAxisDirection) {
       AxisDirection.right => paintOffset.dx,
-      AxisDirection.left  => geometry!.layoutExtent - header!.size.width  - paintOffset.dx,
+      AxisDirection.left  => geometry!.paintExtent - header!.size.width  - paintOffset.dx,
       AxisDirection.down  => paintOffset.dy,
-      AxisDirection.up    => geometry!.layoutExtent - header!.size.height - paintOffset.dy,
+      AxisDirection.up    => geometry!.paintExtent - header!.size.height - paintOffset.dy,
     };
   }
 

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -628,11 +628,10 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
           // The header will overflow the child sliver.
           // That makes this sliver's geometry a bit more complicated.
 
-          final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
           geometry = SliverGeometry( // TODO review interaction with other slivers
             scrollExtent: geometry.scrollExtent,
             layoutExtent: childExtent,
-            paintExtent: math.max(childExtent, paintedHeaderSize),
+            paintExtent: childExtent,
             maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
             hasVisualOverflow: geometry.hasVisualOverflow
               || headerExtent > constraints.remainingPaintExtent,

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -628,13 +628,28 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
           // The header will overflow the child sliver.
           // That makes this sliver's geometry a bit more complicated.
 
+          // This sliver's paint region consists entirely of the header.
+          final paintExtent = headerExtent;
+          headerOffset = _headerAtCoordinateEnd()
+            ? childExtent - headerExtent // TODO buggy, should be zero
+            : 0.0;
+
+          // Its layout region (affecting where the next sliver begins layout)
+          // is that given by the child sliver.
+          final layoutExtent = childExtent;
+
+          // The paint origin places this sliver's paint region relative to its
+          // layout region.
+          final paintOrigin = 0.0; // TODO buggy
+
           geometry = SliverGeometry( // TODO review interaction with other slivers
             scrollExtent: geometry.scrollExtent,
-            layoutExtent: childExtent,
-            paintExtent: childExtent,
-            maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
+            layoutExtent: layoutExtent,
+            paintExtent: childExtent, // TODO buggy
+            paintOrigin: paintOrigin,
+            maxPaintExtent: math.max(geometry.maxPaintExtent, paintExtent),
             hasVisualOverflow: geometry.hasVisualOverflow
-              || headerExtent > constraints.remainingPaintExtent,
+              || paintExtent > constraints.remainingPaintExtent,
 
             // The cache extent is an extension of layout, not paint; it controls
             // where the next sliver should start laying out content.  (See
@@ -643,10 +658,6 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
             // affect the cache extent.
             cacheExtent: geometry.cacheExtent,
           );
-
-          headerOffset = _headerAtCoordinateEnd()
-            ? childExtent - headerExtent
-            : 0.0;
         }
       } else {
         // The header's item has [StickyHeaderItem.allowOverflow] false.

--- a/lib/widgets/sticky_header.dart
+++ b/lib/widgets/sticky_header.dart
@@ -617,26 +617,38 @@ class _RenderSliverStickyHeaderList extends RenderSliver with RenderSliverHelper
         // even if the (visible part of the) item is smaller than the header,
         // and even if the whole child sliver is smaller than the header.
 
-        final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
-        geometry = SliverGeometry( // TODO review interaction with other slivers
-          scrollExtent: geometry.scrollExtent,
-          layoutExtent: childExtent,
-          paintExtent: math.max(childExtent, paintedHeaderSize),
-          maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
-          hasVisualOverflow: geometry.hasVisualOverflow
-            || headerExtent > constraints.remainingPaintExtent,
+        if (headerExtent <= childExtent) {
+          // The header fits within the child sliver.
+          // So it doesn't affect this sliver's overall geometry.
 
-          // The cache extent is an extension of layout, not paint; it controls
-          // where the next sliver should start laying out content.  (See
-          // [SliverConstraints.remainingCacheExtent].)  The header isn't meant
-          // to affect where the next sliver gets laid out, so it shouldn't
-          // affect the cache extent.
-          cacheExtent: geometry.cacheExtent,
-        );
+          headerOffset = _headerAtCoordinateEnd()
+            ? childExtent - headerExtent
+            : 0.0;
+        } else {
+          // The header will overflow the child sliver.
+          // That makes this sliver's geometry a bit more complicated.
 
-        headerOffset = _headerAtCoordinateEnd()
-          ? childExtent - headerExtent
-          : 0.0;
+          final paintedHeaderSize = calculatePaintOffset(constraints, from: 0, to: headerExtent);
+          geometry = SliverGeometry( // TODO review interaction with other slivers
+            scrollExtent: geometry.scrollExtent,
+            layoutExtent: childExtent,
+            paintExtent: math.max(childExtent, paintedHeaderSize),
+            maxPaintExtent: math.max(geometry.maxPaintExtent, headerExtent),
+            hasVisualOverflow: geometry.hasVisualOverflow
+              || headerExtent > constraints.remainingPaintExtent,
+
+            // The cache extent is an extension of layout, not paint; it controls
+            // where the next sliver should start laying out content.  (See
+            // [SliverConstraints.remainingCacheExtent].)  The header isn't meant
+            // to affect where the next sliver gets laid out, so it shouldn't
+            // affect the cache extent.
+            cacheExtent: geometry.cacheExtent,
+          );
+
+          headerOffset = _headerAtCoordinateEnd()
+            ? childExtent - headerExtent
+            : 0.0;
+        }
       } else {
         // The header's item has [StickyHeaderItem.allowOverflow] false.
         // Keep the header within the item, pushing the header partly out of

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -309,7 +309,8 @@ Future<void> _checkSequence(
       ..every((it) => it.isA<_Header>());
     await tester.tapAt(headerInset(extent - 1));
     await tester.tapAt(headerInset(extent - (expectedHeaderInsetExtent - 1)));
-    check(_TapLogged.takeTapLog()).isEmpty();
+    check(_TapLogged.takeTapLog())..length.equals(2)
+      ..every((it) => it.isA<_Item>());
   }
 
   Future<void> jumpAndCheck(double position) async {
@@ -388,7 +389,7 @@ class _Header extends StatelessWidget implements _TapLogged {
   }
 }
 
-class _Item extends StatelessWidget {
+class _Item extends StatelessWidget implements _TapLogged {
   const _Item(this.index, {required this.height});
 
   final int index;
@@ -399,10 +400,17 @@ class _Item extends StatelessWidget {
     return SizedBox(
       height: height,
       width: height,
-      child: Text("Item $index"));
+      child: GestureDetector(
+        onTap: () => _TapLogged._tapLog.add(this),
+        child: Text("Item $index")));
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IntProperty('index', index));
   }
 }
-
 
 /// Sets [DeviceGestureSettings.touchSlop] for the child subtree
 /// to the given value, by inserting a [MediaQuery].

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:checks/checks.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
@@ -247,27 +248,35 @@ Future<void> _checkSequence(
       child: _Item(i, height: 100));
   }
 
+  const center = ValueKey("center");
+  final slivers = <Widget>[
+    const SliverPadding(
+      key: center,
+      padding: EdgeInsets.zero),
+    SliverStickyHeaderList(
+      headerPlacement: headerPlacement,
+      delegate: SliverChildListDelegate(
+        List.generate(100, (i) => buildItem(i)))),
+  ];
+
+  final double anchor;
+  if (reverseGrowth) {
+    slivers.reverseRange(0, slivers.length);
+    anchor = 1.0;
+  } else {
+    anchor = 0.0;
+  }
+
   final controller = ScrollController();
-  const listKey = ValueKey("list");
-  const emptyKey = ValueKey("empty");
   await tester.pumpWidget(Directionality(
     textDirection: textDirection ?? TextDirection.rtl,
     child: CustomScrollView(
       controller: controller,
       scrollDirection: axis,
       reverse: reverse,
-      anchor: reverseGrowth ? 1.0 : 0.0,
-      center: reverseGrowth ? emptyKey : listKey,
-      slivers: [
-        SliverStickyHeaderList(
-          key: listKey,
-          headerPlacement: headerPlacement,
-          delegate: SliverChildListDelegate(
-            List.generate(100, (i) => buildItem(i)))),
-        const SliverPadding(
-          key: emptyKey,
-          padding: EdgeInsets.zero),
-      ])));
+      anchor: anchor,
+      center: center,
+      slivers: slivers)));
 
   final overallSize = tester.getSize(find.byType(CustomScrollView));
   final extent = overallSize.onAxis(axis);

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -256,7 +256,7 @@ Future<void> _checkSequence(
     SliverStickyHeaderList(
       headerPlacement: headerPlacement,
       delegate: SliverChildListDelegate(
-        List.generate(100, (i) => buildItem(i)))),
+        List.generate(10, (i) => buildItem(i)))),
   ];
 
   final double anchor;

--- a/test/widgets/sticky_header_test.dart
+++ b/test/widgets/sticky_header_test.dart
@@ -237,6 +237,15 @@ Future<void> _checkSequence(
     Axis.vertical   => reverseHeader,
   };
   final reverseGrowth = (growthDirection == GrowthDirection.reverse);
+  final headerPlacement = reverseHeader ^ reverse
+    ? HeaderPlacement.scrollingEnd : HeaderPlacement.scrollingStart;
+
+  Widget buildItem(int i) {
+    return StickyHeaderItem(
+      allowOverflow: allowOverflow,
+      header: _Header(i, height: 20),
+      child: _Item(i, height: 100));
+  }
 
   final controller = ScrollController();
   const listKey = ValueKey("list");
@@ -252,13 +261,9 @@ Future<void> _checkSequence(
       slivers: [
         SliverStickyHeaderList(
           key: listKey,
-          headerPlacement: (reverseHeader ^ reverse)
-            ? HeaderPlacement.scrollingEnd : HeaderPlacement.scrollingStart,
+          headerPlacement: headerPlacement,
           delegate: SliverChildListDelegate(
-            List.generate(100, (i) => StickyHeaderItem(
-              allowOverflow: allowOverflow,
-              header: _Header(i, height: 20),
-              child: _Item(i, height: 100))))),
+            List.generate(100, (i) => buildItem(i)))),
         const SliverPadding(
           key: emptyKey,
           padding: EdgeInsets.zero),
@@ -315,7 +320,8 @@ Future<void> _checkSequence(
   }
 
   Future<void> jumpAndCheck(double position) async {
-    controller.jumpTo(position * (reverseGrowth ? -1 : 1));
+    final scrollPosition = position * (reverseGrowth ? -1 : 1);
+    controller.jumpTo(scrollPosition);
     await tester.pump();
     await checkState();
   }


### PR DESCRIPTION
This is the next round after #1312 (and is stacked atop #1312), fixing another cluster of latent bugs in the sticky_header library to prepare for having two slivers share space back to back in the list.

After #1312, the headers paint correctly in that case. But when the sliver boundary is scrolled to within the header, the hit-testing behavior isn't yet right: trying to tap on the bottom part of the header, where it's overflowing over the bottom sliver, ends up hitting the bottom sliver instead of the header. This PR fixes that.

… Well, it does if the viewport gives the slivers the right paint order (and hit-test order). Making that happen with back-to-back slivers, like the message list needs, requires some more code; and this PR is long enough already. So we'll save that for the next PR.

## Selected commit messages

#### 54c2b68de sticky_header example: Enable ink splashes, to demo hit-testing


#### 2c3a6ea04 sticky_header example: Set allowOverflow true in double-sliver example


#### 421415b9c sticky_header [nfc]: Fix childMainAxisPosition to handle paintOrigin nonzero

This fixes a latent bug: this method would give wrong answers if the
sliver's paintOrigin were nonzero.  See the new comments.

The bug is latent because performLayout currently always produces a
zero paintOrigin.  But we'll start using paintOrigin soon, as part of
making hit-testing work correctly when a sticky header is painted by
one sliver but needs to encroach on the layout area of another sliver.
The framework calls this method as part of hit-testing, so that
requires fixing this bug too.


#### a76ba67a8 sticky_header: Fix hit-testing when header overflows sliver

When the sticky header overflows the sliver that provides it -- that
is, when the sliver boundary is scrolled to within the area the
header covers -- the existing code already got the right visual
result, painting the header at its full size.

But it didn't work properly for hit-testing: trying to tap the
header in the portion where it's overflowing wouldn't work, and
would instead go through to whatever's underneath (like the top of
the next sliver).  That's because the geometry it was reporting from
this `performLayout` method didn't reflect the geometry it would
actually paint in the `paint` method.  When hit-testing, that
reported geometry gets interpreted by the framework code before
calling this render object's other methods.

Fix that by reporting an accurate `paintOrigin` and `paintExtent`.

After this fix, sticky headers overflowing into the next sliver
seem to work completely correctly... as long as the viewport paints
the slivers in the necessary order.  We'll take care of that next.


#### 90e4b5f1d sticky_header [nfc]: Doc overflow behavior and paint-order constraints
