### PR TITLE
anchors 7/n: Start splitting slivers!

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -580,7 +580,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   }
 
   Widget _buildListView(BuildContext context) {
-    final length = model!.items.length;
+    final numItems = model!.items.length;
     const centerSliverKey = ValueKey('center sliver');
     final zulipLocalizations = ZulipLocalizations.of(context);
 
@@ -603,22 +603,24 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         // have state that needs to be preserved have not been given keys
         // and will not trigger this callback.
         findChildIndexCallback: (Key key) {
-          final valueKey = key as ValueKey<int>;
-          final index = model!.findItemWithMessageId(valueKey.value);
-          if (index == -1) return null;
-          return length - 1 - (index - 3);
+          final messageId = (key as ValueKey<int>).value;
+          final itemIndex = model!.findItemWithMessageId(messageId);
+          if (itemIndex == -1) return null;
+          final childIndex = numItems - 1 - (itemIndex - 3);
+          return childIndex;
         },
-        childCount: length + 3,
-        (context, i) {
+        childCount: numItems + 3,
+        (context, childIndex) {
           // To reinforce that the end of the feed has been reached:
           //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680603
-          if (i == 0) return const SizedBox(height: 36);
+          if (childIndex == 0) return const SizedBox(height: 36);
 
-          if (i == 1) return MarkAsReadWidget(narrow: widget.narrow);
+          if (childIndex == 1) return MarkAsReadWidget(narrow: widget.narrow);
 
-          if (i == 2) return TypingStatusWidget(narrow: widget.narrow);
+          if (childIndex == 2) return TypingStatusWidget(narrow: widget.narrow);
 
-          final data = model!.items[length - 1 - (i - 3)];
+          final itemIndex = numItems - 1 - (childIndex - 3);
+          final data = model!.items[itemIndex];
           return _buildItem(zulipLocalizations, data);
         }));
 
@@ -641,7 +643,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       },
 
       controller: scrollController,
-      semanticChildCount: length, // TODO(#537): what's the right value for this?
+      semanticChildCount: numItems, // TODO(#537): what's the right value for this?
       center: centerSliverKey,
       paintOrder: SliverPaintOrder.firstIsTop,
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -641,7 +641,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       },
 
       controller: scrollController,
-      semanticChildCount: length + 2,
+      semanticChildCount: length, // TODO(#537): what's the right value for this?
       center: centerSliverKey,
       paintOrder: SliverPaintOrder.firstIsTop,
 

