### PR TITLE
msglist [nfc]: Handle start markers within widget code, not model

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -569,7 +569,6 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
   Widget _buildListView(BuildContext context) {
     const centerSliverKey = ValueKey('center sliver');
-    final zulipLocalizations = ZulipLocalizations.of(context);
 
     // The list has two slivers: a top sliver growing upward,
     // and a bottom sliver growing downward.
@@ -611,7 +610,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         (context, childIndex) {
           final itemIndex = totalItems - 1 - (childIndex + bottomItems);
           final data = model.items[itemIndex];
-          final item = _buildItem(zulipLocalizations, data);
+          final item = _buildItem(data);
           return item;
         }));
 
@@ -657,7 +656,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
           final itemIndex = topItems + childIndex;
           final data = model.items[itemIndex];
-          return _buildItem(zulipLocalizations, data);
+          return _buildItem(data);
         }));
 
     if (!ComposeBox.hasComposeBox(widget.narrow)) {
@@ -689,18 +688,12 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       ]);
   }
 
-  Widget _buildItem(ZulipLocalizations zulipLocalizations, MessageListItem data) {
+  Widget _buildItem(MessageListItem data) {
     switch (data) {
       case MessageListHistoryStartItem():
-        return Center(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16.0),
-            child: Text(zulipLocalizations.noEarlierMessages))); // TODO use an icon
+        return const _MessageListHistoryStart();
       case MessageListLoadingItem():
-        return const Center(
-          child: Padding(
-            padding: EdgeInsets.symmetric(vertical: 16.0),
-            child: CircularProgressIndicator())); // TODO perhaps a different indicator
+        return const _MessageListLoadingMore();
       case MessageListRecipientHeaderItem():
         final header = RecipientHeader(message: data.message, narrow: widget.narrow);
         return StickyHeaderItem(allowOverflow: true,
@@ -718,6 +711,31 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           trailingWhitespace: 11,
           item: data);
     }
