### PR TITLE
general chat #2: support sending to empty topic from channel narrow, hide resolve/unresolve conditionally

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -300,7 +300,11 @@ void showTopicActionSheet(BuildContext context, {
       pageContext: pageContext);
   }));
 
-  if (someMessageIdInTopic != null) {
+  // TODO: check for other cases that may disallow this action (e.g.: time
+  //   limit for editing topics).
+  if (someMessageIdInTopic != null
+      // ignore: unnecessary_null_comparison // null topic names soon to be enabled
+      && topic.displayName != null) {
     optionButtons.add(ResolveUnresolveButton(pageContext: pageContext,
       topic: topic,
       someMessageIdInTopic: someMessageIdInTopic));

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -579,8 +579,15 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     super.dispose();
   }
 
-  /// The topic name to use in the hint text.
-  TopicName _hintTopic() {
+  /// The topic name to show in the hint text, or null to show no topic.
+  TopicName? _hintTopic() {
+    if (widget.controller.topic.isTopicVacuous) {
+      if (widget.controller.topic.mandatory) {
+        // The chosen topic can't be sent to, so don't show it.
+        return null;
+      }
+    }
+
     return TopicName(widget.controller.topic.textNormalized);
   }
 
@@ -591,12 +598,13 @@ class _StreamContentInputState extends State<_StreamContentInput> {
 
     final streamName = store.streams[widget.narrow.streamId]?.name
       ?? zulipLocalizations.unknownChannelName;
-    final hintDestination =
+    final hintTopic = _hintTopic();
+    final hintDestination = hintTopic == null
       // No i18n of this use of "#" and ">" string; those are part of how
       // Zulip expresses channels and topics, not any normal English punctuation,
       // so don't make sense to translate. See:
       //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-      '#$streamName > ${_hintTopic().displayName}';
+      ? '#$streamName' : '#$streamName > ${hintTopic.displayName}';
 
     return _ContentInput(
       narrow: widget.narrow,

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -658,7 +658,8 @@ class _FixedDestinationContentInput extends StatelessWidget {
           // Zulip expresses channels and topics, not any normal English punctuation,
           // so don't make sense to translate. See:
           //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-          '#$streamName > ${topic.displayName}');
+          // ignore: dead_null_aware_expression // null topic names soon to be enabled
+          '#$streamName > ${topic.displayName ?? store.realmEmptyTopicDisplayName}');
 
       case DmNarrow(otherRecipientIds: []): // The self-1:1 thread.
         return zulipLocalizations.composeBoxSelfDmContentHint;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -579,23 +579,31 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     super.dispose();
   }
 
+  /// The topic name to use in the hint text.
+  TopicName _hintTopic() {
+    return TopicName(widget.controller.topic.textNormalized);
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
+
     final streamName = store.streams[widget.narrow.streamId]?.name
       ?? zulipLocalizations.unknownChannelName;
-    final topic = TopicName(widget.controller.topic.textNormalized);
+    final hintDestination =
+      // No i18n of this use of "#" and ">" string; those are part of how
+      // Zulip expresses channels and topics, not any normal English punctuation,
+      // so don't make sense to translate. See:
+      //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
+      '#$streamName > ${_hintTopic().displayName}';
+
     return _ContentInput(
       narrow: widget.narrow,
-      destination: TopicNarrow(widget.narrow.streamId, topic),
+      destination: TopicNarrow(widget.narrow.streamId,
+        TopicName(widget.controller.topic.textNormalized)),
       controller: widget.controller,
-      hintText: zulipLocalizations.composeBoxChannelContentHint(
-        // No i18n of this use of "#" and ">" string; those are part of how
-        // Zulip expresses channels and topics, not any normal English punctuation,
-        // so don't make sense to translate. See:
-        //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-        '#$streamName > ${topic.displayName}'));
+      hintText: zulipLocalizations.composeBoxChannelContentHint(hintDestination));
   }
 }
 

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -370,11 +370,20 @@ void main() {
       });
     });
 
-    testWidgets('to TopicNarrow', (tester) async {
-      await prepare(tester,
-        narrow: TopicNarrow(channel.streamId, TopicName('topic')));
-      checkComposeBoxHintTexts(tester,
-        contentHintText: 'Message #${channel.name} > topic');
+    group('to TopicNarrow', () {
+      testWidgets('with non-empty topic', (tester) async {
+        await prepare(tester,
+          narrow: TopicNarrow(channel.streamId, TopicName('topic')));
+        checkComposeBoxHintTexts(tester,
+          contentHintText: 'Message #${channel.name} > topic');
+      });
+
+      testWidgets('with empty topic', (tester) async {
+        await prepare(tester,
+          narrow: TopicNarrow(channel.streamId, TopicName('')));
+        checkComposeBoxHintTexts(tester, contentHintText:
+          'Message #${channel.name} > ${eg.defaultRealmEmptyTopicDisplayName}');
+      }, skip: true); // null topic names soon to be enabled
     });
 
     testWidgets('to DmNarrow with self', (tester) async {


### PR DESCRIPTION
Similar to #1297, this PR focuses on part of the general chat feature, with some final "do not merge" commits to make it testable.

This includes the following commits:

* 5ad98d9bb compose: Support sending to empty topic
* 1e31660a3 compose: Change content input hint text if topic is empty and mandatory
* 073042a69 compose [nfc]: Make isTopicVacuous private
* dd47653d3 compose [nfc]: Handle empty topics for fixed destination input hint text
* 73c46b5e3 compose test [nfc]: Extract ChannelNarrow variable
* 0f4e7948d action_sheet [nfc]: Hide resolve/unresolve button for empty topic

The remaining commits should be reviewed in #1297, but neither PR blocks each other, as they each focuses on a specific part of the feature.

<details>
<summary>Screenshots</summary>

| mandatory topics | non-empty topic | content is focused | content isn't focused |
| - | - | - | - |
| true | ![mandatory-channel-non-empty](https://github.com/user-attachments/assets/f4b80f0f-20ae-4ca4-b55d-60f7cffcf45a) | ![mandatory-channel-empty-focused](https://github.com/user-attachments/assets/337bfeb2-0247-4c29-b8ae-f7a284eb20e4) | ![mandatory-channel-empty-non-focused](https://github.com/user-attachments/assets/b9212495-5e9b-4c0f-a02a-56e8894e3903) |
| false | ![non-mandatory-channel-non-empty](https://github.com/user-attachments/assets/15403d61-6088-44e4-a361-d27accdb72bc) | ![non-mandatory-channel-empty-focused](https://github.com/user-attachments/assets/569d42cd-c492-419a-b400-c0c4f9638d6e) | ![non-mandatory-channel-empty-non-focused](https://github.com/user-attachments/assets/a0eca4f4-acea-4755-84e5-676f5ac48c0b) |
| false (legacy, FL<334) | / | ![non-mandatory-channel-empty-focused-legacy](https://github.com/user-attachments/assets/84981053-80f2-4918-9e99-5171910bfd8c) | ![non-mandatory-channel-empty-non-focused-legacy](https://github.com/user-attachments/assets/afc06898-f20f-4628-8941-d801606fc9d1) |
| hide resolve | ![resolve](https://github.com/user-attachments/assets/d09b5b05-d947-4c7e-a2e7-9624689aa96a) | |
</details>



