### PR TITLE
mailmap: Add Tomlin7's mailmap entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,6 +18,7 @@ K Akhil <kssakhilraj@gmail.com>
 Lalit Kumar Singh <lalitkumarsingh3716@gmail.com>
 Rajesh Malviya <rmalviya@zulip.com> <rajveer0malviya@gmail.com>
 Shu Chen <shu@zulip.com> <shu.chen@freelancedreams.com>
+Tomlin7 <billydevbusiness@gmail.com>
 
 # The goal when editing this file is to group all of a given person's
 # contributions together, and under their preferred name and email


### PR DESCRIPTION
This pr adds my (`tomlin7`) entry to the `.mailmap` file because my name appears as `billy` in the git log. This wasn't intended, and it is my bad that I didn't keep my local git config up-to-date.