### PR TITLE
Edit-message (7/n): Implement edit-message methods on MessageStore

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -747,6 +747,21 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
     // TODO(#649) notify [unreads] of the just-fetched messages
     // TODO(#650) notify [recentDmConversationsView] of the just-fetched messages
   }
+  @override
+  bool? getEditMessageErrorStatus(int messageId) {
+    assert(!_disposed);
+    return _messages.getEditMessageErrorStatus(messageId);
+  }
+  @override
+  void editMessage({required int messageId, required String newContent}) {
+    assert(!_disposed);
+    return _messages.editMessage(messageId: messageId, newContent: newContent);
+  }
+  @override
+  String takeFailedMessageEdit(int messageId) {
+    assert(!_disposed);
+    return _messages.takeFailedMessageEdit(messageId);
+  }
 
   @override
   Set<MessageListView> get debugMessageListViews => _messages.debugMessageListViews;

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -737,6 +737,11 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
   void unregisterMessageList(MessageListView view) =>
     _messages.unregisterMessageList(view);
   @override
+  Future<void> sendMessage({required MessageDestination destination, required String content}) {
+    assert(!_disposed);
+    return _messages.sendMessage(destination: destination, content: content);
+  }
+  @override
   void reconcileMessages(List<Message> messages) {
     _messages.reconcileMessages(messages);
     // TODO(#649) notify [unreads] of the just-fetched messages
@@ -902,12 +907,6 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
       case UnexpectedEvent():
         assert(debugLog("server event: ${jsonEncode(event.toJson())}")); // TODO log better
     }
-  }
-
-  @override
-  Future<void> sendMessage({required MessageDestination destination, required String content}) {
-    assert(!_disposed);
-    return _messages.sendMessage(destination: destination, content: content);
   }
 
   static List<CustomProfileField> _sortCustomProfileFields(List<CustomProfileField> initialCustomProfileFields) {


### PR DESCRIPTION
This PR, toward the edit-message feature #126, implements three new methods on `MessageStore`:

`editMessage`, to be called when the user taps the "Edit message" button in the message action sheet:

`getEditMessageErrorStatus`, to be called when rendering the message list; showing a loading state when we haven't gotten the update-message event yet, and an error state for a failed edit request:

<img width="470" alt="image" src="https://github.com/user-attachments/assets/f535d937-3aef-4f5b-b3da-f324aee319b0" />

<img width="323" alt="image" src="https://github.com/user-attachments/assets/87ba9979-47bc-4924-8bf2-c02a4088f096" />

(The UI text isn't final; see updates on CZO: [#mobile-design > edit message @ 💬](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/edit.20message/near/1930073))

`takeFailedMessageEdit`, to be called when you tap the error message pictured above, so we can put you back in the edit box, starting with the text you'd tried to edit to. This part is from CZO discussion: [#mobile-design > edit message @ 💬](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/edit.20message/near/2129901)

Related: #126