+  }
+}
+
+class _MessageListHistoryStart extends StatelessWidget {
+  const _MessageListHistoryStart();
+
+  @override
+  Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16.0),
+        child: Text(zulipLocalizations.noEarlierMessages))); // TODO use an icon
+  }
+}
+
+class _MessageListLoadingMore extends StatelessWidget {
+  const _MessageListLoadingMore();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 16.0),
+        child: CircularProgressIndicator())); // TODO perhaps a different indicator
   }
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -448,8 +448,11 @@ class MessageList extends StatefulWidget {
 }
 
 class _MessageListState extends State<MessageList> with PerAccountStoreAwareStateMixin<MessageList> {
-  MessageListView? model;
+  MessageListView get model => _model!;
+  MessageListView? _model;
+
   final MessageListScrollController scrollController = MessageListScrollController();
+
   final ValueNotifier<bool> _scrollToBottomVisible = ValueNotifier<bool>(false);
 
   @override
@@ -460,32 +463,32 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
   @override
   void onNewStore() { // TODO(#464) try to keep using old model until new one gets messages
-    model?.dispose();
+    _model?.dispose();
     _initModel(PerAccountStoreWidget.of(context));
   }
 
   @override
   void dispose() {
-    model?.dispose();
+    _model?.dispose();
     scrollController.dispose();
     _scrollToBottomVisible.dispose();
     super.dispose();
   }
 
   void _initModel(PerAccountStore store) {
-    model = MessageListView.init(store: store, narrow: widget.narrow);
-    model!.addListener(_modelChanged);
-    model!.fetchInitial();
+    _model = MessageListView.init(store: store, narrow: widget.narrow);
+    model.addListener(_modelChanged);
+    model.fetchInitial();
   }
 
   void _modelChanged() {
-    if (model!.narrow != widget.narrow) {
+    if (model.narrow != widget.narrow) {
       // Either:
       // - A message move event occurred, where propagate mode is
       //   [PropagateMode.changeAll] or [PropagateMode.changeLater]. Or:
       // - We fetched a "with" / topic-permalink narrow, and the response
       //   redirected us to the new location of the operand message ID.
-      widget.onNarrowChanged(model!.narrow);
+      widget.onNarrowChanged(model.narrow);
     }
     setState(() {
       // The actual state lives in the [MessageListView] model.
@@ -507,7 +510,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       //   but makes things a bit more complicated to reason about.
       //   The cause seems to be that this gets called again with maxScrollExtent
       //   still not yet updated to account for the newly-added messages.
-      model!.fetchOlder();
+      model.fetchOlder();
     }
   }
 
@@ -528,8 +531,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
   @override
   Widget build(BuildContext context) {
-    assert(model != null);
-    if (!model!.fetched) return const Center(child: CircularProgressIndicator());
+    if (!model.fetched) return const Center(child: CircularProgressIndicator());
 
     // Pad the left and right insets, for small devices in landscape.
     return SafeArea(
@@ -571,9 +573,9 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
     // The list has two slivers: a top sliver growing upward,
     // and a bottom sliver growing downward.
-    // Each sliver has some of the items from `model!.items`.
+    // Each sliver has some of the items from `model.items`.
     const maxBottomItems = 1;
-    final totalItems = model!.items.length;
+    final totalItems = model.items.length;
     final bottomItems = totalItems <= maxBottomItems ? totalItems : maxBottomItems;
     final topItems = totalItems - bottomItems;
 
@@ -599,7 +601,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         // and will not trigger this callback.
         findChildIndexCallback: (Key key) {
           final messageId = (key as ValueKey<int>).value;
-          final itemIndex = model!.findItemWithMessageId(messageId);
+          final itemIndex = model.findItemWithMessageId(messageId);
           if (itemIndex == -1) return null;
           final childIndex = totalItems - 1 - (itemIndex + bottomItems);
           if (childIndex < 0) return null;
@@ -608,7 +610,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         childCount: topItems,
         (context, childIndex) {
           final itemIndex = totalItems - 1 - (childIndex + bottomItems);
-          final data = model!.items[itemIndex];
+          final data = model.items[itemIndex];
           final item = _buildItem(zulipLocalizations, data);
           return item;
         }));
@@ -637,7 +639,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         // and will not trigger this callback.
         findChildIndexCallback: (Key key) {
           final messageId = (key as ValueKey<int>).value;
-          final itemIndex = model!.findItemWithMessageId(messageId);
+          final itemIndex = model.findItemWithMessageId(messageId);
           if (itemIndex == -1) return null;
           final childIndex = itemIndex - topItems;
           if (childIndex < 0) return null;
@@ -654,7 +656,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           if (childIndex == bottomItems) return TypingStatusWidget(narrow: widget.narrow);
 
           final itemIndex = topItems + childIndex;
-          final data = model!.items[itemIndex];
+          final data = model.items[itemIndex];
           return _buildItem(zulipLocalizations, data);
         }));
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -507,7 +507,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       //   but makes things a bit more complicated to reason about.
       //   The cause seems to be that this gets called again with maxScrollExtent
       //   still not yet updated to account for the newly-added messages.
-      model?.fetchOlder();
+      model!.fetchOlder();
     }
   }
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1791,7 +1791,6 @@ void main() {
     // We check showSender has the right values in [checkInvariants],
     // but to make this test explicit:
     check(model.items).deepEquals(<void Function(Subject<Object?>)>[
-      (it) => it.isA<MessageListHistoryStartItem>(),
       (it) => it.isA<MessageListRecipientHeaderItem>(),
       (it) => it.isA<MessageListMessageItem>().showSender.isTrue(),
       (it) => it.isA<MessageListMessageItem>().showSender.isFalse(),
@@ -1964,12 +1963,6 @@ void checkInvariants(MessageListView model) {
   }
 
   int i = 0;
-  if (model.haveOldest) {
-    check(model.items[i++]).isA<MessageListHistoryStartItem>();
-  }
-  if (model.fetchingOlder || model.fetchOlderCoolingDown) {
-    check(model.items[i++]).isA<MessageListLoadingItem>();
-  }
   for (int j = 0; j < model.messages.length; j++) {
     bool forcedShowSender = false;
     if (j == 0
@@ -1991,9 +1984,7 @@ void checkInvariants(MessageListView model) {
         i == model.items.length || switch (model.items[i]) {
           MessageListMessageItem()
           || MessageListDateSeparatorItem() => false,
-          MessageListRecipientHeaderItem()
-          || MessageListHistoryStartItem()
-          || MessageListLoadingItem()       => true,
+          MessageListRecipientHeaderItem()  => true,
         });
   }
   check(model.items).length.equals(i);


### PR DESCRIPTION
The view-model already exposes flags that express all the same information.  By leaving these markers out of the list of items, we can save ourselves a bunch of stateful updates.

The main commit has a nice negative diffstat:
```
 lib/model/message_list.dart       | 49 ---------------------------------------------
 lib/widgets/message_list.dart     | 21 ++++++++++++++-----
 test/model/message_list_test.dart | 11 +---------
 3 files changed, 17 insertions(+), 64 deletions(-)
```

This comes up as part of my work toward #82: with this approach, we'll avoid needing to maintain marker items at the end of the list to depend on whether we've fetched the newest messages. Those markers would be more complex than the markers at the start, because they'd also include things like the typing-status line and the mark-as-read button.

@PIG208 I think this also makes for a small simplification in handling outbox-messages, in #1453.
