### PR TITLE
Sync translatable strings from v0.0.30 release

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -919,9 +919,9 @@
   "@errorNotificationOpenTitle": {
     "description": "Error title when notification opening fails"
   },
-  "errorNotificationOpenAccountMissing": "The account associated with this notification no longer exists.",
-  "@errorNotificationOpenAccountMissing": {
-    "description": "Error message when the account associated with the notification is not found"
+  "errorNotificationOpenAccountNotFound": "The account associated with this notification could not be found.",
+  "@errorNotificationOpenAccountNotFound": {
+    "description": "Error message when the account associated with the notification could not be found"
   },
   "errorReactionAddingFailedTitle": "Adding reaction failed",
   "@errorReactionAddingFailedTitle": {

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -132,6 +132,10 @@
   "@actionSheetOptionMarkAsUnread":  {
     "description": "Label for mark as unread button on action sheet."
   },
+  "actionSheetOptionHideMutedMessage": "Hide muted message again",
+  "@actionSheetOptionHideMutedMessage":  {
+    "description": "Label for hide muted message again button on action sheet."
+  },
   "actionSheetOptionShare": "Share",
   "@actionSheetOptionShare":  {
     "description": "Label for share button on action sheet."
@@ -381,6 +385,10 @@
   "@discardDraftForEditConfirmationDialogMessage": {
     "description": "Message for a confirmation dialog for discarding message text that was typed into the compose box, when editing a message."
   },
+  "discardDraftForMessageNotSentConfirmationDialogMessage": "When you restore a message not sent, the content that was previously in the compose box is discarded.",
+  "@discardDraftForMessageNotSentConfirmationDialogMessage": {
+    "description": "Message for a confirmation dialog when restoring a message not sent, for discarding message text that was typed into the compose box."
+  },
   "discardDraftConfirmationDialogConfirmButton": "Discard",
   "@discardDraftConfirmationDialogConfirmButton": {
     "description": "Label for the 'Discard' button on a confirmation dialog for discarding message text that was typed into the compose box."
@@ -400,6 +408,34 @@
   "composeBoxGenericContentHint": "Type a message",
   "@composeBoxGenericContentHint": {
     "description": "Hint text for content input when sending a message."
+  },
+  "newDmSheetBackButtonLabel": "Back",
+  "@newDmSheetBackButtonLabel": {
+    "description": "Label for the back button in the new DM sheet, allowing the user to return to the previous screen."
+  },
+  "newDmSheetNextButtonLabel": "Next",
+  "@newDmSheetNextButtonLabel": {
+    "description": "Label for the front button in the new DM sheet, if applicable, for navigation or action."
+  },
+  "newDmSheetScreenTitle": "New DM",
+  "@newDmSheetScreenTitle": {
+    "description": "Title displayed at the top of the new DM screen."
+  },
+  "newDmFabButtonLabel": "New DM",
+  "@newDmFabButtonLabel": {
+    "description": "Label for the floating action button (FAB) that opens the new DM sheet."
+  },
+  "newDmSheetSearchHintEmpty": "Add one or more users",
+  "@newDmSheetSearchHintEmpty": {
+    "description": "Hint text for the search bar when no users are selected"
+  },
+  "newDmSheetSearchHintSomeSelected": "Add another user…",
+  "@newDmSheetSearchHintSomeSelected": {
+    "description": "Hint text for the search bar when at least one user is selected"
+  },
+  "newDmSheetNoUsersFound": "No users found",
+  "@newDmSheetNoUsersFound": {
+    "description": "Message shown in the new DM sheet when no users match the search."
   },
   "composeBoxDmContentHint": "Message @{user}",
   "@composeBoxDmContentHint": {
@@ -872,6 +908,10 @@
   "@messageIsMovedLabel": {
     "description": "Label for a moved message. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)"
   },
+  "messageNotSentLabel": "MESSAGE NOT SENT",
+  "@messageNotSentLabel": {
+    "description": "Text on a message in the message list saying that a send message request failed. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)"
+  },
   "pollVoterNames": "({voterNames})",
   "@pollVoterNames": {
     "description": "The list of people who voted for a poll option, wrapped in parentheses.",
@@ -942,6 +982,18 @@
   "noEarlierMessages": "No earlier messages",
   "@noEarlierMessages": {
     "description": "Text to show at the start of a message list if there are no earlier messages."
+  },
+  "mutedSender": "Muted sender",
+  "@mutedSender": {
+    "description": "Name for a muted user to display in message list."
+  },
+  "revealButtonLabel": "Reveal message for muted sender",
+  "@revealButtonLabel": {
+    "description": "Label for the button revealing hidden message from a muted sender in message list."
+  },
+  "mutedUser": "Muted user",
+  "@mutedUser": {
+    "description": "Name for a muted user to display all over the app."
   },
   "scrollToBottomTooltip": "Scroll to bottom",
   "@scrollToBottomTooltip": {

--- a/assets/l10n/app_pl.arb
+++ b/assets/l10n/app_pl.arb
@@ -557,10 +557,6 @@
   "@errorNotificationOpenTitle": {
     "description": "Error title when notification opening fails"
   },
-  "errorNotificationOpenAccountMissing": "Konto związane z tym powiadomieniem już nie istnieje.",
-  "@errorNotificationOpenAccountMissing": {
-    "description": "Error message when the account associated with the notification is not found"
-  },
   "aboutPageOpenSourceLicenses": "Licencje otwartego źródła",
   "@aboutPageOpenSourceLicenses": {
     "description": "Item title in About Zulip page to navigate to Licenses page"

--- a/assets/l10n/app_ru.arb
+++ b/assets/l10n/app_ru.arb
@@ -287,10 +287,6 @@
   "@errorNotificationOpenTitle": {
     "description": "Error title when notification opening fails"
   },
-  "errorNotificationOpenAccountMissing": "Учетной записи, связанной с этим оповещением, больше нет.",
-  "@errorNotificationOpenAccountMissing": {
-    "description": "Error message when the account associated with the notification is not found"
-  },
   "switchAccountButton": "Сменить учетную запись",
   "@switchAccountButton": {
     "description": "Label for main-menu button leading to the choose-account page."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1367,11 +1367,11 @@ abstract class ZulipLocalizations {
   /// **'Failed to open notification'**
   String get errorNotificationOpenTitle;
 
-  /// Error message when the account associated with the notification is not found
+  /// Error message when the account associated with the notification could not be found
   ///
   /// In en, this message translates to:
-  /// **'The account associated with this notification no longer exists.'**
-  String get errorNotificationOpenAccountMissing;
+  /// **'The account associated with this notification could not be found.'**
+  String get errorNotificationOpenAccountNotFound;
 
   /// Error title when adding a message reaction fails
   ///

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -323,6 +323,12 @@ abstract class ZulipLocalizations {
   /// **'Mark as unread from here'**
   String get actionSheetOptionMarkAsUnread;
 
+  /// Label for hide muted message again button on action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide muted message again'**
+  String get actionSheetOptionHideMutedMessage;
+
   /// Label for share button on action sheet.
   ///
   /// In en, this message translates to:
@@ -649,6 +655,12 @@ abstract class ZulipLocalizations {
   /// **'When you edit a message, the content that was previously in the compose box is discarded.'**
   String get discardDraftForEditConfirmationDialogMessage;
 
+  /// Message for a confirmation dialog when restoring a message not sent, for discarding message text that was typed into the compose box.
+  ///
+  /// In en, this message translates to:
+  /// **'When you restore a message not sent, the content that was previously in the compose box is discarded.'**
+  String get discardDraftForMessageNotSentConfirmationDialogMessage;
+
   /// Label for the 'Discard' button on a confirmation dialog for discarding message text that was typed into the compose box.
   ///
   /// In en, this message translates to:
@@ -678,6 +690,48 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Type a message'**
   String get composeBoxGenericContentHint;
+
+  /// Label for the back button in the new DM sheet, allowing the user to return to the previous screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get newDmSheetBackButtonLabel;
+
+  /// Label for the front button in the new DM sheet, if applicable, for navigation or action.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get newDmSheetNextButtonLabel;
+
+  /// Title displayed at the top of the new DM screen.
+  ///
+  /// In en, this message translates to:
+  /// **'New DM'**
+  String get newDmSheetScreenTitle;
+
+  /// Label for the floating action button (FAB) that opens the new DM sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'New DM'**
+  String get newDmFabButtonLabel;
+
+  /// Hint text for the search bar when no users are selected
+  ///
+  /// In en, this message translates to:
+  /// **'Add one or more users'**
+  String get newDmSheetSearchHintEmpty;
+
+  /// Hint text for the search bar when at least one user is selected
+  ///
+  /// In en, this message translates to:
+  /// **'Add another user…'**
+  String get newDmSheetSearchHintSomeSelected;
+
+  /// Message shown in the new DM sheet when no users match the search.
+  ///
+  /// In en, this message translates to:
+  /// **'No users found'**
+  String get newDmSheetNoUsersFound;
 
   /// Hint text for content input when sending a message to one other person.
   ///
@@ -1301,6 +1355,12 @@ abstract class ZulipLocalizations {
   /// **'MOVED'**
   String get messageIsMovedLabel;
 
+  /// Text on a message in the message list saying that a send message request failed. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)
+  ///
+  /// In en, this message translates to:
+  /// **'MESSAGE NOT SENT'**
+  String get messageNotSentLabel;
+
   /// The list of people who voted for a poll option, wrapped in parentheses.
   ///
   /// In en, this message translates to:
@@ -1402,6 +1462,24 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'No earlier messages'**
   String get noEarlierMessages;
+
+  /// Name for a muted user to display in message list.
+  ///
+  /// In en, this message translates to:
+  /// **'Muted sender'**
+  String get mutedSender;
+
+  /// Label for the button revealing hidden message from a muted sender in message list.
+  ///
+  /// In en, this message translates to:
+  /// **'Reveal message for muted sender'**
+  String get revealButtonLabel;
+
+  /// Name for a muted user to display all over the app.
+  ///
+  /// In en, this message translates to:
+  /// **'Muted user'**
+  String get mutedUser;
 
   /// Tooltip for button to scroll to bottom.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -114,6 +114,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Share';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -711,6 +739,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get messageIsMovedLabel => 'MOVED';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -764,6 +795,15 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -747,8 +747,8 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Failed to open notification';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Adding reaction failed';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -114,6 +114,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Share';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -711,6 +739,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get messageIsMovedLabel => 'MOVED';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -764,6 +795,15 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -747,8 +747,8 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Failed to open notification';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Adding reaction failed';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -114,6 +114,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Share';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -711,6 +739,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get messageIsMovedLabel => 'MOVED';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -764,6 +795,15 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -747,8 +747,8 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Failed to open notification';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Adding reaction failed';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -747,8 +747,8 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Failed to open notification';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Adding reaction failed';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -114,6 +114,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Share';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -711,6 +739,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get messageIsMovedLabel => 'MOVED';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -764,6 +795,15 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -114,6 +114,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Share';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -711,6 +739,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get messageIsMovedLabel => 'MOVED';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -764,6 +795,15 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -747,8 +747,8 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Failed to open notification';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Adding reaction failed';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -119,6 +119,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Odtąd oznacz jako nieprzeczytane';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Udostępnij';
 
   @override
@@ -329,6 +332,10 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Miej na uwadze, że przechodząc do zmiany wiadomości wyczyścisz okno nowej wiadomości.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Odrzuć';
 
   @override
@@ -342,6 +349,27 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Wpisz wiadomość';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -720,6 +748,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get messageIsMovedLabel => 'PRZENIESIONO';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -775,6 +806,15 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'Brak historii';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Przewiń do dołu';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -757,8 +757,8 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Otwieranie powiadomienia bez powodzenia';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'Konto związane z tym powiadomieniem już nie istnieje.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Dodanie reakcji bez powodzenia';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -119,6 +119,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'Отметить как непрочитанные начиная отсюда';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Поделиться';
 
   @override
@@ -330,6 +333,10 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'При изменении сообщения текст из поля для редактирования удаляется.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Сбросить';
 
   @override
@@ -343,6 +350,27 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Ввести сообщение';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -724,6 +752,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get messageIsMovedLabel => 'ПЕРЕМЕЩЕНО';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -778,6 +809,15 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'Предшествующих сообщений нет';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Пролистать вниз';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -761,8 +761,8 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Не удалось открыть оповещения';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'Учетной записи, связанной с этим оповещением, больше нет.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Не удалось добавить реакцию';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -115,6 +115,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'Označiť ako neprečítané od tejto správy';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Zdielať';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -713,6 +741,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get messageIsMovedLabel => 'PRESUNUTÉ';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -766,6 +797,15 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -749,8 +749,8 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Nepodarilo sa otvoriť oznámenie';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Nepodarilo sa pridať reakciu';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -761,8 +761,8 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Не вдалося відкрити сповіщення';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'Обліковий запис, пов’язаний із цим сповіщенням, більше не існує.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Не вдалося додати реакцію';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -119,6 +119,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Позначити як непрочитане звідси';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Поширити';
 
   @override
@@ -331,6 +334,10 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -344,6 +351,27 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Ввести повідомлення';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -723,6 +751,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get messageIsMovedLabel => 'ПЕРЕМІЩЕНО';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -778,6 +809,15 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'Немає попередніх повідомлень';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Прокрутити вниз';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -747,8 +747,8 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get errorNotificationOpenTitle => 'Failed to open notification';
 
   @override
-  String get errorNotificationOpenAccountMissing =>
-      'The account associated with this notification no longer exists.';
+  String get errorNotificationOpenAccountNotFound =>
+      'The account associated with this notification could not be found.';
 
   @override
   String get errorReactionAddingFailedTitle => 'Adding reaction failed';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -114,6 +114,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get actionSheetOptionMarkAsUnread => 'Mark as unread from here';
 
   @override
+  String get actionSheetOptionHideMutedMessage => 'Hide muted message again';
+
+  @override
   String get actionSheetOptionShare => 'Share';
 
   @override
@@ -322,6 +325,10 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
       'When you edit a message, the content that was previously in the compose box is discarded.';
 
   @override
+  String get discardDraftForMessageNotSentConfirmationDialogMessage =>
+      'When you restore a message not sent, the content that was previously in the compose box is discarded.';
+
+  @override
   String get discardDraftConfirmationDialogConfirmButton => 'Discard';
 
   @override
@@ -335,6 +342,27 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
 
   @override
   String get composeBoxGenericContentHint => 'Type a message';
+
+  @override
+  String get newDmSheetBackButtonLabel => 'Back';
+
+  @override
+  String get newDmSheetNextButtonLabel => 'Next';
+
+  @override
+  String get newDmSheetScreenTitle => 'New DM';
+
+  @override
+  String get newDmFabButtonLabel => 'New DM';
+
+  @override
+  String get newDmSheetSearchHintEmpty => 'Add one or more users';
+
+  @override
+  String get newDmSheetSearchHintSomeSelected => 'Add another user…';
+
+  @override
+  String get newDmSheetNoUsersFound => 'No users found';
 
   @override
   String composeBoxDmContentHint(String user) {
@@ -711,6 +739,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get messageIsMovedLabel => 'MOVED';
 
   @override
+  String get messageNotSentLabel => 'MESSAGE NOT SENT';
+
+  @override
   String pollVoterNames(String voterNames) {
     return '($voterNames)';
   }
@@ -764,6 +795,15 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
 
   @override
   String get noEarlierMessages => 'No earlier messages';
+
+  @override
+  String get mutedSender => 'Muted sender';
+
+  @override
+  String get revealButtonLabel => 'Reveal message for muted sender';
+
+  @override
+  String get mutedUser => 'Muted user';
 
   @override
   String get scrollToBottomTooltip => 'Scroll to bottom';

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -507,7 +507,7 @@ class NotificationDisplayManager {
       final zulipLocalizations = ZulipLocalizations.of(context);
       showErrorDialog(context: context,
         title: zulipLocalizations.errorNotificationOpenTitle,
-        message: zulipLocalizations.errorNotificationOpenAccountMissing);
+        message: zulipLocalizations.errorNotificationOpenAccountNotFound);
       return null;
     }
 

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -1137,7 +1137,7 @@ void main() {
       check(pushedRoutes.single).isA<DialogRoute<void>>();
       await tester.tap(find.byWidget(checkErrorDialog(tester,
         expectedTitle: zulipLocalizations.errorNotificationOpenTitle,
-        expectedMessage: zulipLocalizations.errorNotificationOpenAccountMissing)));
+        expectedMessage: zulipLocalizations.errorNotificationOpenAccountNotFound)));
     });
 
     testWidgets('mismatching account', (tester) async {
@@ -1149,7 +1149,7 @@ void main() {
       check(pushedRoutes.single).isA<DialogRoute<void>>();
       await tester.tap(find.byWidget(checkErrorDialog(tester,
         expectedTitle: zulipLocalizations.errorNotificationOpenTitle,
-        expectedMessage: zulipLocalizations.errorNotificationOpenAccountMissing)));
+        expectedMessage: zulipLocalizations.errorNotificationOpenAccountNotFound)));
     });
 
     testWidgets('find account among several', (tester) async {


### PR DESCRIPTION
This will enable our translation contributors to start translating these ahead of the upcoming launch, even though the features that use them aren't yet merged to main.

Related issue: #276 
