### PR TITLE
android build: Allow gradle to use more memory

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx3072M
 android.useAndroidX=true
 android.enableJetifier=true
 


### PR DESCRIPTION
Fixes #1330.

Recently, we have been running out of memory for the CI builds. It's likely that we were close to reaching the upperbound for some time, and some upstream change pushes us past that limit. Allocate more memory so that the CI can pass again.

CZO discussion:
  https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/Execution.20failed.20for.20task.20'.3Aapp.3AcompileDebugKotlin'