### PR TITLE
anchors 5/n: Control scroll position

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -622,7 +622,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           if (i == 2) return TypingStatusWidget(narrow: widget.narrow);
 
           final data = model!.items[length - 1 - (i - 3)];
-          return _buildItem(zulipLocalizations, data, i);
+          return _buildItem(zulipLocalizations, data);
         }));
 
     if (!ComposeBox.hasComposeBox(widget.narrow)) {
@@ -659,7 +659,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       ]);
   }
 
-  Widget _buildItem(ZulipLocalizations zulipLocalizations, MessageListItem data, int i) {
+  Widget _buildItem(ZulipLocalizations zulipLocalizations, MessageListItem data) {
     switch (data) {
       case MessageListHistoryStartItem():
         return Center(
@@ -685,7 +685,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         return MessageItem(
           key: ValueKey(data.message.id),
           header: header,
-          trailingWhitespace: i == 1 ? 8 : 11,
+          trailingWhitespace: 11,
           item: data);
     }
   }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -466,7 +466,7 @@ class MessageList extends StatefulWidget {
 
 class _MessageListState extends State<MessageList> with PerAccountStoreAwareStateMixin<MessageList> {
   MessageListView? model;
-  final ScrollController scrollController = ScrollController();
+  final ScrollController scrollController = MessageListScrollController();
   final ValueNotifier<bool> _scrollToBottomVisibleValue = ValueNotifier<bool>(false);
 
   @override

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -631,7 +631,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       sliver = SliverSafeArea(sliver: sliver);
     }
 
-    return CustomPaintOrderScrollView(
+    return MessageListScrollView(
       // TODO: Offer `ScrollViewKeyboardDismissBehavior.interactive` (or
       //   similar) if that is ever offered:
       //     https://github.com/flutter/flutter/issues/57609#issuecomment-1355340849

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -645,7 +645,6 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
       controller: scrollController,
       semanticChildCount: length + 2,
-      anchor: 1.0,
       center: centerSliverKey,
       paintOrder: SliverPaintOrder.firstIsTop,
 

--- a/lib/widgets/scrolling.dart
+++ b/lib/widgets/scrolling.dart
@@ -244,3 +244,95 @@ class RenderCustomPaintOrderViewport extends RenderViewport {
     };
   }
 }
+
+/// A version of [CustomScrollView] adapted for the Zulip message list.
+///
+/// This lets us customize behavior in ways that aren't currently supported
+/// by the fields of [CustomScrollView] itself.
+class MessageListScrollView extends CustomPaintOrderScrollView {
+  const MessageListScrollView({
+    super.key,
+    super.scrollDirection,
+    super.reverse,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.scrollBehavior,
+    // super.shrinkWrap, // omitted, always false
+    super.center,
+    super.anchor,
+    super.cacheExtent,
+    super.slivers,
+    super.semanticChildCount,
+    super.dragStartBehavior,
+    super.keyboardDismissBehavior,
+    super.restorationId,
+    super.clipBehavior,
+    super.hitTestBehavior,
+    super.paintOrder,
+  });
+
+  @override
+  Widget buildViewport(BuildContext context, ViewportOffset offset,
+      AxisDirection axisDirection, List<Widget> slivers) {
+    return MessageListViewport(
+      axisDirection: axisDirection,
+      offset: offset,
+      slivers: slivers,
+      cacheExtent: cacheExtent,
+      center: center,
+      anchor: anchor,
+      clipBehavior: clipBehavior,
+      paintOrder_: paintOrder_,
+    );
+  }
+}
+
+/// The version of [Viewport] that underlies [MessageListScrollView].
+class MessageListViewport extends CustomPaintOrderViewport {
+  MessageListViewport({
+    super.key,
+    super.axisDirection,
+    super.crossAxisDirection,
+    super.anchor,
+    required super.offset,
+    super.center,
+    super.cacheExtent,
+    super.cacheExtentStyle,
+    super.slivers,
+    super.clipBehavior,
+    required super.paintOrder_,
+  });
+
+  @override
+  RenderViewport createRenderObject(BuildContext context) {
+    return RenderMessageListViewport(
+      axisDirection: axisDirection,
+      crossAxisDirection: crossAxisDirection
+        ?? Viewport.getDefaultCrossAxisDirection(context, axisDirection),
+      anchor: anchor,
+      offset: offset,
+      cacheExtent: cacheExtent,
+      cacheExtentStyle: cacheExtentStyle,
+      clipBehavior: clipBehavior,
+      paintOrder_: paintOrder_,
+    );
+  }
+}
+
+/// The version of [RenderViewport] that underlies [MessageListViewport]
+/// and [MessageListScrollView].
+class RenderMessageListViewport extends RenderCustomPaintOrderViewport {
+  RenderMessageListViewport({
+    super.axisDirection,
+    required super.crossAxisDirection,
+    required super.offset,
+    super.anchor,
+    super.children,
+    super.center,
+    super.cacheExtent,
+    super.cacheExtentStyle,
+    super.clipBehavior,
+    required super.paintOrder_,
+  });
+}

--- a/lib/widgets/scrolling.dart
+++ b/lib/widgets/scrolling.dart
@@ -248,6 +248,43 @@ class RenderCustomPaintOrderViewport extends RenderViewport {
   }
 }
 
+/// A version of [ScrollPosition] adapted for the Zulip message list,
+/// used by [MessageListScrollController].
+class MessageListScrollPosition extends ScrollPositionWithSingleContext {
+  MessageListScrollPosition({
+    required super.physics,
+    required super.context,
+    super.initialPixels,
+    super.keepScrollOffset,
+    super.oldPosition,
+    super.debugLabel,
+  });
+}
+
+/// A version of [ScrollController] adapted for the Zulip message list.
+class MessageListScrollController extends ScrollController {
+  MessageListScrollController({
+    super.initialScrollOffset,
+    super.keepScrollOffset,
+    super.debugLabel,
+    super.onAttach,
+    super.onDetach,
+  });
+
+  @override
+  ScrollPosition createScrollPosition(ScrollPhysics physics,
+      ScrollContext context, ScrollPosition? oldPosition) {
+    return MessageListScrollPosition(
+      physics: physics,
+      context: context,
+      initialPixels: initialScrollOffset,
+      keepScrollOffset: keepScrollOffset,
+      oldPosition: oldPosition,
+      debugLabel: debugLabel,
+    );
+  }
+}
+
 /// A version of [CustomScrollView] adapted for the Zulip message list.
 ///
 /// This lets us customize behavior in ways that aren't currently supported

--- a/lib/widgets/scrolling.dart
+++ b/lib/widgets/scrolling.dart
@@ -300,7 +300,6 @@ class MessageListScrollView extends CustomPaintOrderScrollView {
     super.scrollBehavior,
     // super.shrinkWrap, // omitted, always false
     super.center,
-    super.anchor,
     super.cacheExtent,
     super.slivers,
     super.semanticChildCount,
@@ -321,7 +320,6 @@ class MessageListScrollView extends CustomPaintOrderScrollView {
       slivers: slivers,
       cacheExtent: cacheExtent,
       center: center,
-      anchor: anchor,
       clipBehavior: clipBehavior,
       paintOrder_: paintOrder_,
     );
@@ -334,7 +332,6 @@ class MessageListViewport extends CustomPaintOrderViewport {
     super.key,
     super.axisDirection,
     super.crossAxisDirection,
-    super.anchor,
     required super.offset,
     super.center,
     super.cacheExtent,
@@ -350,7 +347,6 @@ class MessageListViewport extends CustomPaintOrderViewport {
       axisDirection: axisDirection,
       crossAxisDirection: crossAxisDirection
         ?? Viewport.getDefaultCrossAxisDirection(context, axisDirection),
-      anchor: anchor,
       offset: offset,
       cacheExtent: cacheExtent,
       cacheExtentStyle: cacheExtentStyle,
@@ -369,7 +365,6 @@ class RenderMessageListViewport extends RenderCustomPaintOrderViewport {
     super.axisDirection,
     required super.crossAxisDirection,
     required super.offset,
-    super.anchor,
     super.children,
     super.center,
     super.cacheExtent,
@@ -377,6 +372,9 @@ class RenderMessageListViewport extends RenderCustomPaintOrderViewport {
     super.clipBehavior,
     required super.paintOrder_,
   });
+
+  @override
+  double get anchor => 1.0;
 
   double? _calculatedCacheExtent;
 
@@ -499,6 +497,7 @@ class RenderMessageListViewport extends RenderCustomPaintOrderViewport {
     // centerOffset is the offset from the leading edge of the RenderViewport
     // to the zero scroll offset (the line between the forward slivers and the
     // reverse slivers).
+    assert(anchor == 1.0);
     final double centerOffset = mainAxisExtent * anchor - correctedOffset;
     final double reverseDirectionRemainingPaintExtent = clampDouble(
       centerOffset,

--- a/test/widgets/scrolling_test.dart
+++ b/test/widgets/scrolling_test.dart
@@ -243,6 +243,35 @@ void main() {
         .bottom.equals(600);
     });
 
+    testWidgets('stick to end of list when it grows', (tester) async {
+      final controller = MessageListScrollController();
+      await prepare(tester, controller: controller,
+        topHeight: 400, bottomHeight: 400);
+      check(tester.getRect(findBottom))..top.equals(200)..bottom.equals(600);
+
+      // Bottom sliver grows; remain scrolled to (new) bottom.
+      await prepare(tester, controller: controller,
+        topHeight: 400, bottomHeight: 500);
+      check(tester.getRect(findBottom))..top.equals(100)..bottom.equals(600);
+    });
+
+    testWidgets('when not at end, let it grow without following', (tester) async {
+      final controller = MessageListScrollController();
+      await prepare(tester, controller: controller,
+        topHeight: 400, bottomHeight: 400);
+      check(tester.getRect(findBottom))..top.equals(200)..bottom.equals(600);
+
+      // Scroll up (by dragging down) to detach from end of list.
+      await tester.drag(findBottom, Offset(0, 100));
+      await tester.pump();
+      check(tester.getRect(findBottom))..top.equals(300)..bottom.equals(700);
+
+      // Bottom sliver grows; remain at existing position, now farther from end.
+      await prepare(tester, controller: controller,
+        topHeight: 400, bottomHeight: 500);
+      check(tester.getRect(findBottom))..top.equals(300)..bottom.equals(800);
+    });
+
     testWidgets('position preserved when scrollable rebuilds', (tester) async {
       // Tests that [MessageListScrollPosition.absorb] does its job.
       //


### PR DESCRIPTION
This is the next round after #1435 ~~(and is stacked atop it)~~, toward #82.

In this PR, we take more control of how the scroll position works in the presence of back-to-back slivers. In particular the [ScrollView.anchor](https://main-api.flutter.dev/flutter/widgets/ScrollView/anchor.html) property doesn't really have enough flexibility to express the behavior we need, so we replace the logic that consumes it.

Once that's done, we're very close to being able to start splitting the real message list into back-to-back slivers. That will come in the next PR, #1468.


## Selected commit messages

#### 8702ad3ea msglist [nfc]: Introduce MessageListScrollView, not yet doing anything different


#### 92676fd72 scroll [nfc]: Copy RenderViewport.performLayout and friends from upstream

Some of the behavior we'd like to customize isn't currently cleanly
exposed to subclasses any more than it is to parent widgets passing
constructor arguments.  In particular, we'll want to change a few
bits of logic in [RenderViewport.performLayout], replacing the
handling of the `anchor` field with something more flexible.

In order to do that, we'll start from a copy of that method, so that
we can edit the copy.

Then the base class's `performLayout` refers to a private helper
method `_attemptLayout`, so we need a copy of that too; and they
each refer to a number of private fields, so we need copies of
those too; and to make those work correctly, we need copies of all
the other members that refer to those fields, so that they're all
referring correctly to the same version of those fields (namely
the one on the subclass) rather than to a mix of the versions on
the base class and those on the subclass.

Fortunately, flood-filling that graph of members which refer to
private members, which are referred to by other members, etc.,
terminates with a connected component which is... not small, but a
lot smaller and less unwieldy than if we had to copy the whole
upstream file these are defined in.


#### 96b81dc54 msglist [nfc]: Introduce MessageListScrollPosition


#### 1667c6e30 scroll: Start out scrolled to bottom of list

This is NFC as to the real message list, because so far the bottom
sliver there always has height 0, so that maxScrollExtent is always 0.

This is a step toward letting us move part of the message list into
the bottom sliver, because it means that doing so would preserve the
list's current behavior of starting out scrolled to the end.


#### 07a390513 scroll: Keep short list pinned at bottom of viewport, not past bottom

This is NFC as to the real message list, because so far the bottom
sliver there always has height 0.

Before this change, the user could always scroll up (moving the
content down) so that the bottom sliver was entirely off the bottom
of the viewport, even if that exposed blank space at the top of the
viewport because the top sliver was shorter than the viewport.
After this change, it's never in bounds to have part of the viewport
be blank for lack of content while there's content scrolled out of
the viewport at the other end.

This is a step toward letting us move part of the message list into
the bottom sliver, because it fixes a bug that would otherwise create
in the case where the top sliver fits entirely on the screen.


#### 0f7bc7a55 scroll: Stay at end once there

This is NFC as to the real message list, because so far the bottom
sliver there always has height 0, so that both maxScrollExtent and
this.maxScrollExtent are always 0.

This is a step toward letting us move part of the message list into
the bottom sliver, because it means that doing so would preserve the
list's current behavior of remaining scrolled to the end once there
as e.g. new messages arrive.
