### PR TITLE
Move more data to PerAccountStoreBase

### DIFF
--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -192,19 +192,19 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
     required String? stillUrl,
     required String emojiName,
   }) {
-    final source = Uri.tryParse(sourceUrl);
-    if (source == null) return TextEmojiDisplay(emojiName: emojiName);
+    final resolvedUrl = tryResolveUrl(realmUrl, sourceUrl);
+    if (resolvedUrl == null) return TextEmojiDisplay(emojiName: emojiName);
 
-    Uri? still;
+    Uri? resolvedStillUrl;
     if (stillUrl != null) {
-      still = Uri.tryParse(stillUrl);
-      if (still == null) return TextEmojiDisplay(emojiName: emojiName);
+      resolvedStillUrl = tryResolveUrl(realmUrl, stillUrl);
+      if (resolvedStillUrl == null) return TextEmojiDisplay(emojiName: emojiName);
     }
 
     return ImageEmojiDisplay(
       emojiName: emojiName,
-      resolvedUrl: realmUrl.resolveUri(source),
-      resolvedStillUrl: still == null ? null : realmUrl.resolveUri(still),
+      resolvedUrl: resolvedUrl,
+      resolvedStillUrl: resolvedStillUrl,
     );
   }
 

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -137,14 +137,11 @@ mixin EmojiStore {
 /// Generally the only code that should need this class is [PerAccountStore]
 /// itself.  Other code accesses this functionality through [PerAccountStore],
 /// or through the mixin [EmojiStore] which describes its interface.
-class EmojiStoreImpl with EmojiStore {
+class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
   EmojiStoreImpl({
-    required this.realmUrl,
+    required super.core,
     required this.allRealmEmoji,
   }) : _serverEmojiData = null; // TODO(#974) maybe start from a hard-coded baseline
-
-  /// The same as [PerAccountStore.realmUrl].
-  final Uri realmUrl;
 
   /// The realm's custom emoji, indexed by their [RealmEmojiItem.emojiCode],
   /// including deactivated emoji not available for new uses.

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -192,12 +192,12 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
     required String? stillUrl,
     required String emojiName,
   }) {
-    final resolvedUrl = tryResolveUrl(realmUrl, sourceUrl);
+    final resolvedUrl = this.tryResolveUrl(sourceUrl);
     if (resolvedUrl == null) return TextEmojiDisplay(emojiName: emojiName);
 
     Uri? resolvedStillUrl;
     if (stillUrl != null) {
-      resolvedStillUrl = tryResolveUrl(realmUrl, stillUrl);
+      resolvedStillUrl = this.tryResolveUrl(stillUrl);
       if (resolvedStillUrl == null) return TextEmojiDisplay(emojiName: emojiName);
     }
 

--- a/lib/model/recent_dm_conversations.dart
+++ b/lib/model/recent_dm_conversations.dart
@@ -7,18 +7,19 @@ import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
 import '../api/model/events.dart';
 import 'narrow.dart';
+import 'store.dart';
 
 /// A view-model for the recent-DM-conversations UI.
 ///
 /// This maintains the list of recent DM conversations,
 /// plus additional data in order to efficiently maintain the list.
-class RecentDmConversationsView extends ChangeNotifier {
+class RecentDmConversationsView extends PerAccountStoreBase with ChangeNotifier {
   factory RecentDmConversationsView({
+    required CorePerAccountStore core,
     required List<RecentDmConversation> initial,
-    required int selfUserId,
   }) {
     final entries = initial.map((conversation) => MapEntry(
-        DmNarrow.ofRecentDmConversation(conversation, selfUserId: selfUserId),
+        DmNarrow.ofRecentDmConversation(conversation, selfUserId: core.selfUserId),
         conversation.maxMessageId,
       )).toList()..sort((a, b) => -a.value.compareTo(b.value));
 
@@ -33,18 +34,18 @@ class RecentDmConversationsView extends ChangeNotifier {
     }
 
     return RecentDmConversationsView._(
+      core: core,
       map: Map.fromEntries(entries),
       sorted: QueueList.from(entries.map((e) => e.key)),
       latestMessagesByRecipient: latestMessagesByRecipient,
-      selfUserId: selfUserId,
     );
   }
 
   RecentDmConversationsView._({
+    required super.core,
     required this.map,
     required this.sorted,
     required this.latestMessagesByRecipient,
-    required this.selfUserId,
   });
 
   /// The latest message ID in each conversation.
@@ -61,8 +62,6 @@ class RecentDmConversationsView extends ChangeNotifier {
   /// (The identified message was not necessarily sent by the identified user;
   /// it might have been sent by anyone in its conversation.)
   final Map<int, int> latestMessagesByRecipient;
-
-  final int selfUserId;
 
   /// Insert the key at the proper place in [sorted].
   ///

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -570,7 +570,8 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   /// The [Account] this store belongs to.
   ///
-  /// Will throw if called after [dispose] has been called.
+  /// Will throw if the account has been removed from the global store,
+  /// which is possible only if [dispose] has been called on this store.
   Account get account => _globalStore.getAccount(accountId)!;
 
   final UserSettings? userSettings; // TODO(server-5)

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -338,10 +338,12 @@ class CorePerAccountStore {
   CorePerAccountStore._({
     required GlobalStore globalStore,
     required this.connection,
+    required this.accountId,
   }) : _globalStore = globalStore;
 
   final GlobalStore _globalStore;
   final ApiConnection connection; // TODO(#135): update zulipFeatureLevel with events
+  final int accountId;
 }
 
 /// A base class for [PerAccountStore] and its substores,
@@ -352,9 +354,17 @@ abstract class PerAccountStoreBase {
 
   final CorePerAccountStore _core;
 
+  ////////////////////////////////
+  // Where data comes from in the first place.
+
   GlobalStore get _globalStore => _core._globalStore;
 
   ApiConnection get connection => _core.connection;
+
+  ////////////////////////////////
+  // Data attached to the self-account on the realm.
+
+  int get accountId => _core.accountId;
 }
 
 /// Store for the user's data for a given Zulip account.
@@ -401,6 +411,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     final core = CorePerAccountStore._(
       globalStore: globalStore,
       connection: connection,
+      accountId: accountId,
     );
     final channels = ChannelStoreImpl(initialSnapshot: initialSnapshot);
     return PerAccountStore._(
@@ -418,7 +429,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
       emailAddressVisibility: initialSnapshot.emailAddressVisibility,
       emoji: EmojiStoreImpl(
         realmUrl: realmUrl, allRealmEmoji: initialSnapshot.realmEmoji),
-      accountId: accountId,
       userSettings: initialSnapshot.userSettings,
       typingNotifier: TypingNotifier(
         core: core,
@@ -461,7 +471,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     required this.customProfileFields,
     required this.emailAddressVisibility,
     required EmojiStoreImpl emoji,
-    required this.accountId,
     required this.userSettings,
     required this.typingNotifier,
     required UserStoreImpl users,
@@ -471,7 +480,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     required this.unreads,
     required this.recentDmConversationsView,
     required this.recentSenders,
-  }) : assert(realmUrl == globalStore.getAccount(accountId)!.realmUrl),
+  }) : assert(realmUrl == globalStore.getAccount(core.accountId)!.realmUrl),
        assert(realmUrl == core.connection.realmUrl),
        assert(emoji.realmUrl == realmUrl),
        _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
@@ -571,8 +580,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   ////////////////////////////////
   // Data attached to the self-account on the realm.
-
-  final int accountId;
 
   /// The [Account] this store belongs to.
   ///

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -335,8 +335,12 @@ class AccountNotFoundException implements Exception {}
 /// Calling [PerAccountStore.dispose] also disposes the [CorePerAccountStore]
 /// (for example, it calls [ApiConnection.dispose] on [connection]).
 class CorePerAccountStore {
-  CorePerAccountStore._({required this.connection});
+  CorePerAccountStore._({
+    required GlobalStore globalStore,
+    required this.connection,
+  }) : _globalStore = globalStore;
 
+  final GlobalStore _globalStore;
   final ApiConnection connection; // TODO(#135): update zulipFeatureLevel with events
 }
 
@@ -347,6 +351,8 @@ abstract class PerAccountStoreBase {
     : _core = core;
 
   final CorePerAccountStore _core;
+
+  GlobalStore get _globalStore => _core._globalStore;
 
   ApiConnection get connection => _core.connection;
 }
@@ -392,7 +398,10 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     }
 
     final realmUrl = account.realmUrl;
-    final core = CorePerAccountStore._(connection: connection);
+    final core = CorePerAccountStore._(
+      globalStore: globalStore,
+      connection: connection,
+    );
     final channels = ChannelStoreImpl(initialSnapshot: initialSnapshot);
     return PerAccountStore._(
       globalStore: globalStore,
@@ -465,7 +474,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
   }) : assert(realmUrl == globalStore.getAccount(accountId)!.realmUrl),
        assert(realmUrl == core.connection.realmUrl),
        assert(emoji.realmUrl == realmUrl),
