### PR TITLE
Edit-message (3/n): Implement ZulipWebUiKitButton, for "Cancel" / "Save" buttons

### DIFF
--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+/// Apply [Transform.scale] to the child widget when tapped, and reset its scale
+/// when released, while animating the transitions.
+class AnimatedScaleOnTap extends StatefulWidget {
+  const AnimatedScaleOnTap({
+    super.key,
+    required this.scaleEnd,
+    required this.duration,
+    required this.child,
+  });
+
+  /// The terminal scale to animate to.
+  final double scaleEnd;
+
+  /// The duration over which to animate the scale change.
+  final Duration duration;
+
+  final Widget child;
+
+  @override
+  State<AnimatedScaleOnTap> createState() => _AnimatedScaleOnTapState();
+}
+
+class _AnimatedScaleOnTapState extends State<AnimatedScaleOnTap> {
+  double _scale = 1;
+
+  void _changeScale(double scale) {
+    setState(() {
+      _scale = scale;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTapDown: (_) =>  _changeScale(widget.scaleEnd),
+      onTapUp: (_) =>    _changeScale(1),
+      onTapCancel: () => _changeScale(1),
+      child: AnimatedScale(
+        scale: _scale,
+        duration: widget.duration,
+        curve: Curves.easeOut,
+        child: widget.child));
+  }
+}

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -1,4 +1,126 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+
+import 'color.dart';
+import 'text.dart';
+import 'theme.dart';
+
+/// The "Button" component from Zulip Web UI kit.
+///
+/// The Figma uses this for the "Cancel" and "Save" buttons in the compose box
+/// for editing an already-sent message.
+///
+/// See Figma:
+///   * Component: https://www.figma.com/design/msWyAJ8cnMHgOMPxi7BUvA/Zulip-Web-UI-kit?node-id=1-2780&t=Wia0D0i1I0GXdD9z-0
+///   * Edit-message compose box: https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=3988-38201&m=dev
+class ZulipWebUiKitButton extends StatelessWidget {
+  const ZulipWebUiKitButton({
+    super.key,
+    this.attention = ZulipWebUiKitButtonAttention.medium,
+    this.intent = ZulipWebUiKitButtonIntent.info,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final ZulipWebUiKitButtonAttention attention;
+  final ZulipWebUiKitButtonIntent intent;
+  final String label;
+  final VoidCallback? onPressed;
+
+  WidgetStateColor _backgroundColor(DesignVariables designVariables) {
+    switch ((attention, intent)) {
+      case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.info):
+        return WidgetStateColor.fromMap({
+          WidgetState.pressed: designVariables.btnBgAttMediumIntInfoActive,
+          ~WidgetState.pressed: designVariables.btnBgAttMediumIntInfoNormal,
+        });
+      case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.info):
+        return WidgetStateColor.fromMap({
+          WidgetState.pressed: designVariables.btnBgAttHighIntInfoActive,
+          ~WidgetState.pressed: designVariables.btnBgAttHighIntInfoNormal,
+        });
+    }
+  }
+
+  Color _labelColor(DesignVariables designVariables) {
+    switch ((attention, intent)) {
+      case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.info):
+        return designVariables.btnLabelAttMediumIntInfo;
+      case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.info):
+        return designVariables.btnLabelAttHigh;
+    }
+  }
+
+  TextStyle _labelStyle(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    return TextStyle(
+      color: _labelColor(designVariables),
+      fontSize: 17,
+      height: 1.20,
+      letterSpacing: proportionalLetterSpacing(context,
+        0.006, baseFontSize: 17),
+    ).merge(weightVariableTextStyle(context, wght: 600));
+  }
+
+  BorderSide _borderSide(DesignVariables designVariables) {
+    switch (attention) {
+      case ZulipWebUiKitButtonAttention.medium:
+        // TODO inner shadow effect like `box-shadow: inset`, following Figma;
+        //   needs Flutter support for something like that:
+        //     https://github.com/flutter/flutter/issues/18636
+        //     https://github.com/flutter/flutter/issues/52999
+        //   For now, we just use a solid-stroke border with half the opacity
+        //   and half the width.
+        return BorderSide(
+          color: designVariables.btnShadowAttMed.withFadedAlpha(0.5),
+          width: 0.5);
+      case ZulipWebUiKitButtonAttention.high:
+        return BorderSide.none;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    return AnimatedScaleOnTap(
+      scaleEnd: 0.96,
+      duration: Duration(milliseconds: 50),
+      child: TextButton(
+        style: TextButton.styleFrom(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          foregroundColor: _labelColor(designVariables),
+          shape: RoundedRectangleBorder(
+            side: _borderSide(designVariables),
+            borderRadius: BorderRadius.circular(4)),
+          splashFactory: NoSplash.splashFactory,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          minimumSize: Size(kMinInteractiveDimension, 28),
+        ).copyWith(backgroundColor: _backgroundColor(designVariables)),
+        onPressed: onPressed,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: 240),
+          child: Text(label,
+            maxLines: 1,
+            style: _labelStyle(context),
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis))));
+  }
+}
+
+enum ZulipWebUiKitButtonAttention {
+  high,
+  medium,
+  // low,
+}
+
+enum ZulipWebUiKitButtonIntent {
+  // neutral,
+  // warning,
+  // danger,
+  info,
+  // success,
+  // brand,
+}
 
 /// Apply [Transform.scale] to the child widget when tapped, and reset its scale
 /// when released, while animating the transitions.

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -8,6 +8,7 @@ import 'about_zulip.dart';
 import 'action_sheet.dart';
 import 'app.dart';
 import 'app_bar.dart';
