### PR TITLE
[Flutter Migration] migrate emoji_reaction_test.dart

### DIFF
--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_checks/flutter_checks.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:legacy_checks/legacy_checks.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/realm.dart';
@@ -141,8 +142,8 @@ void main() {
                 await setupChipsInBox(tester, reactions: reactions);
 
                 final reactionChipsList = tester.element(find.byType(ReactionChipsList));
-                check(MediaQuery.of(reactionChipsList))
-                  .textScaler.equals(TextScaler.linear(textScaleFactor));
+                check(MediaQuery.of(reactionChipsList).textScaler).legacyMatcher(
+                  isSystemTextScaler(withScaleFactor: textScaleFactor));
                 check(Directionality.of(reactionChipsList)).equals(textDirection);
 
                 // TODO(upstream) Do these in an addTearDown, once we can:


### PR DESCRIPTION
Flutter PR https://github.com/flutter/flutter/pull/159999 (fixes a bug where `MediaQuery` provides an incorrect `TextScaler`) breaks a test in `emoji_reaction_test.dart`.

Currently the `isSystemTextScaler` matcher from the `flutter_test` package can be used to match the system text scaler and is intended to be used for migration. Unfortunately it does not have a `checks` equivalent since flutter / flutter_tests is still using matchers and not importing `checks`.