### PR TITLE
[nfc]:added "(you)" indicator next to the name with reduced opacity

### DIFF
--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -87,10 +87,12 @@ class RecentDmConversationsItem extends StatelessWidget {
 
     final String title;
     final Widget avatar;
+    bool self=false;
     switch (narrow.otherRecipientIds) { // TODO dedupe with DM items in [InboxPage]
       case []:
         title = selfUser.fullName;
         avatar = AvatarImage(userId: selfUser.userId, size: _avatarSize);
+        self=true;
       case [var otherUserId]:
         // TODO(#296) actually don't show this row if the user is muted?
         //   (should we offer a "spam folder" style summary screen of recent
@@ -125,16 +127,29 @@ class RecentDmConversationsItem extends StatelessWidget {
             const SizedBox(width: 8),
             Expanded(child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
-              child: Text(
-                style: TextStyle(
-                  fontSize: 17,
-                  height: (20 / 17),
-                  // TODO(design) check if this is the right variable
-                  color: designVariables.labelMenuButton,
-                ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                title))),
+              child: Row(
+                children:[Text(
+                  style: TextStyle(
+                    fontSize: 17,
+                    height: (20 / 17),
+                    // TODO(design) check if this is the right variable
+                    color: designVariables.labelMenuButton,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  title),if (self) // Conditionally add "(you)"
+                    Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: Text(
+                        "(you)",
+                        style: TextStyle(
+                          fontSize: 17,
+                          height: (20 / 17),
+                          color: designVariables.labelMenuButton.withAlpha(180),
+                        ),
+                      ),
+                    ),]
+              ))),
             const SizedBox(width: 12),
             unreadCount > 0
               ? Padding(padding: const EdgeInsetsDirectional.only(end: 16),


### PR DESCRIPTION
fixes: #1320 
I have implemented the requested changes by adding a "(you)" indicator next to the name with reduced opacity using withAlpha().

![Screenshot_1738699019](https://github.com/user-attachments/assets/a1d1f3fe-2cd4-4fd1-989e-704fa23fcc00)
![Screenshot_1738747203](https://github.com/user-attachments/assets/bf75d06e-5abd-4271-938e-959335ce3f19)

