### PR TITLE
notif: Use live value for app ID on registering APNs token

### DIFF
--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -310,10 +310,12 @@ class LinuxDeviceInfo implements BaseDeviceInfo {
 class PackageInfo {
   final String version;
   final String buildNumber;
+  final String packageName;
 
   const PackageInfo({
     required this.version,
     required this.buildNumber,
+    required this.packageName,
   });
 }
 
@@ -427,6 +429,7 @@ class LiveZulipBinding extends ZulipBinding {
       _syncPackageInfo = PackageInfo(
         version: info.version,
         buildNumber: info.buildNumber,
+        packageName: info.packageName,
       );
     } catch (e, st) {
       assert(debugLog('Failed to prefetch package info: $e\n$st')); // TODO(log)

--- a/lib/notifications/receive.dart
+++ b/lib/notifications/receive.dart
@@ -149,8 +149,10 @@ class NotificationService {
         await addFcmToken(connection, token: token);
 
       case TargetPlatform.iOS:
-        const appBundleId = 'com.zulip.flutter'; // TODO(#407) find actual value live
-        await addApnsToken(connection, token: token, appid: appBundleId);
+        final packageInfo = await ZulipBinding.instance.packageInfo;
+        await addApnsToken(connection,
+          token: token,
+          appid: packageInfo!.packageName);
 
       case TargetPlatform.linux:
       case TargetPlatform.macOS:

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -460,7 +460,7 @@ void main() {
       });
     }
 
-    const packageInfo = PackageInfo(version: '0.0.1', buildNumber: '1');
+    final packageInfo = eg.packageInfo(version: '0.0.1', buildNumber: '1');
 
     const testCases = [
       ('ZulipFlutter/0.0.1+1 (Android 14)',             AndroidDeviceInfo(release: '14', sdkInt: 34),                      ),

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -10,6 +10,7 @@ import 'package:zulip/api/model/submessage.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/api/route/channels.dart';
+import 'package:zulip/model/binding.dart';
 import 'package:zulip/model/database.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/settings.dart';
@@ -993,4 +994,16 @@ UpdateMachine updateMachine({
     account: account, initialSnapshot: initialSnapshot);
   return UpdateMachine.fromInitialSnapshot(
     store: store, initialSnapshot: initialSnapshot);
+}
+
+PackageInfo packageInfo({
+  String? version,
+  String? buildNumber,
+  String? packageName,
+}) {
+  return PackageInfo(
+    version: version ?? '1.0.0',
+    buildNumber: buildNumber ?? '1',
+    packageName: packageName ?? 'com.example.app',
+  );
 }

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -260,7 +260,7 @@ class TestZulipBinding extends ZulipBinding {
 
   /// The value that `ZulipBinding.instance.packageInfo` should return.
   PackageInfo packageInfoResult = _defaultPackageInfo;
-  static const _defaultPackageInfo = PackageInfo(version: '0.0.1', buildNumber: '1');
+  static final _defaultPackageInfo = eg.packageInfo();
 
   void _resetPackageInfo() {
     packageInfoResult = _defaultPackageInfo;


### PR DESCRIPTION
Fixes #407 

Changes made:
- Replaced the hardcoded app bundle ID with `packageInfo.packageName`.
- Added a new test that sets a specific appId via packageInfo and confirms it’s used in a notification request.

The first change caused the "token initially unknown" test in `store_test.dart` to fail due to the added asynchronous call to `ZulipBinding.instance.packageInfo`, which delayed the completion of `registerToken`.

To resolve this, a `flushMicrotasks` was added after `await startFuture` in the test to ensure `_registerNotificationToken` completes before the test checks for the request.

