### PR TITLE
Edit-message (1/n): Refactor compose-box banner logic

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1389,7 +1389,7 @@ abstract class _Banner extends StatelessWidget {
   /// To control the element's distance from the end edge, override [padEnd].
   Widget? buildTrailing(BuildContext context);
 
-  /// Whether to add 8px trailing padding.
+  /// Whether to apply `end: 8` in [SafeArea.minimum].
   ///
   /// Subclasses can use `false` when the [buildTrailing] element
   /// is meant to abut the edge of the screen
@@ -1410,7 +1410,7 @@ abstract class _Banner extends StatelessWidget {
       decoration: BoxDecoration(
         color: getBackgroundColor(designVariables)),
       child: SafeArea(
-        minimum: const EdgeInsetsDirectional.only(start: 8)
+        minimum: EdgeInsetsDirectional.only(start: 8, end: padEnd ? 8 : 0)
           // (SafeArea.minimum doesn't take an EdgeInsetsDirectional)
           .resolve(Directionality.of(context)),
         child: Padding(
@@ -1426,7 +1426,6 @@ abstract class _Banner extends StatelessWidget {
                 const SizedBox(width: 8),
                 trailing,
               ],
-              if (padEnd) const SizedBox(width: 8),
             ]))));
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1376,10 +1376,13 @@ class StreamComposeBoxController extends ComposeBoxController {
 
 class FixedDestinationComposeBoxController extends ComposeBoxController {}
 
-class _ErrorBanner extends StatelessWidget {
-  const _ErrorBanner({required this.label});
+abstract class _Banner extends StatelessWidget {
+  const _Banner({required this.label});
 
   final String label;
+
+  Color getLabelColor(DesignVariables designVariables);
+  Color getBackgroundColor(DesignVariables designVariables);
 
   @override
   Widget build(BuildContext context) {
@@ -1387,12 +1390,12 @@ class _ErrorBanner extends StatelessWidget {
     final labelTextStyle = TextStyle(
       fontSize: 17,
       height: 22 / 17,
-      color: designVariables.btnLabelAttMediumIntDanger,
+      color: getLabelColor(designVariables),
     ).merge(weightVariableTextStyle(context, wght: 600));
 
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: designVariables.bannerBgIntDanger),
+        color: getBackgroundColor(designVariables)),
       child: SafeArea(
         minimum: const EdgeInsetsDirectional.only(start: 8)
           // (SafeArea.minimum doesn't take an EdgeInsetsDirectional)
@@ -1405,10 +1408,22 @@ class _ErrorBanner extends StatelessWidget {
                 child: Text(style: labelTextStyle,
                   label))),
             const SizedBox(width: 8),
-            // TODO(#720) "x" button goes here.
+            // TODO(#720) "x" button for the error banner goes here.
             //   24px square with 8px touchable padding in all directions?
           ])));
   }
+}
+
+class _ErrorBanner extends _Banner {
+  const _ErrorBanner({required super.label});
+
+  @override
+  Color getLabelColor(DesignVariables designVariables) =>
+    designVariables.btnLabelAttMediumIntDanger;
+
+  @override
+  Color getBackgroundColor(DesignVariables designVariables) =>
+    designVariables.bannerBgIntDanger;
 }
 
 /// The compose box.

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1400,17 +1400,19 @@ abstract class _Banner extends StatelessWidget {
         minimum: const EdgeInsetsDirectional.only(start: 8)
           // (SafeArea.minimum doesn't take an EdgeInsetsDirectional)
           .resolve(Directionality.of(context)),
-        child: Row(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsetsDirectional.fromSTEB(8, 9, 0, 9),
-                child: Text(style: labelTextStyle,
-                  label))),
-            const SizedBox(width: 8),
-            // TODO(#720) "x" button for the error banner goes here.
-            //   24px square with 8px touchable padding in all directions?
-          ])));
+        child: Padding(
+          padding: const EdgeInsetsDirectional.fromSTEB(8, 5, 0, 5),
+          child: Row(
+            children: [
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(style: labelTextStyle,
+                    label))),
+              const SizedBox(width: 8),
+              // TODO(#720) "x" button for the error banner goes here.
+              //   24px square with 8px touchable padding in all directions?
+            ]))));
   }
 }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1521,7 +1521,8 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     super.dispose();
   }
 
