### PR TITLE
android build: Bump Gradle max memory use to 6 GiB

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs=-Xmx6G
 android.useAndroidX=true
 android.enableJetifier=true
 


### PR DESCRIPTION
Fixes, potentially, #1360.

Even after the bump to 4 GiB, CI is still occasionally flaking with a "Java heap space" error in the `android` suite:
  https://github.com/zulip/zulip-flutter/actions/runs/13152142737/job/36817594452?pr=1327

So try bumping the memory limit still further.  It's not entirely clear this will be enough (or that an even bigger number would be):
  https://github.com/zulip/zulip-flutter/issues/1360#issuecomment-2661191343
but we'll find out.