--- a/lib/widgets/scrolling.dart
+++ b/lib/widgets/scrolling.dart
@@ -245,10 +245,13 @@ class MessageListScrollPosition extends ScrollPositionWithSingleContext {
 
     if (!_hasEverCompletedLayout) {
       // The list is being laid out for the first time (its first performLayout).
-      // Start out scrolled to the end.
+      // Start out scrolled down so the bottom sliver (the new messages)
+      // occupies 75% of the viewport,
+      // or at the in-range scroll position closest to that.
       // This also brings [pixels] within bounds, which
       // the initial value of 0.0 might not have been.
-      final target = maxScrollExtent;
+      final target = clampDouble(0.75 * viewportDimension,
+        minScrollExtent, maxScrollExtent);
       if (!hasPixels || pixels != target) {
         correctPixels(target);
         changed = true;

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -142,6 +142,18 @@ extension TextEditingControllerChecks on Subject<TextEditingController> {
   Subject<String?> get text => has((t) => t.text, 'text');
 }
 
+extension ScrollMetricsChecks on Subject<ScrollMetrics> {
+  Subject<double> get minScrollExtent => has((x) => x.minScrollExtent, 'minScrollExtent');
+  Subject<double> get maxScrollExtent => has((x) => x.maxScrollExtent, 'maxScrollExtent');
+  Subject<double> get pixels => has((x) => x.pixels, 'pixels');
+  Subject<double> get extentBefore => has((x) => x.extentBefore, 'extentBefore');
+  Subject<double> get extentAfter => has((x) => x.extentAfter, 'extentAfter');
+}
+
+extension ScrollPositionChecks on Subject<ScrollPosition> {
+  Subject<ScrollActivity?> get activity => has((x) => x.activity, 'activity');
+}
+
 extension ScrollActivityChecks on Subject<ScrollActivity> {
   Subject<double> get velocity => has((x) => x.velocity, 'velocity');
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1450,28 +1450,28 @@ void main() {
         .deepEquals(expected..insertAll(0, [101, 103, 105]));
 
       // … and on MessageEvent.
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 301, stream: stream1, topic: 'A')));
+      await store.addMessage(
+        eg.streamMessage(id: 301, stream: stream1, topic: 'A'));
       checkNotifiedOnce();
       check(model.messages.map((m) => m.id)).deepEquals(expected..add(301));
 
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 302, stream: stream1, topic: 'B')));
+      await store.addMessage(
+        eg.streamMessage(id: 302, stream: stream1, topic: 'B'));
       checkNotNotified();
       check(model.messages.map((m) => m.id)).deepEquals(expected);
 
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 303, stream: stream2, topic: 'C')));
+      await store.addMessage(
+        eg.streamMessage(id: 303, stream: stream2, topic: 'C'));
       checkNotifiedOnce();
       check(model.messages.map((m) => m.id)).deepEquals(expected..add(303));
 
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 304, stream: stream2, topic: 'D')));
+      await store.addMessage(
+        eg.streamMessage(id: 304, stream: stream2, topic: 'D'));
       checkNotNotified();
       check(model.messages.map((m) => m.id)).deepEquals(expected);
 
-      await store.handleEvent(eg.messageEvent(
-        eg.dmMessage(id: 305, from: eg.otherUser, to: [eg.selfUser])));
+      await store.addMessage(
+        eg.dmMessage(id: 305, from: eg.otherUser, to: [eg.selfUser]));
       checkNotifiedOnce();
       check(model.messages.map((m) => m.id)).deepEquals(expected..add(305));
     });
@@ -1507,18 +1507,18 @@ void main() {
         .deepEquals(expected..insertAll(0, [101, 102]));
 
       // … and on MessageEvent.
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 301, stream: stream, topic: 'A')));
+      await store.addMessage(
+        eg.streamMessage(id: 301, stream: stream, topic: 'A'));
       checkNotifiedOnce();
       check(model.messages.map((m) => m.id)).deepEquals(expected..add(301));
 
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 302, stream: stream, topic: 'B')));
+      await store.addMessage(
+        eg.streamMessage(id: 302, stream: stream, topic: 'B'));
       checkNotifiedOnce();
       check(model.messages.map((m) => m.id)).deepEquals(expected..add(302));
 
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 303, stream: stream, topic: 'C')));
+      await store.addMessage(
+        eg.streamMessage(id: 303, stream: stream, topic: 'C'));
       checkNotNotified();
       check(model.messages.map((m) => m.id)).deepEquals(expected);
     });
@@ -1549,8 +1549,8 @@ void main() {
         .deepEquals(expected..insertAll(0, [101]));
 
       // … and on MessageEvent.
-      await store.handleEvent(eg.messageEvent(
-        eg.streamMessage(id: 301, stream: stream, topic: 'A')));
+      await store.addMessage(
+        eg.streamMessage(id: 301, stream: stream, topic: 'A'));
       checkNotifiedOnce();
       check(model.messages.map((m) => m.id)).deepEquals(expected..add(301));
     });
