### PR TITLE
actions [nfc]: Namespace actions as statics on a ZulipAction class, and document

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -796,7 +796,8 @@ class MarkAsUnreadButton extends MessageActionSheetMenuItemButton {
 
   @override void onPressed() async {
     final narrow = findMessageListPage().narrow;
-    unawaited(markNarrowAsUnreadFromMessage(pageContext, message, narrow));
+    unawaited(ZulipAction.markNarrowAsUnreadFromMessage(pageContext,
+      message, narrow));
   }
 }
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -17,6 +17,11 @@ import 'store.dart';
 /// But they don't belong in `lib/api/`, because they also interact with widgets
 /// in order to present success or error feedback to the user through the UI.
 abstract final class ZulipAction {
+  /// Mark the given narrow as read,
+  /// showing feedback to the user on progress or failure.
+  ///
+  /// This is mostly a wrapper around [updateMessageFlagsStartingFromAnchor];
+  /// for details on the UI feedback, see there.
   static Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
     final store = PerAccountStoreWidget.of(context);
     final connection = store.connection;
@@ -63,6 +68,11 @@ abstract final class ZulipAction {
     }
   }
 
+  /// Mark the given narrow as unread from the given message onward,
+  /// showing feedback to the user on progress or failure.
+  ///
+  /// This is a wrapper around [updateMessageFlagsStartingFromAnchor];
+  /// for details on the UI feedback, see there.
   static Future<void> markNarrowAsUnreadFromMessage(
     BuildContext context,
     Message message,

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -1,11 +1,3 @@
-/// Methods that act through the Zulip API and show feedback in the UI.
-///
-/// The methods in this file can be thought of as higher-level wrappers for
-/// some of the Zulip API endpoint binding methods in `lib/api/route/`.
-/// But they don't belong in `lib/api/`, because they also interact with widgets
-/// in order to present success or error feedback to the user through the UI.
-library;
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -18,206 +10,214 @@ import '../model/narrow.dart';
 import 'dialog.dart';
 import 'store.dart';
 
-Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
-  final store = PerAccountStoreWidget.of(context);
-  final connection = store.connection;
-  final zulipLocalizations = ZulipLocalizations.of(context);
-  final useLegacy = connection.zulipFeatureLevel! < 155; // TODO(server-6)
-  if (useLegacy) {
-    try {
-      await _legacyMarkNarrowAsRead(context, narrow);
-      return;
-    } catch (e) {
-      if (!context.mounted) return;
-      showErrorDialog(context: context,
-        title: zulipLocalizations.errorMarkAsReadFailedTitle,
-        message: e.toString()); // TODO(#741): extract user-facing message better
-      return;
-    }
-  }
-
-  final didPass = await updateMessageFlagsStartingFromAnchor(
-    context: context,
-    // Include `is:unread` in the narrow.  That has a database index, so
-    // this can be an important optimization in narrows with a lot of history.
-    // The server applies the same optimization within the (deprecated)
-    // specialized endpoints for marking messages as read; see
-    // `do_mark_stream_messages_as_read` in `zulip:zerver/actions/message_flags.py`.
-    apiNarrow: narrow.apiEncode()..add(ApiNarrowIs(IsOperand.unread)),
-    // Use [AnchorCode.oldest], because [AnchorCode.firstUnread]
-    // will be the oldest non-muted unread message, which would
-    // result in muted unreads older than the first unread not
-    // being processed.
-    anchor: AnchorCode.oldest,
-    // [AnchorCode.oldest] is an anchor ID lower than any valid
-    // message ID.
-    includeAnchor: false,
-    op: UpdateMessageFlagsOp.add,
-    flag: MessageFlag.read,
-    onCompletedMessage: zulipLocalizations.markAsReadComplete,
-    progressMessage: zulipLocalizations.markAsReadInProgress,
-    onFailedTitle: zulipLocalizations.errorMarkAsReadFailedTitle);
-
-  if (!didPass || !context.mounted) return;
-  if (narrow is CombinedFeedNarrow) {
-    PerAccountStoreWidget.of(context).unreads.handleAllMessagesReadSuccess();
-  }
-}
-
-Future<void> markNarrowAsUnreadFromMessage(
-  BuildContext context,
-  Message message,
-  Narrow narrow,
-) async {
-  final connection = PerAccountStoreWidget.of(context).connection;
-  assert(connection.zulipFeatureLevel! >= 155); // TODO(server-6)
-  final zulipLocalizations = ZulipLocalizations.of(context);
-  await updateMessageFlagsStartingFromAnchor(
-    context: context,
-    apiNarrow: narrow.apiEncode(),
-    anchor: NumericAnchor(message.id),
-    includeAnchor: true,
-    op: UpdateMessageFlagsOp.remove,
-    flag: MessageFlag.read,
-    onCompletedMessage: zulipLocalizations.markAsUnreadComplete,
-    progressMessage: zulipLocalizations.markAsUnreadInProgress,
-    onFailedTitle: zulipLocalizations.errorMarkAsUnreadFailedTitle);
-}
-
-/// Add or remove the given flag from the anchor to the end of the narrow,
-/// showing feedback to the user on progress or failure.
+/// Methods that act through the Zulip API and show feedback in the UI.
 ///
