### PR TITLE
api: Like zulip-mobile, don't allow connecting to Zulip Server <7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ good time to [report them as issues][dart-test-tracker].
 
 #### Server compatibility
 
-We support Zulip Server 4.0 and later.
+We support Zulip Server 7.0 and later.
 
 For API features added in newer versions, use `TODO(server-N)`
 comments (like those you see in the existing code.)

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -14,13 +14,14 @@ import 'exception.dart';
 ///
 /// When updating this, also update [kMinSupportedZulipFeatureLevel]
 /// and the README.
-const kMinSupportedZulipVersion = '4.0';
+// TODO(#268) address all TODO(server-5), TODO(server-6), and TODO(server-7)
+const kMinSupportedZulipVersion = '7.0';
 
 /// The Zulip feature level reserved for the [kMinSupportedZulipVersion] release.
 ///
 /// For this value, see the API changelog:
 ///   https://zulip.com/api/changelog
-const kMinSupportedZulipFeatureLevel = 65;
+const kMinSupportedZulipFeatureLevel = 185;
 
 /// The doc stating our oldest supported server version.
 // TODO: Instead, link to new Help Center doc once we have it:


### PR DESCRIPTION
This goes rather farther than #1456, which is for bumping this number just to 5.0. This is OK; we recently bumped zulip-mobile to use 7.0, in the v27.235 release.

zulip-mobile shows a "nag banner" to nudge server admins to upgrade. As of v27.235 (PR zulip/zulip-mobile#5922), that banner appears on 7.x servers, the latest 7.x having recently aged out of our 18-month support window. So we should feel comfortable nudging this number in zulip-flutter to 8.0 once v27.235 has been out for a little while.

Fixes: #1456