-  Widget? _errorBanner(BuildContext context) {
+  /// An [_ErrorBanner] that replaces the compose box's text inputs.
+  Widget? _errorBannerComposingNotAllowed(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     switch (widget.narrow) {
       case ChannelNarrow(:final streamId):
@@ -1553,7 +1554,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
   Widget build(BuildContext context) {
     final Widget? body;
 
-    final errorBanner = _errorBanner(context);
+    final errorBanner = _errorBannerComposingNotAllowed(context);
     if (errorBanner != null) {
       return _ComposeBoxContainer(body: null, errorBanner: errorBanner);
     }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1384,6 +1384,18 @@ abstract class _Banner extends StatelessWidget {
   Color getLabelColor(DesignVariables designVariables);
   Color getBackgroundColor(DesignVariables designVariables);
 
+  /// A trailing element, with no outer padding for spacing/positioning.
+  ///
+  /// To control the element's distance from the end edge, override [padEnd].
+  Widget? buildTrailing(BuildContext context);
+
+  /// Whether to add 8px trailing padding.
+  ///
+  /// Subclasses can use `false` when the [buildTrailing] element
+  /// is meant to abut the edge of the screen
+  /// in the common case that there are no horizontal device insets.
+  bool get padEnd => true;
+
   @override
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
@@ -1393,6 +1405,7 @@ abstract class _Banner extends StatelessWidget {
       color: getLabelColor(designVariables),
     ).merge(weightVariableTextStyle(context, wght: 600));
 
+    final trailing = buildTrailing(context);
     return DecoratedBox(
       decoration: BoxDecoration(
         color: getBackgroundColor(designVariables)),
@@ -1409,9 +1422,11 @@ abstract class _Banner extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(vertical: 4),
                   child: Text(style: labelTextStyle,
                     label))),
-              const SizedBox(width: 8),
-              // TODO(#720) "x" button for the error banner goes here.
-              //   24px square with 8px touchable padding in all directions?
+              if (trailing != null) ...[
+                const SizedBox(width: 8),
+                trailing,
+              ],
+              if (padEnd) const SizedBox(width: 8),
             ]))));
   }
 }
@@ -1426,6 +1441,15 @@ class _ErrorBanner extends _Banner {
   @override
   Color getBackgroundColor(DesignVariables designVariables) =>
     designVariables.bannerBgIntDanger;
+
+  @override
+  Widget? buildTrailing(context) {
+    // TODO(#720) "x" button goes here.
+    //   24px square with 8px touchable padding in all directions?
+    //   and `bool get padEnd => false`; see Figma:
+    //     https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=4031-17029&m=dev
+    return null;
+  }
 }
 
 /// The compose box.

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1173,17 +1173,17 @@ class _SendButtonState extends State<_SendButton> {
 class _ComposeBoxContainer extends StatelessWidget {
   const _ComposeBoxContainer({
     required this.body,
-    this.errorBanner,
-  }) : assert(body != null || errorBanner != null);
+    this.banner,
+  }) : assert(body != null || banner != null);
 
   /// The text inputs, compose-button row, and send button.
   ///
   /// This widget does not need a [SafeArea] to consume any device insets.
   ///
-  /// Can be null, but only if [errorBanner] is non-null.
+  /// Can be null, but only if [banner] is non-null.
   final Widget? body;
 
-  /// An error bar that goes at the top.
+  /// A bar that goes at the top.
   ///
   /// This may be present on its own or with a [body].
   /// If [body] is null this must be present.
