### PR TITLE
local echo (6.75/7): Revised commit for local echo (sans retrieving failed outbox content)

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -394,6 +394,8 @@ class MessageStoreImpl extends PerAccountStoreBase with MessageStore, _OutboxMes
       }
     }
 
+    // TODO predict outbox message moves using propagateMode
+
     for (final view in _messageListViews) {
       view.messagesMoved(messageMove: messageMove, messageIds: event.messageIds);
     }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -814,6 +814,9 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
           key: ValueKey(data.message.id),
           header: header,
           item: data);
+      case MessageListOutboxMessageItem():
+        final header = RecipientHeader(message: data.message, narrow: widget.narrow);
+        return MessageItem(header: header, item: data);
     }
   }
 }
@@ -1152,6 +1155,7 @@ class MessageItem extends StatelessWidget {
       child: Column(children: [
         switch (item) {
           MessageListMessageItem() => MessageWithPossibleSender(item: item),
+          MessageListOutboxMessageItem() => OutboxMessageWithPossibleSender(item: item),
         },
         // TODO refine this padding; discussion:
         //   https://github.com/zulip/zulip-flutter/pull/1453#discussion_r2106526985
@@ -1730,5 +1734,33 @@ class _RestoreEditMessageGestureDetector extends StatelessWidget {
         composeBoxState.startEditInteraction(messageId);
       },
       child: child);
+  }
+}
+
+/// A "local echo" placeholder for a Zulip message to be sent by the self-user.
+///
+/// See also [OutboxMessage].
+class OutboxMessageWithPossibleSender extends StatelessWidget {
+  const OutboxMessageWithPossibleSender({super.key, required this.item});
+
+  final MessageListOutboxMessageItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = item.message;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(children: [
+        if (item.showSender)
+          _SenderRow(message: message, showTimestamp: false),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          // This is adapted from [MessageContent].
+          // TODO(#576): Offer InheritedMessage ancestor once we are ready
+          //   to support local echoing images and lightbox.
+          child: DefaultTextStyle(
+            style: ContentTheme.of(context).textStylePlainParagraph,
+            child: BlockContentList(nodes: item.content.nodes))),
+      ]));
   }
 }

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -42,6 +42,10 @@ extension StreamConversationChecks on Subject<StreamConversation> {
   Subject<String?> get displayRecipient => has((x) => x.displayRecipient, 'displayRecipient');
 }
 