-/// This has the semantics of [updateMessageFlagsForNarrow]
-/// (see https://zulip.com/api/update-message-flags-for-narrow)
-/// with `numBefore: 0` and infinite `numAfter`.  It operates by calling that
-/// endpoint with a finite `numAfter` as a batch size, in a loop.
-///
-/// If the operation requires more than one batch, the user is shown progress
-/// feedback through [SnackBar], using [progressMessage] and [onCompletedMessage].
-/// If the operation fails, the user is shown an error dialog box with title
-/// [onFailedTitle].
-///
-/// Returns true just if the operation finished successfully.
-Future<bool> updateMessageFlagsStartingFromAnchor({
-  required BuildContext context,
-  required List<ApiNarrowElement> apiNarrow,
-  required Anchor anchor,
-  required bool includeAnchor,
-  required UpdateMessageFlagsOp op,
-  required MessageFlag flag,
-  required String Function(int) onCompletedMessage,
-  required String progressMessage,
-  required String onFailedTitle,
-}) async {
-  try {
+/// The static methods on this class can be thought of as higher-level wrappers
+/// for some of the Zulip API endpoint binding methods in `lib/api/route/`.
+/// But they don't belong in `lib/api/`, because they also interact with widgets
+/// in order to present success or error feedback to the user through the UI.
+abstract final class ZulipAction {
+  static Future<void> markNarrowAsRead(BuildContext context, Narrow narrow) async {
     final store = PerAccountStoreWidget.of(context);
     final connection = store.connection;
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
-
-    // Compare web's `mark_all_as_read` in web/src/unread_ops.js
-    // and zulip-mobile's `markAsUnreadFromMessage` in src/action-sheets/index.js .
-    int responseCount = 0;
-    int updatedCount = 0;
-    while (true) {
-      final result = await updateMessageFlagsForNarrow(connection,
-        anchor: anchor,
-        includeAnchor: includeAnchor,
-        // There is an upper limit of 5000 messages per batch
-        // (numBefore + numAfter <= 5000) enforced on the server.
-        // See `update_message_flags_in_narrow` in zerver/views/message_flags.py .
-        // zulip-mobile uses `numAfter` of 5000, but web uses 1000
-        // for more responsive feedback. See zulip@f0d87fcf6.
-        numBefore: 0,
-        numAfter: 1000,
-        narrow: apiNarrow,
-        op: op,
-        flag: flag);
-      if (!context.mounted) {
-        scaffoldMessenger.clearSnackBars();
-        return false;
-      }
-      responseCount++;
-      updatedCount += result.updatedCount;
-
-      if (result.foundNewest) {
-        if (responseCount > 1) {
-          // We previously showed an in-progress [SnackBar], so say we're done.
-          // There may be a backlog of [SnackBar]s accumulated in the queue
-          // so be sure to clear them out here.
-          scaffoldMessenger
-            ..clearSnackBars()
-            ..showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
-                content: Text(onCompletedMessage(updatedCount))));
-        }
-        return true;
-      }
-
-      if (result.lastProcessedId == null) {
-        final zulipLocalizations = ZulipLocalizations.of(context);
-        // No messages were in the range of the request.
-        // This should be impossible given that `foundNewest` was false
-        // (and that our `numAfter` was positive.)
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final useLegacy = connection.zulipFeatureLevel! < 155; // TODO(server-6)
+    if (useLegacy) {
+      try {
+        await _legacyMarkNarrowAsRead(context, narrow);
+        return;
+      } catch (e) {
+        if (!context.mounted) return;
         showErrorDialog(context: context,
-          title: onFailedTitle,
-          message: zulipLocalizations.errorInvalidResponse);
-        return false;
+          title: zulipLocalizations.errorMarkAsReadFailedTitle,
+          message: e.toString()); // TODO(#741): extract user-facing message better
+        return;
       }
-      anchor = NumericAnchor(result.lastProcessedId!);
-      includeAnchor = false;
-
-      // The task is taking a while, so tell the user we're working on it.
-      // TODO: Ideally we'd have a progress widget here that showed up based
-      //   on actual time elapsed -- so it could appear before the first
-      //   batch returns, if that takes a while -- and that then stuck
-      //   around continuously until the task ends. For now we use a
-      //   series of [SnackBar]s, which may feel a bit janky.
-      //   There is complexity in tracking the status of each [SnackBar],
-      //   due to having no way to determine which is currently active,
-      //   or if there is an active one at all.  Resetting the [SnackBar] here
-      //   results in the same message popping in and out and the user experience
-      //   is better for now if we allow them to run their timer through
-      //   and clear the backlog later.
-      scaffoldMessenger.showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
-        content: Text(progressMessage)));
     }
-  } catch (e) {
-    if (!context.mounted) return false;
-    showErrorDialog(context: context,
-      title: onFailedTitle,
-      message: e.toString()); // TODO(#741): extract user-facing message better
-    return false;
-  }
-}
 
