### PR TITLE
ios: MinimumOSVersion 12.0 to 14.0 in ios/Flutter/AppFrameworkInfo.plist

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>14.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,6 @@
 # This should match the iOS Deployment Target
 # (in Xcode, that's in project > Runner > Info)
+# and MinimumOSVersion in ios/Flutter/AppFrameworkInfo.plist.
 platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.


### PR DESCRIPTION
The Flutter doc on deploying an iOS app says this number should match the deployment target we set in Xcode (which we also specify in ios/Podfile):
  https://docs.flutter.dev/deployment/ios#updating-the-apps-deployment-version
; sure, go ahead and update it.

Prompted by noticing that `flutter run` started bumping it to 13.0 (in flutter/flutter@09d4dabd6; see discussion:
  https://github.com/zulip/zulip-flutter/pull/1489#issuecomment-2843657156
) and realizing that 14.0 is actually what it should be for us.