### PR TITLE
emoji: Generate popular candidates using names from server data

### DIFF
--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -115,11 +115,7 @@ mixin EmojiStore {
   ///
   /// See description in the web code:
   ///   https://github.com/zulip/zulip/blob/83a121c7e/web/shared/src/typeahead.ts#L3-L21
-  // Someday this list may start varying rather than being hard-coded,
-  // and then this will become a non-static member on EmojiStore.
-  // For now, though, the fact it's constant is convenient when writing
-  // tests of the logic that uses this data; so we guarantee it in the API.
-  static Iterable<EmojiCandidate> get popularEmojiCandidates {
+  Iterable<EmojiCandidate> get popularEmojiCandidates {
     return EmojiStoreImpl._popularCandidates;
   }
 
@@ -319,7 +315,7 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
 
     // Include the "popular" emoji, in their canonical order
     // relative to each other.
-    results.addAll(EmojiStore.popularEmojiCandidates);
+    results.addAll(popularEmojiCandidates);
 
     final namesOverridden = {
       for (final emoji in activeRealmEmoji) emoji.name,

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -221,10 +221,10 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
 
   static List<EmojiCandidate> _generatePopularCandidates() {
     EmojiCandidate candidate(String emojiCode, List<String> names) {
-      final emojiName = names.removeAt(0);
+      final [emojiName, ...aliases] = names;
       final emojiUnicode = tryParseEmojiCodeToUnicode(emojiCode)!;
       return EmojiCandidate(emojiType: ReactionType.unicodeEmoji,
-        emojiCode: emojiCode, emojiName: emojiName, aliases: names,
+        emojiCode: emojiCode, emojiName: emojiName, aliases: aliases,
         emojiDisplay: UnicodeEmojiDisplay(
           emojiName: emojiName, emojiUnicode: emojiUnicode));
     }

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -221,32 +221,44 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
   static final _popularCandidates = _generatePopularCandidates();
 
   static List<EmojiCandidate> _generatePopularCandidates() {
-    EmojiCandidate candidate(String emojiCode, String emojiUnicode,
-        List<String> names) {
+    EmojiCandidate candidate(String emojiCode, List<String> names) {
       final emojiName = names.removeAt(0);
-      assert(emojiUnicode == tryParseEmojiCodeToUnicode(emojiCode));
+      final emojiUnicode = tryParseEmojiCodeToUnicode(emojiCode)!;
       return EmojiCandidate(emojiType: ReactionType.unicodeEmoji,
         emojiCode: emojiCode, emojiName: emojiName, aliases: names,
         emojiDisplay: UnicodeEmojiDisplay(
           emojiName: emojiName, emojiUnicode: emojiUnicode));
     }
+    final list = _popularEmojiCodesList;
     return [
-      // This list should match web:
-      //   https://github.com/zulip/zulip/blob/83a121c7e/web/shared/src/typeahead.ts#L22-L29
-      candidate('1f44d', '👍', ['+1', 'thumbs_up', 'like']),
-      candidate('1f389', '🎉', ['tada']),
-      candidate('1f642', '🙂', ['smile']),
-      candidate( '2764', '❤', ['heart', 'love', 'love_you']),
-      candidate('1f6e0', '🛠', ['working_on_it', 'hammer_and_wrench', 'tools']),
-      candidate('1f419', '🐙', ['octopus']),
+      candidate(list[0], ['+1', 'thumbs_up', 'like']),
+      candidate(list[1], ['tada']),
+      candidate(list[2], ['smile']),
+      candidate(list[3], ['heart', 'love', 'love_you']),
+      candidate(list[4], ['working_on_it', 'hammer_and_wrench', 'tools']),
+      candidate(list[5], ['octopus']),
     ];
   }
 
-  static final _popularEmojiCodes = (() {
-    assert(_popularCandidates.every((c) =>
-      c.emojiType == ReactionType.unicodeEmoji));
-    return Set.of(_popularCandidates.map((c) => c.emojiCode));
+  /// Codes for the popular emoji, in order; all are Unicode emoji.
+  // This list should match web:
+  //   https://github.com/zulip/zulip/blob/83a121c7e/web/shared/src/typeahead.ts#L22-L29
+  static final List<String> _popularEmojiCodesList = (() {
+    String check(String emojiCode, String emojiUnicode) {
+      assert(emojiUnicode == tryParseEmojiCodeToUnicode(emojiCode));
+      return emojiCode;
+    }
+    return [
+      check('1f44d', '👍'),
+      check('1f389', '🎉'),
+      check('1f642', '🙂'),
+      check('2764', '❤'),
+      check('1f6e0', '🛠'),
+      check('1f419', '🐙'),
+    ];
   })();
+
+  static final Set<String> _popularEmojiCodes = Set.of(_popularEmojiCodesList);
 
   static bool _isPopularEmoji(EmojiCandidate candidate) {
     return candidate.emojiType == ReactionType.unicodeEmoji

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -319,7 +319,7 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
 
     // Include the "popular" emoji, in their canonical order
     // relative to each other.
-    results.addAll(_popularCandidates);
+    results.addAll(EmojiStore.popularEmojiCandidates);
 
     final namesOverridden = {
       for (final emoji in activeRealmEmoji) emoji.name,

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -115,9 +115,7 @@ mixin EmojiStore {
   ///
   /// See description in the web code:
   ///   https://github.com/zulip/zulip/blob/83a121c7e/web/shared/src/typeahead.ts#L3-L21
-  Iterable<EmojiCandidate> popularEmojiCandidates() {
-    return EmojiStoreImpl._popularCandidates;
-  }
+  Iterable<EmojiCandidate> popularEmojiCandidates();
 
   Iterable<EmojiCandidate> allEmojiCandidates();
 
@@ -215,6 +213,11 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
   Map<String, List<String>>? _serverEmojiData;
 
   static final _popularCandidates = _generatePopularCandidates();
+
+  @override
+  Iterable<EmojiCandidate> popularEmojiCandidates() {
+    return _popularCandidates;
+  }
 
   static List<EmojiCandidate> _generatePopularCandidates() {
     EmojiCandidate candidate(String emojiCode, List<String> names) {

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -115,7 +115,7 @@ mixin EmojiStore {
   ///
   /// See description in the web code:
   ///   https://github.com/zulip/zulip/blob/83a121c7e/web/shared/src/typeahead.ts#L3-L21
-  Iterable<EmojiCandidate> get popularEmojiCandidates {
+  Iterable<EmojiCandidate> popularEmojiCandidates() {
     return EmojiStoreImpl._popularCandidates;
   }
 
@@ -315,7 +315,7 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
 
     // Include the "popular" emoji, in their canonical order
     // relative to each other.
-    results.addAll(popularEmojiCandidates);
+    results.addAll(popularEmojiCandidates());
 
     final namesOverridden = {
       for (final emoji in activeRealmEmoji) emoji.name,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -612,6 +612,9 @@ class PerAccountStore extends PerAccountStoreBase with ChangeNotifier, EmojiStor
   }
 
   @override
+  Iterable<EmojiCandidate> popularEmojiCandidates() => _emoji.popularEmojiCandidates();
+
+  @override
   Iterable<EmojiCandidate> allEmojiCandidates() => _emoji.allEmojiCandidates();
 
   EmojiStoreImpl _emoji;

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -698,11 +698,12 @@ class ReactionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(EmojiStore.popularEmojiCandidates.every(
+    final store = PerAccountStoreWidget.of(pageContext);
+    final popularEmojiCandidates = store.popularEmojiCandidates;
+    assert(popularEmojiCandidates.every(
       (emoji) => emoji.emojiType == ReactionType.unicodeEmoji));
 
     final zulipLocalizations = ZulipLocalizations.of(context);
-    final store = PerAccountStoreWidget.of(pageContext);
     final designVariables = DesignVariables.of(context);
 
     bool hasSelfVote(EmojiCandidate emoji) {
@@ -718,7 +719,7 @@ class ReactionButtons extends StatelessWidget {
         color: designVariables.contextMenuItemBg.withFadedAlpha(0.12)),
       child: Row(children: [
         Flexible(child: Row(spacing: 1, children: List.unmodifiable(
-          EmojiStore.popularEmojiCandidates.mapIndexed((index, emoji) =>
+          popularEmojiCandidates.mapIndexed((index, emoji) =>
             _buildButton(
               context: context,
               emoji: emoji,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -699,7 +699,7 @@ class ReactionButtons extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(pageContext);
-    final popularEmojiCandidates = store.popularEmojiCandidates;
+    final popularEmojiCandidates = store.popularEmojiCandidates();
     assert(popularEmojiCandidates.every(
       (emoji) => emoji.emojiType == ReactionType.unicodeEmoji));
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -555,6 +555,8 @@ void showMessageActionSheet({required BuildContext context, required Message mes
   final pageContext = PageRoot.contextOf(context);
   final store = PerAccountStoreWidget.of(pageContext);
 
+  final popularEmojiLoaded = store.popularEmojiCandidates().isNotEmpty;
+
   // The UI that's conditioned on this won't live-update during this appearance
   // of the action sheet (we avoid calling composeBoxControllerOf in a build
   // method; see its doc).
@@ -568,7 +570,8 @@ void showMessageActionSheet({required BuildContext context, required Message mes
   final showMarkAsUnreadButton = markAsUnreadSupported && isMessageRead;
 
   final optionButtons = [
-    ReactionButtons(message: message, pageContext: pageContext),
+    if (popularEmojiLoaded)
+      ReactionButtons(message: message, pageContext: pageContext),
     StarButton(message: message, pageContext: pageContext),
     if (isComposeBoxOffered)
       QuoteAndReplyButton(message: message, pageContext: pageContext),
@@ -702,6 +705,12 @@ class ReactionButtons extends StatelessWidget {
     final popularEmojiCandidates = store.popularEmojiCandidates();
     assert(popularEmojiCandidates.every(
       (emoji) => emoji.emojiType == ReactionType.unicodeEmoji));
+    // (if this is empty, the widget isn't built in the first place)
+    assert(popularEmojiCandidates.isNotEmpty);
+    // UI not designed to handle more than 6 popular emoji.
+    // (We might have fewer if ServerEmojiData is lacking expected data,
+    // but that looks fine in manual testing, even when there's just one.)
+    assert(popularEmojiCandidates.length <= 6);
 
     final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);

--- a/test/api/route/realm_test.dart
+++ b/test/api/route/realm_test.dart
@@ -22,7 +22,7 @@ void main() {
     }
 
     final fakeResult = ServerEmojiData(codeToNames: {
-      '1f642': ['smile'],
+      '1f642': ['slight_smile'],
       '1f34a': ['orange', 'tangerine', 'mandarin'],
     });
 

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -129,6 +129,28 @@ GetServerSettingsResult serverSettings({
   );
 }
 
+ServerEmojiData serverEmojiDataPopular = ServerEmojiData(codeToNames: {
+  '1f44d': ['+1', 'thumbs_up', 'like'],
+  '1f389': ['tada'],
+  '1f642': ['smile'],
+  '2764': ['heart', 'love', 'love_you'],
+  '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
+  '1f419': ['octopus'],
+});
+
+ServerEmojiData serverEmojiDataPopularPlus(ServerEmojiData data) {
+  final a = serverEmojiDataPopular;
+  final b = data;
+  final result = ServerEmojiData(
+    codeToNames: {...a.codeToNames, ...b.codeToNames},
+  );
+  assert(
+    result.codeToNames.length == a.codeToNames.length + b.codeToNames.length,
+    'eg.serverEmojiDataPopularPlus called with data that collides with eg.serverEmojiDataPopular',
+  );
+  return result;
+}
+
 RealmEmojiItem realmEmojiItem({
   required String emojiCode,
   required String emojiName,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -132,7 +132,7 @@ GetServerSettingsResult serverSettings({
 ServerEmojiData serverEmojiDataPopular = ServerEmojiData(codeToNames: {
   '1f44d': ['+1', 'thumbs_up', 'like'],
   '1f389': ['tada'],
-  '1f642': ['smile'],
+  '1f642': ['slight_smile'],
   '2764': ['heart', 'love', 'love_you'],
   '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
   '1f419': ['octopus'],
@@ -151,15 +151,15 @@ ServerEmojiData serverEmojiDataPopularPlus(ServerEmojiData data) {
   return result;
 }
 
-/// Like [serverEmojiDataPopular], but with the modern '1f642': ['slight_smile']
-/// instead of '1f642': ['smile']; see zulip/zulip@9feba0f16f.
+/// Like [serverEmojiDataPopular], but with the legacy '1f642': ['smile']
+/// instead of '1f642': ['slight_smile']; see zulip/zulip@9feba0f16f.
 ///
 /// zulip/zulip@9feba0f16f is a Server 11 commit.
-// TODO(server-11) can drop legacy data
-ServerEmojiData serverEmojiDataPopularModern = ServerEmojiData(codeToNames: {
+// TODO(server-11) can drop this
+ServerEmojiData serverEmojiDataPopularLegacy = ServerEmojiData(codeToNames: {
   '1f44d': ['+1', 'thumbs_up', 'like'],
   '1f389': ['tada'],
-  '1f642': ['slight_smile'],
+  '1f642': ['smile'],
   '2764': ['heart', 'love', 'love_you'],
   '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
   '1f419': ['octopus'],

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -151,6 +151,20 @@ ServerEmojiData serverEmojiDataPopularPlus(ServerEmojiData data) {
   return result;
 }
 
+/// Like [serverEmojiDataPopular], but with the modern '1f642': ['slight_smile']
+/// instead of '1f642': ['smile']; see zulip/zulip@9feba0f16f.
+///
+/// zulip/zulip@9feba0f16f is a Server 11 commit.
+// TODO(server-11) can drop legacy data
+ServerEmojiData serverEmojiDataPopularModern = ServerEmojiData(codeToNames: {
+  '1f44d': ['+1', 'thumbs_up', 'like'],
+  '1f389': ['tada'],
+  '1f642': ['slight_smile'],
+  '2764': ['heart', 'love', 'love_you'],
+  '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
+  '1f419': ['octopus'],
+});
+
 RealmEmojiItem realmEmojiItem({
   required String emojiCode,
   required String emojiName,

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -10,6 +10,24 @@ import 'package:zulip/model/store.dart';
 import '../example_data.dart' as eg;
 
 void main() {
+  PerAccountStore prepare({
+    Map<String, RealmEmojiItem> realmEmoji = const {},
+    bool addServerDataForPopular = true,
+    Map<String, List<String>>? unicodeEmoji,
+  }) {
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(realmEmoji: realmEmoji));
+
+    if (addServerDataForPopular || unicodeEmoji != null) {
+      final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
+      final emojiData = addServerDataForPopular
+        ? eg.serverEmojiDataPopularPlus(extraEmojiData)
+        : extraEmojiData;
+      store.setServerEmojiData(emojiData);
+    }
+    return store;
+  }
+
   group('emojiDisplayFor', () {
     test('Unicode emoji', () {
       check(eg.store().emojiDisplayFor(emojiType: ReactionType.unicodeEmoji,
@@ -118,24 +136,6 @@ void main() {
 
   group('allEmojiCandidates', () {
     // TODO test emojiDisplay of candidates matches emojiDisplayFor
-
-    PerAccountStore prepare({
-      Map<String, RealmEmojiItem> realmEmoji = const {},
-      bool addServerDataForPopular = true,
-      Map<String, List<String>>? unicodeEmoji,
-    }) {
-      final store = eg.store(
-        initialSnapshot: eg.initialSnapshot(realmEmoji: realmEmoji));
-
-      if (addServerDataForPopular || unicodeEmoji != null) {
-        final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
-        final emojiData = addServerDataForPopular
-          ? eg.serverEmojiDataPopularPlus(extraEmojiData)
-          : extraEmojiData;
-        store.setServerEmojiData(emojiData);
-      }
-      return store;
-    }
 
     test('popular emoji appear even when no server emoji data', () {
       final store = prepare(unicodeEmoji: null, addServerDataForPopular: false);
@@ -321,24 +321,6 @@ void main() {
 
     List<Condition<Object?>> arePopularResults = popularCandidates.map(
       (c) => isUnicodeResult(emojiCode: c.emojiCode)).toList();
-
-    PerAccountStore prepare({
-      Map<String, RealmEmojiItem> realmEmoji = const {},
-      bool addServerDataForPopular = true,
-      Map<String, List<String>>? unicodeEmoji,
-    }) {
-      final store = eg.store(
-        initialSnapshot: eg.initialSnapshot(realmEmoji: realmEmoji));
-
-      if (addServerDataForPopular || unicodeEmoji != null) {
-        final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
-        final emojiData = addServerDataForPopular
-          ? eg.serverEmojiDataPopularPlus(extraEmojiData)
-          : extraEmojiData;
-        store.setServerEmojiData(emojiData);
-      }
-      return store;
-    }
 
     test('results can include all three emoji types', () async {
       final store = prepare(

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -323,15 +323,13 @@ void main() {
       (c) => isUnicodeResult(emojiCode: c.emojiCode)).toList();
 
     PerAccountStore prepare({
-      Map<String, String> realmEmoji = const {},
+      Map<String, RealmEmojiItem> realmEmoji = const {},
       bool addServerDataForPopular = true,
       Map<String, List<String>>? unicodeEmoji,
     }) {
       final store = eg.store(
-        initialSnapshot: eg.initialSnapshot(realmEmoji: {
-          for (final MapEntry(:key, :value) in realmEmoji.entries)
-            key: eg.realmEmojiItem(emojiCode: key, emojiName: value),
-        }));
+        initialSnapshot: eg.initialSnapshot(realmEmoji: realmEmoji));
+
       if (addServerDataForPopular || unicodeEmoji != null) {
         final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
         final emojiData = addServerDataForPopular
@@ -344,7 +342,9 @@ void main() {
 
     test('results can include all three emoji types', () async {
       final store = prepare(
-        realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f516': ['bookmark']});
+        realmEmoji: {'1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'happy')},
+        unicodeEmoji: {'1f516': ['bookmark']},
+      );
       final view = EmojiAutocompleteView.init(store: store,
         query: EmojiAutocompleteQuery(''));
       bool done = false;
@@ -361,7 +361,8 @@ void main() {
 
     test('results update after query change', () async {
       final store = prepare(
-        realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f516': ['bookmark']});
+        realmEmoji: {'1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'happy')},
+        unicodeEmoji: {'1f516': ['bookmark']});
       final view = EmojiAutocompleteView.init(store: store,
         query: EmojiAutocompleteQuery('hap'));
       bool done = false;
@@ -381,7 +382,7 @@ void main() {
 
     Future<Iterable<EmojiAutocompleteResult>> resultsOf(
       String query, {
-      Map<String, String> realmEmoji = const {},
+      Map<String, RealmEmojiItem> realmEmoji = const {},
       Map<String, List<String>>? unicodeEmoji,
     }) async {
       final store = prepare(realmEmoji: realmEmoji, unicodeEmoji: unicodeEmoji);

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -78,7 +78,7 @@ void main() {
     });
   });
 
-  final popularCandidates = EmojiStore.popularEmojiCandidates;
+  final popularCandidates = eg.store().popularEmojiCandidates;
 
   Condition<Object?> isUnicodeCandidate(String? emojiCode, List<String>? names) {
     return (it_) {

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -78,7 +78,10 @@ void main() {
     });
   });
 
-  final popularCandidates = eg.store().popularEmojiCandidates();
+  final popularCandidates = (
+    eg.store()..setServerEmojiData(eg.serverEmojiDataPopular)
+  ).popularEmojiCandidates();
+  assert(popularCandidates.length == 6);
 
   Condition<Object?> isUnicodeCandidate(String? emojiCode, List<String>? names) {
     return (it_) {
@@ -118,18 +121,25 @@ void main() {
 
     PerAccountStore prepare({
       Map<String, RealmEmojiItem> realmEmoji = const {},
+      bool addServerDataForPopular = true,
       Map<String, List<String>>? unicodeEmoji,
     }) {
       final store = eg.store(
         initialSnapshot: eg.initialSnapshot(realmEmoji: realmEmoji));
-      if (unicodeEmoji != null) {
-        store.setServerEmojiData(ServerEmojiData(codeToNames: unicodeEmoji));
+
+      if (addServerDataForPopular || unicodeEmoji != null) {
+        final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
+        final emojiData = addServerDataForPopular
+          ? eg.serverEmojiDataPopularPlus(extraEmojiData)
+          : extraEmojiData;
+        store.setServerEmojiData(emojiData);
       }
       return store;
     }
 
     test('popular emoji appear even when no server emoji data', () {
-      final store = prepare(unicodeEmoji: null);
+      final store = prepare(unicodeEmoji: null, addServerDataForPopular: false);
+      check(store.debugServerEmojiData).isNull();
       check(store.allEmojiCandidates()).deepEquals([
         ...arePopularCandidates,
         isZulipCandidate(),
@@ -139,7 +149,8 @@ void main() {
     test('popular emoji appear in their canonical order', () {
       // In the server's emoji data, have the popular emoji in a permuted order,
       // and interspersed with other emoji.
-      final store = prepare(unicodeEmoji: {
+      assert(popularCandidates.length == 6);
+      final store = prepare(addServerDataForPopular: false, unicodeEmoji: {
         '1f603': ['smiley'],
         for (final candidate in popularCandidates.skip(3))
           candidate.emojiCode: [candidate.emojiName, ...candidate.aliases],
@@ -246,15 +257,17 @@ void main() {
     });
 
     test('updates on setServerEmojiData', () {
-      final store = prepare();
+      final store = prepare(unicodeEmoji: null, addServerDataForPopular: false);
+      check(store.debugServerEmojiData).isNull();
       check(store.allEmojiCandidates()).deepEquals([
         ...arePopularCandidates,
         isZulipCandidate(),
       ]);
 
-      store.setServerEmojiData(ServerEmojiData(codeToNames: {
-        '1f516': ['bookmark'],
-      }));
+      store.setServerEmojiData(eg.serverEmojiDataPopularPlus(
+        ServerEmojiData(codeToNames: {
+          '1f516': ['bookmark'],
+        })));
       check(store.allEmojiCandidates()).deepEquals([
         ...arePopularCandidates,
         isUnicodeCandidate('1f516', ['bookmark']),
@@ -318,9 +331,9 @@ void main() {
           for (final MapEntry(:key, :value) in realmEmoji.entries)
             key: eg.realmEmojiItem(emojiCode: key, emojiName: value),
         }));
-      if (unicodeEmoji != null) {
-        store.setServerEmojiData(ServerEmojiData(codeToNames: unicodeEmoji));
-      }
+      final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
+      ServerEmojiData emojiData = eg.serverEmojiDataPopularPlus(extraEmojiData);
+      store.setServerEmojiData(emojiData);
       return store;
     }
 

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -137,15 +137,6 @@ void main() {
   group('allEmojiCandidates', () {
     // TODO test emojiDisplay of candidates matches emojiDisplayFor
 
-    test('popular emoji appear even when no server emoji data', () {
-      final store = prepare(unicodeEmoji: null, addServerDataForPopular: false);
-      check(store.debugServerEmojiData).isNull();
-      check(store.allEmojiCandidates()).deepEquals([
-        ...arePopularCandidates,
-        isZulipCandidate(),
-      ]);
-    });
-
     test('popular emoji appear in their canonical order', () {
       // In the server's emoji data, have the popular emoji in a permuted order,
       // and interspersed with other emoji.
@@ -260,7 +251,6 @@ void main() {
       final store = prepare(unicodeEmoji: null, addServerDataForPopular: false);
       check(store.debugServerEmojiData).isNull();
       check(store.allEmojiCandidates()).deepEquals([
-        ...arePopularCandidates,
         isZulipCandidate(),
       ]);
 
@@ -300,6 +290,44 @@ void main() {
       });
       final candidates = store.allEmojiCandidates();
       check(store.allEmojiCandidates()).identicalTo(candidates);
+    });
+  });
+
+  group('popularEmojiCandidates', () {
+    test('memoizes result, before setServerEmojiData', () {
+      final store = eg.store();
+      check(store.debugServerEmojiData).isNull();
+      final candidates = store.popularEmojiCandidates();
+      check(store.popularEmojiCandidates())
+        ..isEmpty()..identicalTo(candidates);
+    });
+
+    test('memoizes result, after setServerEmojiData', () {
+      final store = prepare();
+      check(store.debugServerEmojiData).isNotNull();
+      final candidates = store.popularEmojiCandidates();
+      check(store.popularEmojiCandidates())
+        ..isNotEmpty()..identicalTo(candidates);
+    });
+
+    test('updates on first and subsequent setServerEmojiData', () {
+      final store = eg.store();
+      check(store.debugServerEmojiData).isNull();
+
+      final candidates1 = store.popularEmojiCandidates();
+      check(candidates1).isEmpty();
+
+      store.setServerEmojiData(eg.serverEmojiDataPopular);
+      final candidates2 = store.popularEmojiCandidates();
+      check(candidates2)
+        ..isNotEmpty()
+        ..not((it) => it.identicalTo(candidates1));
+
+      store.setServerEmojiData(eg.serverEmojiDataPopularModern);
+      final candidates3 = store.popularEmojiCandidates();
+      check(candidates3)
+        ..isNotEmpty()
+        ..not((it) => it.identicalTo(candidates2));
     });
   });
 

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -343,7 +343,7 @@ void main() {
 
     test('results update after query change', () async {
       final store = prepare(
-        realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f642': ['smile']});
+        realmEmoji: {'1': 'happy'}, unicodeEmoji: {'1f516': ['bookmark']});
       final view = EmojiAutocompleteView.init(store: store,
         query: EmojiAutocompleteQuery('hap'));
       bool done = false;
@@ -354,11 +354,11 @@ void main() {
         isRealmResult(emojiName: 'happy'));
 
       done = false;
-      view.query = EmojiAutocompleteQuery('sm');
+      view.query = EmojiAutocompleteQuery('bo');
       await Future(() {});
       check(done).isTrue();
       check(view.results).single.which(
-        isUnicodeResult(names: ['smile']));
+        isUnicodeResult(names: ['bookmark']));
     });
 
     Future<Iterable<EmojiAutocompleteResult>> resultsOf(

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -78,7 +78,7 @@ void main() {
     });
   });
 
-  final popularCandidates = eg.store().popularEmojiCandidates;
+  final popularCandidates = eg.store().popularEmojiCandidates();
 
   Condition<Object?> isUnicodeCandidate(String? emojiCode, List<String>? names) {
     return (it_) {

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -324,6 +324,7 @@ void main() {
 
     PerAccountStore prepare({
       Map<String, String> realmEmoji = const {},
+      bool addServerDataForPopular = true,
       Map<String, List<String>>? unicodeEmoji,
     }) {
       final store = eg.store(
@@ -331,9 +332,13 @@ void main() {
           for (final MapEntry(:key, :value) in realmEmoji.entries)
             key: eg.realmEmojiItem(emojiCode: key, emojiName: value),
         }));
-      final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
-      ServerEmojiData emojiData = eg.serverEmojiDataPopularPlus(extraEmojiData);
-      store.setServerEmojiData(emojiData);
+      if (addServerDataForPopular || unicodeEmoji != null) {
+        final extraEmojiData = ServerEmojiData(codeToNames: unicodeEmoji ?? {});
+        final emojiData = addServerDataForPopular
+          ? eg.serverEmojiDataPopularPlus(extraEmojiData)
+          : extraEmojiData;
+        store.setServerEmojiData(emojiData);
+      }
       return store;
     }
 

--- a/test/model/emoji_test.dart
+++ b/test/model/emoji_test.dart
@@ -31,9 +31,9 @@ void main() {
   group('emojiDisplayFor', () {
     test('Unicode emoji', () {
       check(eg.store().emojiDisplayFor(emojiType: ReactionType.unicodeEmoji,
-        emojiCode: '1f642', emojiName: 'smile')
+        emojiCode: '1f642', emojiName: 'slight_smile')
       ).isA<UnicodeEmojiDisplay>()
-        ..emojiName.equals('smile')
+        ..emojiName.equals('slight_smile')
         ..emojiUnicode.equals('🙂');
     });
 
@@ -317,13 +317,13 @@ void main() {
       final candidates1 = store.popularEmojiCandidates();
       check(candidates1).isEmpty();
 
-      store.setServerEmojiData(eg.serverEmojiDataPopular);
+      store.setServerEmojiData(eg.serverEmojiDataPopularLegacy);
       final candidates2 = store.popularEmojiCandidates();
       check(candidates2)
         ..isNotEmpty()
         ..not((it) => it.identicalTo(candidates1));
 
-      store.setServerEmojiData(eg.serverEmojiDataPopularModern);
+      store.setServerEmojiData(eg.serverEmojiDataPopular);
       final candidates3 = store.popularEmojiCandidates();
       check(candidates3)
         ..isNotEmpty()
@@ -418,7 +418,7 @@ void main() {
       check(await resultsOf('')).deepEquals([
         isUnicodeResult(names: ['+1', 'thumbs_up', 'like']),
         isUnicodeResult(names: ['tada']),
-        isUnicodeResult(names: ['smile']),
+        isUnicodeResult(names: ['slight_smile']),
         isUnicodeResult(names: ['heart', 'love', 'love_you']),
         isUnicodeResult(names: ['working_on_it', 'hammer_and_wrench', 'tools']),
         isUnicodeResult(names: ['octopus']),
@@ -431,6 +431,7 @@ void main() {
         isUnicodeResult(names: ['tada']),
         isUnicodeResult(names: ['working_on_it', 'hammer_and_wrench', 'tools']),
         // other
+        isUnicodeResult(names: ['slight_smile']),
         isUnicodeResult(names: ['heart', 'love', 'love_you']),
         isUnicodeResult(names: ['octopus']),
       ]);
@@ -441,6 +442,7 @@ void main() {
         isUnicodeResult(names: ['working_on_it', 'hammer_and_wrench', 'tools']),
         // other
         isUnicodeResult(names: ['+1', 'thumbs_up', 'like']),
+        isUnicodeResult(names: ['slight_smile']),
       ]);
     });
 

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -705,7 +705,7 @@ void main() {
 
     final emojiDataUrl = Uri.parse('https://cdn.example/emoji.json');
     final data = {
-      '1f642': ['smile'],
+      '1f642': ['slight_smile'],
       '1f34a': ['orange', 'tangerine', 'mandarin'],
     };
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -829,7 +829,7 @@ void main() {
 
   group('message action sheet', () {
     group('ReactionButtons', () {
-      final popularCandidates = eg.store().popularEmojiCandidates;
+      final popularCandidates = eg.store().popularEmojiCandidates();
 
       for (final emoji in popularCandidates) {
         final emojiDisplay = emoji.emojiDisplay as UnicodeEmojiDisplay;

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -82,8 +82,8 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
   connection = store.connection as FakeApiConnection;
   if (shouldSetServerEmojiData) {
     store.setServerEmojiData(useLegacyServerEmojiData
-      ? eg.serverEmojiDataPopular
-      : eg.serverEmojiDataPopularModern);
+      ? eg.serverEmojiDataPopularLegacy
+      : eg.serverEmojiDataPopular);
   }
 
   connection.prepare(json: eg.newestGetMessagesResult(
@@ -849,8 +849,8 @@ void main() {
         final popularCandidates =
           (eg.store()..setServerEmojiData(
             useLegacy
-              ? eg.serverEmojiDataPopular
-              : eg.serverEmojiDataPopularModern))
+              ? eg.serverEmojiDataPopularLegacy
+              : eg.serverEmojiDataPopular))
             .popularEmojiCandidates();
         for (final emoji in popularCandidates) {
           final emojiDisplay = emoji.emojiDisplay as UnicodeEmojiDisplay;

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -78,6 +78,7 @@ Future<void> setupToMessageActionSheet(WidgetTester tester, {
     await store.addSubscription(eg.subscription(stream));
   }
   connection = store.connection as FakeApiConnection;
+  store.setServerEmojiData(eg.serverEmojiDataPopular);
 
   connection.prepare(json: eg.newestGetMessagesResult(
     foundOldest: true, messages: [message]).toJson());
@@ -829,7 +830,9 @@ void main() {
 
   group('message action sheet', () {
     group('ReactionButtons', () {
-      final popularCandidates = eg.store().popularEmojiCandidates();
+      final popularCandidates =
+        (eg.store()..setServerEmojiData(eg.serverEmojiDataPopular))
+          .popularEmojiCandidates();
 
       for (final emoji in popularCandidates) {
         final emojiDisplay = emoji.emojiDisplay as UnicodeEmojiDisplay;

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -829,7 +829,7 @@ void main() {
 
   group('message action sheet', () {
     group('ReactionButtons', () {
-      final popularCandidates = EmojiStore.popularEmojiCandidates;
+      final popularCandidates = eg.store().popularEmojiCandidates;
 
       for (final emoji in popularCandidates) {
         final emojiDisplay = emoji.emojiDisplay as UnicodeEmojiDisplay;

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -332,6 +332,11 @@ void main() {
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
         child: MessageListPage(initNarrow: narrow)));
 
+      store.setServerEmojiData(eg.serverEmojiDataPopularPlus(
+        ServerEmojiData(codeToNames: {
+          '1f4a4': ['zzz', 'sleepy'], // (just 'zzz' in real data)
+        })));
+
       // global store, per-account store, and message list get loaded
       await tester.pumpAndSettle();
       // request the message action sheet
@@ -339,10 +344,6 @@ void main() {
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
 
-      store.setServerEmojiData(eg.serverEmojiDataPopularPlus(
-        ServerEmojiData(codeToNames: {
-          '1f4a4': ['zzz', 'sleepy'], // (just 'zzz' in real data)
-        })));
       await store.handleEvent(RealmEmojiUpdateEvent(id: 1, realmEmoji: {
         '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'buzzing'),
       }));

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -299,7 +299,9 @@ void main() {
   // - Non-animated image emoji is selected when intended
 
   group('EmojiPicker', () {
-    final popularCandidates = eg.store().popularEmojiCandidates();
+    final popularCandidates =
+      (eg.store()..setServerEmojiData(eg.serverEmojiDataPopular))
+        .popularEmojiCandidates();
 
     Future<void> setupEmojiPicker(WidgetTester tester, {
       required StreamMessage message,
@@ -337,9 +339,10 @@ void main() {
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
 
-      store.setServerEmojiData(ServerEmojiData(codeToNames: {
-        '1f4a4': ['zzz', 'sleepy'], // (just 'zzz' in real data)
-      }));
+      store.setServerEmojiData(eg.serverEmojiDataPopularPlus(
+        ServerEmojiData(codeToNames: {
+          '1f4a4': ['zzz', 'sleepy'], // (just 'zzz' in real data)
+        })));
       await store.handleEvent(RealmEmojiUpdateEvent(id: 1, realmEmoji: {
         '1': eg.realmEmojiItem(emojiCode: '1', emojiName: 'buzzing'),
       }));

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -299,7 +299,7 @@ void main() {
   // - Non-animated image emoji is selected when intended
 
   group('EmojiPicker', () {
-    final popularCandidates = EmojiStore.popularEmojiCandidates;
+    final popularCandidates = eg.store().popularEmojiCandidates;
 
     Future<void> setupEmojiPicker(WidgetTester tester, {
       required StreamMessage message,

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -161,7 +161,7 @@ void main() {
             // Base JSON for various unicode emoji reactions. Just missing user_id.
             final u1 = {'emoji_name': '+1', 'emoji_code': '1f44d', 'reaction_type': 'unicode_emoji'};
             final u2 = {'emoji_name': 'family_man_man_girl_boy', 'emoji_code': '1f468-200d-1f468-200d-1f467-200d-1f466', 'reaction_type': 'unicode_emoji'};
-            final u3 = {'emoji_name': 'smile', 'emoji_code': '1f642', 'reaction_type': 'unicode_emoji'};
+            final u3 = {'emoji_name': 'slight_smile', 'emoji_code': '1f642', 'reaction_type': 'unicode_emoji'};
             final u4 = {'emoji_name': 'tada', 'emoji_code': '1f389', 'reaction_type': 'unicode_emoji'};
             final u5 = {'emoji_name': 'exploding_head', 'emoji_code': '1f92f', 'reaction_type': 'unicode_emoji'};
 
@@ -239,7 +239,7 @@ void main() {
     await setupChipsInBox(tester, reactions: [
       Reaction.fromJson({
         'user_id': eg.selfUser.userId,
-        'emoji_name': 'smile', 'emoji_code': '1f642', 'reaction_type': 'unicode_emoji'}),
+        'emoji_name': 'slight_smile', 'emoji_code': '1f642', 'reaction_type': 'unicode_emoji'}),
       Reaction.fromJson({
         'user_id': eg.otherUser.userId,
         'emoji_name': 'tada', 'emoji_code': '1f389', 'reaction_type': 'unicode_emoji'}),
@@ -251,7 +251,7 @@ void main() {
       return material.color;
     }
 
-    check(backgroundColor('smile')).isNotNull()
+    check(backgroundColor('slight_smile')).isNotNull()
       .isSameColorAs(EmojiReactionTheme.light.bgSelected);
     check(backgroundColor('tada')).isNotNull()
       .isSameColorAs(EmojiReactionTheme.light.bgUnselected);
@@ -261,13 +261,13 @@ void main() {
 
     await tester.pump(kThemeAnimationDuration * 0.4);
     final expectedLerped = EmojiReactionTheme.light.lerp(EmojiReactionTheme.dark, 0.4);
-    check(backgroundColor('smile')).isNotNull()
+    check(backgroundColor('slight_smile')).isNotNull()
       .isSameColorAs(expectedLerped.bgSelected);
     check(backgroundColor('tada')).isNotNull()
       .isSameColorAs(expectedLerped.bgUnselected);
 
     await tester.pump(kThemeAnimationDuration * 0.6);
-    check(backgroundColor('smile')).isNotNull()
+    check(backgroundColor('slight_smile')).isNotNull()
       .isSameColorAs(EmojiReactionTheme.dark.bgSelected);
     check(backgroundColor('tada')).isNotNull()
       .isSameColorAs(EmojiReactionTheme.dark.bgUnselected);

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -299,7 +299,7 @@ void main() {
   // - Non-animated image emoji is selected when intended
 
   group('EmojiPicker', () {
-    final popularCandidates = eg.store().popularEmojiCandidates;
+    final popularCandidates = eg.store().popularEmojiCandidates();
 
     Future<void> setupEmojiPicker(WidgetTester tester, {
       required StreamMessage message,


### PR DESCRIPTION
The server change in zulip/zulip#34177, renaming `:smile:` to
`:slight_smile:`, broke the corresponding reaction button in the
message action sheet. We've been sending the add/remove-reaction
request with the old name 'smile', which modern servers reject.

To fix, take the popular emoji names from ServerEmojiData, so that
we'll use the correct name on servers before and after the change.

API-design discussion:
  https://chat.zulip.org/#narrow/channel/378-api-design/topic/.23F1495.20smile.2Fslight_smile.20change.20broke.20reaction.20button/near/2170354

Fixes: #1495