### PR TITLE
notif: Ignore notifications for logged out accounts

### DIFF
--- a/lib/model/actions.dart
+++ b/lib/model/actions.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
+import '../notifications/display.dart';
 import '../notifications/receive.dart';
 import 'store.dart';
 
@@ -10,6 +13,10 @@ Future<void> logOutAccount(GlobalStore globalStore, int accountId) async {
 
   // Unawaited, to not block removing the account on this request.
   unawaited(unregisterToken(globalStore, accountId));
+
+  if (defaultTargetPlatform == TargetPlatform.android) {
+    unawaited(NotificationDisplayManager.removeNotificationsForAccount(account.realmUrl, account.userId));
+  }
 
   await globalStore.removeAccount(accountId);
 }

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:http/http.dart' as http;
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart' hide Notification;
+import 'package:http/http.dart' as http;
 
 import '../api/model/model.dart';
 import '../api/notifications.dart';
@@ -231,7 +231,7 @@ class NotificationDisplayManager {
   static Future<void> _onMessageFcmMessage(MessageFcmMessage data, Map<String, dynamic> dataJson) async {
     assert(debugLog('notif message content: ${data.content}'));
     final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-    final groupKey = _groupKey(data);
+    final groupKey = _groupKey(data.realmUrl, data.userId);
     final conversationKey = _conversationKey(data, groupKey);
 
     final oldMessagingStyle = await _androidHost
@@ -365,7 +365,7 @@ class NotificationDisplayManager {
     // There may be a lot of messages mentioned here, across a lot of
     // conversations.  But they'll all be for one account, so they'll
     // fall under one notification group.
-    final groupKey = _groupKey(data);
+    final groupKey = _groupKey(data.realmUrl, data.userId);
 
     // Find any conversations we can cancel the notification for.
     // The API doesn't lend itself to removing individual messages as
@@ -445,10 +445,10 @@ class NotificationDisplayManager {
     return '$groupKey|$conversation';
   }
 
-  static String _groupKey(FcmMessageWithIdentity data) {
+  static String _groupKey(Uri realmUrl, int userId) {
     // The realm URL can't contain a `|`, because `|` is not a URL code point:
     //   https://url.spec.whatwg.org/#url-code-points
-    return "${data.realmUrl}|${data.userId}";
+    return "$realmUrl|$userId";
   }
 
   static String _personKey(Uri realmUrl, int userId) => "$realmUrl|$userId";

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -217,10 +217,12 @@ class NotificationChannelManager {
 /// Service for managing the notifications shown to the user.
 class NotificationDisplayManager {
   static Future<void> init() async {
+    assert(defaultTargetPlatform == TargetPlatform.android);
     await NotificationChannelManager.ensureChannel();
   }
 
   static void onFcmMessage(FcmMessage data, Map<String, dynamic> dataJson) {
+    assert(defaultTargetPlatform == TargetPlatform.android);
     switch (data) {
       case MessageFcmMessage(): _onMessageFcmMessage(data, dataJson);
       case RemoveFcmMessage(): _onRemoveFcmMessage(data);
@@ -434,6 +436,8 @@ class NotificationDisplayManager {
   }
 
   static Future<void> removeNotificationsForAccount(Uri realmUrl, int userId) async {
+    assert(defaultTargetPlatform == TargetPlatform.android);
+
     final groupKey = _groupKey(realmUrl, userId);
     final activeNotifications = await _androidHost.getActiveNotifications(
       desiredExtras: []);
@@ -488,6 +492,8 @@ class NotificationDisplayManager {
     required BuildContext context,
     required Uri url,
   }) {
+    assert(defaultTargetPlatform == TargetPlatform.android);
+
     final globalStore = GlobalStoreWidget.of(context);
 
     assert(debugLog('got notif: url: $url'));
@@ -516,6 +522,7 @@ class NotificationDisplayManager {
   /// generated with [NotificationOpenPayload.buildUrl] while creating
   /// the notification.
   static Future<void> navigateForNotification(Uri url) async {
+    assert(defaultTargetPlatform == TargetPlatform.android);
     assert(debugLog('opened notif: url: $url'));
 
     NavigatorState navigator = await ZulipApp.navigator;


### PR DESCRIPTION
Fixes: #1264

## Changes
- Ignores notifications received for accounts that were logged out while the app was offline
- Removes notifications (if there exist) of the user when the user logs out