-       _globalStore = globalStore,
        _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
        _emoji = emoji,
        _users = users,
@@ -477,8 +485,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   ////////////////////////////////
   // Where data comes from in the first place.
-
-  final GlobalStore _globalStore;
 
   final String queueId;
   UpdateMachine? get updateMachine => _updateMachine;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -421,7 +421,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
       throw Exception("bad initial snapshot: missing queueId");
     }
 
-    final realmUrl = account.realmUrl;
     final core = CorePerAccountStore._(
       globalStore: globalStore,
       connection: connection,
@@ -440,7 +439,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
       customProfileFields: _sortCustomProfileFields(initialSnapshot.customProfileFields),
       emailAddressVisibility: initialSnapshot.emailAddressVisibility,
       emoji: EmojiStoreImpl(
-        realmUrl: realmUrl, allRealmEmoji: initialSnapshot.realmEmoji),
+        core: core, allRealmEmoji: initialSnapshot.realmEmoji),
       userSettings: initialSnapshot.userSettings,
       typingNotifier: TypingNotifier(
         core: core,
@@ -490,8 +489,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     required this.unreads,
     required this.recentDmConversationsView,
     required this.recentSenders,
-  }) : assert(emoji.realmUrl == core.connection.realmUrl),
-       _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
+  }) : _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
        _emoji = emoji,
        _users = users,
        _channels = channels,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -363,6 +363,12 @@ abstract class PerAccountStoreBase {
   ApiConnection get connection => _core.connection;
 
   ////////////////////////////////
+  // Data attached to the realm or the server.
+
+  /// Always equal to `account.realmUrl` and `connection.realmUrl`.
+  Uri get realmUrl => connection.realmUrl;
+
+  ////////////////////////////////
   // Data attached to the self-account on the realm.
 
   int get accountId => _core.accountId;
@@ -425,7 +431,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     return PerAccountStore._(
       core: core,
       queueId: queueId,
-      realmUrl: realmUrl,
       realmWildcardMentionPolicy: initialSnapshot.realmWildcardMentionPolicy,
       realmMandatoryTopics: initialSnapshot.realmMandatoryTopics,
       realmWaitingPeriodThreshold: initialSnapshot.realmWaitingPeriodThreshold,
@@ -467,7 +472,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
   PerAccountStore._({
     required super.core,
     required this.queueId,
-    required this.realmUrl,
     required this.realmWildcardMentionPolicy,
     required this.realmMandatoryTopics,
     required this.realmWaitingPeriodThreshold,
@@ -486,8 +490,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     required this.unreads,
     required this.recentDmConversationsView,
     required this.recentSenders,
-  }) : assert(realmUrl == core.connection.realmUrl),
-       assert(emoji.realmUrl == realmUrl),
+  }) : assert(emoji.realmUrl == core.connection.realmUrl),
        _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
        _emoji = emoji,
        _users = users,
