### PR TITLE
Fix DB downgrades to match creating from scratch

### DIFF
--- a/lib/model/database.dart
+++ b/lib/model/database.dart
@@ -92,17 +92,19 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   // When updating the schema:
-  //  * Make the change in the table classes, and bump schemaVersion.
+  //  * Make the change in the table classes, and bump latestSchemaVersion.
   //  * Export the new schema and generate test migrations with drift:
   //    $ tools/check --fix drift
   //    and generate database code with build_runner.
   //    See ../../README.md#generated-files for more
   //    information on using the build_runner.
-  //  * Update [_getSchema] to handle the new schemaVersion.
+  //  * Update [_getSchema] to handle the new latestSchemaVersion.
   //  * Write a migration in `_migrationSteps` below.
   //  * Write tests.
+  static const int latestSchemaVersion = 5; // See note.
+
   @override
-  int get schemaVersion => 5; // See note.
+  int get schemaVersion => latestSchemaVersion;
 
   static Future<void> _dropAndCreateAll(Migrator m, {
     required int schemaVersion,
@@ -175,7 +177,7 @@ class AppDatabase extends _$AppDatabase {
           await _dropAndCreateAll(m, schemaVersion: to);
           return;
         }
-        assert(1 <= from && from <= to && to <= schemaVersion);
+        assert(1 <= from && from <= to && to <= latestSchemaVersion);
 
         await m.runMigrationSteps(from: from, to: to, steps: _migrationSteps);
       });

--- a/lib/model/database.dart
+++ b/lib/model/database.dart
@@ -174,6 +174,13 @@ class AppDatabase extends _$AppDatabase {
           // drop everything from the database and start over.
           // TODO(log): log schema downgrade as an error
           assert(debugLog('Downgrading schema from v$from to v$to.'));
+
+          // In the actual app, the target schema version is always
+          // the latest version as of the code that's being run.
+          // Migrating to earlier versions is useful only for isolating steps
+          // in migration tests; we can forego that for testing downgrades.
+          assert(to == latestSchemaVersion);
+
           await _dropAndCreateAll(m, schemaVersion: to);
           return;
         }

--- a/lib/model/database.dart
+++ b/lib/model/database.dart
@@ -135,14 +135,16 @@ class AppDatabase extends _$AppDatabase {
     },
   );
 
+  Future<void> _createLatestSchema(Migrator m) async {
+    await m.createAll();
+    // Corresponds to `from4to5` above.
+    await into(globalSettings).insert(GlobalSettingsCompanion());
+  }
+
   @override
   MigrationStrategy get migration {
     return MigrationStrategy(
-      onCreate: (Migrator m) async {
-        await m.createAll();
-        // Corresponds to `from4to5` above.
-        await into(globalSettings).insert(GlobalSettingsCompanion());
-      },
+      onCreate: _createLatestSchema,
       onUpgrade: (Migrator m, int from, int to) async {
         if (from > to) {
           // This should only ever happen in dev.  As a dev convenience,
@@ -157,7 +159,7 @@ class AppDatabase extends _$AppDatabase {
           assert(to == latestSchemaVersion);
 
           await _dropAll(m);
-          await m.createAll();
+          await _createLatestSchema(m);
           return;
         }
         assert(1 <= from && from <= to && to <= latestSchemaVersion);

--- a/test/model/database_test.dart
+++ b/test/model/database_test.dart
@@ -153,15 +153,16 @@ void main() {
       const versions = GeneratedHelper.versions;
       final latestVersion = versions.last;
 
-      int fromVersion = versions.first;
+      int prev = versions.first;
       for (final toVersion in versions.skip(1)) {
+        final fromVersion = prev;
         test('from v$fromVersion to v$toVersion', () async {
           final connection = await verifier.startAt(fromVersion);
           final db = AppDatabase(connection);
           await verifier.migrateAndValidate(db, toVersion);
           await db.close();
         });
-        fromVersion = toVersion;
+        prev = toVersion;
       }
 
       for (final fromVersion in versions) {

--- a/test/model/database_test.dart
+++ b/test/model/database_test.dart
@@ -147,6 +147,8 @@ void main() {
       // does not have the extra tables and columns.
       final after = AppDatabase(schema.newConnection());
       await verifier.migrateAndValidate(after, toVersion, validateDropped: true);
+      // Check that a custom migration/setup step of ours got run too.
+      check(await after.getGlobalSettings()).themeSetting.isNull();
       await after.close();
     });
 

--- a/test/model/database_test.dart
+++ b/test/model/database_test.dart
@@ -127,7 +127,8 @@ void main() {
     });
 
     test('downgrading', () async {
-      final schema = await verifier.schemaAt(2);
+      final toVersion = AppDatabase.latestSchemaVersion;
+      final schema = await verifier.schemaAt(toVersion);
 
       // This simulates the scenario during development when running the app
       // with a future schema version that has additional tables and columns.
@@ -135,17 +136,17 @@ void main() {
       await before.customStatement('CREATE TABLE test_extra (num int)');
       await before.customStatement('ALTER TABLE accounts ADD extra_column int');
       await check(verifier.migrateAndValidate(
-        before, 2, validateDropped: true)).throws<SchemaMismatch>();
+        before, toVersion, validateDropped: true)).throws<SchemaMismatch>();
       // Override the schema version by modifying the underlying value
       // drift internally keeps track of in the database.
       // TODO(drift): Expose a better interface for testing this.
-      await before.customStatement('PRAGMA user_version = 999;');
+      await before.customStatement('PRAGMA user_version = ${toVersion + 1};');
       await before.close();
 
       // Simulate starting up the app, with an older schema version that
       // does not have the extra tables and columns.
       final after = AppDatabase(schema.newConnection());
-      await verifier.migrateAndValidate(after, 2, validateDropped: true);
+      await verifier.migrateAndValidate(after, toVersion, validateDropped: true);
       await after.close();
     });
 


### PR DESCRIPTION
Fixes #1427.

Prerequisite for #1421.

## Selected commit messages

#### f64450168 db test: Fix migration tests to use intended source versions

The `fromVersion` reference inside this test body, for each of the
test cases, was referring to the same one, mutable `fromVersion`
variable.  So by the time any of them ran, its value was 5, and they
tested migrating from 5 to 2, 5 to 3, 5 to 4, 5 to 5 respectively.
Meanwhile the test names reflected the intended migrations, because
the names were computed eagerly, reading the value of `fromVersion`
before moving on to the next iteration.

To fix the issue, make a fresh `fromVersion` binding inside each
iteration of the loop.


#### 8ed6c5b8e db [nfc]: Assert downgrades are always to current version

And adjust a test to make that true in tests too.


#### e90ea1055 db [nfc]: Simplify downgrades by using that target is latest

As explained in the parent commit, and asserted just above the
_dropAndCreateAll call site, this fact always holds.  That lets
us simplify how downgrades work, and as a bonus cut one step
from the checklist for making schema updates.

This reverts some of the changes made in 601936da7.


#### 4d8a667fb db: Cut transaction wrappers within migrations

No transactions here will do any good if the changes aren't in a
transaction with the `PRAGMA user_version =` statements that update
the database's record of what version the schema is at, and therefore
of which migrations might be needed.

And if Drift is setting up for us such a transaction, it'll
necessarily enclose the whole migration anyway.


#### f03630805 db: Fix downgrades so they match creating from scratch

Fixes #1427.
