### PR TITLE
lightbox: Allow zooming in with video lightbox.

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -549,19 +549,22 @@ class _VideoLightboxPageState extends State<VideoLightboxPage> with PerAccountSt
       message: widget.message,
       buildAppBarBottom: (context) => null,
       buildBottomAppBar: _buildBottomAppBar,
-      child: SafeArea(
-        child: Center(
-          child: Stack(alignment: Alignment.center, children: [
-            if (_controller != null && _controller!.value.isInitialized)
-              AspectRatio(
-                aspectRatio: _controller!.value.aspectRatio,
-                child: VideoPlayer(_controller!)),
-            if (_controller == null || !_controller!.value.isInitialized || _controller!.value.isBuffering)
-              const SizedBox(
-                width: 32,
-                height: 32,
-                child: CircularProgressIndicator(color: Colors.white)),
-            ]))));
+      child: Stack(alignment: Alignment.center, children: [
+        InteractiveViewer(
+          child: SafeArea(
+            child: Center(
+              child: (_controller != null && _controller!.value.isInitialized)
+                ? AspectRatio(
+                    aspectRatio: _controller!.value.aspectRatio,
+                    child: VideoPlayer(_controller!))
+                : Container()))
+        ),
+        if (_controller == null || !_controller!.value.isInitialized || _controller!.value.isBuffering)
+          const SizedBox(
+            width: 32,
+            height: 32,
+            child: CircularProgressIndicator(color: Colors.white)),
+      ]));
   }
 }
 

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -557,5 +557,38 @@ void main() {
       check(position).isGreaterThan(basePosition);
       check(platform.position).equals(position);
     });
+
+    testWidgets('video can be zoomed in and out', (tester) async {
+      await setupPage(tester, videoSrc: Uri.parse(kTestVideoUrl));
+      check(platform.isPlaying).isTrue();
+
+      final initialRect = tester.getRect(find.byType(VideoPlayer));
+      final bottomRight = initialRect.bottomRight;
+      // Define initial positions for two fingers near bottom right corner:
+      //   In the case of mismatch between media and device orientation,
+      //   the zoom gesture is still expected to work,
+      //   even if the fingers are not in the image's frame.
+      final Offset finger1Start = bottomRight + const Offset(-70.0, -70.0);
+      final Offset finger2Start = bottomRight + const Offset(-20.0, -20.0);
+      final TestGesture gesture1 = await tester.startGesture(finger1Start);
+      final TestGesture gesture2 = await tester.startGesture(finger2Start);
+      await tester.pump();
+
+      // Simulate pinch out (zoom in)
+      await gesture1.moveBy(const Offset(-20.0, -20.0));
+      await gesture2.moveBy(const Offset(20.0, 20.0));
+      await tester.pump();
+      final zoomedInRect = tester.getRect(find.byType(VideoPlayer));
+      check(zoomedInRect.width).isGreaterThan(initialRect.width);
+      check(zoomedInRect.height).isGreaterThan(initialRect.height);
+
+      // Simulate pinch out (zoom in)
+      await gesture1.moveBy(const Offset(30.0, 30.0));
+      await gesture2.moveBy(const Offset(-30.0, -30.0));
+      await tester.pump();
+      final zoomedOutRect = tester.getRect(find.byType(VideoPlayer));
+      check(zoomedOutRect.width).isLessThan(zoomedInRect.width);
+      check(zoomedOutRect.height).isLessThan(zoomedInRect.height);
+    });
   });
 }


### PR DESCRIPTION
Implement zoom in with video lightbox.
Working Example:

https://github.com/user-attachments/assets/a1a999ba-bb2a-4f97-a19f-cb5cfa7dc264



Key changes:
- Wrap `InteractiveViwer` around `SafeArea` widget.
I changed the layer order in `_LightboxPageLayout`'s child because the loading indicator would get zoomed out of screen if I wrap the `InteractiveViwer` before `Stack`. Though some syntax changes, the functionality stays the same, and all previous test pass.
- Add test to check video player zooming in/ out correctly.
I intentionally start the zoom gesture from the corner instead of the center because the wrong setting would leave dead areas where gesutre is not received(see [Flutter Doc](https://api.flutter.dev/flutter/widgets/InteractiveViewer-class.html)).
This is just to make the zoom in functionality for video lightbox coherent with that for image lightbox.

I hope this explain how and why I made those changes. This is my first Zulip PR and open-source contribution. I'd love to hear any suggestions or feedback!

Fixes[ #1287](https://github.com/zulip/zulip-flutter/issues/1287)