### PR TITLE
msglist: Follow user settings for message timestamps

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1334,7 +1334,10 @@ class MessageWithPossibleSender extends StatelessWidget {
 
     Widget? senderRow;
     if (item.showSender) {
-      final time = _kMessageTimestampFormat
+      final userSettings = store.userSettings;
+      final is24HourFormat = userSettings?.twentyFourHourTime;
+      final timeFormat = DateFormat(getTimeFormat(is24HourFormat ?? false), ZulipLocalizations.of(context).localeName);
+      final time = timeFormat
         .format(DateTime.fromMillisecondsSinceEpoch(1000 * message.timestamp));
       senderRow = Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -1438,4 +1441,6 @@ class MessageWithPossibleSender extends StatelessWidget {
 }
 
 // TODO(i18n): web seems to ignore locale in formatting time, but we could do better
-final _kMessageTimestampFormat = DateFormat('h:mm aa', 'en_US');
+String getTimeFormat(bool is24Hour) {
+  return is24Hour ? 'HH:mm' : 'h:mm aa';
+}


### PR DESCRIPTION
### Fixes: #1015 

### Summary  
The message timestamps now uses user's `twentyFourHourTime` settings. 

Previously, timestamps were always formatted in 12-hour format (`h:mm aa`), irrespective of the user's preference. 

With this fix, timestamps now correctly switch between:  
- **24-hour format:** `HH:mm`  
- **12-hour format:** `h:mm aa`  

### Changes Made
- Retrieved the user's `twentyFourHourTime` setting from `userSettings`.
- Applied the appropriate time format based on the user's preference.

### Screenshots

| 12-Hour Format | 24-Hour Format |  
| -------------- | -------------- |  
| ![12-Hour](https://github.com/user-attachments/assets/a79a2511-0468-46b9-ba21-19b46966859f) | ![24-Hour](https://github.com/user-attachments/assets/bb02bc4c-3a19-4851-b8e7-e66a62246c92) |  