### PR TITLE
Use max_topic_length instead of hardcoded limit of 60

### DIFF
--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -24,6 +24,8 @@ class InitialSnapshot {
 
   final List<CustomProfileField> customProfileFields;
 
+  final int maxTopicLength;
+
   /// The realm-level policy, on pre-FL 163 servers, for visibility of real email addresses.
   ///
   /// Search for "email_address_visibility" in https://zulip.com/api/register-queue.
@@ -123,6 +125,7 @@ class InitialSnapshot {
     required this.zulipMergeBase,
     required this.alertWords,
     required this.customProfileFields,
+    required this.maxTopicLength,
     required this.emailAddressVisibility,
     required this.serverTypingStartedExpiryPeriodMilliseconds,
     required this.serverTypingStoppedWaitPeriodMilliseconds,

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -22,6 +22,7 @@ InitialSnapshot _$InitialSnapshotFromJson(
       (json['custom_profile_fields'] as List<dynamic>)
           .map((e) => CustomProfileField.fromJson(e as Map<String, dynamic>))
           .toList(),
+  maxTopicLength: (json['max_topic_length'] as num).toInt(),
   emailAddressVisibility: $enumDecodeNullable(
     _$EmailAddressVisibilityEnumMap,
     json['email_address_visibility'],
@@ -115,6 +116,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(InitialSnapshot instance) =>
       'zulip_merge_base': instance.zulipMergeBase,
       'alert_words': instance.alertWords,
       'custom_profile_fields': instance.customProfileFields,
+      'max_topic_length': instance.maxTopicLength,
       'email_address_visibility':
           _$EmailAddressVisibilityEnumMap[instance.emailAddressVisibility],
       'server_typing_started_expiry_period_milliseconds':

--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -155,8 +155,6 @@ class GetMessagesResult {
   Map<String, dynamic> toJson() => _$GetMessagesResultToJson(this);
 }
 
-// https://zulip.com/api/send-message#parameter-topic
-const int kMaxTopicLengthCodePoints = 60;
 
 // https://zulip.com/api/send-message#parameter-content
 const int kMaxMessageLengthCodePoints = 10000;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -333,6 +333,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
       realmEmptyTopicDisplayName: initialSnapshot.realmEmptyTopicDisplayName,
       realmDefaultExternalAccounts: initialSnapshot.realmDefaultExternalAccounts,
       customProfileFields: _sortCustomProfileFields(initialSnapshot.customProfileFields),
+      maxTopicLength: initialSnapshot.maxTopicLength,
       emailAddressVisibility: initialSnapshot.emailAddressVisibility,
       emoji: EmojiStoreImpl(
         realmUrl: realmUrl, allRealmEmoji: initialSnapshot.realmEmoji),
@@ -376,6 +377,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
     required String? realmEmptyTopicDisplayName,
     required this.realmDefaultExternalAccounts,
     required this.customProfileFields,
+    required this.maxTopicLength,
     required this.emailAddressVisibility,
     required EmojiStoreImpl emoji,
     required this.accountId,
@@ -456,6 +458,7 @@ class PerAccountStore extends ChangeNotifier with EmojiStore, UserStore, Channel
     return _realmEmptyTopicDisplayName ?? 'general chat';
   }
   final String? _realmEmptyTopicDisplayName; // TODO(#668): update this realm setting
+  final int maxTopicLength;
 
   final Map<String, RealmDefaultExternalAccount> realmDefaultExternalAccounts;
   List<CustomProfileField> customProfileFields;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -143,6 +143,7 @@ enum TopicValidationError {
 
 class ComposeTopicController extends ComposeController<TopicValidationError> {
   ComposeTopicController({required this.store}) {
+    maxLengthUnicodeCodePoints = store.maxTopicLength;
     _update();
   }
 
@@ -151,8 +152,7 @@ class ComposeTopicController extends ComposeController<TopicValidationError> {
   // TODO(#668): listen to [PerAccountStore] once we subscribe to this value
   bool get mandatory => store.realmMandatoryTopics;
 
-  // TODO(#307) use `max_topic_length` instead of hardcoded limit
-  @override final maxLengthUnicodeCodePoints = kMaxTopicLengthCodePoints;
+  @override late int maxLengthUnicodeCodePoints;
 
   @override
   String _computeTextNormalized() {

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -902,6 +902,7 @@ InitialSnapshot initialSnapshot({
   String? zulipMergeBase,
   List<String>? alertWords,
   List<CustomProfileField>? customProfileFields,
+  int? maxTopicLength,
   EmailAddressVisibility? emailAddressVisibility,
   int? serverTypingStartedExpiryPeriodMilliseconds,
   int? serverTypingStoppedWaitPeriodMilliseconds,
@@ -932,6 +933,7 @@ InitialSnapshot initialSnapshot({
     zulipMergeBase: zulipMergeBase ?? recentZulipVersion,
     alertWords: alertWords ?? ['klaxon'],
     customProfileFields: customProfileFields ?? [],
+    maxTopicLength: maxTopicLength ?? 60,
     emailAddressVisibility: emailAddressVisibility ?? EmailAddressVisibility.everyone,
     serverTypingStartedExpiryPeriodMilliseconds:
       serverTypingStartedExpiryPeriodMilliseconds ?? 15000,

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -301,20 +301,20 @@ void main() {
 
       testWidgets('too-long topic is rejected', (tester) async {
         await prepareWithTopic(tester,
-          makeStringWithCodePoints(kMaxTopicLengthCodePoints + 1));
+          makeStringWithCodePoints(store.maxTopicLength + 1));
         await tapSendButton(tester);
         await checkErrorResponse(tester);
       });
 
       testWidgets('max-length topic not rejected', (tester) async {
         await prepareWithTopic(tester,
-          makeStringWithCodePoints(kMaxTopicLengthCodePoints));
+          makeStringWithCodePoints(store.maxTopicLength));
         await tapSendButton(tester);
         checkNoErrorDialog(tester);
       });
 
       testWidgets('code points not counted unnecessarily', (tester) async {
-        await prepareWithTopic(tester, 'a' * kMaxTopicLengthCodePoints);
+        await prepareWithTopic(tester, 'a' * store.maxTopicLength);
         check((controller as StreamComposeBoxController)
           .topic.debugLengthUnicodeCodePointsIfLong).isNull();
       });


### PR DESCRIPTION
### Fixes: #307  

### Changes  
- Added `maxTopicLength` field to the initial snapshot to retrieve the value from the server.  
- Stored `maxTopicLength` in `PerAccountStore` from the initial snapshot.  
- Updated `ComposeTopicController` in `compose_box` to use the value from `PerAccountStore`.  
- Removed the hardcoded value.  

### Testing  
- Updated tests to use the new value from `PerAccountStore` instead of the hardcoded value.  
