### PR TITLE
android build: Disable lint AndroidGradlePluginVersion

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,6 +78,7 @@ android {
         checkAllWarnings = true
         warningsAsErrors = true
         baseline = file("lint-baseline.xml")
+        disable += ['AndroidGradlePluginVersion']
     }
 }
 

--- a/android/app/lint-baseline.xml
+++ b/android/app/lint-baseline.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="6" by="lint 8.5.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.2)" variant="all" version="8.5.2">
 
+    <!--TODO(#855) see if this is no longer needed-->
     <issue
         id="InvalidPackage"
         message="Invalid package reference in library; not included in Android: `javax.xml.stream`. Referenced from `org.apache.tika.utils.XMLReaderUtils`.">


### PR DESCRIPTION
    android build: Disable lint AndroidGradlePluginVersion
    
    We're successfully managing our Gradle and AGP upgrades without this
    lint rule, and it's annoying that it fails our CI builds.
    Discussion:
      https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/CI.20fail.3A.20lint.20on.20Gradle.20version.3F/near/2179323