@@ -520,9 +523,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   ////////////////////////////////
   // Data attached to the realm or the server.
-
-  /// Always equal to `account.realmUrl` and `connection.realmUrl`.
-  final Uri realmUrl;
 
   /// Resolve [reference] as a URL relative to [realmUrl].
   ///

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -328,8 +328,14 @@ abstract class GlobalStore extends ChangeNotifier {
 class AccountNotFoundException implements Exception {}
 
 /// A bundle of items that are useful to [PerAccountStore] and its substores.
+///
+/// Each instance of this class is constructed as part of constructing a
+/// [PerAccountStore] instance,
+/// and is shared by that [PerAccountStore] and its substores.
+/// Calling [PerAccountStore.dispose] also disposes the [CorePerAccountStore]
+/// (for example, it calls [ApiConnection.dispose] on [connection]).
 class CorePerAccountStore {
-  CorePerAccountStore({required this.connection});
+  CorePerAccountStore._({required this.connection});
 
   final ApiConnection connection; // TODO(#135): update zulipFeatureLevel with events
 }
@@ -386,7 +392,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     }
 
     final realmUrl = account.realmUrl;
-    final core = CorePerAccountStore(connection: connection);
+    final core = CorePerAccountStore._(connection: connection);
     final channels = ChannelStoreImpl(initialSnapshot: initialSnapshot);
     return PerAccountStore._(
       globalStore: globalStore,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -365,6 +365,13 @@ abstract class PerAccountStoreBase {
   // Data attached to the self-account on the realm.
 
   int get accountId => _core.accountId;
+
+  /// The [Account] this store belongs to.
+  ///
+  /// Will throw if the account has been removed from the global store,
+  /// which is possible only if [PerAccountStore.dispose] has been called
+  /// on this store.
+  Account get account => _globalStore.getAccount(accountId)!;
 }
 
 /// Store for the user's data for a given Zulip account.
@@ -580,12 +587,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   ////////////////////////////////
   // Data attached to the self-account on the realm.
-
-  /// The [Account] this store belongs to.
-  ///
-  /// Will throw if the account has been removed from the global store,
-  /// which is possible only if [dispose] has been called on this store.
-  Account get account => _globalStore.getAccount(accountId)!;
 
   final UserSettings? userSettings; // TODO(server-5)
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -412,7 +412,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
       accountId: accountId,
       userSettings: initialSnapshot.userSettings,
       typingNotifier: TypingNotifier(
-        connection: connection,
+        core: core,
         typingStoppedWaitPeriod: Duration(
           milliseconds: initialSnapshot.serverTypingStoppedWaitPeriodMilliseconds),
         typingStartedWaitPeriod: Duration(

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -368,6 +368,11 @@ abstract class PerAccountStoreBase {
   /// Always equal to `account.realmUrl` and `connection.realmUrl`.
   Uri get realmUrl => connection.realmUrl;
 
+  /// Resolve [reference] as a URL relative to [realmUrl].
+  ///
+  /// This returns null if [reference] fails to parse as a URL.
+  Uri? tryResolveUrl(String reference) => _tryResolveUrl(realmUrl, reference);
+
   ////////////////////////////////
   // Data attached to the self-account on the realm.
 
@@ -379,6 +384,17 @@ abstract class PerAccountStoreBase {
   /// which is possible only if [PerAccountStore.dispose] has been called
   /// on this store.
   Account get account => _globalStore.getAccount(accountId)!;
+}
+
+const _tryResolveUrl = tryResolveUrl;
+
+/// Like [Uri.resolve], but on failure return null instead of throwing.
+Uri? tryResolveUrl(Uri baseUrl, String reference) {
+  try {
+    return baseUrl.resolve(reference);
+  } on FormatException {
+    return null;
+  }
 }
 
 /// Store for the user's data for a given Zulip account.
@@ -521,11 +537,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   ////////////////////////////////
   // Data attached to the realm or the server.
-
-  /// Resolve [reference] as a URL relative to [realmUrl].
-  ///
-  /// This returns null if [reference] fails to parse as a URL.
-  Uri? tryResolveUrl(String reference) => _tryResolveUrl(realmUrl, reference);
 
   /// Always equal to `connection.zulipFeatureLevel`
   /// and `account.zulipFeatureLevel`.
@@ -897,17 +908,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
 
   @override
   String toString() => '${objectRuntimeType(this, 'PerAccountStore')}#${shortHash(this)}';
-}
-
-const _tryResolveUrl = tryResolveUrl;
-
-/// Like [Uri.resolve], but on failure return null instead of throwing.
-Uri? tryResolveUrl(Uri baseUrl, String reference) {
-  try {
-    return baseUrl.resolve(reference);
-  } on FormatException {
-    return null;
-  }
 }
 
 /// A [GlobalStoreBackend] that uses a live, persistent local database.

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -339,7 +339,8 @@ class CorePerAccountStore {
     required GlobalStore globalStore,
     required this.connection,
     required this.accountId,
-  }) : _globalStore = globalStore;
+  }) : _globalStore = globalStore,
+       assert(connection.realmUrl == globalStore.getAccount(accountId)!.realmUrl);
 
   final GlobalStore _globalStore;
   final ApiConnection connection; // TODO(#135): update zulipFeatureLevel with events
