### PR TITLE
check: Ensure GNU coreutils are used on macOS

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -18,6 +18,9 @@ set -euo pipefail
 
 this_dir=${BASH_SOURCE[0]%/*}
 
+# shellcheck source=tools/lib/ensure-coreutils.sh
+. "${this_dir}"/lib/ensure-coreutils.sh
+
 # shellcheck source=tools/lib/git.sh
 . "${this_dir}"/lib/git.sh
 


### PR DESCRIPTION
Without this, there are failures when running `./tools/check` script with `--verbose` flag:

    Test command: ./tools/check pigeon --all-files --fix --verbose
    date: illegal option -- -
    usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
                [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
                [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]
    Time now:
    zulip-flutter e0df0ed10 • 2025-02-26 05:01:14 +0000