### PR TITLE
test [nfc]: Make globalSettings optional on TestGlobalStore

### DIFF
--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -885,16 +885,12 @@ GlobalSettingsData globalSettings({
     themeSetting: themeSetting,
   );
 }
-const _globalSettings = globalSettings;
 
 TestGlobalStore globalStore({
   GlobalSettingsData? globalSettings,
   List<Account> accounts = const [],
 }) {
-  return TestGlobalStore(
-    globalSettings: globalSettings ?? _globalSettings(),
-    accounts: accounts,
-  );
+  return TestGlobalStore(globalSettings: globalSettings, accounts: accounts);
 }
 const _globalStore = globalStore;
 

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -1152,9 +1152,7 @@ void main() {
 }
 
 class LoadingTestGlobalStore extends TestGlobalStore {
-  LoadingTestGlobalStore({
-    required super.accounts,
-  }) : super(globalSettings: eg.globalSettings());
+  LoadingTestGlobalStore({required super.accounts});
 
   Map<int, List<Completer<PerAccountStore>>> completers = {};
 

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -23,7 +23,10 @@ import '../example_data.dart' as eg;
 ///
 /// See also [TestZulipBinding.globalStore], which provides one of these.
 class TestGlobalStore extends GlobalStore {
-  TestGlobalStore({required super.globalSettings, required super.accounts});
+  TestGlobalStore({
+    GlobalSettingsData? globalSettings,
+    required super.accounts,
+  }) : super(globalSettings: globalSettings ?? eg.globalSettings());
 
   @override
   Future<void> doUpdateGlobalSettings(GlobalSettingsCompanion data) async {


### PR DESCRIPTION
This has a natural default, at least in tests, because most tests don't care about the specific value of the global settings.

(By contrast most tests that interact with the store at all will care what set of accounts exist, so there isn't as natural a default for `accounts`.)

Originally noticed this here:
  https://github.com/zulip/zulip-flutter/pull/1386#discussion_r1990358363