@@ -422,7 +423,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     );
     final channels = ChannelStoreImpl(initialSnapshot: initialSnapshot);
     return PerAccountStore._(
-      globalStore: globalStore,
       core: core,
       queueId: queueId,
       realmUrl: realmUrl,
@@ -465,7 +465,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
   }
 
   PerAccountStore._({
-    required GlobalStore globalStore,
     required super.core,
     required this.queueId,
     required this.realmUrl,
@@ -487,8 +486,7 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     required this.unreads,
     required this.recentDmConversationsView,
     required this.recentSenders,
-  }) : assert(realmUrl == globalStore.getAccount(core.accountId)!.realmUrl),
-       assert(realmUrl == core.connection.realmUrl),
+  }) : assert(realmUrl == core.connection.realmUrl),
        assert(emoji.realmUrl == realmUrl),
        _realmEmptyTopicDisplayName = realmEmptyTopicDisplayName,
        _emoji = emoji,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -482,19 +482,18 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
           milliseconds: initialSnapshot.serverTypingStartedWaitPeriodMilliseconds),
       ),
       users: UserStoreImpl(core: core, initialSnapshot: initialSnapshot),
-      typingStatus: TypingStatus(
-        selfUserId: account.userId,
+      typingStatus: TypingStatus(core: core,
         typingStartedExpiryPeriod: Duration(milliseconds: initialSnapshot.serverTypingStartedExpiryPeriodMilliseconds),
       ),
       channels: channels,
       messages: MessageStoreImpl(core: core),
       unreads: Unreads(
         initial: initialSnapshot.unreadMsgs,
-        selfUserId: account.userId,
+        core: core,
         channelStore: channels,
       ),
-      recentDmConversationsView: RecentDmConversationsView(
-        initial: initialSnapshot.recentPrivateConversations, selfUserId: account.userId),
+      recentDmConversationsView: RecentDmConversationsView(core: core,
+        initial: initialSnapshot.recentPrivateConversations),
       recentSenders: RecentSenders(),
     );
   }

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -11,13 +11,12 @@ import 'store.dart';
 /// The model for tracking the typing status organized by narrows.
 ///
 /// Listeners are notified when a typist is added or removed from any narrow.
