### PR TITLE
Adjust compose hints toward "general chat"

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -579,8 +579,15 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     super.dispose();
   }
 
-  /// The topic name to use in the hint text.
-  TopicName _hintTopic() {
+  /// The topic name to show in the hint text, or null to show no topic.
+  TopicName? _hintTopic() {
+    if (widget.controller.topic.isTopicVacuous) {
+      if (widget.controller.topic.mandatory) {
+        // The chosen topic can't be sent to, so don't show it.
+        return null;
+      }
+    }
+
     return TopicName(widget.controller.topic.textNormalized);
   }
 
@@ -591,12 +598,13 @@ class _StreamContentInputState extends State<_StreamContentInput> {
 
     final streamName = store.streams[widget.narrow.streamId]?.name
       ?? zulipLocalizations.unknownChannelName;
-    final hintDestination =
+    final hintTopic = _hintTopic();
+    final hintDestination = hintTopic == null ?
       // No i18n of this use of "#" and ">" string; those are part of how
       // Zulip expresses channels and topics, not any normal English punctuation,
       // so don't make sense to translate. See:
       //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-      '#$streamName > ${_hintTopic().displayName}';
+      '#$streamName' : '#$streamName > ${hintTopic.displayName}';
 
     return _ContentInput(
       narrow: widget.narrow,

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -579,23 +579,31 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     super.dispose();
   }
 
+  /// The topic name to use in the hint text.
+  TopicName _hintTopic() {
+    return TopicName(widget.controller.topic.textNormalized);
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
+
     final streamName = store.streams[widget.narrow.streamId]?.name
       ?? zulipLocalizations.unknownChannelName;
-    final topic = TopicName(widget.controller.topic.textNormalized);
+    final hintDestination =
+      // No i18n of this use of "#" and ">" string; those are part of how
+      // Zulip expresses channels and topics, not any normal English punctuation,
+      // so don't make sense to translate. See:
+      //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
+      '#$streamName > ${_hintTopic().displayName}';
+
     return _ContentInput(
       narrow: widget.narrow,
-      destination: TopicNarrow(widget.narrow.streamId, topic),
+      destination: TopicNarrow(widget.narrow.streamId,
+        TopicName(widget.controller.topic.textNormalized)),
       controller: widget.controller,
-      hintText: zulipLocalizations.composeBoxChannelContentHint(
-        // No i18n of this use of "#" and ">" string; those are part of how
-        // Zulip expresses channels and topics, not any normal English punctuation,
-        // so don't make sense to translate. See:
-        //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-        '#$streamName > ${topic.displayName}'));
+      hintText: zulipLocalizations.composeBoxChannelContentHint(hintDestination));
   }
 }
 


### PR DESCRIPTION
Prompted by these comments on #1364, toward #1250:
https://github.com/zulip/zulip-flutter/pull/1364#discussion_r2006560558
https://github.com/zulip/zulip-flutter/pull/1364#discussion_r2006563873

@PIG208 I recommend updating #1364 like so:
* Include the first commit:
  940aeaf7a compose [nfc]: Pull out method for computing topic for hint text

* Complete the second commit:
  750a233ba WIP compose: Omit "(no topic)" from hint when not allowed to send there; TODO fix tests, add tests

  by taking some of the tests from this commit in the other PR which includes a similar behavior change:
  442d11296 compose: Change content input hint text if topic is empty and mandatory

* Rebase the remainder of what's done in the other PR's main two commits:
  442d11296 compose: Change content input hint text if topic is empty and mandatory
  dcaf1659a compose: Support sending to empty topic

  to go atop those changes and use this `_hintTopic` method.