@@ -1589,7 +1589,7 @@ void main() {
       // … and on MessageEvent.
       final messages = getMessages(301);
       for (var i = 0; i < 3; i += 1) {
-        await store.handleEvent(eg.messageEvent(messages[i]));
+        await store.addMessage(messages[i]);
         checkNotifiedOnce();
         check(model.messages.map((m) => m.id)).deepEquals(expected..add(301 + i));
       }
@@ -1627,7 +1627,7 @@ void main() {
       // … and on MessageEvent.
       final messages = getMessages(301);
       for (var i = 0; i < 2; i += 1) {
-        await store.handleEvent(eg.messageEvent(messages[i]));
+        await store.addMessage(messages[i]);
         checkNotifiedOnce();
         check(model.messages.map((m) => m.id)).deepEquals(expected..add(301 + i));
       }
@@ -1718,11 +1718,11 @@ void main() {
     checkNotified(count: 2);
 
     // Then test MessageEvent, where a new header is needed…
-    await store.handleEvent(eg.messageEvent(streamMessage(13)));
+    await store.addMessage(streamMessage(13));
     checkNotifiedOnce();
 
     // … and where it's not.
-    await store.handleEvent(eg.messageEvent(streamMessage(14)));
+    await store.addMessage(streamMessage(14));
     checkNotifiedOnce();
 
     // Then test UpdateMessageEvent edits, where a header is and remains needed…

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -129,7 +129,7 @@ void main() {
       check(store.messages).isEmpty();
 
       final newMessage = eg.streamMessage();
-      await store.handleEvent(eg.messageEvent(newMessage));
+      await store.addMessage(newMessage);
       check(store.messages).deepEquals({
         newMessage.id: newMessage,
       });
@@ -148,7 +148,7 @@ void main() {
       });
 
       final newMessage = eg.streamMessage();
-      await store.handleEvent(eg.messageEvent(newMessage));
+      await store.addMessage(newMessage);
       check(store.messages).deepEquals({
         for (final m in messages) m.id: m,
         newMessage.id: newMessage,
@@ -162,7 +162,7 @@ void main() {
       check(store.messages).deepEquals({1: message});
 
       final newMessage = eg.streamMessage(id: 1, content: '<p>bar</p>');
-      await store.handleEvent(eg.messageEvent(newMessage));
+      await store.addMessage(newMessage);
       check(store.messages).deepEquals({1: newMessage});
     });
   });
@@ -859,7 +859,7 @@ void main() {
         ]);
 
         await prepare();
-        await store.handleEvent(eg.messageEvent(message));
+        await store.addMessage(message);
       }
 
       test('smoke', () async {
@@ -930,7 +930,7 @@ void main() {
           ),
         ]);
         await prepare();
