### PR TITLE
content test: Test tap-link behavior when invalid URL

### DIFF
--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -871,7 +871,18 @@ void main() {
         .single.equals((url: Uri.parse('https://a/'), mode: LaunchMode.inAppBrowserView));
     });
 
-    testWidgets('error dialog if invalid link', (tester) async {
+    testWidgets('error dialog if invalid URL', (tester) async {
+      await prepare(tester,
+        '<p><a href="::invalid::">word</a></p>');
+      await tapText(tester, find.text('word'));
+      await tester.pump();
+      check(testBinding.takeLaunchUrlCalls()).isEmpty();
+      checkErrorDialog(tester,
+        expectedTitle: 'Unable to open link',
+        expectedMessage: 'Link could not be opened: ::invalid::');
+    });
+
+    testWidgets('error dialog if platform cannot open link', (tester) async {
       await prepare(tester,
         '<p><a href="file:///etc/bad">word</a></p>');
       testBinding.launchUrlResult = false;


### PR DESCRIPTION
Thanks Zixuan for noticing we haven't been covering this:
  https://github.com/zulip/zulip-flutter/pull/1410#discussion_r1999450438

-----

Skipping maintainer review just because this is a tiny change; please let me know if this is wrong.