### PR TITLE
anchors 9/n: Add anchor, fetchNewer, haveNewest to msglist view-model

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -77,7 +77,7 @@ enum FetchingStatus {
   idle,
 
   /// The model has an active `fetchOlder` request.
-  fetchOlder,
+  fetchingMore,
 
   /// The model is in a backoff period from a failed request.
   backoff,
@@ -135,7 +135,7 @@ mixin _MessageSequence {
   /// This is true both when the recent request is still outstanding,
   /// and when it failed and the backoff from that is still in progress.
   bool get busyFetchingMore => switch (_status) {
-    FetchingStatus.fetchOlder || FetchingStatus.backoff => true,
+    FetchingStatus.fetchingMore || FetchingStatus.backoff => true,
     _ => false,
   };
 
@@ -609,7 +609,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       || (narrow as TopicNarrow).with_ == null);
     assert(messages.isNotEmpty);
     assert(_status == FetchingStatus.idle);
-    _status = FetchingStatus.fetchOlder;
+    _status = FetchingStatus.fetchingMore;
     notifyListeners();
     final generation = this.generation;
     bool hasFetchError = false;
@@ -647,7 +647,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       _haveOldest = result.foundOldest;
     } finally {
       if (this.generation == generation) {
-        assert(_status == FetchingStatus.fetchOlder);
+        assert(_status == FetchingStatus.fetchingMore);
         if (hasFetchError) {
           _status = FetchingStatus.backoff;
           unawaited((_fetchBackoffMachine ??= BackoffMachine())

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -523,14 +523,20 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     }
   }
 
+  void _setStatus(FetchingStatus value, {FetchingStatus? was}) {
+    assert(was == null || _status == was);
+    _status = value;
+    if (!fetched) return;
+    notifyListeners();
+  }
+
   /// Fetch messages, starting from scratch.
   Future<void> fetchInitial() async {
     // TODO(#80): fetch from anchor firstUnread, instead of newest
     // TODO(#82): fetch from a given message ID as anchor
     assert(!fetched && !haveOldest && !busyFetchingMore);
     assert(messages.isEmpty && contents.isEmpty);
-    assert(_status == FetchingStatus.unstarted);
-    _status = FetchingStatus.fetchInitial;
+    _setStatus(FetchingStatus.fetchInitial, was: FetchingStatus.unstarted);
     // TODO schedule all this in another isolate
     final generation = this.generation;
     final result = await getMessages(store.connection,
@@ -554,10 +560,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       _addMessage(message);
       // Now [middleMessage] is the last message (the one just added).
     }
-    assert(_status == FetchingStatus.fetchInitial);
-    _status = FetchingStatus.idle;
     _haveOldest = result.foundOldest;
-    notifyListeners();
+    _setStatus(FetchingStatus.idle, was: FetchingStatus.fetchInitial);
   }
 
   /// Update [narrow] for the result of a "with" narrow (topic permalink) fetch.
@@ -608,9 +612,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       // We only intend to send "with" in [fetchInitial]; see there.
       || (narrow as TopicNarrow).with_ == null);
     assert(messages.isNotEmpty);
-    assert(_status == FetchingStatus.idle);
-    _status = FetchingStatus.fetchingMore;
-    notifyListeners();
+    _setStatus(FetchingStatus.fetchingMore, was: FetchingStatus.idle);
     final generation = this.generation;
     bool hasFetchError = false;
     try {
@@ -647,21 +649,17 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       _haveOldest = result.foundOldest;
     } finally {
       if (this.generation == generation) {
-        assert(_status == FetchingStatus.fetchingMore);
         if (hasFetchError) {
-          _status = FetchingStatus.backoff;
+          _setStatus(FetchingStatus.backoff, was: FetchingStatus.fetchingMore);
           unawaited((_fetchBackoffMachine ??= BackoffMachine())
             .wait().then((_) {
               if (this.generation != generation) return;
-              assert(_status == FetchingStatus.backoff);
-              _status = FetchingStatus.idle;
-              notifyListeners();
+              _setStatus(FetchingStatus.idle, was: FetchingStatus.backoff);
             }));
         } else {
-          _status = FetchingStatus.idle;
+          _setStatus(FetchingStatus.idle, was: FetchingStatus.fetchingMore);
           _fetchBackoffMachine = null;
         }
-        notifyListeners();
       }
     }
   }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -94,7 +94,7 @@ mixin _MessageSequence {
   ///
   /// This may or may not represent all the message history that
   /// conceptually belongs in this message list.
-  /// That information is expressed in [fetched] and [haveOldest].
+  /// That information is expressed in [fetched], [haveOldest], [haveNewest].
   ///
   /// See also [middleMessage], an index which divides this list
   /// into a top slice and a bottom slice.
@@ -121,10 +121,18 @@ mixin _MessageSequence {
 
   /// Whether we know we have the oldest messages for this narrow.
   ///
-  /// (Currently we always have the newest messages for the narrow,
-  /// once [fetched] is true, because we start from the newest.)
+  /// See also [haveNewest].
   bool get haveOldest => _haveOldest;
   bool _haveOldest = false;
+
+  /// Whether we know we have the newest messages for this narrow.
+  ///
+  /// (Currently this is always true once [fetched] is true,
+  /// because we start from the newest.)
+  ///
+  /// See also [haveOldest].
+  bool get haveNewest => _haveNewest;
+  bool _haveNewest = false;
 
   /// Whether this message list is currently busy when it comes to
   /// fetching more messages.
@@ -158,7 +166,7 @@ mixin _MessageSequence {
   /// before, between, or after the messages.
   ///
   /// This information is completely derived from [messages] and
-  /// the flags [haveOldest] and [busyFetchingMore].
+  /// the flags [haveOldest], [haveNewest], and [busyFetchingMore].
   /// It exists as an optimization, to memoize that computation.
   ///
   /// See also [middleItem], an index which divides this list
@@ -315,6 +323,7 @@ mixin _MessageSequence {
     messages.clear();
     middleMessage = 0;
     _haveOldest = false;
+    _haveNewest = false;
     _status = FetchingStatus.unstarted;
     _fetchBackoffMachine = null;
     contents.clear();
@@ -534,7 +543,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   Future<void> fetchInitial() async {
     // TODO(#80): fetch from anchor firstUnread, instead of newest
     // TODO(#82): fetch from a given message ID as anchor
-    assert(!fetched && !haveOldest && !busyFetchingMore);
+    assert(!fetched && !haveOldest && !haveNewest && !busyFetchingMore);
     assert(messages.isEmpty && contents.isEmpty);
     _setStatus(FetchingStatus.fetchInitial, was: FetchingStatus.unstarted);
     // TODO schedule all this in another isolate
@@ -561,6 +570,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       // Now [middleMessage] is the last message (the one just added).
     }
     _haveOldest = result.foundOldest;
+    _haveNewest = true; // TODO(#82)
     _setStatus(FetchingStatus.idle, was: FetchingStatus.fetchInitial);
   }
 
@@ -715,8 +725,16 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     if (!narrow.containsMessage(message) || !_messageVisible(message)) {
       return;
     }
-    if (!fetched) {
-      // TODO mitigate this fetch/event race: save message to add to list later
+    if (!haveNewest) {
+      // This message list's [messages] doesn't yet reach the new end
+      // of the narrow's message history.  (Either [fetchInitial] hasn't yet
+      // completed, or if it has then it was in the middle of history and no
+      // subsequent fetch has reached the end.)
+      // So this still-newer message doesn't belong.
+      // Leave it to be found by a subsequent fetch when appropriate.
+      // TODO mitigate this fetch/event race: save message to add to list later,
+      //   in case the fetch that reaches the end is already ongoing and
+      //   didn't include this message.
       return;
     }
     // TODO insert in middle instead, when appropriate

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -570,7 +570,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       // Now [middleMessage] is the last message (the one just added).
     }
     _haveOldest = result.foundOldest;
-    _haveNewest = true; // TODO(#82)
+    _haveNewest = result.foundNewest;
     _setStatus(FetchingStatus.idle, was: FetchingStatus.fetchInitial);
   }
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -697,7 +697,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     if (!narrow.containsMessage(message) || !_messageVisible(message)) {
       return;
     }
-    if (!_fetched) {
+    if (!fetched) {
       // TODO mitigate this fetch/event race: save message to add to list later
       return;
     }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -126,28 +126,18 @@ mixin _MessageSequence {
   bool get haveOldest => _haveOldest;
   bool _haveOldest = false;
 
-  /// Whether we are currently fetching the next batch of older messages.
+  /// Whether this message list is currently busy when it comes to
+  /// fetching more messages.
   ///
-  /// When this is true, [fetchOlder] is a no-op.
-  /// That method is called frequently by Flutter's scrolling logic,
-  /// and this field helps us avoid spamming the same request just to get
-  /// the same response each time.
-  ///
-  /// See also [fetchOlderCoolingDown].
-  bool get fetchingOlder => _status == FetchingStatus.fetchOlder;
-
-  /// Whether [fetchOlder] had a request error recently.
-  ///
-  /// When this is true, [fetchOlder] is a no-op.
-  /// That method is called frequently by Flutter's scrolling logic,
-  /// and this field mitigates spamming the same request and getting
-  /// the same error each time.
-  ///
-  /// "Recently" is decided by a [BackoffMachine] that resets
-  /// when a [fetchOlder] request succeeds.
-  ///
-  /// See also [fetchingOlder].
-  bool get fetchOlderCoolingDown => _status == FetchingStatus.fetchOlderCoolingDown;
+  /// Here "busy" means a new call to fetch more messages would do nothing,
+  /// rather than make any request to the server,
+  /// as a result of an existing recent request.
+  /// This is true both when the recent request is still outstanding,
+  /// and when it failed and the backoff from that is still in progress.
+  bool get busyFetchingMore => switch (_status) {
+    FetchingStatus.fetchOlder || FetchingStatus.fetchOlderCoolingDown => true,
+    _ => false,
+  };
 
   FetchingStatus _status = FetchingStatus.unstarted;
 
@@ -168,7 +158,7 @@ mixin _MessageSequence {
   /// before, between, or after the messages.
   ///
   /// This information is completely derived from [messages] and
-  /// the flags [haveOldest], [fetchingOlder] and [fetchOlderCoolingDown].
+  /// the flags [haveOldest] and [busyFetchingMore].
   /// It exists as an optimization, to memoize that computation.
   ///
   /// See also [middleItem], an index which divides this list
@@ -537,7 +527,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   Future<void> fetchInitial() async {
     // TODO(#80): fetch from anchor firstUnread, instead of newest
     // TODO(#82): fetch from a given message ID as anchor
-    assert(!fetched && !haveOldest && !fetchingOlder && !fetchOlderCoolingDown);
+    assert(!fetched && !haveOldest && !busyFetchingMore);
     assert(messages.isEmpty && contents.isEmpty);
     assert(_status == FetchingStatus.unstarted);
     _status = FetchingStatus.fetchInitial;
@@ -603,10 +593,16 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   }
 
   /// Fetch the next batch of older messages, if applicable.
+  ///
+  /// If there are no older messages to fetch (i.e. if [haveOldest]),
+  /// or if this message list is already busy fetching more messages
+  /// (i.e. if [busyFetchingMore], which includes backoff from failed requests),
+  /// then this method does nothing and immediately returns.
+  /// That makes this method suitable to call frequently, e.g. every frame,
+  /// whenever it looks likely to be useful to have more messages.
   Future<void> fetchOlder() async {
     if (haveOldest) return;
-    if (fetchingOlder) return;
-    if (fetchOlderCoolingDown) return;
+    if (busyFetchingMore) return;
     assert(fetched);
     assert(narrow is! TopicNarrow
       // We only intend to send "with" in [fetchInitial]; see there.

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -448,13 +448,19 @@ bool _sameDay(DateTime date1, DateTime date2) {
 ///  * When the object will no longer be used, call [dispose] to free
 ///    resources on the [PerAccountStore].
 class MessageListView with ChangeNotifier, _MessageSequence {
-  MessageListView._({required this.store, required this.narrow});
-
   factory MessageListView.init(
       {required PerAccountStore store, required Narrow narrow}) {
-    final view = MessageListView._(store: store, narrow: narrow);
-    store.registerMessageList(view);
-    return view;
+    return MessageListView._(store: store, narrow: narrow)
+      .._register();
+  }
+
+  MessageListView._({required this.store, required this.narrow});
+
+  final PerAccountStore store;
+  Narrow narrow;
+
+  void _register() {
+    store.registerMessageList(this);
   }
 
   @override
@@ -462,9 +468,6 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     store.unregisterMessageList(this);
     super.dispose();
   }
-
-  final PerAccountStore store;
-  Narrow narrow;
 
   /// Whether [message] should actually appear in this message list,
   /// given that it does belong to the narrow.

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -14,6 +14,8 @@ import 'message.dart';
 import 'narrow.dart';
 import 'store.dart';
 
+export '../api/route/messages.dart' show Anchor, AnchorCode, NumericAnchor;
+
 /// The number of messages to fetch in each request.
 const kMessageListFetchBatchSize = 100; // TODO tune
 
@@ -126,9 +128,6 @@ mixin _MessageSequence {
   bool _haveOldest = false;
 
   /// Whether we know we have the newest messages for this narrow.
-  ///
-  /// (Currently this is always true once [fetched] is true,
-  /// because we start from the newest.)
   ///
   /// See also [haveOldest].
   bool get haveNewest => _haveNewest;
@@ -448,14 +447,20 @@ bool _sameDay(DateTime date1, DateTime date2) {
 ///  * When the object will no longer be used, call [dispose] to free
 ///    resources on the [PerAccountStore].
 class MessageListView with ChangeNotifier, _MessageSequence {
-  factory MessageListView.init(
-      {required PerAccountStore store, required Narrow narrow}) {
-    return MessageListView._(store: store, narrow: narrow)
+  factory MessageListView.init({
+    required PerAccountStore store,
+    required Narrow narrow,
+    Anchor anchor = AnchorCode.newest, // TODO(#82): make required, for explicitness
+  }) {
+    return MessageListView._(store: store, narrow: narrow, anchor: anchor)
       .._register();
   }
 
-  MessageListView._({required this.store, required Narrow narrow})
-    : _narrow = narrow;
+  MessageListView._({
+    required this.store,
+    required Narrow narrow,
+    required Anchor anchor,
+  }) : _narrow = narrow, _anchor = anchor;
 
   final PerAccountStore store;
 
@@ -464,6 +469,17 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   /// This can change over time, notably if showing a topic that gets moved.
   Narrow get narrow => _narrow;
   Narrow _narrow;
+
+  /// The anchor point this message list starts from in the message history.
+  ///
+  /// This is passed to the server in the get-messages request
+  /// sent by [fetchInitial].
+  /// That includes not only the original [fetchInitial] call made by
+  /// the message-list widget, but any additional [fetchInitial] calls
+  /// which might be made internally by this class in order to
+  /// fetch the messages from scratch, e.g. after certain events.
+  Anchor get anchor => _anchor;
+  final Anchor _anchor;
 
   void _register() {
     store.registerMessageList(this);
@@ -550,8 +566,6 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   /// Fetch messages, starting from scratch.
   Future<void> fetchInitial() async {
-    // TODO(#80): fetch from anchor firstUnread, instead of newest
-    // TODO(#82): fetch from a given message ID as anchor
     assert(!fetched && !haveOldest && !haveNewest && !busyFetchingMore);
     assert(messages.isEmpty && contents.isEmpty);
     _setStatus(FetchingStatus.fetchInitial, was: FetchingStatus.unstarted);
@@ -559,7 +573,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     final generation = this.generation;
     final result = await getMessages(store.connection,
       narrow: narrow.apiEncode(),
-      anchor: AnchorCode.newest,
+      anchor: anchor,
       numBefore: kMessageListFetchBatchSize,
       numAfter: kMessageListFetchBatchSize,
       allowEmptyTopicName: true,
@@ -571,12 +585,20 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     store.reconcileMessages(result.messages);
     store.recentSenders.handleMessages(result.messages); // TODO(#824)
 
-    // We'll make the bottom slice start at the last visible message, if any.
+    // The bottom slice will start at the "anchor message".
+    // This is the first visible message at or past [anchor] if any,
+    // else the last visible message if any.  [reachedAnchor] helps track that.
+    bool reachedAnchor = false;
     for (final message in result.messages) {
       if (!_messageVisible(message)) continue;
-      middleMessage = messages.length;
+      if (!reachedAnchor) {
+        // Push the previous message into the top slice.
+        middleMessage = messages.length;
+        // We could interpret [anchor] for ourselves; but the server has already
+        // done that work, reducing it to an int, `result.anchor`.  So use that.
+        reachedAnchor = message.id >= result.anchor;
+      }
       _addMessage(message);
-      // Now [middleMessage] is the last message (the one just added).
     }
     _haveOldest = result.foundOldest;
     _haveNewest = result.foundNewest;

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -454,10 +454,16 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       .._register();
   }
 
-  MessageListView._({required this.store, required this.narrow});
+  MessageListView._({required this.store, required Narrow narrow})
+    : _narrow = narrow;
 
   final PerAccountStore store;
-  Narrow narrow;
+
+  /// The narrow shown in this message list.
+  ///
+  /// This can change over time, notably if showing a topic that gets moved.
+  Narrow get narrow => _narrow;
+  Narrow _narrow;
 
   void _register() {
     store.registerMessageList(this);
@@ -601,9 +607,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         // This can't be a redirect; a redirect can't produce an empty result.
         // (The server only redirects if the message is accessible to the user,
         // and if it is, it'll appear in the result, making it non-empty.)
-        this.narrow = narrow.sansWith();
+        _narrow = narrow.sansWith();
       case StreamMessage():
-        this.narrow = TopicNarrow.ofMessage(someFetchedMessageOrNull);
+        _narrow = TopicNarrow.ofMessage(someFetchedMessageOrNull);
       case DmMessage(): // TODO(log)
         assert(false);
     }
@@ -786,7 +792,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     switch (propagateMode) {
       case PropagateMode.changeAll:
       case PropagateMode.changeLater:
-        narrow = newNarrow;
+        _narrow = newNarrow;
         _reset();
         fetchInitial();
       case PropagateMode.changeOne:

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -561,7 +561,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       narrow: narrow.apiEncode(),
       anchor: AnchorCode.newest,
       numBefore: kMessageListFetchBatchSize,
-      numAfter: 0,
+      numAfter: kMessageListFetchBatchSize,
       allowEmptyTopicName: true,
     );
     if (this.generation > generation) return;

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -78,7 +78,7 @@ enum FetchingStatus {
   /// and has no outstanding requests or backoff.
   idle,
 
-  /// The model has an active `fetchOlder` request.
+  /// The model has an active `fetchOlder` or `fetchNewer` request.
   fetchingMore,
 
   /// The model is in a backoff period from a failed request.
@@ -673,6 +673,42 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       });
   }
 
+  /// Fetch the next batch of newer messages, if applicable.
+  ///
+  /// If there are no newer messages to fetch (i.e. if [haveNewest]),
+  /// or if this message list is already busy fetching more messages
+  /// (i.e. if [busyFetchingMore], which includes backoff from failed requests),
+  /// then this method does nothing and immediately returns.
+  /// That makes this method suitable to call frequently, e.g. every frame,
+  /// whenever it looks likely to be useful to have more messages.
+  Future<void> fetchNewer() async {
+    if (haveNewest) return;
+    if (busyFetchingMore) return;
+    assert(fetched);
+    assert(messages.isNotEmpty);
+    await _fetchMore(
+      anchor: NumericAnchor(messages.last.id),
+      numBefore: 0,
+      numAfter: kMessageListFetchBatchSize,
+      processResult: (result) {
+        if (result.messages.isNotEmpty
+            && result.messages.first.id == messages.last.id) {
+          // TODO(server-6): includeAnchor should make this impossible
+          result.messages.removeAt(0);
+        }
+
+        store.reconcileMessages(result.messages);
+        store.recentSenders.handleMessages(result.messages); // TODO(#824)
+
+        for (final message in result.messages) {
+          if (_messageVisible(message)) {
+            _addMessage(message);
+          }
+        }
+        _haveNewest = result.foundNewest;
+      });
+  }
+
   Future<void> _fetchMore({
     required Anchor anchor,
     required int numBefore,
@@ -775,7 +811,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       // This message list's [messages] doesn't yet reach the new end
       // of the narrow's message history.  (Either [fetchInitial] hasn't yet
       // completed, or if it has then it was in the middle of history and no
-      // subsequent fetch has reached the end.)
+      // subsequent [fetchNewer] has reached the end.)
       // So this still-newer message doesn't belong.
       // Leave it to be found by a subsequent fetch when appropriate.
       // TODO mitigate this fetch/event race: save message to add to list later,

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -450,7 +450,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   factory MessageListView.init({
     required PerAccountStore store,
     required Narrow narrow,
-    Anchor anchor = AnchorCode.newest, // TODO(#82): make required, for explicitness
+    required Anchor anchor,
   }) {
     return MessageListView._(store: store, narrow: narrow, anchor: anchor)
       .._register();

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -517,7 +517,11 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   }
 
   void _initModel(PerAccountStore store) {
-    _model = MessageListView.init(store: store, narrow: widget.narrow);
+    // TODO(#82): get anchor as page/route argument, instead of using newest
+    // TODO(#80): default to anchor firstUnread, instead of newest
+    final anchor = AnchorCode.newest;
+    _model = MessageListView.init(store: store,
+      narrow: widget.narrow, anchor: anchor);
     model.addListener(_modelChanged);
     model.fetchInitial();
   }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -732,13 +732,8 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     // in backoff from it; and even if the fetch is/was for the other direction.
     // The loading indicator really means "busy, working on it"; and that's the
     // right summary even if the fetch is internally queued behind other work.
-
-    // (This assertion is an invariant of [MessageListView].)
-    assert(!(model.fetchingOlder && model.fetchOlderCoolingDown));
-    final busyFetchingMore =
-      model.fetchingOlder || model.fetchOlderCoolingDown;
     return model.haveOldest ? const _MessageListHistoryStart()
-      : busyFetchingMore ? const _MessageListLoadingMore()
+      : model.busyFetchingMore ? const _MessageListLoadingMore()
       : const SizedBox.shrink();
   }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -725,16 +725,21 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   }
 
   Widget _buildStartCap() {
-    // These assertions are invariants of [MessageListView].
+    // If we're done fetching older messages, show that.
+    // Else if we're busy with fetching, then show a loading indicator.
+    //
+    // This applies even if the fetch is over, but failed, and we're still
+    // in backoff from it; and even if the fetch is/was for the other direction.
+    // The loading indicator really means "busy, working on it"; and that's the
+    // right summary even if the fetch is internally queued behind other work.
+
+    // (This assertion is an invariant of [MessageListView].)
     assert(!(model.fetchingOlder && model.fetchOlderCoolingDown));
-    final effectiveFetchingOlder =
+    final busyFetchingMore =
       model.fetchingOlder || model.fetchOlderCoolingDown;
-    assert(!(model.haveOldest && effectiveFetchingOlder));
-    return switch ((effectiveFetchingOlder, model.haveOldest)) {
-      (true, _) => const _MessageListLoadingMore(),
-      (_, true) => const _MessageListHistoryStart(),
-      (_,    _) => const SizedBox.shrink(),
-    };
+    return model.haveOldest ? const _MessageListHistoryStart()
+      : busyFetchingMore ? const _MessageListLoadingMore()
+      : const SizedBox.shrink();
   }
 
   Widget _buildEndCap() {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -686,15 +686,9 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           if (childIndex < 0) return null;
           return childIndex;
         },
-        childCount: bottomItems + 3,
+        childCount: bottomItems + 1,
         (context, childIndex) {
-          // To reinforce that the end of the feed has been reached:
-          //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680603
-          if (childIndex == bottomItems + 2) return const SizedBox(height: 36);
-
-          if (childIndex == bottomItems + 1) return MarkAsReadWidget(narrow: widget.narrow);
-
-          if (childIndex == bottomItems) return TypingStatusWidget(narrow: widget.narrow);
+          if (childIndex == bottomItems) return _buildEndCap();
 
           final itemIndex = topItems + childIndex;
           final data = model.items[itemIndex];
@@ -741,6 +735,16 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       (_, true) => const _MessageListHistoryStart(),
       (_,    _) => const SizedBox.shrink(),
     };
+  }
+
+  Widget _buildEndCap() {
+    return Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+      TypingStatusWidget(narrow: widget.narrow),
+      MarkAsReadWidget(narrow: widget.narrow),
+      // To reinforce that the end of the feed has been reached:
+      //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680603
+      const SizedBox(height: 36),
+    ]);
   }
 
   Widget _buildItem(MessageListItem data) {

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -608,6 +608,26 @@ GetMessagesResult newestGetMessagesResult({
   );
 }
 
+/// A GetMessagesResult the server might return on an initial request
+/// when the anchor is in the middle of history (e.g., a /near/ link).
+GetMessagesResult nearGetMessagesResult({
+  required int anchor,
+  bool foundAnchor = true,
+  required bool foundOldest,
+  required bool foundNewest,
+  bool historyLimited = false,
+  required List<Message> messages,
+}) {
+  return GetMessagesResult(
+    anchor: anchor,
+    foundAnchor: foundAnchor,
+    foundOldest: foundOldest,
+    foundNewest: foundNewest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
+}
+
 /// A GetMessagesResult the server might return when we request older messages.
 GetMessagesResult olderGetMessagesResult({
   required int anchor,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -687,6 +687,24 @@ GetMessagesResult olderGetMessagesResult({
   );
 }
 
+/// A GetMessagesResult the server might return when we request newer messages.
+GetMessagesResult newerGetMessagesResult({
+  required int anchor,
+  bool foundAnchor = false, // the value if the server understood includeAnchor false
+  required bool foundNewest,
+  bool historyLimited = false,
+  required List<Message> messages,
+}) {
+  return GetMessagesResult(
+    anchor: anchor,
+    foundAnchor: foundAnchor,
+    foundOldest: false,
+    foundNewest: foundNewest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
+}
+
 int _nextLocalMessageId = 1;
 
 StreamOutboxMessage streamOutboxMessage({

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -589,23 +589,64 @@ DmMessage dmMessage({
   }) as Map<String, dynamic>);
 }
 
-/// A GetMessagesResult the server might return on an `anchor=newest` request.
+/// A GetMessagesResult the server might return for
+/// a request that sent the given [anchor].
+///
+/// The request's anchor controls the response's [GetMessagesResult.anchor],
+/// affects the default for [foundAnchor],
+/// and in some cases forces the value of [foundOldest] or [foundNewest].
+GetMessagesResult getMessagesResult({
+  required Anchor anchor,
+  bool? foundAnchor,
+  bool? foundOldest,
+  bool? foundNewest,
+  bool historyLimited = false,
+  required List<Message> messages,
+}) {
+  final resultAnchor = switch (anchor) {
+    AnchorCode.oldest => 0,
+    NumericAnchor(:final messageId) => messageId,
+    AnchorCode.firstUnread =>
+      throw ArgumentError("firstUnread not accepted in this helper; try NumericAnchor"),
+    AnchorCode.newest => 10_000_000_000_000_000, // that's 16 zeros
+  };
+
+  switch (anchor) {
+    case AnchorCode.oldest || AnchorCode.newest:
+      assert(foundAnchor == null);
+      foundAnchor = false;
+    case AnchorCode.firstUnread || NumericAnchor():
+      foundAnchor ??= true;
+  }
+
+  if (anchor == AnchorCode.oldest) {
+    assert(foundOldest == null);
+    foundOldest = true;
+  } else if (anchor == AnchorCode.newest) {
+    assert(foundNewest == null);
+    foundNewest = true;
+  }
+  if (foundOldest == null || foundNewest == null) throw ArgumentError();
+
+  return GetMessagesResult(
+    anchor: resultAnchor,
+    foundAnchor: foundAnchor,
+    foundOldest: foundOldest,
+    foundNewest: foundNewest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
+}
+
+/// A GetMessagesResult the server might return on an `anchor=newest` request,
+/// or `anchor=first_unread` when there are no unreads.
 GetMessagesResult newestGetMessagesResult({
   required bool foundOldest,
   bool historyLimited = false,
   required List<Message> messages,
 }) {
-  return GetMessagesResult(
-    // These anchor, foundAnchor, and foundNewest values are what the server
-    // appears to always return when the request had `anchor=newest`.
-    anchor: 10000000000000000, // that's 16 zeros
-    foundAnchor: false,
-    foundNewest: true,
-
-    foundOldest: foundOldest,
-    historyLimited: historyLimited,
-    messages: messages,
-  );
+  return getMessagesResult(anchor: AnchorCode.newest, foundOldest: foundOldest,
+    historyLimited: historyLimited, messages: messages);
 }
 
 /// A GetMessagesResult the server might return on an initial request

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -157,7 +157,7 @@ void main() {
           narrow: narrow.apiEncode(),
           anchor: 'newest',
           numBefore: kMessageListFetchBatchSize,
-          numAfter: 0,
+          numAfter: kMessageListFetchBatchSize,
           allowEmptyTopicName: true,
         );
       }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1381,12 +1381,14 @@ void main() {
 
       int notifiedCount1 = 0;
       final model1 = MessageListView.init(store: store,
-          narrow: ChannelNarrow(stream.streamId))
+          narrow: ChannelNarrow(stream.streamId),
+          anchor: AnchorCode.newest)
         ..addListener(() => notifiedCount1++);
 
       int notifiedCount2 = 0;
       final model2 = MessageListView.init(store: store,
-          narrow: eg.topicNarrow(stream.streamId, 'hello'))
+          narrow: eg.topicNarrow(stream.streamId, 'hello'),
+          anchor: AnchorCode.newest)
         ..addListener(() => notifiedCount2++);
 
       for (final m in [model1, model2]) {
@@ -1426,7 +1428,8 @@ void main() {
       await store.handleEvent(mkEvent(message));
 
       // init msglist *after* event was handled
-      model = MessageListView.init(store: store, narrow: const CombinedFeedNarrow());
+      model = MessageListView.init(store: store,
+        narrow: const CombinedFeedNarrow(), anchor: AnchorCode.newest);
       checkInvariants(model);
 
       connection.prepare(json:

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -322,8 +322,7 @@ void main() {
     });
 
     test('nop when already fetching', () async {
-      const narrow = CombinedFeedNarrow();
-      await prepare(narrow: narrow);
+      await prepare();
       await prepareMessages(foundOldest: false,
         messages: List.generate(100, (i) => eg.streamMessage(id: 1000 + i)));
 
@@ -351,7 +350,7 @@ void main() {
     });
 
     test('nop when already haveOldest true', () async {
-      await prepare(narrow: const CombinedFeedNarrow());
+      await prepare();
       await prepareMessages(foundOldest: true, messages:
         List.generate(30, (i) => eg.streamMessage()));
       check(model)
@@ -370,7 +369,7 @@ void main() {
     test('nop during backoff', () => awaitFakeAsync((async) async {
       final olderMessages = List.generate(5, (i) => eg.streamMessage());
       final initialMessages = List.generate(5, (i) => eg.streamMessage());
-      await prepare(narrow: const CombinedFeedNarrow());
+      await prepare();
       await prepareMessages(foundOldest: false, messages: initialMessages);
       check(connection.takeRequests()).single;
 
@@ -400,8 +399,7 @@ void main() {
     }));
 
     test('handles servers not understanding includeAnchor', () async {
-      const narrow = CombinedFeedNarrow();
-      await prepare(narrow: narrow);
+      await prepare();
       await prepareMessages(foundOldest: false,
         messages: List.generate(100, (i) => eg.streamMessage(id: 1000 + i)));
 
@@ -419,8 +417,7 @@ void main() {
 
     // TODO(#824): move this test
     test('recent senders track all the messages', () async {
-      const narrow = CombinedFeedNarrow();
-      await prepare(narrow: narrow);
+      await prepare();
       final initialMessages = List.generate(10, (i) => eg.streamMessage(id: 100 + i));
       await prepareMessages(foundOldest: false, messages: initialMessages);
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -150,7 +150,8 @@ void main() {
         checkNotifiedOnce();
         check(model)
           ..messages.length.equals(kMessageListFetchBatchSize)
-          ..haveOldest.isFalse();
+          ..haveOldest.isFalse()
+          ..haveNewest.isTrue();
         checkLastRequest(
           narrow: narrow.apiEncode(),
           anchor: 'newest',
@@ -180,7 +181,8 @@ void main() {
       checkNotifiedOnce();
       check(model)
         ..messages.length.equals(30)
-        ..haveOldest.isTrue();
+        ..haveOldest.isTrue()
+        ..haveNewest.isTrue();
     });
 
     test('no messages found', () async {
@@ -194,7 +196,8 @@ void main() {
       check(model)
         ..fetched.isTrue()
         ..messages.isEmpty()
-        ..haveOldest.isTrue();
+        ..haveOldest.isTrue()
+        ..haveNewest.isTrue();
     });
 
     // TODO(#824): move this test
@@ -416,6 +419,10 @@ void main() {
       checkNotNotified();
       check(model).messages.length.equals(30);
     });
+
+    test('while in mid-history', () async {
+    }, skip: true, // TODO(#82): not yet possible to exercise this case
+    );
 
     test('before fetch', () async {
       final stream = eg.stream();
@@ -2139,9 +2146,10 @@ void checkInvariants(MessageListView model) {
     check(model)
       ..messages.isEmpty()
       ..haveOldest.isFalse()
+      ..haveNewest.isFalse()
       ..busyFetchingMore.isFalse();
   }
-  if (model.haveOldest) {
+  if (model.haveOldest && model.haveNewest) {
     check(model).busyFetchingMore.isFalse();
   }
 
@@ -2286,5 +2294,6 @@ extension MessageListViewChecks on Subject<MessageListView> {
   Subject<int> get middleItem => has((x) => x.middleItem, 'middleItem');
   Subject<bool> get fetched => has((x) => x.fetched, 'fetched');
   Subject<bool> get haveOldest => has((x) => x.haveOldest, 'haveOldest');
+  Subject<bool> get haveNewest => has((x) => x.haveNewest, 'haveNewest');
   Subject<bool> get busyFetchingMore => has((x) => x.busyFetchingMore, 'busyFetchingMore');
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -26,6 +26,7 @@ import 'recent_senders_test.dart' as recent_senders_test;
 import 'test_store.dart';
 
 const newestResult = eg.newestGetMessagesResult;
+const nearResult = eg.nearGetMessagesResult;
 const olderResult = eg.olderGetMessagesResult;
 
 void main() {
@@ -183,6 +184,24 @@ void main() {
         ..messages.length.equals(30)
         ..haveOldest.isTrue()
         ..haveNewest.isTrue();
+    });
+
+    test('early in history', () async {
+      // For now, this gets a response that isn't realistic for the
+      // request it sends, to simulate when we start sending requests
+      // that would make this response realistic.
+      // TODO(#82): send appropriate fetch request
+      await prepare();
+      connection.prepare(json: nearResult(
+        anchor: 1000, foundOldest: true, foundNewest: false,
+        messages: List.generate(111, (i) => eg.streamMessage(id: 990 + i)),
+      ).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model)
+        ..messages.length.equals(111)
+        ..haveOldest.isTrue()
+        ..haveNewest.isFalse();
     });
 
     test('no messages found', () async {
@@ -421,8 +440,20 @@ void main() {
     });
 
     test('while in mid-history', () async {
-    }, skip: true, // TODO(#82): not yet possible to exercise this case
-    );
+      final stream = eg.stream();
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      connection.prepare(json: nearResult(
+        anchor: 1000, foundOldest: true, foundNewest: false,
+        messages: List.generate(30,
+          (i) => eg.streamMessage(id: 1000 + i, stream: stream))).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+
+      check(model).messages.length.equals(30);
+      await store.addMessage(eg.streamMessage(stream: stream));
+      checkNotNotified();
+      check(model).messages.length.equals(30);
+    });
 
     test('before fetch', () async {
       final stream = eg.stream();

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -51,7 +51,6 @@ void main() {
 
   /// Initialize [store] and the rest of the test state.
   Future<void> prepare({
-    Narrow narrow = const CombinedFeedNarrow(),
     ZulipStream? stream,
     int? zulipFeatureLevel,
   }) async {
@@ -64,7 +63,9 @@ void main() {
     await store.addSubscription(subscription);
     connection = store.connection as FakeApiConnection;
     notifiedCount = 0;
-    messageList = MessageListView.init(store: store, narrow: narrow)
+    messageList = MessageListView.init(store: store,
+        narrow: const CombinedFeedNarrow(),
+        anchor: AnchorCode.newest)
       ..addListener(() {
         notifiedCount++;
       });

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -404,7 +404,7 @@ void main() {
             'narrow': jsonEncode(narrow.apiEncode()),
             'anchor': AnchorCode.newest.toJson(),
             'num_before': kMessageListFetchBatchSize.toString(),
-            'num_after': '0',
+            'num_after': kMessageListFetchBatchSize.toString(),
             'allow_empty_topic_name': 'true',
           });
       });
@@ -437,7 +437,7 @@ void main() {
             'narrow': jsonEncode(narrow.apiEncode()),
             'anchor': AnchorCode.newest.toJson(),
             'num_before': kMessageListFetchBatchSize.toString(),
-            'num_after': '0',
+            'num_after': kMessageListFetchBatchSize.toString(),
             'allow_empty_topic_name': 'true',
           });
       });


### PR DESCRIPTION
This is the next round after #1507 (plus #1512), toward #82 and #80.

At the end of this branch, the view-model MessageListView has everything it needs for #82 and #80: the message list can start at an arbitrary anchor, including a numeric message-ID anchor or AnchorCode.firstUnread, and can fetch more history from there in both directions.

This doesn't yet actually use the new functionality outside of tests. As a result this branch is NFC as to the live app, given a well-behaved server (there are a couple of commits that are not NFC in how they act with a server that gives incoherent responses). I have a draft branch (as I mentioned at [#mobile-team > beta release management @ 💬](https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/beta.20release.20management/near/2174229)) that completes both #82 and #80; that'll be for an upcoming PR or two.


## Selected commit messages

#### 83b89a967 msglist [nfc]: Say we'll show "loading" even when fetch is at other end

This is NFC ultimately because we currently only ever fetch, or
show loading indicators, at one end of the message list, namely
the start.

When we do start supporting a message list in the middle of history,
though (#82), and consequently loading newer as well as older
messages, my conclusion after thinking it through is that we'll want
a "busy fetching" state at one end to mean we show a loading
indicator at the other end too, if it still has more to be fetched.

This would look weird if the user actually saw both at the same time
-- but that shouldn't happen, because if both ends (or even either
end) is still open then the original fetch should have found plenty of
messages to separate them, many screenfuls' worth.

And conversely, if the user does kick off a fetch at one end and then
scroll swiftly to the other end and witness how that appears, we want
to show them a "loading" sign.  The situation is exactly like if
they'd had a fetch attempt on that same end and we were backing off
from failure: there's no fetch right now, but there won't be one yet,
so effectively the loading is busy.


#### e3588e99c msglist [nfc]: Use `fetched` getter when reading

Generally this is helpful because it means that viewing references
to the field will highlight specifically the places that set it.

Here it's also helpful because we're about to replace the field
with an enum shared across several getters.


#### 0d5e84bf4 msglist [nfc]: Use an enum for fetched/fetching/backoff state

This makes the relationships between these flags clearer.

It will also simplify some upcoming refactors that change their
semantics.


#### 5e1f2677f msglist [nfc]: Rename backoff state to share between older/newer

If a fetch in one direction has recently failed, we'll want the
backoff to apply to any attempt to fetch in the other direction too;
after all, it's the same server.

We can also drop the term "cooldown" here, which is effectively
redundant with "backoff".


#### 9fcd55053 msglist [nfc]: Introduce haveNewest in model, always true for now


#### e12d706fe msglist: Set haveNewest from response, like haveOldest

This is NFC with a correctly-behaved server: we set `anchor=newest`,
so the server always sets `found_newest` to true.

Conversely, this will be helpful as we generalize `fetchInitial` to
work with other anchor values; we'll use the `found_newest` value
given by the server, without trying to predict it from the anchor.

The server behavior that makes this effectively NFC isn't quite
explicit in the API docs.  Those say:

  found_newest: boolean

  Whether the server promises that the messages list includes the
  very newest messages matching the narrow (used by clients that
  paginate their requests to decide whether there may be more
  messages to fetch).

  https://zulip.com/api/get-messages#response

But with `anchor=newest`, the response does need to include the very
newest messages in the narrow -- that's the meaning of that `anchor`
value.  So the server is in fact promising the list includes those,
and `found_newest` is therefore required to be true.

(And indeed in practice the server does set `found_newest` to true
when `anchor=newest`; it has specific logic to do so.)


#### f9efd71bb msglist [nfc]: Document narrow field; make setter private

Even if the reader is already sure that the field doesn't get mutated
from outside this file, giving it a different name from the getter is
useful for seeing exactly where it does get mutated: now one can look
at the references to `_narrow`, and see the mutation sites without
having them intermingled with all the sites that just read it.


#### 7b0e40509 msglist: Send positive numAfter for fetchInitial

This is effectively NFC given normal server behavior.  In particular,
the Zulip server is smart enough to skip doing any actual work to
fetch later messages when the anchor is already `newest`.

When we start passing anchors other than `newest`, we'll need this.


#### 8ea4c8d3c msglist: Make initial fetch from any anchor, in model

This is NFC as to the live app, because we continue to always set
the anchor to AnchorCode.newest there.


#### 80516305b msglist [nfc]: Factor out _fetchMore from fetchOlder


#### 4e7a18843 msglist: Add fetchNewer method to model

This completes the model layer of #82 and #80: the message list can
start at an arbitrary anchor, including a numeric message-ID anchor
or AnchorCode.firstUnread, and can fetch more history from there
in both directions.

Still to do is to work that into the widgets layer.  This change is
therefore NFC as to the live app: nothing calls this method yet.