+extension DmConversationChecks on Subject<DmConversation> {
+  Subject<List<int>> get allRecipientIds => has((x) => x.allRecipientIds, 'allRecipientIds');
+}
+
 extension MessageBaseChecks<T extends Conversation> on Subject<MessageBase<T>> {
   Subject<int?> get id => has((e) => e.id, 'id');
   Subject<int> get senderId => has((e) => e.senderId, 'senderId');

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1,8 +1,11 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:collection/collection.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
+import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/scaffolding.dart';
 import 'package:zulip/api/backoff.dart';
@@ -10,8 +13,10 @@ import 'package:zulip/api/exception.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/narrow.dart';
+import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/algorithms.dart';
 import 'package:zulip/model/content.dart';
+import 'package:zulip/model/message.dart';
 import 'package:zulip/model/message_list.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
@@ -21,7 +26,9 @@ import '../api/model/model_checks.dart';
 import '../example_data.dart' as eg;
 import '../fake_async.dart';
 import '../stdlib_checks.dart';
+import 'binding.dart';
 import 'content_checks.dart';
+import 'message_checks.dart';
 import 'recent_senders_test.dart' as recent_senders_test;
 import 'test_store.dart';
 
@@ -49,6 +56,8 @@ void main() {
     FlutterError.dumpErrorToConsole(details, forceReport: true);
   };
 
+  TestZulipBinding.ensureInitialized();
+
   // These variables are the common state operated on by each test.
   // Each test case calls [prepare] to initialize them.
   late Subscription subscription;
@@ -71,8 +80,9 @@ void main() {
   Future<void> prepare({
     Narrow narrow = const CombinedFeedNarrow(),
     Anchor anchor = AnchorCode.newest,
+    ZulipStream? stream,
   }) async {
-    final stream = eg.stream(streamId: eg.defaultStreamMessageStreamId);
+    stream ??= eg.stream(streamId: eg.defaultStreamMessageStreamId);
     subscription = eg.subscription(stream);
     store = eg.store();
     await store.addStream(stream);
@@ -106,6 +116,26 @@ void main() {
     connection.prepare(json: result.toJson());
     await model.fetchInitial();
     checkNotifiedOnce();
+  }
+
+  Future<void> prepareOutboxMessages({
+    required int count,
+    required ZulipStream stream,
+    String topic = 'some topic',
+  }) async {
+    for (int i = 0; i < count; i++) {
+      connection.prepare(json: SendMessageResult(id: 123).toJson());
+      await store.sendMessage(
+        destination: StreamDestination(stream.streamId, eg.t(topic)),
+        content: 'content');
+    }
+  }
+
+  Future<void> prepareOutboxMessagesTo(List<MessageDestination> destinations) async {
+    for (final destination in destinations) {
+      connection.prepare(json: SendMessageResult(id: 123).toJson());
+      await store.sendMessage(destination: destination, content: 'content');
+    }
   }
 
   void checkLastRequest({
@@ -245,6 +275,105 @@ void main() {
       test('newest',      () => checkFetchWithAnchor(AnchorCode.newest));
       test('numeric',     () => checkFetchWithAnchor(NumericAnchor(12345)));
     });
+
+    test('no messages found in fetch; outbox messages present', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(
+        narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
+
+      await prepareOutboxMessages(count: 1, stream: stream, topic: 'topic');
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+      check(model)
+        ..fetched.isFalse()
+        ..outboxMessages.isEmpty();
+
+      connection.prepare(
+        json: newestResult(foundOldest: true, messages: []).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model)
+        ..fetched.isTrue()
+        ..outboxMessages.length.equals(1);
+    }));
+
+    test('some messages found in fetch; outbox messages present', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(
+        narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
+
+      await prepareOutboxMessages(count: 1, stream: stream, topic: 'topic');
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+      check(model)
+        ..fetched.isFalse()
+        ..outboxMessages.isEmpty();
+
+      connection.prepare(json: newestResult(foundOldest: true,
+        messages: [eg.streamMessage(stream: stream, topic: 'topic')]).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model)
+        ..fetched.isTrue()
+        ..outboxMessages.length.equals(1);
+    }));
+
+    test('outbox messages not added until haveNewest', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(
+        narrow: eg.topicNarrow(stream.streamId, 'topic'),
+        anchor: AnchorCode.firstUnread,
+        stream: stream);
+
+      await prepareOutboxMessages(count: 1, stream: stream, topic: 'topic');
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+      check(model)..fetched.isFalse()..outboxMessages.isEmpty();
+
+      final message = eg.streamMessage(stream: stream, topic: 'topic');
+      connection.prepare(json: nearResult(
+        anchor: message.id,
+        foundOldest: true,
+        foundNewest: false,
+        messages: [message]).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model)..fetched.isTrue()..haveNewest.isFalse()..outboxMessages.isEmpty();
+
+      connection.prepare(json: newerResult(anchor: message.id, foundNewest: true,
+        messages: [eg.streamMessage(stream: stream, topic: 'topic')]).toJson());
+      final fetchFuture = model.fetchNewer();
+      checkNotifiedOnce();
+      await fetchFuture;
+      checkNotifiedOnce();
+      check(model)..haveNewest.isTrue()..outboxMessages.length.equals(1);
+    }));
+
+    test('ignore [OutboxMessage]s outside narrow or with `hidden: true`', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      final otherStream = eg.stream();
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await store.addUserTopic(stream, 'muted', UserTopicVisibilityPolicy.muted);
+      await prepareOutboxMessagesTo([
+        StreamDestination(stream.streamId, eg.t('topic')),
+        StreamDestination(stream.streamId, eg.t('muted')),
+        StreamDestination(otherStream.streamId, eg.t('topic')),
+      ]);
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+
+      await prepareOutboxMessagesTo(
+        [StreamDestination(stream.streamId, eg.t('topic'))]);
+      assert(store.outboxMessages.values.last.hidden);
+
+      connection.prepare(json:
+        newestResult(foundOldest: true, messages: []).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model).outboxMessages.single.isA<StreamOutboxMessage>().conversation
+        ..streamId.equals(stream.streamId)
+        ..topic.equals(eg.t('topic'));
+    }));
 
     // TODO(#824): move this test
     test('recent senders track all the messages', () async {
@@ -614,6 +743,199 @@ void main() {
       checkNotNotified();
       check(model).fetched.isFalse();
     });
+
+    test('when there are outbox messages', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream)));
+
+      await prepareOutboxMessages(count: 5, stream: stream);
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 5);
+      check(model)
+        ..messages.length.equals(30)
+        ..outboxMessages.length.equals(5);
+
+      await store.handleEvent(eg.messageEvent(eg.streamMessage(stream: stream)));
+      checkNotifiedOnce();
+      check(model)
+        ..messages.length.equals(31)
+        ..outboxMessages.length.equals(5);
+    }));
+
+    test('from another client (localMessageId present but unrecognized)', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(narrow: eg.topicNarrow(stream.streamId, 'topic'));
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
+
+      check(model)
+        ..messages.length.equals(30)
+        ..outboxMessages.isEmpty();
+
+      await store.handleEvent(eg.messageEvent(
+        eg.streamMessage(stream: stream, topic: 'topic'),
+        localMessageId: 1234));
+      check(store.outboxMessages).isEmpty();
+      checkNotifiedOnce();
+      check(model)
+        ..messages.length.equals(31)
+        ..outboxMessages.isEmpty();
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+    }));
+
+    test('for an OutboxMessage in the narrow', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream)));
+
+      await prepareOutboxMessages(count: 5, stream: stream);
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 5);
+      final localMessageId = store.outboxMessages.keys.first;
+      check(model)
+        ..messages.length.equals(30)
+        ..outboxMessages.length.equals(5)
+        ..outboxMessages.any((message) =>
+            message.localMessageId.equals(localMessageId));
+
+      await store.handleEvent(eg.messageEvent(eg.streamMessage(stream: stream),
+        localMessageId: localMessageId));
+      checkNotifiedOnce();
+      check(model)
+        ..messages.length.equals(31)
+        ..outboxMessages.length.equals(4)
+        ..outboxMessages.every((message) =>
+            message.localMessageId.not((m) => m.equals(localMessageId)));
+    }));
+
+    test('for an OutboxMessage outside the narrow', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(narrow: eg.topicNarrow(stream.streamId, 'topic'));
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
+
+      await prepareOutboxMessages(count: 5, stream: stream, topic: 'other');
+      final localMessageId = store.outboxMessages.keys.first;
+      check(model)
+        ..messages.length.equals(30)
+        ..outboxMessages.isEmpty();
+
+      await store.handleEvent(eg.messageEvent(
+        eg.streamMessage(stream: stream, topic: 'other'),
+        localMessageId: localMessageId));
+      checkNotNotified();
+      check(model)
+        ..messages.length.equals(30)
+        ..outboxMessages.isEmpty();
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+    }));
+  });
+
+  group('addOutboxMessage', () {
+    final stream = eg.stream();
+
+    test('in narrow', () => awaitFakeAsync((async) async {
+      await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream)));
+      await prepareOutboxMessages(count: 5, stream: stream);
+      check(model).outboxMessages.isEmpty();
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 5);
+      check(model).outboxMessages.length.equals(5);
+    }));
+
+    test('not in narrow', () => awaitFakeAsync((async) async {
+      await prepare(narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
+      await prepareOutboxMessages(count: 5, stream: stream, topic: 'other topic');
+      check(model).outboxMessages.isEmpty();
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+      check(model).outboxMessages.isEmpty();
+    }));
+
+    test('before fetch', () => awaitFakeAsync((async) async {
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await prepareOutboxMessages(count: 5, stream: stream);
+      check(model)
+        ..fetched.isFalse()
+        ..outboxMessages.isEmpty();
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+      check(model)
+        ..fetched.isFalse()
+        ..outboxMessages.isEmpty();
+    }));
+  });
+
+  group('removeOutboxMessage', () {
+    final stream = eg.stream();
+
+    Future<void> prepareFailedOutboxMessages(FakeAsync async, {
+      required int count,
+      required ZulipStream stream,
+      String topic = 'some topic',
+    }) async {
+      for (int i = 0; i < count; i++) {
+        connection.prepare(httpException: SocketException('failed'));
+        await check(store.sendMessage(
+          destination: StreamDestination(stream.streamId, eg.t(topic)),
+          content: 'content')).throws();
+      }
+    }
+
+    test('in narrow', () => awaitFakeAsync((async) async {
+      await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
+      await prepareFailedOutboxMessages(async,
+        count: 5, stream: stream);
+      check(model).outboxMessages.length.equals(5);
+      checkNotified(count: 5);
+
+      store.takeOutboxMessage(store.outboxMessages.keys.first);
+      checkNotifiedOnce();
+      check(model).outboxMessages.length.equals(4);
+    }));
+
+    test('not in narrow', () => awaitFakeAsync((async) async {
+      await prepare(narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
+      await prepareMessages(foundOldest: true, messages:
+        List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
+      await prepareFailedOutboxMessages(async,
+        count: 5, stream: stream, topic: 'other topic');
+      check(model).outboxMessages.isEmpty();
+      checkNotNotified();
+
+      store.takeOutboxMessage(store.outboxMessages.keys.first);
+      check(model).outboxMessages.isEmpty();
+      checkNotNotified();
+    }));
+
+    test('removed outbox message is the only message in narrow', () => awaitFakeAsync((async) async {
+      await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
+      await prepareMessages(foundOldest: true, messages: []);
+      await prepareFailedOutboxMessages(async,
+        count: 1, stream: stream);
+      check(model).outboxMessages.single;
+      checkNotified(count: 1);
+
+      store.takeOutboxMessage(store.outboxMessages.keys.first);
+      check(model).outboxMessages.isEmpty();
+      checkNotifiedOnce();
+    }));
   });
 
   group('UserTopicEvent', () {
@@ -637,7 +959,7 @@ void main() {
       await setVisibility(policy);
     }
 
-    test('mute a visible topic', () async {
+    test('mute a visible topic', () => awaitFakeAsync((async) async {
       await prepare(narrow: const CombinedFeedNarrow());
       await prepareMutes();
       final otherStream = eg.stream();
@@ -651,10 +973,49 @@ void main() {
       ]);
       checkHasMessageIds([1, 2, 3, 4]);
 
+      await prepareOutboxMessagesTo([
+        StreamDestination(stream.streamId, eg.t(topic)),
+        StreamDestination(stream.streamId, eg.t('elsewhere')),
+        DmDestination(userIds: [eg.selfUser.userId]),
+      ]);
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 3);
+      check(model).outboxMessages.deepEquals(<Condition<Object?>>[
+        (it) => it.isA<StreamOutboxMessage>()
+                  .conversation.topic.equals(eg.t(topic)),
+        (it) => it.isA<StreamOutboxMessage>()
+                  .conversation.topic.equals(eg.t('elsewhere')),
+        (it) => it.isA<DmOutboxMessage>()
+                  .conversation.allRecipientIds.deepEquals([eg.selfUser.userId]),
+      ]);
+
       await setVisibility(UserTopicVisibilityPolicy.muted);
       checkNotifiedOnce();
       checkHasMessageIds([1, 3, 4]);
-    });
+      check(model).outboxMessages.deepEquals(<Condition<Object?>>[
+        (it) => it.isA<StreamOutboxMessage>()
+                  .conversation.topic.equals(eg.t('elsewhere')),
+        (it) => it.isA<DmOutboxMessage>()
+                  .conversation.allRecipientIds.deepEquals([eg.selfUser.userId]),
+      ]);
+    }));
+
+    test('mute a visible topic containing only outbox messages', () => awaitFakeAsync((async) async {
+      await prepare(narrow: const CombinedFeedNarrow());
+      await prepareMutes();
+      await prepareMessages(foundOldest: true, messages: []);
+      await prepareOutboxMessagesTo([
+        StreamDestination(stream.streamId, eg.t(topic)),
+        StreamDestination(stream.streamId, eg.t(topic)),
+      ]);
+      async.elapse(kLocalEchoDebounceDuration);
+      check(model).outboxMessages.length.equals(2);
+      checkNotified(count: 2);
+
+      await setVisibility(UserTopicVisibilityPolicy.muted);
+      check(model).outboxMessages.isEmpty();
+      checkNotifiedOnce();
+    }));
 
     test('in CombinedFeedNarrow, use combined-feed visibility', () async {
       // Compare the parallel ChannelNarrow test below.
@@ -729,7 +1090,7 @@ void main() {
       checkHasMessageIds([1]);
     });
 
-    test('no affected messages -> no notification', () async {
+    test('no affected messages -> no notification', () => awaitFakeAsync((async) async {
       await prepare(narrow: const CombinedFeedNarrow());
       await prepareMutes();
       await prepareMessages(foundOldest: true, messages: [
@@ -737,10 +1098,17 @@ void main() {
       ]);
       checkHasMessageIds([1]);
 
+      await prepareOutboxMessagesTo(
+        [StreamDestination(stream.streamId, eg.t('bar'))]);
+      async.elapse(kLocalEchoDebounceDuration);
+      final outboxMessage = model.outboxMessages.single;
+      checkNotifiedOnce();
+
       await setVisibility(UserTopicVisibilityPolicy.muted);
       checkNotNotified();
       checkHasMessageIds([1]);
-    });
+      check(model).outboxMessages.single.equals(outboxMessage);
+    }));
 
     test('unmute a topic -> refetch from scratch', () => awaitFakeAsync((async) async {
       await prepare(narrow: const CombinedFeedNarrow());
@@ -750,7 +1118,14 @@ void main() {
         eg.streamMessage(id: 2, stream: stream, topic: topic),
       ];
       await prepareMessages(foundOldest: true, messages: messages);
+      await store.addUserTopic(stream, 'muted', UserTopicVisibilityPolicy.muted);
+      await prepareOutboxMessagesTo([
+        StreamDestination(stream.streamId, eg.t(topic)),
+        StreamDestination(stream.streamId, eg.t('muted')),
+      ]);
+      async.elapse(kLocalEchoDebounceDuration);
       checkHasMessageIds([1]);
+      check(model).outboxMessages.isEmpty();
 
       connection.prepare(
         json: newestResult(foundOldest: true, messages: messages).toJson());
@@ -758,10 +1133,14 @@ void main() {
       checkNotifiedOnce();
       check(model).fetched.isFalse();
       checkHasMessageIds([]);
+      check(model).outboxMessages.isEmpty();
 
       async.elapse(Duration.zero);
       checkNotifiedOnce();
       checkHasMessageIds([1, 2]);
+      check(model).outboxMessages.single.isA<StreamOutboxMessage>().conversation
+        ..streamId.equals(stream.streamId)
+        ..topic.equals(eg.t(topic));
     }));
 
     test('unmute a topic before initial fetch completes -> do nothing', () => awaitFakeAsync((async) async {
@@ -907,6 +1286,38 @@ void main() {
     });
   });
 
+  group('notifyListenersIfOutboxMessagePresent', () {
+    final stream = eg.stream();
+
+    test('message present', () => awaitFakeAsync((async) async {
+      await prepare(narrow: const CombinedFeedNarrow(), stream: stream);
+      await prepareMessages(foundOldest: true, messages: []);
+      await prepareOutboxMessages(count: 5, stream: stream);
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 5);
+
+      model.notifyListenersIfOutboxMessagePresent(
+        store.outboxMessages.keys.first);
+      checkNotifiedOnce();
+    }));
+
+    test('message not present', () => awaitFakeAsync((async) async {
+      await prepare(
+        narrow: eg.topicNarrow(stream.streamId, 'some topic'), stream: stream);
+      await prepareMessages(foundOldest: true, messages: []);
+      await prepareOutboxMessages(count: 5,
+        stream: stream, topic: 'other topic');
+
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+
+      model.notifyListenersIfOutboxMessagePresent(
+        store.outboxMessages.keys.first);
+      checkNotNotified();
+    }));
+  });
+
   group('messageContentChanged', () {
     test('message present', () async {
       await prepare(narrow: const CombinedFeedNarrow());
@@ -1035,6 +1446,26 @@ void main() {
         checkHasMessages(initialMessages);
         checkNotifiedOnce();
       });
+
+      test('channel -> new channel (with outbox messages): remove moved messages; outbox messages unaffected', () => awaitFakeAsync((async) async {
+        final narrow = ChannelNarrow(stream.streamId);
+        await prepareNarrow(narrow, initialMessages + movedMessages);
+        connection.prepare(json: SendMessageResult(id: 1).toJson());
+        await prepareOutboxMessages(count: 5, stream: stream);
+
+        async.elapse(kLocalEchoDebounceDuration);
+        checkNotified(count: 5);
+        final outboxMessagesCopy = model.outboxMessages.toList();
+
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: movedMessages,
+          newTopicStr: 'new',
+          newStreamId: otherStream.streamId,
+        ));
+        checkHasMessages(initialMessages);
+        check(model).outboxMessages.deepEquals(outboxMessagesCopy);
+        checkNotifiedOnce();
+      }));
 
       test('unrelated channel -> new channel: unaffected', () async {
         final thirdStream = eg.stream();
@@ -1737,6 +2168,39 @@ void main() {
       checkHasMessageIds(expected);
     });
 
+    test('handle outbox messages', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream));
+      await store.addUserTopic(stream, 'muted', UserTopicVisibilityPolicy.muted);
+      await prepareMessages(foundOldest: true, messages: []);
+
+      // Check filtering on sent messages…
+      await prepareOutboxMessagesTo([
+        StreamDestination(stream.streamId, eg.t('not muted')),
+        StreamDestination(stream.streamId, eg.t('muted')),
+      ]);
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotifiedOnce();
+      check(model.outboxMessages).single.isA<StreamOutboxMessage>()
+        .conversation.topic.equals(eg.t('not muted'));
+
+      final messages = [eg.streamMessage(stream: stream)];
+      connection.prepare(json: newestResult(
+        foundOldest: true, messages: messages).toJson());
+      // Check filtering on fetchInitial…
+      await store.handleEvent(eg.updateMessageEventMoveTo(
+        newMessages: messages,
+        origStreamId: eg.stream().streamId));
+      checkNotifiedOnce();
+      check(model).fetched.isFalse();
+      async.elapse(Duration.zero);
+      check(model).fetched.isTrue();
+      check(model.outboxMessages).single.isA<StreamOutboxMessage>()
+        .conversation.topic.equals(eg.t('not muted'));
+    }));
+
     test('in TopicNarrow', () async {
       final stream = eg.stream();
       await prepare(narrow: eg.topicNarrow(stream.streamId, 'A'));
@@ -2115,7 +2579,55 @@ void main() {
     });
   });
 
-  test('recipient headers are maintained consistently', () async {
+  group('findItemWithMessageId', () {
+    test('has MessageListDateSeparatorItem with null message ID', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      final message = eg.streamMessage(stream: stream, topic: 'topic',
+        timestamp: eg.utcTimestamp(clock.daysAgo(1)));
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: [message]);
+
+      // `findItemWithMessageId` uses binary search.  Set up just enough
+      // outbox message items, so that a [MessageListDateSeparatorItem] for
+      // the outbox messages is right in the middle.
+      await prepareOutboxMessages(count: 2, stream: stream, topic: 'topic');
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 2);
+      check(model.items).deepEquals(<Condition<Object?>>[
+        (it) => it.isA<MessageListRecipientHeaderItem>(),
+        (it) => it.isA<MessageListMessageItem>(),
+        (it) => it.isA<MessageListDateSeparatorItem>().message.id.isNull(),
+        (it) => it.isA<MessageListOutboxMessageItem>(),
+        (it) => it.isA<MessageListOutboxMessageItem>(),
+      ]);
+      check(model.findItemWithMessageId(message.id)).equals(1);
+    }));
+
+    test('has MessageListOutboxMessageItem', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      final message = eg.streamMessage(stream: stream, topic: 'topic',
+        timestamp: eg.utcTimestamp(clock.now()));
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await prepareMessages(foundOldest: true, messages: [message]);
+
+      // `findItemWithMessageId` uses binary search.  Set up just enough
+      // outbox message items, so that a [MessageListOutboxMessageItem]
+      // is right in the middle.
+      await prepareOutboxMessages(count: 3, stream: stream, topic: 'topic');
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 3);
+      check(model.items).deepEquals(<Condition<Object?>>[
+        (it) => it.isA<MessageListRecipientHeaderItem>(),
+        (it) => it.isA<MessageListMessageItem>(),
+        (it) => it.isA<MessageListOutboxMessageItem>(),
+        (it) => it.isA<MessageListOutboxMessageItem>(),
+        (it) => it.isA<MessageListOutboxMessageItem>(),
+      ]);
+      check(model.findItemWithMessageId(message.id)).equals(1);
+    }));
+  });
+
+  test('recipient headers are maintained consistently', () => awaitFakeAsync((async) async {
     // TODO test date separators are maintained consistently too
     // This tests the code that maintains the invariant that recipient headers
     // are present just where they're required.
@@ -2128,7 +2640,7 @@ void main() {
     // just needs messages that have the same recipient, and that don't, and
     // doesn't need to exercise the different reasons that messages don't.
 
-    const timestamp = 1693602618;
+    final timestamp = eg.utcTimestamp(clock.now());
     final stream = eg.stream(streamId: eg.defaultStreamMessageStreamId);
     Message streamMessage(int id) =>
       eg.streamMessage(id: id, stream: stream, topic: 'foo', timestamp: timestamp);
@@ -2187,6 +2699,20 @@ void main() {
     model.reassemble();
     checkNotifiedOnce();
 
+    // Then test outbox message, where a new header is needed…
+    connection.prepare(json: SendMessageResult(id: 1).toJson());
+    await store.sendMessage(
+      destination: DmDestination(userIds: [eg.selfUser.userId]), content: 'hi');
+    async.elapse(kLocalEchoDebounceDuration);
+    checkNotifiedOnce();
+
+    // … and where it's not.
+    connection.prepare(json: SendMessageResult(id: 1).toJson());
+    await store.sendMessage(
+      destination: DmDestination(userIds: [eg.selfUser.userId]), content: 'hi');
+    async.elapse(kLocalEchoDebounceDuration);
+    checkNotifiedOnce();
+
     // Have a new fetchOlder reach the oldest, so that a history-start marker appears…
     connection.prepare(json: olderResult(
       anchor: model.messages[0].id,
@@ -2199,17 +2725,33 @@ void main() {
     // … and then test reassemble again.
     model.reassemble();
     checkNotifiedOnce();
-  });
 
-  test('showSender is maintained correctly', () async {
+    final outboxMessageIds = store.outboxMessages.keys.toList();
+    // Then test removing the first outbox message…
+    await store.handleEvent(eg.messageEvent(
+      dmMessage(15), localMessageId: outboxMessageIds.first));
+    checkNotifiedOnce();
+
+    // … and handling a new non-outbox message…
+    await store.handleEvent(eg.messageEvent(streamMessage(16)));
+    checkNotifiedOnce();
+
+    // … and removing the second outbox message.
+    await store.handleEvent(eg.messageEvent(
+      dmMessage(17), localMessageId: outboxMessageIds.last));
+    checkNotifiedOnce();
+  }));
+
+  test('showSender is maintained correctly', () => awaitFakeAsync((async) async {
     // TODO(#150): This will get more complicated with message moves.
     // Until then, we always compute this sequentially from oldest to newest.
     // So we just need to exercise the different cases of the logic for
     // whether the sender should be shown, but the difference between
     // fetchInitial and handleMessageEvent etc. doesn't matter.
 
-    const t1 = 1693602618;
-    const t2 = t1 + 86400;
+    final now = clock.now();
+    final t1 = eg.utcTimestamp(now.subtract(Duration(days: 1)));
+    final t2 = eg.utcTimestamp(now);
     final stream = eg.stream(streamId: eg.defaultStreamMessageStreamId);
     Message streamMessage(int id, int timestamp, User sender) =>
       eg.streamMessage(id: id, sender: sender,
@@ -2217,6 +2759,8 @@ void main() {
     Message dmMessage(int id, int timestamp, User sender) =>
       eg.dmMessage(id: id, from: sender, timestamp: timestamp,
         to: [sender.userId == eg.selfUser.userId ? eg.otherUser : eg.selfUser]);
+    DmDestination dmDestination(List<User> users) =>
+      DmDestination(userIds: users.map((user) => user.userId).toList());
 
     await prepare();
     await prepareMessages(foundOldest: true, messages: [
@@ -2226,6 +2770,13 @@ void main() {
       dmMessage(4,     t1, eg.otherUser), // same sender, but new recipient
       dmMessage(5,     t2, eg.otherUser), // same sender/recipient, but new day
     ]);
+    await prepareOutboxMessagesTo([
+      dmDestination([eg.selfUser, eg.otherUser]), // same day, but new sender
+      dmDestination([eg.selfUser, eg.otherUser]), // hide sender
+    ]);
+    assert(
+      store.outboxMessages.values.every((message) => message.timestamp == t2));
+    async.elapse(kLocalEchoDebounceDuration);
 
     // We check showSender has the right values in [checkInvariants],
     // but to make this test explicit:
@@ -2238,8 +2789,10 @@ void main() {
       (it) => it.isA<MessageListMessageItem>().showSender.isTrue(),
       (it) => it.isA<MessageListDateSeparatorItem>(),
       (it) => it.isA<MessageListMessageItem>().showSender.isTrue(),
+      (it) => it.isA<MessageListOutboxMessageItem>().showSender.isTrue(),
+      (it) => it.isA<MessageListOutboxMessageItem>().showSender.isFalse(),
     ]);
-  });
+  }));
 
   group('haveSameRecipient', () {
     test('stream messages vs DMs, no match', () {
@@ -2310,6 +2863,16 @@ void main() {
       doTest('same letters, different diacritics', 'ma',   'mǎ',   false);
       doTest('having different CJK characters',    '嗎', '馬', false);
     });
+
+    test('outbox messages', () {
+      final stream = eg.stream();
+      final streamMessage1 = eg.streamOutboxMessage(stream: stream, topic: 'foo');
+      final streamMessage2 = eg.streamOutboxMessage(stream: stream, topic: 'bar');
+      final dmMessage = eg.dmOutboxMessage(from: eg.selfUser, to: [eg.otherUser]);
+      check(haveSameRecipient(streamMessage1, streamMessage1)).isTrue();
+      check(haveSameRecipient(streamMessage1, streamMessage2)).isFalse();
+      check(haveSameRecipient(streamMessage1, dmMessage)).isFalse();
+    });
   });
 
   test('messagesSameDay', () {
@@ -2345,6 +2908,14 @@ void main() {
               eg.dmMessage(from: eg.selfUser, to: [], timestamp: timestampFromLocalTime(time0)),
               eg.dmMessage(from: eg.selfUser, to: [], timestamp: timestampFromLocalTime(time1)),
             )).equals(i0 == i1);
+            check(because: 'times $time0, $time1', messagesSameDay(
+              eg.streamOutboxMessage(timestamp: timestampFromLocalTime(time0)),
+              eg.streamOutboxMessage(timestamp: timestampFromLocalTime(time1)),
+            )).equals(i0 == i1);
+            check(because: 'times $time0, $time1', messagesSameDay(
+              eg.dmOutboxMessage(from: eg.selfUser, to: [], timestamp: timestampFromLocalTime(time0)),
+              eg.dmOutboxMessage(from: eg.selfUser, to: [], timestamp: timestampFromLocalTime(time1)),
+            )).equals(i0 == i1);
           }
         }
       }
@@ -2360,6 +2931,7 @@ void checkInvariants(MessageListView model) {
   if (!model.fetched) {
     check(model)
       ..messages.isEmpty()
+      ..outboxMessages.isEmpty()
       ..haveOldest.isFalse()
       ..haveNewest.isFalse()
       ..busyFetchingMore.isFalse();
@@ -2371,8 +2943,15 @@ void checkInvariants(MessageListView model) {
   for (final message in model.messages) {
     check(model.store.messages)[message.id].isNotNull().identicalTo(message);
   }
+  if (model.outboxMessages.isNotEmpty) {
+    check(model.haveNewest).isTrue();
+  }
+  for (final message in model.outboxMessages) {
+    check(message).hidden.isFalse();
+    check(model.store.outboxMessages)[message.localMessageId].isNotNull().identicalTo(message);
+  }
 
-  final allMessages = <MessageBase<Conversation>>[...model.messages];
+  final allMessages = [...model.messages, ...model.outboxMessages];
 
   for (final message in allMessages) {
     check(model.narrow.containsMessage(message)).isTrue();
@@ -2394,6 +2973,8 @@ void checkInvariants(MessageListView model) {
   }
 
   check(isSortedWithoutDuplicates(model.messages.map((m) => m.id).toList()))
+    .isTrue();
+  check(isSortedWithoutDuplicates(model.outboxMessages.map((m) => m.localMessageId).toList()))
     .isTrue();
 
   check(model).middleMessage
@@ -2444,7 +3025,8 @@ void checkInvariants(MessageListView model) {
         ..message.identicalTo(model.messages[j])
         ..content.identicalTo(model.contents[j]);
     } else {
-      assert(false);
+      check(model.items[i]).isA<MessageListOutboxMessageItem>()
+        .message.identicalTo(model.outboxMessages[j-model.messages.length]);
     }
     check(model.items[i++]).isA<MessageListMessageBaseItem>()
       ..showSender.equals(
@@ -2452,6 +3034,7 @@ void checkInvariants(MessageListView model) {
       ..isLastInBlock.equals(
         i == model.items.length || switch (model.items[i]) {
           MessageListMessageItem()
+          || MessageListOutboxMessageItem()
           || MessageListDateSeparatorItem() => false,
           MessageListRecipientHeaderItem()  => true,
         });
@@ -2461,8 +3044,14 @@ void checkInvariants(MessageListView model) {
   check(model).middleItem
     ..isGreaterOrEqual(0)
     ..isLessOrEqual(model.items.length);
-  if (model.middleItem == model.items.length) {
-    check(model.middleMessage).equals(model.messages.length);
+  if (model.middleMessage == model.messages.length) {
+    if (model.outboxMessages.isEmpty) {
+      // the bottom slice of `model.messages` is empty
+      check(model).middleItem.equals(model.items.length);
+    } else {
+      check(model.items[model.middleItem]).isA<MessageListOutboxMessageItem>()
+        .message.identicalTo(model.outboxMessages.first);
+    }
   } else {
     check(model.items[model.middleItem]).isA<MessageListMessageItem>()
       .message.identicalTo(model.messages[model.middleMessage]);
@@ -2503,6 +3092,7 @@ extension MessageListViewChecks on Subject<MessageListView> {
   Subject<PerAccountStore> get store => has((x) => x.store, 'store');
   Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
   Subject<List<Message>> get messages => has((x) => x.messages, 'messages');
+  Subject<List<OutboxMessage>> get outboxMessages => has((x) => x.outboxMessages, 'outboxMessages');
   Subject<int> get middleMessage => has((x) => x.middleMessage, 'middleMessage');
   Subject<List<ZulipMessageContent>> get contents => has((x) => x.contents, 'contents');
   Subject<List<MessageListItem>> get items => has((x) => x.items, 'items');

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -173,7 +173,7 @@ void main() {
 
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
-      checkNotNotified(); // TODO once (it appears)
+      checkNotifiedOnce();
 
       await receiveMessage(eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]));
       check(store.outboxMessages).isEmpty();
@@ -188,7 +188,7 @@ void main() {
 
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
-      checkNotNotified(); // TODO once (it appears)
+      checkNotifiedOnce();
 
       await receiveMessage(eg.streamMessage(stream: stream, topic: 'foo'));
       check(store.outboxMessages).isEmpty();
@@ -202,7 +202,7 @@ void main() {
 
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
-      checkNotNotified(); // TODO once (it appears)
+      checkNotifiedOnce();
 
       // Wait till we reach at least [kSendMessageOfferRestoreWaitPeriod] after
       // the send request was initiated.
@@ -220,11 +220,11 @@ void main() {
         kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
-      checkNotNotified(); // TODO once (it appears)
+      checkNotifiedOnce();
 
       async.elapse(kSendMessageOfferRestoreWaitPeriod - kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waitPeriodExpired);
-      checkNotNotified(); // TODO once (it offers restore)
+      checkNotifiedOnce();
 
       await check(outboxMessageFailFuture).throws();
     }));
@@ -242,12 +242,12 @@ void main() {
         destination: streamDestination, content: 'content');
       async.elapse(kSendMessageOfferRestoreWaitPeriod);
       checkState().equals(OutboxMessageState.waitPeriodExpired);
-      checkNotNotified(); // TODO twice (it appears; it offers restore)
+      checkNotified(count: 2);
 
       // Wait till the [sendMessage] request succeeds.
       await future;
       checkState().equals(OutboxMessageState.waiting);
-      checkNotNotified(); // TODO once (it un-offers restore)
+      checkNotifiedOnce();
 
       // Wait till we reach at least [kSendMessageOfferRestoreWaitPeriod] after
       // returning to the waiting state.
@@ -267,7 +267,7 @@ void main() {
 
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
-        checkNotNotified(); // TODO once (it appears, offering restore)
+        checkNotifiedOnce();
 
         // Wait till we reach at least [kSendMessageOfferRestoreWaitPeriod] after
         // the send request was initiated.
@@ -284,11 +284,11 @@ void main() {
           kLocalEchoDebounceDuration + Duration(seconds: 1));
         async.elapse(kLocalEchoDebounceDuration);
         checkState().equals(OutboxMessageState.waiting);
-        checkNotNotified(); // TODO once (it appears)
+        checkNotifiedOnce();
 
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
-        checkNotNotified(); // TODO once (it offers restore)
+        checkNotifiedOnce();
       }));
 
       test('waitPeriodExpired -> failed', () => awaitFakeAsync((async) async {
@@ -296,11 +296,11 @@ void main() {
           kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
         async.elapse(kSendMessageOfferRestoreWaitPeriod);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
-        checkNotNotified(); // TODO twice (it appears; it offers restore)
+        checkNotified(count: 2);
 
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
-        checkNotNotified(); // TODO once (it shows failure text)
+        checkNotifiedOnce();
       }));
     });
 
@@ -339,7 +339,7 @@ void main() {
         await prepareOutboxMessage();
         async.elapse(kLocalEchoDebounceDuration);
         checkState().equals(OutboxMessageState.waiting);
-        checkNotNotified(); // TODO once (it appears)
+        checkNotifiedOnce();
 
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
@@ -353,7 +353,7 @@ void main() {
           kLocalEchoDebounceDuration + Duration(seconds: 1));
         async.elapse(kLocalEchoDebounceDuration);
         checkState().equals(OutboxMessageState.waiting);
-        checkNotNotified(); // TODO once (it appears)
+        checkNotifiedOnce();
 
         // Received the message event while the message is being sent.
         await receiveMessage();
@@ -374,7 +374,7 @@ void main() {
           kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
         async.elapse(kSendMessageOfferRestoreWaitPeriod);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
-        checkNotNotified(); // TODO twice (it appears; it offers restore)
+        checkNotified(count: 2);
 
         // Received the message event while the message is being sent.
         await receiveMessage();
@@ -395,18 +395,18 @@ void main() {
           kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
         async.elapse(kSendMessageOfferRestoreWaitPeriod);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
-        checkNotNotified(); // TODO twice (it appears; it offers restore)
+        checkNotified(count: 2);
 
         store.takeOutboxMessage(store.outboxMessages.keys.single);
         check(store.outboxMessages).isEmpty();
-        checkNotNotified(); // TODO once (it disappears)
+        checkNotifiedOnce();
       }));
 
       test('failed -> (delete) because event received', () => awaitFakeAsync((async) async {
         await prepareOutboxMessageToFailAfterDelay(Duration.zero);
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
-        checkNotNotified(); // TODO once (it appears, offering restore)
+        checkNotifiedOnce();
 
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
@@ -417,11 +417,11 @@ void main() {
         await prepareOutboxMessageToFailAfterDelay(Duration.zero);
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
-        checkNotNotified(); // TODO once (it appears, offering restore)
+        checkNotifiedOnce();
 
         store.takeOutboxMessage(store.outboxMessages.keys.single);
         check(store.outboxMessages).isEmpty();
-        checkNotNotified(); // TODO once (it disappears)
+        checkNotifiedOnce();
       }));
     });
 
@@ -463,13 +463,13 @@ void main() {
       await check(store.sendMessage(
         destination: StreamDestination(stream.streamId, eg.t('topic')),
         content: 'content')).throws();
-      checkNotNotified(); // TODO once (it appears, offering restore)
+      checkNotifiedOnce();
     }
 
     final localMessageIds = store.outboxMessages.keys.toList();
     store.takeOutboxMessage(localMessageIds.removeAt(5));
     check(store.outboxMessages).keys.deepEquals(localMessageIds);
-    checkNotNotified(); // TODO once (it disappears)
+    checkNotifiedOnce();
   });
 
   group('reconcileMessages', () {

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -169,32 +169,40 @@ void main() {
       await prepareOutboxMessage(destination: DmDestination(
         userIds: [eg.selfUser.userId, eg.otherUser.userId]));
       checkState().equals(OutboxMessageState.hidden);
+      checkNotNotified();
 
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified(); // TODO once (it appears)
 
       await receiveMessage(eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]));
       check(store.outboxMessages).isEmpty();
+      checkNotifiedOnce();
     }));
 
     test('smoke stream message: hidden -> waiting -> (delete)', () => awaitFakeAsync((async) async {
       await prepareOutboxMessage(destination: StreamDestination(
         stream.streamId, eg.t('foo')));
       checkState().equals(OutboxMessageState.hidden);
+      checkNotNotified();
 
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified(); // TODO once (it appears)
 
       await receiveMessage(eg.streamMessage(stream: stream, topic: 'foo'));
       check(store.outboxMessages).isEmpty();
+      checkNotifiedOnce();
     }));
 
     test('hidden -> waiting and never transition to waitPeriodExpired', () => awaitFakeAsync((async) async {
       await prepareOutboxMessage();
       checkState().equals(OutboxMessageState.hidden);
+      checkNotNotified();
 
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified(); // TODO once (it appears)
 
       // Wait till we reach at least [kSendMessageOfferRestoreWaitPeriod] after
       // the send request was initiated.
@@ -204,6 +212,7 @@ void main() {
       // The outbox message should stay in the waiting state;
       // it should not transition to waitPeriodExpired.
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified();
     }));
 
     test('waiting -> waitPeriodExpired', () => awaitFakeAsync((async) async {
@@ -211,9 +220,11 @@ void main() {
         kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
       async.elapse(kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified(); // TODO once (it appears)
 
       async.elapse(kSendMessageOfferRestoreWaitPeriod - kLocalEchoDebounceDuration);
       checkState().equals(OutboxMessageState.waitPeriodExpired);
+      checkNotNotified(); // TODO once (it offers restore)
 
       await check(outboxMessageFailFuture).throws();
     }));
@@ -231,10 +242,12 @@ void main() {
         destination: streamDestination, content: 'content');
       async.elapse(kSendMessageOfferRestoreWaitPeriod);
       checkState().equals(OutboxMessageState.waitPeriodExpired);
+      checkNotNotified(); // TODO twice (it appears; it offers restore)
 
       // Wait till the [sendMessage] request succeeds.
       await future;
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified(); // TODO once (it un-offers restore)
 
       // Wait till we reach at least [kSendMessageOfferRestoreWaitPeriod] after
       // returning to the waiting state.
@@ -243,15 +256,18 @@ void main() {
       // The outbox message should stay in the waiting state;
       // it should not transition to waitPeriodExpired.
       checkState().equals(OutboxMessageState.waiting);
+      checkNotNotified();
     }));
 
     group('… -> failed', () {
       test('hidden -> failed', () => awaitFakeAsync((async) async {
         await prepareOutboxMessageToFailAfterDelay(Duration.zero);
         checkState().equals(OutboxMessageState.hidden);
+        checkNotNotified();
 
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
+        checkNotNotified(); // TODO once (it appears, offering restore)
 
         // Wait till we reach at least [kSendMessageOfferRestoreWaitPeriod] after
         // the send request was initiated.
@@ -260,6 +276,7 @@ void main() {
         // The outbox message should stay in the failed state;
         // it should not transition to waitPeriodExpired.
         checkState().equals(OutboxMessageState.failed);
+        checkNotNotified();
       }));
 
       test('waiting -> failed', () => awaitFakeAsync((async) async {
@@ -267,9 +284,11 @@ void main() {
           kLocalEchoDebounceDuration + Duration(seconds: 1));
         async.elapse(kLocalEchoDebounceDuration);
         checkState().equals(OutboxMessageState.waiting);
+        checkNotNotified(); // TODO once (it appears)
 
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
+        checkNotNotified(); // TODO once (it offers restore)
       }));
 
       test('waitPeriodExpired -> failed', () => awaitFakeAsync((async) async {
@@ -277,9 +296,11 @@ void main() {
           kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
         async.elapse(kSendMessageOfferRestoreWaitPeriod);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
+        checkNotNotified(); // TODO twice (it appears; it offers restore)
 
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
+        checkNotNotified(); // TODO once (it shows failure text)
       }));
     });
 
@@ -287,9 +308,11 @@ void main() {
       test('hidden -> (delete) because event received', () => awaitFakeAsync((async) async {
         await prepareOutboxMessage();
         checkState().equals(OutboxMessageState.hidden);
+        checkNotNotified();
 
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
       }));
 
       test('hidden -> (delete) when event arrives before send request fails', () => awaitFakeAsync((async) async {
@@ -297,25 +320,30 @@ void main() {
         // the message event to arrive.
         await prepareOutboxMessageToFailAfterDelay(const Duration(seconds: 1));
         checkState().equals(OutboxMessageState.hidden);
+        checkNotNotified();
 
         // Received the message event while the message is being sent.
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
 
         // Complete the send request.  There should be no error despite
         // the send request failure, because the outbox message is not
         // in the store any more.
         await check(outboxMessageFailFuture).completes();
         async.elapse(const Duration(seconds: 1));
+        checkNotNotified();
       }));
 
       test('waiting -> (delete) because event received', () => awaitFakeAsync((async) async {
         await prepareOutboxMessage();
         async.elapse(kLocalEchoDebounceDuration);
         checkState().equals(OutboxMessageState.waiting);
+        checkNotNotified(); // TODO once (it appears)
 
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
       }));
 
       test('waiting -> (delete) when event arrives before send request fails', () => awaitFakeAsync((async) async {
@@ -325,15 +353,18 @@ void main() {
           kLocalEchoDebounceDuration + Duration(seconds: 1));
         async.elapse(kLocalEchoDebounceDuration);
         checkState().equals(OutboxMessageState.waiting);
+        checkNotNotified(); // TODO once (it appears)
 
         // Received the message event while the message is being sent.
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
 
         // Complete the send request.  There should be no error despite
         // the send request failure, because the outbox message is not
         // in the store any more.
         await check(outboxMessageFailFuture).completes();
+        checkNotNotified();
       }));
 
       test('waitPeriodExpired -> (delete) when event arrives before send request fails', () => awaitFakeAsync((async) async {
@@ -343,15 +374,18 @@ void main() {
           kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
         async.elapse(kSendMessageOfferRestoreWaitPeriod);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
+        checkNotNotified(); // TODO twice (it appears; it offers restore)
 
         // Received the message event while the message is being sent.
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
 
         // Complete the send request.  There should be no error despite
         // the send request failure, because the outbox message is not
         // in the store any more.
         await check(outboxMessageFailFuture).completes();
+        checkNotNotified();
       }));
 
       test('waitPeriodExpired -> (delete) because outbox message was taken', () => awaitFakeAsync((async) async {
@@ -361,27 +395,33 @@ void main() {
           kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
         async.elapse(kSendMessageOfferRestoreWaitPeriod);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
+        checkNotNotified(); // TODO twice (it appears; it offers restore)
 
         store.takeOutboxMessage(store.outboxMessages.keys.single);
         check(store.outboxMessages).isEmpty();
+        checkNotNotified(); // TODO once (it disappears)
       }));
 
       test('failed -> (delete) because event received', () => awaitFakeAsync((async) async {
         await prepareOutboxMessageToFailAfterDelay(Duration.zero);
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
+        checkNotNotified(); // TODO once (it appears, offering restore)
 
         await receiveMessage();
         check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
       }));
 
       test('failed -> (delete) because outbox message was taken', () => awaitFakeAsync((async) async {
         await prepareOutboxMessageToFailAfterDelay(Duration.zero);
         await check(outboxMessageFailFuture).throws();
         checkState().equals(OutboxMessageState.failed);
+        checkNotNotified(); // TODO once (it appears, offering restore)
 
         store.takeOutboxMessage(store.outboxMessages.keys.single);
         check(store.outboxMessages).isEmpty();
+        checkNotNotified(); // TODO once (it disappears)
       }));
     });
 
@@ -423,11 +463,13 @@ void main() {
       await check(store.sendMessage(
         destination: StreamDestination(stream.streamId, eg.t('topic')),
         content: 'content')).throws();
+      checkNotNotified(); // TODO once (it appears, offering restore)
     }
 
     final localMessageIds = store.outboxMessages.keys.toList();
     store.takeOutboxMessage(localMessageIds.removeAt(5));
     check(store.outboxMessages).keys.deepEquals(localMessageIds);
+    checkNotNotified(); // TODO once (it disappears)
   });
 
   group('reconcileMessages', () {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -15,6 +15,7 @@ import 'package:zulip/api/route/channels.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/actions.dart';
 import 'package:zulip/model/localizations.dart';
+import 'package:zulip/model/message.dart';
 import 'package:zulip/model/message_list.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
@@ -1622,6 +1623,42 @@ void main() {
       checkUser(users[2], isBot: false);
 
       debugNetworkImageHttpClientProvider = null;
+    });
+  });
+
+  group('OutboxMessageWithPossibleSender', () {
+    final stream = eg.stream();
+    final topic = 'topic';
+    final topicNarrow = eg.topicNarrow(stream.streamId, topic);
+    const content = 'outbox message content';
+
+    final contentInputFinder = find.byWidgetPredicate(
+      (widget) => widget is TextField && widget.controller is ComposeContentController);
+
+    Finder outboxMessageFinder = find.widgetWithText(
+      OutboxMessageWithPossibleSender, content, skipOffstage: true);
+
+    Future<void> sendMessageAndSucceed(WidgetTester tester, {
+      Duration delay = Duration.zero,
+    }) async {
+      connection.prepare(json: SendMessageResult(id: 1).toJson(), delay: delay);
+      await tester.enterText(contentInputFinder, content);
+      await tester.tap(find.byIcon(ZulipIcons.send));
+      await tester.pump(Duration.zero);
+    }
+
+    // State transitions are tested more thoroughly in
+    // test/model/message_test.dart .
+
+    testWidgets('hidden -> waiting, outbox message appear', (tester) async {
+      await setupMessageListPage(tester,
+        narrow: topicNarrow, streams: [stream],
+        messages: []);
+      await sendMessageAndSucceed(tester);
+      check(outboxMessageFinder).findsNothing();
+
+      await tester.pump(kLocalEchoDebounceDuration);
+      check(outboxMessageFinder).findsOne();
     });
   });
 


### PR DESCRIPTION
Here's a revised version of a substantive commit from #1453:

9c0b95568 msglist: Add and manage outbox message objects in message list view

That just leaves one more substantive commit from that PR:

1fa9f24c8 msglist: Support retrieving failed outbox message content