### PR TITLE
Edit-message (2/n): Implement variant of content input without a typing notifier

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -486,7 +486,7 @@ class _TypingNotifierState extends State<_TypingNotifier> with WidgetsBindingObs
   Widget build(BuildContext context) => widget.child;
 }
 
-class _ContentInput extends StatefulWidget {
+class _ContentInput extends StatelessWidget {
   const _ContentInput({
     required this.narrow,
     required this.controller,
@@ -497,11 +497,6 @@ class _ContentInput extends StatefulWidget {
   final ComposeBoxController controller;
   final String hintText;
 
-  @override
-  State<StatefulWidget> createState() => _ContentInputState();
-}
-
-class _ContentInputState<T extends _ContentInput> extends State<T> {
   static double maxHeight(BuildContext context) {
     final clampingTextScaler = MediaQuery.textScalerOf(context)
       .clamp(maxScaleFactor: 1.5);
@@ -532,9 +527,9 @@ class _ContentInputState<T extends _ContentInput> extends State<T> {
     final designVariables = DesignVariables.of(context);
 
     return ComposeAutocomplete(
-      narrow: widget.narrow,
-      controller: widget.controller.content,
-      focusNode: widget.controller.contentFocusNode,
+      narrow: narrow,
+      controller: controller.content,
+      focusNode: controller.contentFocusNode,
       fieldViewBuilder: (context) => ConstrainedBox(
         constraints: BoxConstraints(maxHeight: maxHeight(context)),
         // This [ClipRect] replaces the [TextField] clipping we disable below.
@@ -543,8 +538,8 @@ class _ContentInputState<T extends _ContentInput> extends State<T> {
             top: _verticalPadding, bottom: _verticalPadding,
             color: designVariables.composeBoxBg,
             child: TextField(
-              controller: widget.controller.content,
-              focusNode: widget.controller.contentFocusNode,
+              controller: controller.content,
+              focusNode: controller.contentFocusNode,
               // Let the content show through the `contentPadding` so that
               // our [InsetShadowBox] can fade it smoothly there.
               clipBehavior: Clip.none,
@@ -570,7 +565,7 @@ class _ContentInputState<T extends _ContentInput> extends State<T> {
                 // that 54px distance while also making the scrolling work like
                 // this and offering two lines of touchable area.
                 contentPadding: const EdgeInsets.symmetric(vertical: _verticalPadding),
-                hintText: widget.hintText,
+                hintText: hintText,
                 hintStyle: TextStyle(
                   color: designVariables.textInput.withFadedAlpha(0.5))))))));
   }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -394,24 +394,22 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   }
 }
 
-class _ContentInput extends StatefulWidget {
-  const _ContentInput({
-    required this.narrow,
+class _TypingNotifier extends StatefulWidget {
+  const _TypingNotifier({
     required this.destination,
     required this.controller,
-    required this.hintText,
+    required this.child,
   });
 
-  final Narrow narrow;
   final SendableNarrow destination;
   final ComposeBoxController controller;
-  final String hintText;
+  final Widget child;
 
   @override
-  State<_ContentInput> createState() => _ContentInputState();
+  State<_TypingNotifier> createState() => _TypingNotifierState();
 }
 
-class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserver {
+class _TypingNotifierState extends State<_TypingNotifier> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
@@ -421,7 +419,7 @@ class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserve
   }
 
   @override
-  void didUpdateWidget(covariant _ContentInput oldWidget) {
+  void didUpdateWidget(covariant _TypingNotifier oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller.content.removeListener(_contentChanged);
@@ -484,6 +482,26 @@ class _ContentInputState extends State<_ContentInput> with WidgetsBindingObserve
     }
   }
 
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class _ContentInput extends StatefulWidget {
+  const _ContentInput({
+    required this.narrow,
+    required this.controller,
+    required this.hintText,
+  });
+
+  final Narrow narrow;
+  final ComposeBoxController controller;
+  final String hintText;
+
+  @override
+  State<StatefulWidget> createState() => _ContentInputState();
+}
+
+class _ContentInputState<T extends _ContentInput> extends State<T> {
   static double maxHeight(BuildContext context) {
     final clampingTextScaler = MediaQuery.textScalerOf(context)
       .clamp(maxScaleFactor: 1.5);
@@ -645,12 +663,14 @@ class _StreamContentInputState extends State<_StreamContentInput> {
       // ignore: dead_null_aware_expression // null topic names soon to be enabled
       : '#$streamName > ${hintTopic.displayName ?? store.realmEmptyTopicDisplayName}';
 
-    return _ContentInput(
-      narrow: widget.narrow,
+    return _TypingNotifier(
       destination: TopicNarrow(widget.narrow.streamId,
         TopicName(widget.controller.topic.textNormalized)),
       controller: widget.controller,
-      hintText: zulipLocalizations.composeBoxChannelContentHint(hintDestination));
+      child: _ContentInput(
+        narrow: widget.narrow,
+        controller: widget.controller,
+        hintText: zulipLocalizations.composeBoxChannelContentHint(hintDestination)));
   }
 }
 
@@ -732,11 +752,13 @@ class _FixedDestinationContentInput extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _ContentInput(
-      narrow: narrow,
+    return _TypingNotifier(
       destination: narrow,
       controller: controller,
-      hintText: _hintText(context));
+      child: _ContentInput(
+        narrow: narrow,
+        controller: controller,
+        hintText: _hintText(context)));
   }
 }
 


### PR DESCRIPTION
The edit-message compose box (#126) shouldn't send [typing notifications](https://zulip.com/help/typing-notifications) like the regular compose box does.

(There's actually [a different kind of typing notification](https://zulip.com/api/set-typing-status-for-message-edit) that we'll want to implement eventually; that's #1350. But that's not for us to do now.)

This PR implements `_ContentInput.noTypingNotifier`, as prep for implementing the edit-message compose box.

Related: #126