### PR TITLE
home: Center align the "try another account" message in loading placeholder

### DIFF
--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -212,7 +212,8 @@ class _LoadingPlaceholderPageState extends State<_LoadingPlaceholderPage> {
                 child: Column(
                   children: [
                     const SizedBox(height: 16),
-                    Text(zulipLocalizations.tryAnotherAccountMessage(account.realmUrl.toString())),
+                    Text(textAlign: TextAlign.center,
+                      zulipLocalizations.tryAnotherAccountMessage(account.realmUrl.toString())),
                     const SizedBox(height: 8),
                     ElevatedButton(
                       onPressed: () => Navigator.push(context,


### PR DESCRIPTION
Resolves [#1246](https://github.com/zulip/zulip-flutter/issues/1246).

## Screenshot

![Screenshot](https://github.com/user-attachments/assets/aa8e3823-71c0-43f6-8907-9bd5cd712a31)