-Future<void> _legacyMarkNarrowAsRead(BuildContext context, Narrow narrow) async {
-  final store = PerAccountStoreWidget.of(context);
-  final connection = store.connection;
-  switch (narrow) {
-    case CombinedFeedNarrow():
-      await markAllAsRead(connection);
-    case ChannelNarrow(:final streamId):
-      await markStreamAsRead(connection, streamId: streamId);
-    case TopicNarrow(:final streamId, :final topic):
-      await markTopicAsRead(connection, streamId: streamId, topicName: topic);
-    case DmNarrow():
-      final unreadDms = store.unreads.dms[narrow];
-      // Silently ignore this race-condition as the outcome
-      // (no unreads in this narrow) was the desired end-state
-      // of pushing the button.
-      if (unreadDms == null) return;
-      await updateMessageFlags(connection,
-        messages: unreadDms,
-        op: UpdateMessageFlagsOp.add,
-        flag: MessageFlag.read);
-    case MentionsNarrow():
-      final unreadMentions = store.unreads.mentions.toList();
-      if (unreadMentions.isEmpty) return;
-      await updateMessageFlags(connection,
-        messages: unreadMentions,
-        op: UpdateMessageFlagsOp.add,
-        flag: MessageFlag.read);
-    case StarredMessagesNarrow():
-      // TODO: Implement unreads handling.
-      return;
+    final didPass = await updateMessageFlagsStartingFromAnchor(
+      context: context,
+      // Include `is:unread` in the narrow.  That has a database index, so
+      // this can be an important optimization in narrows with a lot of history.
+      // The server applies the same optimization within the (deprecated)
+      // specialized endpoints for marking messages as read; see
+      // `do_mark_stream_messages_as_read` in `zulip:zerver/actions/message_flags.py`.
+      apiNarrow: narrow.apiEncode()..add(ApiNarrowIs(IsOperand.unread)),
+      // Use [AnchorCode.oldest], because [AnchorCode.firstUnread]
+      // will be the oldest non-muted unread message, which would
+      // result in muted unreads older than the first unread not
+      // being processed.
+      anchor: AnchorCode.oldest,
+      // [AnchorCode.oldest] is an anchor ID lower than any valid
+      // message ID.
+      includeAnchor: false,
+      op: UpdateMessageFlagsOp.add,
+      flag: MessageFlag.read,
+      onCompletedMessage: zulipLocalizations.markAsReadComplete,
+      progressMessage: zulipLocalizations.markAsReadInProgress,
+      onFailedTitle: zulipLocalizations.errorMarkAsReadFailedTitle);
+
+    if (!didPass || !context.mounted) return;
+    if (narrow is CombinedFeedNarrow) {
+      PerAccountStoreWidget.of(context).unreads.handleAllMessagesReadSuccess();
+    }
+  }
+
+  static Future<void> markNarrowAsUnreadFromMessage(
+    BuildContext context,
+    Message message,
+    Narrow narrow,
+  ) async {
+    final connection = PerAccountStoreWidget.of(context).connection;
+    assert(connection.zulipFeatureLevel! >= 155); // TODO(server-6)
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    await updateMessageFlagsStartingFromAnchor(
+      context: context,
+      apiNarrow: narrow.apiEncode(),
+      anchor: NumericAnchor(message.id),
+      includeAnchor: true,
+      op: UpdateMessageFlagsOp.remove,
+      flag: MessageFlag.read,
+      onCompletedMessage: zulipLocalizations.markAsUnreadComplete,
+      progressMessage: zulipLocalizations.markAsUnreadInProgress,
+      onFailedTitle: zulipLocalizations.errorMarkAsUnreadFailedTitle);
+  }
+
+  /// Add or remove the given flag from the anchor to the end of the narrow,
+  /// showing feedback to the user on progress or failure.
+  ///
+  /// This has the semantics of [updateMessageFlagsForNarrow]
+  /// (see https://zulip.com/api/update-message-flags-for-narrow)
+  /// with `numBefore: 0` and infinite `numAfter`.  It operates by calling that
+  /// endpoint with a finite `numAfter` as a batch size, in a loop.
+  ///
+  /// If the operation requires more than one batch, the user is shown progress
+  /// feedback through [SnackBar], using [progressMessage] and [onCompletedMessage].
+  /// If the operation fails, the user is shown an error dialog box with title
+  /// [onFailedTitle].
+  ///
+  /// Returns true just if the operation finished successfully.
+  static Future<bool> updateMessageFlagsStartingFromAnchor({
+    required BuildContext context,
+    required List<ApiNarrowElement> apiNarrow,
+    required Anchor anchor,
+    required bool includeAnchor,
+    required UpdateMessageFlagsOp op,
+    required MessageFlag flag,
+    required String Function(int) onCompletedMessage,
+    required String progressMessage,
+    required String onFailedTitle,
+  }) async {
+    try {
+      final store = PerAccountStoreWidget.of(context);
+      final connection = store.connection;
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+
+      // Compare web's `mark_all_as_read` in web/src/unread_ops.js
+      // and zulip-mobile's `markAsUnreadFromMessage` in src/action-sheets/index.js .
+      int responseCount = 0;
+      int updatedCount = 0;
+      while (true) {
+        final result = await updateMessageFlagsForNarrow(connection,
+          anchor: anchor,
+          includeAnchor: includeAnchor,
+          // There is an upper limit of 5000 messages per batch
+          // (numBefore + numAfter <= 5000) enforced on the server.
+          // See `update_message_flags_in_narrow` in zerver/views/message_flags.py .
+          // zulip-mobile uses `numAfter` of 5000, but web uses 1000
+          // for more responsive feedback. See zulip@f0d87fcf6.
+          numBefore: 0,
+          numAfter: 1000,
+          narrow: apiNarrow,
+          op: op,
+          flag: flag);
+        if (!context.mounted) {
+          scaffoldMessenger.clearSnackBars();
+          return false;
+        }
+        responseCount++;
+        updatedCount += result.updatedCount;
+
+        if (result.foundNewest) {
+          if (responseCount > 1) {
+            // We previously showed an in-progress [SnackBar], so say we're done.
+            // There may be a backlog of [SnackBar]s accumulated in the queue
+            // so be sure to clear them out here.
+            scaffoldMessenger
+              ..clearSnackBars()
+              ..showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
+                  content: Text(onCompletedMessage(updatedCount))));
+          }
+          return true;
+        }
+
+        if (result.lastProcessedId == null) {
+          final zulipLocalizations = ZulipLocalizations.of(context);
+          // No messages were in the range of the request.
+          // This should be impossible given that `foundNewest` was false
+          // (and that our `numAfter` was positive.)
+          showErrorDialog(context: context,
+            title: onFailedTitle,
+            message: zulipLocalizations.errorInvalidResponse);
+          return false;
+        }
+        anchor = NumericAnchor(result.lastProcessedId!);
+        includeAnchor = false;
+
+        // The task is taking a while, so tell the user we're working on it.
+        // TODO: Ideally we'd have a progress widget here that showed up based
+        //   on actual time elapsed -- so it could appear before the first
+        //   batch returns, if that takes a while -- and that then stuck
+        //   around continuously until the task ends. For now we use a
+        //   series of [SnackBar]s, which may feel a bit janky.
+        //   There is complexity in tracking the status of each [SnackBar],
+        //   due to having no way to determine which is currently active,
+        //   or if there is an active one at all.  Resetting the [SnackBar] here
+        //   results in the same message popping in and out and the user experience
+        //   is better for now if we allow them to run their timer through
+        //   and clear the backlog later.
+        scaffoldMessenger.showSnackBar(SnackBar(behavior: SnackBarBehavior.floating,
+          content: Text(progressMessage)));
+      }
+    } catch (e) {
+      if (!context.mounted) return false;
+      showErrorDialog(context: context,
+        title: onFailedTitle,
+        message: e.toString()); // TODO(#741): extract user-facing message better
+      return false;
+    }
+  }
+
+  static Future<void> _legacyMarkNarrowAsRead(BuildContext context, Narrow narrow) async {
+    final store = PerAccountStoreWidget.of(context);
+    final connection = store.connection;
+    switch (narrow) {
+      case CombinedFeedNarrow():
+        await markAllAsRead(connection);
+      case ChannelNarrow(:final streamId):
+        await markStreamAsRead(connection, streamId: streamId);
+      case TopicNarrow(:final streamId, :final topic):
+        await markTopicAsRead(connection, streamId: streamId, topicName: topic);
+      case DmNarrow():
+        final unreadDms = store.unreads.dms[narrow];
+        // Silently ignore this race-condition as the outcome
+        // (no unreads in this narrow) was the desired end-state
+        // of pushing the button.
+        if (unreadDms == null) return;
+        await updateMessageFlags(connection,
+          messages: unreadDms,
+          op: UpdateMessageFlagsOp.add,
+          flag: MessageFlag.read);
+      case MentionsNarrow():
+        final unreadMentions = store.unreads.mentions.toList();
+        if (unreadMentions.isEmpty) return;
+        await updateMessageFlags(connection,
+          messages: unreadMentions,
+          op: UpdateMessageFlagsOp.add,
+          flag: MessageFlag.read);
+      case StarredMessagesNarrow():
+        // TODO: Implement unreads handling.
+        return;
+    }
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -803,7 +803,7 @@ class _MarkAsReadWidgetState extends State<MarkAsReadWidget> {
   void _handlePress(BuildContext context) async {
     if (!context.mounted) return;
     setState(() => _loading = true);
-    await markNarrowAsRead(context, widget.narrow);
+    await ZulipAction.markNarrowAsRead(context, widget.narrow);
     setState(() => _loading = false);
   }
 

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -56,7 +56,7 @@ void main() {
         processedCount: 11, updatedCount: 3,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: true).toJson());
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       final apiNarrow = narrow.apiEncode()..add(ApiNarrowIs(IsOperand.unread));
@@ -81,7 +81,7 @@ void main() {
         processedCount: 11, updatedCount: 3,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: true).toJson());
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(connection.lastRequest).isA<http.Request>()
@@ -107,7 +107,7 @@ void main() {
         processedCount: 11, updatedCount: 3,
         firstProcessedId: null, lastProcessedId: null,
         foundOldest: true, foundNewest: true).toJson());
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(store.unreads.oldUnreadsMissing).isFalse();
@@ -121,7 +121,7 @@ void main() {
 
       connection.zulipFeatureLevel = 154;
       connection.prepare(json: {});
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(connection.lastRequest).isA<http.Request>()
@@ -140,7 +140,7 @@ void main() {
       await prepare(tester);
       connection.zulipFeatureLevel = 154;
       connection.prepare(json: {});
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(connection.lastRequest).isA<http.Request>()
@@ -156,7 +156,7 @@ void main() {
       await prepare(tester);
       connection.zulipFeatureLevel = 154;
       connection.prepare(json: {});
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(connection.lastRequest).isA<http.Request>()
@@ -179,7 +179,7 @@ void main() {
       connection.zulipFeatureLevel = 154;
       connection.prepare(json:
         UpdateMessageFlagsResult(messages: [message.id]).toJson());
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(connection.lastRequest).isA<http.Request>()
@@ -200,7 +200,7 @@ void main() {
       connection.zulipFeatureLevel = 154;
       connection.prepare(json:
         UpdateMessageFlagsResult(messages: [message.id]).toJson());
-      final future = markNarrowAsRead(context, narrow);
+      final future = ZulipAction.markNarrowAsRead(context, narrow);
       await tester.pump(Duration.zero);
       await future;
       check(connection.lastRequest).isA<http.Request>()
@@ -222,7 +222,7 @@ void main() {
     final apiNarrow = narrow.apiEncode()..add(ApiNarrowIs(IsOperand.unread));
 
     Future<bool> invokeUpdateMessageFlagsStartingFromAnchor() =>
-      updateMessageFlagsStartingFromAnchor(
+      ZulipAction.updateMessageFlagsStartingFromAnchor(
         context: context,
         apiNarrow: apiNarrow,
         op: UpdateMessageFlagsOp.add,


### PR DESCRIPTION
This makes it explicit at each call site that the method being called
is an action, not (for example) an API endpoint binding.  The
difference is important in particular because it affects how --
really, whether -- the caller should handle errors.

See discussion from when the similarity in appearance to API endpoint
bindings caused confusion:
  https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/.23F1317.20showErrorDialog/near/2080570

Also document the two methods here (other than the private helper) that didn't already have docs.