-class TypingStatus extends ChangeNotifier {
+class TypingStatus extends PerAccountStoreBase with ChangeNotifier {
   TypingStatus({
-    required this.selfUserId,
+    required super.core,
     required this.typingStartedExpiryPeriod,
   });
 
-  final int selfUserId;
   final Duration typingStartedExpiryPeriod;
 
   Iterable<SendableNarrow> get debugActiveNarrows => _timerMapsByNarrow.keys;

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
-import '../api/core.dart';
 import '../api/model/events.dart';
 import '../api/route/typing.dart';
 import 'binding.dart';
 import 'narrow.dart';
+import 'store.dart';
 
 /// The model for tracking the typing status organized by narrows.
 ///
@@ -93,14 +93,13 @@ class TypingStatus extends ChangeNotifier {
 /// See also:
 ///  * https://github.com/zulip/zulip/blob/52a9846cdf4abfbe937a94559690d508e95f4065/web/shared/src/typing_status.ts
 ///  * https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html
-class TypingNotifier {
+class TypingNotifier extends PerAccountStoreBase {
   TypingNotifier({
-    required this.connection,
+    required super.core,
     required this.typingStoppedWaitPeriod,
     required this.typingStartedWaitPeriod,
   });
 
-  final ApiConnection connection;
   final Duration typingStoppedWaitPeriod;
   final Duration typingStartedWaitPeriod;
 

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -2,17 +2,10 @@ import '../api/model/events.dart';
 import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
 import 'localizations.dart';
+import 'store.dart';
 
 /// The portion of [PerAccountStore] describing the users in the realm.
-mixin UserStore {
-  /// The user ID of the "self-user",
-  /// i.e. the account the person using this app is logged into.
-  ///
-  /// This always equals the [Account.userId] on [PerAccountStore.account].
-  ///
-  /// For the corresponding [User] object, see [selfUser].
-  int get selfUserId;
-
+mixin UserStore on PerAccountStoreBase {
   /// The user with the given ID, if that user is known.
   ///
   /// There may be other users that are perfectly real but are
@@ -80,18 +73,15 @@ mixin UserStore {
 /// Generally the only code that should need this class is [PerAccountStore]
 /// itself.  Other code accesses this functionality through [PerAccountStore],
 /// or through the mixin [UserStore] which describes its interface.
-class UserStoreImpl with UserStore {
+class UserStoreImpl extends PerAccountStoreBase with UserStore {
   UserStoreImpl({
-    required this.selfUserId,
+    required super.core,
     required InitialSnapshot initialSnapshot,
   }) : _users = Map.fromEntries(
          initialSnapshot.realmUsers
          .followedBy(initialSnapshot.realmNonActiveUsers)
          .followedBy(initialSnapshot.crossRealmBots)
          .map((user) => MapEntry(user.userId, user)));
-
-  @override
-  final int selfUserId;
 
   final Map<int, User> _users;
 

--- a/test/model/recent_dm_conversations_test.dart
+++ b/test/model/recent_dm_conversations_test.dart
@@ -6,6 +6,7 @@ import 'package:zulip/model/recent_dm_conversations.dart';
 
 import '../example_data.dart' as eg;
 import 'recent_dm_conversations_checks.dart';
+import 'store_checks.dart';
 
 void main() {
   group('RecentDmConversationsView', () {
@@ -18,18 +19,19 @@ void main() {
     }
 
     test('construct from initial data', () {
-      check(RecentDmConversationsView(selfUserId: eg.selfUser.userId,
-        initial: []))
+      check(eg.store(initialSnapshot: eg.initialSnapshot(
+        recentPrivateConversations: [],
+      ))).recentDmConversationsView
           ..map.isEmpty()
           ..sorted.isEmpty()
           ..latestMessagesByRecipient.isEmpty();
 
-      check(RecentDmConversationsView(selfUserId: eg.selfUser.userId,
-        initial: [
+      check(eg.store(initialSnapshot: eg.initialSnapshot(
+        recentPrivateConversations: [
           RecentDmConversation(userIds: [],     maxMessageId: 200),
           RecentDmConversation(userIds: [1],    maxMessageId: 100),
           RecentDmConversation(userIds: [2, 1], maxMessageId: 300), // userIds out of order
-        ]))
+        ]))).recentDmConversationsView
           ..map.deepEquals({
             key([1, 2]): 300,
             key([]):     200,
@@ -41,11 +43,11 @@ void main() {
 
     group('message event (new message)', () {
       RecentDmConversationsView setupView() {
-        return RecentDmConversationsView(selfUserId: eg.selfUser.userId,
-          initial: [
+        return eg.store(initialSnapshot: eg.initialSnapshot(
+          recentPrivateConversations: [
             RecentDmConversation(userIds: [1],    maxMessageId: 200),
             RecentDmConversation(userIds: [1, 2], maxMessageId: 100),
-          ]);
+          ])).recentDmConversationsView;
       }
 
       test('(check base state)', () {

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -77,9 +77,11 @@ void main() {
     int? selfUserId,
     Map<SendableNarrow, List<User>> typistsByNarrow = const {},
   }) {
-    model = TypingStatus(
-      selfUserId: selfUserId ?? eg.selfUser.userId,
-      typingStartedExpiryPeriod: const Duration(milliseconds: 15000));
+    final store = eg.store(
+      account: eg.selfAccount.copyWith(id: selfUserId),
+      initialSnapshot: eg.initialSnapshot(
+        serverTypingStartedExpiryPeriodMilliseconds: 15000));
+    model = store.typingStatus;
     check(model.debugActiveNarrows).isEmpty();
     notifiedCount = 0;
     model.addListener(() => notifiedCount += 1);

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -37,10 +37,11 @@ void main() {
       oldUnreadsMissing: false,
     ),
   }) {
-    channelStore = eg.store();
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(unreadMsgs: initial));
+    channelStore = store;
     notifiedCount = 0;
-    model = Unreads(initial: initial,
-        selfUserId: eg.selfUser.userId, channelStore: channelStore)
+    model = store.unreads
       ..addListener(() {
         notifiedCount++;
       });


### PR DESCRIPTION
This follows up on #1464 by moving several more members to PerAccountStoreBase so as to share them across our substores: the global store, account ID, self-user ID, getters for the realm URL and account, and the method for resolving a URL reference based on the realm URL.

@PIG208 it seems we were thinking on similar lines today :slightly_smiling_face: — I saw #1466 when this was partly written, and incorporated the parts of it for migrating the tests in the commit that starts using PerAccountStoreBase for selfUserId. (Some substore tests had been constructing the substores directly, and need to start getting them from a PerAccountStore.)

After this, there are a few small items that I think we'll also want to move: `queueId` (as in #1466), `zulipFeatureLevel`, `zulipVersion`, and that might be it.

Also in this general direction, we'll want to organize the various realm settings into a RealmSettingsStore. That'll be post-launch, though.


### Selected commit messages

#### 8217a763e store [nfc]: Fix "will throw if disposed" comment on account to be more specific

As far as I can see, just `dispose` won't cause this to throw.
I think this related point is the one this comment was intended
to make.


#### 84d032711 store [nfc]: Move global store up to PerAccountStoreBase too


#### 0aeeb3510 store [nfc]: Move accountId to PerAccountStoreBase


#### 833069df9 store [nfc]: Move `account` getter up to PerAccountStoreBase


#### 678f1cdb9 store [nfc]: Move realmUrl up to PerAccountStoreBase


#### 00bb86eb4 store [nfc]: Move tryResolveUrl up to base, and use it more


#### db2eab6ec user [nfc]: Move selfUserId to PerAccountStoreBase

This `selfUserId` getter has 16 other references across 11 files.
Thankfully our architecture, and in particular this way of combining
the substores:

  class PerAccountStore extends PerAccountStoreBase with ChangeNotifier,
    EmojiStore, UserStore, ChannelStore, MessageStore {

has meant that those all refer to it on the main PerAccountStore type,
rather than on an individual substore like UserStore.  So none of
those need to be touched when we rearrange like this where the data
is stored.


#### 706af43c3 store [nfc]: Get selfUserId on substores from PerAccountStoreBase

Co-authored-by: Zixuan James Li <zixuan@zulip.com>


#### 313f8a9df unreads test [nfc]: Accept that a whole PerAccountStore is used for tests

We've had a couple of approaches we've experimented with for how to write
the tests for a given substore within our data model:

 * Operate on the given substore's individual API.

 * Operate on the API of the overall PerAccountStore, though focusing on
   the particular portion of that API provided by the given substore.

In general I think the outcome of these experiments is that we want to
be writing our tests against the API of the whole PerAccountStore.

Fundamentally that's for the reasons described here:
  https://zulip.readthedocs.io/en/latest/testing/philosophy.html#integration-testing-or-unit-testing
because the overall PerAccountStore is the layer whose API corresponds
naturally to the Zulip server API, which is an interface that's
external to the app and so is the real interface we're committed to
supporting.

This particular test file is one which we originally wrote on the
other side of the experiment, operating on the individual `Unreads`
substore.

But it already had some tension with that approach, ever since we
realized that that substore needed access to another substore, the
ChannelStore, in order to properly handle muting (ffa2d323f,
0d03c8ec7).  To handle that, these tests ended up making a whole
PerAccountStore after all, and had a TODO comment for trying to
fully make the substore-only approach work.

With the advent of CorePerAccountStore, there's no longer a realistic
prospect that we'd want to end up carrying that through.  That's
because the Unreads now gets its value of `selfUserId` from a
CorePerAccountStore, and the only reasonable way to construct one of
those is as part of a whole PerAccountStore.

So resolve the experiment, at least as to this file: remove the
TODO comment, and rename the variable to just `store` accordingly.
