### PR TITLE
Edit-message (5/n): Fix bug where compose progress can be lost on new event queue

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1523,14 +1523,26 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
 
   @override
   void onNewStore() {
+    final newStore = PerAccountStoreWidget.of(context);
+
+    final controller = _controller;
+    if (controller == null) {
+      _setNewController(newStore);
+      return;
+    }
+
+    switch (controller) {
+      case StreamComposeBoxController():
+        controller.topic.store = newStore;
+      case FixedDestinationComposeBoxController():
+        // no reference to the store that needs updating
+    }
+  }
+
+  void _setNewController(PerAccountStore store) {
     switch (widget.narrow) {
       case ChannelNarrow():
-        final store = PerAccountStoreWidget.of(context);
-        if (_controller == null) {
-          _controller = StreamComposeBoxController(store: store);
-        } else {
-          (controller as StreamComposeBoxController).topic.store = store;
-        }
+        _controller = StreamComposeBoxController(store: store);
       case TopicNarrow():
       case DmNarrow():
         _controller = FixedDestinationComposeBoxController();


### PR DESCRIPTION
And factor out a helper for the part that reads `widget.narrow` and sets a new controller accordingly; we'll use this helper for the edit-message UI, to reset the compose box at the end of an edit-message session.

Fixes: #1470