@@ -1191,7 +1191,7 @@ class _ComposeBoxContainer extends StatelessWidget {
   /// This widget should use a [SafeArea] to pad the left, right,
   /// and bottom device insets.
   /// (A bottom inset may occur if [body] is null.)
-  final Widget? errorBanner;
+  final Widget? banner;
 
   Widget _paddedBody() {
     assert(body != null);
@@ -1203,15 +1203,15 @@ class _ComposeBoxContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
 
-    final List<Widget> children = switch ((errorBanner, body)) {
+    final List<Widget> children = switch ((banner, body)) {
       (Widget(), Widget()) => [
         // _paddedBody() already pads the bottom inset,
-        // so make sure the error banner doesn't double-pad it.
+        // so make sure the banner doesn't double-pad it.
         MediaQuery.removePadding(context: context, removeBottom: true,
-          child: errorBanner!),
+          child: banner!),
         _paddedBody(),
       ],
-      (Widget(),     null) => [errorBanner!],
+      (Widget(),     null) => [banner!],
       (null,     Widget()) => [_paddedBody()],
       (null,         null) => throw UnimplementedError(), // not allowed, see dartdoc
     };
@@ -1556,7 +1556,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
 
     final errorBanner = _errorBannerComposingNotAllowed(context);
     if (errorBanner != null) {
-      return _ComposeBoxContainer(body: null, errorBanner: errorBanner);
+      return _ComposeBoxContainer(body: null, banner: errorBanner);
     }
 
     final controller = this.controller;
@@ -1577,6 +1577,6 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     //       errorBanner = _ErrorBanner(label:
     //         ZulipLocalizations.of(context).errorSendMessageTimeout);
     //     }
-    return _ComposeBoxContainer(body: body, errorBanner: null);
+    return _ComposeBoxContainer(body: body, banner: null);
   }
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1377,10 +1377,9 @@ class StreamComposeBoxController extends ComposeBoxController {
 class FixedDestinationComposeBoxController extends ComposeBoxController {}
 
 abstract class _Banner extends StatelessWidget {
-  const _Banner({required this.label});
+  const _Banner();
 
-  final String label;
-
+  String getLabel(ZulipLocalizations zulipLocalizations);
   Color getLabelColor(DesignVariables designVariables);
   Color getBackgroundColor(DesignVariables designVariables);
 
@@ -1398,6 +1397,7 @@ abstract class _Banner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
     final labelTextStyle = TextStyle(
       fontSize: 17,
@@ -1421,7 +1421,7 @@ abstract class _Banner extends StatelessWidget {
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
                   child: Text(style: labelTextStyle,
-                    label))),
+                    getLabel(zulipLocalizations)))),
               if (trailing != null) ...[
                 const SizedBox(width: 8),
                 trailing,
@@ -1431,7 +1431,14 @@ abstract class _Banner extends StatelessWidget {
 }
 
 class _ErrorBanner extends _Banner {
-  const _ErrorBanner({required super.label});
+  const _ErrorBanner({
+    required String Function(ZulipLocalizations) getLabel,
+  }) : _getLabel = getLabel;
+
+  @override
+  String getLabel(ZulipLocalizations zulipLocalizations) =>
+    _getLabel(zulipLocalizations);
+  final String Function(ZulipLocalizations) _getLabel;
 
   @override
   Color getLabelColor(DesignVariables designVariables) =>
@@ -1522,16 +1529,16 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
         final channel = store.streams[streamId];
         if (channel == null || !store.hasPostingPermission(inChannel: channel,
             user: store.selfUser, byDate: DateTime.now())) {
-          return _ErrorBanner(label:
-            ZulipLocalizations.of(context).errorBannerCannotPostInChannelLabel);
+          return _ErrorBanner(getLabel: (zulipLocalizations) =>
+            zulipLocalizations.errorBannerCannotPostInChannelLabel);
         }
 
       case DmNarrow(:final otherRecipientIds):
         final hasDeactivatedUser = otherRecipientIds.any((id) =>
           !(store.getUser(id)?.isActive ?? true));
         if (hasDeactivatedUser) {
-          return _ErrorBanner(label:
-            ZulipLocalizations.of(context).errorBannerDeactivatedDmLabel);
+          return _ErrorBanner(getLabel: (zulipLocalizations) =>
+            zulipLocalizations.errorBannerDeactivatedDmLabel);
         }
 
       case CombinedFeedNarrow():


### PR DESCRIPTION
These commits help get the code ready to implement the blue "Edit message" banner, with the "Cancel" and "Save" buttons; see Figma:

https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=3988-38201&m=dev
<img width="470" alt="image" src="https://github.com/user-attachments/assets/0c41be08-0450-4d8c-b3c1-0089dca7a861" />

The most interesting change is to extract a base class `_Banner` out of `_ErrorBanner`:

We'll make a new subclass with a name like `_EditMessageBanner` for #126; here's a rough sketch of what that'll look like:

```dart
class _EditMessageBanner extends _Banner {
  const _EditMessageBanner();

  @override
  String getLabel(ZulipLocalizations zulipLocalizations) =>
    zulipLocalizations.composeBoxBannerLabelEditMessage;

  @override
  Color getLabelColor(DesignVariables designVariables) =>
    designVariables.bannerTextIntInfo;

  @override
  Color getBackgroundColor(DesignVariables designVariables) =>
    designVariables.bannerBgIntInfo;

  @override
  Widget? buildTrailing(context) {
    return Row(mainAxisSize: MainAxisSize.min, spacing: 8, children: [
      ZulipWebUiKitButton(label: 'Cancel',
        onPressed: () {}),
      ZulipWebUiKitButton(label: 'Save',
        attention: ZulipWebUiKitButtonAttention.high,
        onPressed: () {}),
    ]);
  }
}
```

Related: #126