### PR TITLE
MenuItemButton and SubmenuButton should be used in a menu or menu bar

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -42,26 +43,28 @@ void _showActionSheet(
     useSafeArea: true,
     isScrollControlled: true,
     builder: (BuildContext _) {
-      return SafeArea(
-        minimum: const EdgeInsets.only(bottom: 16),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // TODO(#217): show message text
-              Flexible(child: InsetShadowBox(
-                top: 8, bottom: 8,
-                color: DesignVariables.of(context).bgContextMenu,
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.only(top: 16, bottom: 8),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(7),
-                    child: Column(spacing: 1,
-                      children: optionButtons))))),
-              const ActionSheetCancelButton(),
-            ])));
+      return Semantics(
+        role: SemanticsRole.menu,
+        child: SafeArea(
+          minimum: const EdgeInsets.only(bottom: 16),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // TODO(#217): show message text
+                Flexible(child: InsetShadowBox(
+                  top: 8, bottom: 8,
+                  color: DesignVariables.of(context).bgContextMenu,
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.only(top: 16, bottom: 8),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(7),
+                      child: Column(spacing: 1,
+                        children: optionButtons))))),
+                const ActionSheetCancelButton(),
+              ]))));
     });
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1347,5 +1347,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.8.0-205.0.dev <4.0.0"
-  flutter: ">=3.31.0-1.0.pre.139"
+  dart: ">=3.8.0-227.0.dev <4.0.0"
+  flutter: ">=3.31.0-1.0.pre.274"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.8.0-205.0.dev <4.0.0'
-  flutter: '>=3.31.0-1.0.pre.139'  # a780f85f2cd5ed78c0b9c4ca513bbe6723761c76
+  sdk: '>=3.8.0-227.0.dev <4.0.0'
+  flutter: '>=3.31.0-1.0.pre.274'  # 3b6d9666f8e34f277d45fc9ce37080a1979b2411
 
 # To update dependencies, see instructions in README.md.
 dependencies:

--- a/test/widgets/theme_test.dart
+++ b/test/widgets/theme_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -57,10 +59,14 @@ void main() {
     // IconButton can't have text; skip
 
     doCheck('MenuItemButton',
-      button: MenuItemButton(onPressed: () {}, child: const Text(buttonText)));
+      button: Semantics(
+        role: SemanticsRole.menu,
+        child: MenuItemButton(onPressed: () {}, child: const Text(buttonText))));
 
     doCheck('SubmenuButton',
-      button: const SubmenuButton(menuChildren: [], child: Text(buttonText)));
+      button: Semantics(
+        role: SemanticsRole.menu,
+        child: const SubmenuButton(menuChildren: [], child: Text(buttonText))));
 
     doCheck('OutlinedButton',
       button: OutlinedButton(onPressed: () {}, child: const Text(buttonText)));


### PR DESCRIPTION
This is to unblock PR: https://github.com/flutter/flutter/pull/165596 which has test failures in customer testing.

`MenuItemButton` and `SubmenuButton` widgets are wired up with `SemanticsRole.menuItem` and they require their parent to be either `SemanticsRole.menu` or `SemanticsRole.menuBar`.