+import 'button.dart';
 import 'color.dart';
 import 'content.dart';
 import 'icons.dart';
@@ -599,51 +600,5 @@ class _AboutZulipButton extends _MenuButton {
   @override
   void onPressed(BuildContext context) {
     Navigator.of(context).push(AboutZulipPage.buildRoute(context));
-  }
-}
-
-/// Apply [Transform.scale] to the child widget when tapped, and reset its scale
-/// when released, while animating the transitions.
-class AnimatedScaleOnTap extends StatefulWidget {
-  const AnimatedScaleOnTap({
-    super.key,
-    required this.scaleEnd,
-    required this.duration,
-    required this.child,
-  });
-
-  /// The terminal scale to animate to.
-  final double scaleEnd;
-
-  /// The duration over which to animate the scale change.
-  final Duration duration;
-
-  final Widget child;
-
-  @override
-  State<AnimatedScaleOnTap> createState() => _AnimatedScaleOnTapState();
-}
-
-class _AnimatedScaleOnTapState extends State<AnimatedScaleOnTap> {
-  double _scale = 1;
-
-  void _changeScale(double scale) {
-    setState(() {
-      _scale = scale;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onTapDown: (_) =>  _changeScale(widget.scaleEnd),
-      onTapUp: (_) =>    _changeScale(1),
-      onTapCancel: () => _changeScale(1),
-      child: AnimatedScale(
-        scale: _scale,
-        duration: widget.duration,
-        curve: Curves.easeOut,
-        child: widget.child));
   }
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -138,8 +138,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgTopBar: const Color(0xfff5f5f5),
     borderBar: Colors.black.withValues(alpha: 0.2),
     borderMenuButtonSelected: Colors.black.withValues(alpha: 0.2),
+    btnBgAttHighIntInfoActive: const Color(0xff1e41d3),
+    btnBgAttHighIntInfoNormal: const Color(0xff3c6bff),
+    btnBgAttMediumIntInfoActive: const Color(0xff3c6bff).withValues(alpha: 0.22),
+    btnBgAttMediumIntInfoNormal: const Color(0xff3c6bff).withValues(alpha: 0.12),
+    btnLabelAttHigh: const Color(0xffffffff),
     btnLabelAttLowIntDanger: const Color(0xffc0070a),
+    btnLabelAttMediumIntInfo: const Color(0xff1027a6),
     btnLabelAttMediumIntDanger: const Color(0xffac0508),
+    btnShadowAttMed: const Color(0xff000000).withValues(alpha: 0.20),
     composeBoxBg: const Color(0xffffffff),
     contextMenuCancelText: const Color(0xff222222),
     contextMenuItemBg: const Color(0xff6159e1),
@@ -188,8 +195,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgTopBar: const Color(0xff242424),
     borderBar: const Color(0xffffffff).withValues(alpha: 0.1),
     borderMenuButtonSelected: Colors.white.withValues(alpha: 0.1),
+    btnBgAttHighIntInfoActive: const Color(0xff1e41d3),
+    btnBgAttHighIntInfoNormal: const Color(0xff1e41d3),
+    btnBgAttMediumIntInfoActive: const Color(0xff97b6fe).withValues(alpha: 0.22),
+    btnBgAttMediumIntInfoNormal: const Color(0xff97b6fe).withValues(alpha: 0.12),
+    btnLabelAttHigh: const Color(0xffffffff).withValues(alpha: 0.85),
     btnLabelAttLowIntDanger: const Color(0xffff8b7c),
+    btnLabelAttMediumIntInfo: const Color(0xff97b6fe),
     btnLabelAttMediumIntDanger: const Color(0xffff8b7c),
+    btnShadowAttMed: const Color(0xffffffff).withValues(alpha: 0.21),
     composeBoxBg: const Color(0xff0f0f0f),
     contextMenuCancelText: const Color(0xffffffff).withValues(alpha: 0.75),
     contextMenuItemBg: const Color(0xff7977fe),
@@ -246,8 +260,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.bgTopBar,
     required this.borderBar,
     required this.borderMenuButtonSelected,
+    required this.btnBgAttHighIntInfoActive,
+    required this.btnBgAttHighIntInfoNormal,
+    required this.btnBgAttMediumIntInfoActive,
+    required this.btnBgAttMediumIntInfoNormal,
+    required this.btnLabelAttHigh,
     required this.btnLabelAttLowIntDanger,
+    required this.btnLabelAttMediumIntInfo,
     required this.btnLabelAttMediumIntDanger,
+    required this.btnShadowAttMed,
     required this.composeBoxBg,
     required this.contextMenuCancelText,
     required this.contextMenuItemBg,
@@ -305,8 +326,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color bgTopBar;
   final Color borderBar;
   final Color borderMenuButtonSelected;
+  final Color btnBgAttHighIntInfoActive;
+  final Color btnBgAttHighIntInfoNormal;
+  final Color btnBgAttMediumIntInfoActive;
+  final Color btnBgAttMediumIntInfoNormal;
+  final Color btnLabelAttHigh;
   final Color btnLabelAttLowIntDanger;
+  final Color btnLabelAttMediumIntInfo;
   final Color btnLabelAttMediumIntDanger;
+  final Color btnShadowAttMed;
   final Color composeBoxBg;
   final Color contextMenuCancelText;
   final Color contextMenuItemBg;
@@ -359,8 +387,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? bgTopBar,
     Color? borderBar,
     Color? borderMenuButtonSelected,
+    Color? btnBgAttHighIntInfoActive,
+    Color? btnBgAttHighIntInfoNormal,
+    Color? btnBgAttMediumIntInfoActive,
+    Color? btnBgAttMediumIntInfoNormal,
+    Color? btnLabelAttHigh,
     Color? btnLabelAttLowIntDanger,
+    Color? btnLabelAttMediumIntInfo,
     Color? btnLabelAttMediumIntDanger,
+    Color? btnShadowAttMed,
     Color? composeBoxBg,
     Color? contextMenuCancelText,
     Color? contextMenuItemBg,
@@ -408,8 +443,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       bgTopBar: bgTopBar ?? this.bgTopBar,
       borderBar: borderBar ?? this.borderBar,
       borderMenuButtonSelected: borderMenuButtonSelected ?? this.borderMenuButtonSelected,
+      btnBgAttHighIntInfoActive: btnBgAttHighIntInfoActive ?? this.btnBgAttHighIntInfoActive,
+      btnBgAttHighIntInfoNormal: btnBgAttHighIntInfoNormal ?? this.btnBgAttHighIntInfoNormal,
+      btnBgAttMediumIntInfoActive: btnBgAttMediumIntInfoActive ?? this.btnBgAttMediumIntInfoActive,
+      btnBgAttMediumIntInfoNormal: btnBgAttMediumIntInfoNormal ?? this.btnBgAttMediumIntInfoNormal,
+      btnLabelAttHigh: btnLabelAttHigh ?? this.btnLabelAttHigh,
       btnLabelAttLowIntDanger: btnLabelAttLowIntDanger ?? this.btnLabelAttLowIntDanger,
+      btnLabelAttMediumIntInfo: btnLabelAttMediumIntInfo ?? this.btnLabelAttMediumIntInfo,
       btnLabelAttMediumIntDanger: btnLabelAttMediumIntDanger ?? this.btnLabelAttMediumIntDanger,
+      btnShadowAttMed: btnShadowAttMed ?? this.btnShadowAttMed,
       composeBoxBg: composeBoxBg ?? this.composeBoxBg,
       contextMenuCancelText: contextMenuCancelText ?? this.contextMenuCancelText,
       contextMenuItemBg: contextMenuItemBg ?? this.contextMenuItemBg,
@@ -464,8 +506,15 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       bgTopBar: Color.lerp(bgTopBar, other.bgTopBar, t)!,
       borderBar: Color.lerp(borderBar, other.borderBar, t)!,
       borderMenuButtonSelected: Color.lerp(borderMenuButtonSelected, other.borderMenuButtonSelected, t)!,
+      btnBgAttHighIntInfoActive: Color.lerp(btnBgAttHighIntInfoActive, other.btnBgAttHighIntInfoActive, t)!,
+      btnBgAttHighIntInfoNormal: Color.lerp(btnBgAttHighIntInfoNormal, other.btnBgAttHighIntInfoNormal, t)!,
+      btnBgAttMediumIntInfoActive: Color.lerp(btnBgAttMediumIntInfoActive, other.btnBgAttMediumIntInfoActive, t)!,
+      btnBgAttMediumIntInfoNormal: Color.lerp(btnBgAttMediumIntInfoNormal, other.btnBgAttMediumIntInfoNormal, t)!,
+      btnLabelAttHigh: Color.lerp(btnLabelAttHigh, other.btnLabelAttHigh, t)!,
       btnLabelAttLowIntDanger: Color.lerp(btnLabelAttLowIntDanger, other.btnLabelAttLowIntDanger, t)!,
+      btnLabelAttMediumIntInfo: Color.lerp(btnLabelAttMediumIntInfo, other.btnLabelAttMediumIntInfo, t)!,
       btnLabelAttMediumIntDanger: Color.lerp(btnLabelAttMediumIntDanger, other.btnLabelAttMediumIntDanger, t)!,
+      btnShadowAttMed: Color.lerp(btnShadowAttMed, other.btnShadowAttMed, t)!,
       composeBoxBg: Color.lerp(composeBoxBg, other.composeBoxBg, t)!,
       contextMenuCancelText: Color.lerp(contextMenuCancelText, other.contextMenuCancelText, t)!,
       contextMenuItemBg: Color.lerp(contextMenuItemBg, other.contextMenuItemBg, t)!,


### PR DESCRIPTION
This PR implements some variants of the "Button" component in the "Zulip Web UI kit" in Figma: https://www.figma.com/design/msWyAJ8cnMHgOMPxi7BUvA/Zulip-Web-UI-kit?node-id=1-8&p=f&m=dev

The Figma uses this component for the "Cancel" and "Save" buttons in the edit-message compose box:

https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=3988-38200&m=dev
| Light | Dark |
| --- | --- |
| <img width="305" alt="image" src="https://github.com/user-attachments/assets/19d6ac65-4e17-4c6c-a307-aabdd22c6884" /> | <img width="304" alt="image" src="https://github.com/user-attachments/assets/0143fdb3-6338-4873-9638-c96f9addfd82" /> |

Not all values of the "intent" and "attention" params are implemented here; just the "info" intent with "medium" and "high" attention. In the edit-message compose box banner, both buttons have the "info" intent; the cancel button has "medium" attention and the save button has "high" attention.

Here are screenshots of the buttons, made with these commits and the ones from #1430 (plus the `_EditMessageBanner` class in the PR description):

## Cancel button ("info" intent, "medium" attention)

| Light; normal state | Light; pressed state | Dark; normal state | Dark; pressed state |
| --- | --- | --- | --- |
| <img width="632" alt="image" src="https://github.com/user-attachments/assets/8f6a9fbc-7bca-4617-b020-b1d64190f567" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/e2aba0fa-3867-4643-8d2d-ae875f0e2068" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/54a8282e-6b53-49dd-9873-f4b73f1d8264" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/d6a25e50-a286-4885-abdb-eb0fa4725ca4" /> |

## Save button ("info" intent, "high" attention)

| Light; normal state | Light; pressed state | Dark; normal state | Dark; pressed state |
| --- | --- | --- | --- |
| <img width="632" alt="image" src="https://github.com/user-attachments/assets/da545f0f-f0b0-471d-8aaa-5d8c24a7d54c" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/25140baa-84ac-4fa9-b49a-eaaefbb0e701" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/90395a14-bd63-4bde-8e9d-c8be79faff09" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/cc620a53-e91f-4e0e-b113-ec80b392f243" /> |

Related: #126