-        await store.handleEvent(eg.messageEvent(message));
+        await store.addMessage(message);
         check(store.messages[message.id]).isNotNull().poll.isNull();
       });
     });

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -462,15 +462,21 @@ void main() {
 
     testWidgets('scrolling changes visibility', (tester) async {
       await setupMessageListPage(tester, messageCount: 10);
+      // Scroll position starts at the end, so button hidden.
       final controller = findMessageListScrollController(tester)!;
+      check(controller.position).extentAfter.equals(0);
       check(isButtonVisible(tester)).equals(false);
 
+      // Scrolling up, button becomes visible.
       controller.jumpTo(-600);
       await tester.pump();
+      check(controller.position).extentAfter.isGreaterThan(0);
       check(isButtonVisible(tester)).equals(true);
 
-      controller.jumpTo(0);
+      // Scrolling back down to end, button becomes hidden again.
+      controller.jumpTo(controller.position.maxScrollExtent);
       await tester.pump();
+      check(controller.position).extentAfter.equals(0);
       check(isButtonVisible(tester)).equals(false);
     });
 
@@ -500,13 +506,13 @@ void main() {
       final controller = findMessageListScrollController(tester)!;
       controller.jumpTo(-600);
       await tester.pump();
-      check(controller.position).pixels.equals(-600);
+      check(controller.position).extentAfter.isGreaterOrEqual(600);
 
       // Tap button.
       await tester.tap(find.byType(ScrollToBottomButton));
       // The list scrolls to the end…
       await tester.pumpAndSettle();
-      check(controller.position).pixels.equals(0);
+      check(controller.position).extentAfter.equals(0);
       // … and for good measure confirm the button disappeared.
       check(isButtonVisible(tester)).equals(false);
     });

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -375,7 +375,7 @@ void main() {
     testWidgets('basic', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
         messages: List.generate(300, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
-      check(itemCount(tester)).equals(303);
+      check(itemCount(tester)).equals(301);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -388,7 +388,7 @@ void main() {
       await tester.pump(Duration.zero); // Allow a frame for the response to arrive.
 
       // Now we have more messages.
-      check(itemCount(tester)).equals(403);
+      check(itemCount(tester)).equals(401);
     });
 
     testWidgets('observe double-fetch glitch', (tester) async {
@@ -429,7 +429,7 @@ void main() {
         ...List.generate(100, (i) => eg.streamMessage(id: 1302 + i)),
       ]);
       final lastRequest = connection.lastRequest;
-      check(itemCount(tester)).equals(404);
+      check(itemCount(tester)).equals(402);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -500,13 +500,13 @@ void main() {
       final controller = findMessageListScrollController(tester)!;
       controller.jumpTo(-600);
       await tester.pump();
-      check(controller.position.pixels).equals(-600);
+      check(controller.position).pixels.equals(-600);
 
       // Tap button.
       await tester.tap(find.byType(ScrollToBottomButton));
       // The list scrolls to the end…
       await tester.pumpAndSettle();
-      check(controller.position.pixels).equals(0);
+      check(controller.position).pixels.equals(0);
       // … and for good measure confirm the button disappeared.
       check(isButtonVisible(tester)).equals(false);
     });
@@ -520,7 +520,7 @@ void main() {
       // Scroll a long distance up, many screenfuls.
       controller.jumpTo(-distance);
       await tester.pump();
-      check(controller.position.pixels).equals(-distance);
+      check(controller.position).pixels.equals(-distance);
 
       // Tap button.
       await tester.tap(find.byType(ScrollToBottomButton));

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1510,7 +1510,7 @@ void main() {
 
       // introduce new message
       final newMessage = eg.streamMessage(flags:[MessageFlag.read]);
-      await store.handleEvent(eg.messageEvent(newMessage));
+      await store.addMessage(newMessage);
       await tester.pump(); // process handleEvent
       check(find.byType(MessageItem).evaluate()).length.equals(2);
       check(getAnimation(tester, message.id))

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -462,14 +462,14 @@ void main() {
 
     testWidgets('scrolling changes visibility', (tester) async {
       await setupMessageListPage(tester, messageCount: 10);
-      final scrollController = findMessageListScrollController(tester)!;
+      final controller = findMessageListScrollController(tester)!;
       check(isButtonVisible(tester)).equals(false);
 
-      scrollController.jumpTo(-600);
+      controller.jumpTo(-600);
       await tester.pump();
       check(isButtonVisible(tester)).equals(true);
 
-      scrollController.jumpTo(0);
+      controller.jumpTo(0);
       await tester.pump();
       check(isButtonVisible(tester)).equals(false);
     });
@@ -478,8 +478,8 @@ void main() {
       await setupMessageListPage(tester, messageCount: 100);
 
       // Scroll up, to hide the button.
-      final scrollController = findMessageListScrollController(tester)!;
-      scrollController.jumpTo(-600);
+      final controller = findMessageListScrollController(tester)!;
+      controller.jumpTo(-600);
       await tester.pump();
       check(isButtonVisible(tester)).equals(true);
 
@@ -497,16 +497,16 @@ void main() {
 
     testWidgets('button works', (tester) async {
       await setupMessageListPage(tester, messageCount: 10);
-      final scrollController = findMessageListScrollController(tester)!;
-      scrollController.jumpTo(-600);
+      final controller = findMessageListScrollController(tester)!;
+      controller.jumpTo(-600);
       await tester.pump();
-      check(scrollController.position.pixels).equals(-600);
+      check(controller.position.pixels).equals(-600);
 
       // Tap button.
       await tester.tap(find.byType(ScrollToBottomButton));
       // The list scrolls to the end…
       await tester.pumpAndSettle();
-      check(scrollController.position.pixels).equals(0);
+      check(controller.position.pixels).equals(0);
       // … and for good measure confirm the button disappeared.
       check(isButtonVisible(tester)).equals(false);
     });

--- a/test/widgets/scrolling_test.dart
+++ b/test/widgets/scrolling_test.dart
@@ -124,8 +124,8 @@ void main() {
 
       // Starts out scrolled all the way to the bottom,
       // even though it must have taken several rounds of layout to find that.
-      check(controller.position.pixels)
-        .equals(itemHeight * numItems * (numItems + 1)/2);
+      check(controller.position)
+        .pixels.equals(itemHeight * numItems * (numItems + 1)/2);
       check(tester.getRect(find.text('item ${numItems-1}', skipOffstage: false)))
         .bottom.equals(600);
     });
@@ -198,30 +198,30 @@ void main() {
         await prepare(tester, topHeight: 300, bottomHeight: 600);
         await tester.drag(findBottom, Offset(0, 300));
         await tester.pump();
-        check(position.extentAfter).equals(300);
+        check(position).extentAfter.equals(300);
 
         // Start scrolling to end, from just a short distance up.
         position.scrollToEnd();
         await tester.pump();
-        check(position.extentAfter).equals(300);
-        check(position.activity).isA<ScrollToEndActivity>();
+        check(position).extentAfter.equals(300);
+        check(position).activity.isA<ScrollToEndActivity>();
 
         // The scrolling moves at a stately pace; …
         await tester.pump(Duration(milliseconds: 100));
-        check(position.extentAfter).equals(200);
+        check(position).extentAfter.equals(200);
 
         await tester.pump(Duration(milliseconds: 100));
-        check(position.extentAfter).equals(100);
+        check(position).extentAfter.equals(100);
 
         // … then upon reaching the end, …
         await tester.pump(Duration(milliseconds: 100));
-        check(position.extentAfter).equals(0);
+        check(position).extentAfter.equals(0);
 
         // … goes idle on the next frame, …
         await tester.pump(Duration(milliseconds: 1));
-        check(position.activity).isA<IdleScrollActivity>();
+        check(position).activity.isA<IdleScrollActivity>();
         // … without moving any farther.
-        check(position.extentAfter).equals(0);
+        check(position).extentAfter.equals(0);
       });
 
       testWidgets('long -> bounded speed', (tester) async {
@@ -231,12 +231,12 @@ void main() {
         await prepare(tester, topHeight: distance + 1000, bottomHeight: 300);
         await tester.drag(findBottom, Offset(0, distance));
         await tester.pump();
-        check(position.extentAfter).equals(distance);
+        check(position).extentAfter.equals(distance);
 
         // Start scrolling to end.
         position.scrollToEnd();
         await tester.pump();
-        check(position.activity).isA<ScrollToEndActivity>();
+        check(position).activity.isA<ScrollToEndActivity>();
 
         // Let it scroll, plotting the trajectory.
         final log = <double>[];
@@ -249,12 +249,12 @@ void main() {
           (i) => distance - referenceSpeed * i));
 
         // Having reached the end, …
-        check(position.extentAfter).equals(0);
+        check(position).extentAfter.equals(0);
         // … it goes idle on the next frame, …
         await tester.pump(Duration(milliseconds: 1));
-        check(position.activity).isA<IdleScrollActivity>();
+        check(position).activity.isA<IdleScrollActivity>();
         // … without moving any farther.
-        check(position.extentAfter).equals(0);
+        check(position).extentAfter.equals(0);
       });
 
       testWidgets('starting from overscroll, just drift', (tester) async {
@@ -266,33 +266,33 @@ void main() {
         await tester.pump();
         final offset1 = position.pixels - position.maxScrollExtent;
         check(offset1).isGreaterThan(100 / 2);
-        check(position.activity).isA<BallisticScrollActivity>();
+        check(position).activity.isA<BallisticScrollActivity>();
 
         // Start drifting back into range.
         await tester.pump(Duration(milliseconds: 10));
         final offset2 = position.pixels - position.maxScrollExtent;
         check(offset2)..isGreaterThan(0.0)..isLessThan(offset1);
-        check(position.activity).isA<BallisticScrollActivity>()
+        check(position).activity.isA<BallisticScrollActivity>()
           .velocity.isLessThan(0);
 
         // Invoke `scrollToEnd`.  The motion should stop…
         position.scrollToEnd();
         await tester.pump();
         check(position.pixels - position.maxScrollExtent).equals(offset2);
-        check(position.activity).isA<BallisticScrollActivity>()
+        check(position).activity.isA<BallisticScrollActivity>()
           .velocity.equals(0);
 
         // … and resume drifting from there…
         await tester.pump(Duration(milliseconds: 10));
         final offset3 = position.pixels - position.maxScrollExtent;
         check(offset3)..isGreaterThan(0.0)..isLessThan(offset2);
-        check(position.activity).isA<BallisticScrollActivity>()
+        check(position).activity.isA<BallisticScrollActivity>()
           .velocity.isLessThan(0);
 
         // … to eventually return to being in range.
         await tester.pump(Duration(seconds: 1));
         check(position.pixels - position.maxScrollExtent).equals(0);
-        check(position.activity).isA<IdleScrollActivity>();
+        check(position).activity.isA<IdleScrollActivity>();
 
         debugDefaultTargetPlatformOverride = null;
       });
@@ -305,17 +305,17 @@ void main() {
 
         position.jumpTo(398);
         await tester.pump();
-        check(position.extentAfter).equals(2);
+        check(position).extentAfter.equals(2);
 
         position.scrollToEnd();
         await tester.pump();
-        check(position.extentAfter).equals(2);
+        check(position).extentAfter.equals(2);
 
         // Reach the end in just 150ms, not 300ms.
         await tester.pump(Duration(milliseconds: 75));
-        check(position.extentAfter).equals(1);
+        check(position).extentAfter.equals(1);
         await tester.pump(Duration(milliseconds: 75));
-        check(position.extentAfter).equals(0);
+        check(position).extentAfter.equals(0);
       });
 
       testWidgets('on overscroll, stop', (tester) async {
@@ -325,7 +325,7 @@ void main() {
         // Scroll up…
         position.jumpTo(400);
         await tester.pump();
-        check(position.extentAfter).equals(600);
+        check(position).extentAfter.equals(600);
 
         // … then invoke `scrollToEnd`…
         position.scrollToEnd();
@@ -334,7 +334,7 @@ void main() {
         // … but have the bottom sliver turn out to be shorter than it was.
         await prepare(tester, topHeight: 400, bottomHeight: 600,
           reuseController: true);
-        check(position.extentAfter).equals(200);
+        check(position).extentAfter.equals(200);
 
         // Let the scrolling animation proceed until it hits the end.
         int steps = 0;
@@ -348,10 +348,10 @@ void main() {
         check(position.pixels - position.maxScrollExtent).equals(0);
 
         // … and the animation is done.  Nothing further happens.
-        check(position.activity).isA<IdleScrollActivity>();
+        check(position).activity.isA<IdleScrollActivity>();
         await tester.pump(Duration(milliseconds: 11));
         check(position.pixels - position.maxScrollExtent).equals(0);
-        check(position.activity).isA<IdleScrollActivity>();
+        check(position).activity.isA<IdleScrollActivity>();
 
         debugDefaultTargetPlatformOverride = null;
       });
@@ -362,7 +362,7 @@ void main() {
         // Scroll up…
         position.jumpTo(0);
         await tester.pump();
-        check(position.extentAfter).equals(3000);
+        check(position).extentAfter.equals(3000);
 
         // … then invoke `scrollToEnd`…
         position.scrollToEnd();
@@ -371,7 +371,7 @@ void main() {
         // … but have the bottom sliver turn out to be longer than it was.
         await prepare(tester, topHeight: 1000, bottomHeight: 6000,
           reuseController: true);
-        check(position.extentAfter).equals(6000);
+        check(position).extentAfter.equals(6000);
 
         // Let the scrolling animation go until it stops.
         int steps = 0;


### PR DESCRIPTION
This is the next round after (and is stacked atop) #1486, toward #82.

(The initial draft of this PR said this PR would include the needed changes to the scroll-to-end button. Those ended up being a bigger job than I initially thought, so I've split them into their own PR as #1486.)

On my own device I've been running drafts of this PR merged with drafts of #1486 for a couple of weeks, off and on. Everything seems to behave smoothly from a user perspective.

In this PR:

* We start actually splitting the message list into back-to-back slivers, with the latest message in the bottom message list. Thanks to all the prep work up to this point, this change has only subtle effects in the UX.

* The last commit takes advantage of the back-to-back slivers to make one nice, though small, UX improvement: when opening a message list where the latest message doesn't fit on the screen or nearly doesn't, we make sure to show the top of that latest message instead of the bottom.

  In the future when the bottom sliver represents the unread messages, or the messages starting at another target anchor (anchor in [the Zulip sense](https://zulip.com/api/get-messages#parameter-anchor), not the `ScrollView` sense), this change will become much more important: we'll need to show the top of that potentially very tall bottom sliver, not its bottom.


## Selected commit messages

#### 9e6624ba6 msglist: Split into back-to-back slivers

Thanks to all the preparatory changes we've made in this commit
series and those that came before it, this change should have only
subtle effects on user-visible behavior.

This therefore serves as a testing ground for all the ways that the
message list's scrolling behavior can become more complicated when
two (nontrivial) slivers are involved.  If we find a situation where
the behavior does change noticeably (beyond what's described below),
that will be something to investigate and fix.

In particular:

 * The sticky headers should behave exactly as they did before,
   even when the sliver boundary lies under the sticky header,
   thanks to several previous commit series.

 * On first loading a given message list, it should start out
   scrolled to the end, just as before.

 * When already scrolled to the end, the message list should stay
   there when a new message arrives, or a message is edited, etc.,
   even if the (new) latest message is taller than it was.
   This commit adds a test to confirm that.

Subtle differences include:

 * When scrolled up from the bottom and a new message comes in,
   the behavior is slightly different from before.  The current
   exact behavior is something we probably want to change anyway,
   and I think the new behavior isn't particularly better or worse.

 * The behavior upon overscroll might be slightly different;
   I'm not sure.

 * When a new message arrives, the previously-latest message gets a
   fresh element in the tree, and any UI state on it is lost.  This
   happens because it moves between one sliver-list and the other,
   and the `findChildIndexCallback` mechanism only works within a
   single sliver-list.

   This causes a couple of visible glitches, but they seem tolerable.
   This will also naturally get fixed in the next PR or two toward
   #82: we'll start adding new messages to the bottom sliver, rather
   than having them push anything from the bottom to the top sliver.

   Known symptoms of this are:

   * When the user has just marked messages as read and a new message
     arrives while the unread markers are fading, the marker on the
     previously-latest message will (if it was present) abruptly
     vanish while the others smoothly continue fading.

     We have a test for the smooth fading, and it happened to test
     the latest message, so this commit adjusts the test to avoid
     triggering this issue.

   * If the user had a spoiler expanded on the previously-latest
     message, it will reset to collapsed.


#### 9ded2aa83 scroll: Show start of latest message if long, instead of end

This makes our first payoff in actual UX from having the message list
split into two back-to-back slivers!

With this change, if you open a message list and the latest message
is very tall, the list starts out scrolled so that you can see the
top of that latest message -- plus a bit of context above it (25% of
the viewport's height).  Previously the list would always start out
scrolled to the end, so you'd have to scroll up in order to read
even the one latest message from the beginning.

In addition to a small UX improvement now, this makes a preview of
behavior we'll want to have when the bottom sliver starts at the
first unread message, and may have many messages after that.
This new behavior is nice already with one message, if the message
happens to be very tall; but it'll become critical when the bottom
sliver is routinely many screenfuls tall.
