### PR TITLE
test: Make home-page tests robust to changes in route animation duration

### DIFF
--- a/test/test_navigation.dart
+++ b/test/test_navigation.dart
@@ -6,12 +6,18 @@ import 'package:flutter/widgets.dart';
 
 /// A trivial observer for testing the navigator.
 class TestNavigatorObserver extends NavigatorObserver {
+  void Function(Route<dynamic> topRoute, Route<dynamic>? previousTopRoute)? onChangedTop;
   void Function(Route<dynamic> route, Route<dynamic>? previousRoute)? onPushed;
   void Function(Route<dynamic> route, Route<dynamic>? previousRoute)? onPopped;
   void Function(Route<dynamic> route, Route<dynamic>? previousRoute)? onRemoved;
   void Function(Route<dynamic>? route, Route<dynamic>? previousRoute)? onReplaced;
   void Function(Route<dynamic> route, Route<dynamic>? previousRoute)? onStartUserGesture;
   void Function()? onStopUserGesture;
+
+  @override
+  void didChangeTop(Route<dynamic> topRoute, Route<dynamic>? previousTopRoute) {
+    onChangedTop?.call(topRoute, previousTopRoute);
+  }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -138,15 +138,9 @@ void main () {
   group('menu', () {
     final designVariables = DesignVariables.light;
 
-    final inboxMenuIconFinder = find.descendant(
-      of: find.byType(BottomSheet),
-      matching: find.byIcon(ZulipIcons.inbox));
-    final channelsMenuIconFinder = find.descendant(
-      of: find.byType(BottomSheet),
-      matching: find.byIcon(ZulipIcons.hash_italic));
-    final combinedFeedMenuIconFinder = find.descendant(
-      of: find.byType(BottomSheet),
-      matching: find.byIcon(ZulipIcons.message_feed));
+    final inboxMenuIconFinder = find.byIcon(ZulipIcons.inbox);
+    final channelsMenuIconFinder = find.byIcon(ZulipIcons.hash_italic);
+    final combinedFeedMenuIconFinder = find.byIcon(ZulipIcons.message_feed);
 
     Future<void> tapOpenMenu(WidgetTester tester) async {
       await tester.tap(find.byIcon(ZulipIcons.menu));
@@ -156,12 +150,18 @@ void main () {
     }
 
     void checkIconSelected(WidgetTester tester, Finder finder) {
-      check(tester.widget(finder)).isA<Icon>().color.isNotNull()
+      final widget = tester.widget(find.descendant(
+        of: find.byType(BottomSheet),
+        matching: finder));
+      check(widget).isA<Icon>().color.isNotNull()
         .isSameColorAs(designVariables.iconSelected);
     }
 
     void checkIconNotSelected(WidgetTester tester, Finder finder) {
-      check(tester.widget(finder)).isA<Icon>().color.isNotNull()
+      final widget = tester.widget(find.descendant(
+        of: find.byType(BottomSheet),
+        matching: finder));
+      check(widget).isA<Icon>().color.isNotNull()
         .isSameColorAs(designVariables.icon);
     }
 
@@ -192,7 +192,9 @@ void main () {
       check(find.byType(InboxPageBody)).findsOne();
       check(find.byType(SubscriptionListPageBody)).findsNothing();
 
-      await tester.tap(channelsMenuIconFinder);
+      await tester.tap(find.descendant(
+        of: find.byType(BottomSheet),
+        matching: channelsMenuIconFinder));
       await tester.pump(Duration.zero); // tap the button
       await tester.pump(const Duration(milliseconds: 250)); // wait for animation
       check(find.byType(BottomSheet)).findsNothing();
@@ -208,7 +210,9 @@ void main () {
       await prepare(tester);
       await tapOpenMenu(tester);
 
-      await tester.tap(channelsMenuIconFinder);
+      await tester.tap(find.descendant(
+        of: find.byType(BottomSheet),
+        matching: channelsMenuIconFinder));
       await tester.pump(Duration.zero); // tap the button
       await tester.pump(const Duration(milliseconds: 250)); // wait for animation
       check(find.byType(BottomSheet)).findsNothing();
@@ -237,7 +241,9 @@ void main () {
 
       connection.prepare(json: eg.newestGetMessagesResult(
         foundOldest: true, messages: [eg.streamMessage()]).toJson());
-      await tester.tap(combinedFeedMenuIconFinder);
+      await tester.tap(find.descendant(
+        of: find.byType(BottomSheet),
+        matching: combinedFeedMenuIconFinder));
       await tester.pump(Duration.zero); // tap the button
       await tester.pump(const Duration(milliseconds: 250)); // wait for animation
 

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -336,7 +336,7 @@ void main () {
       checkOnLoadingPage();
     }
 
-    Future<void> tapChooseAccount(WidgetTester tester) async {
+    Future<void> tapTryAnotherAccount(WidgetTester tester) async {
       await tester.tap(find.text('Try another account'));
       await tester.pump(Duration.zero); // tap the button
       await tester.pump(const Duration(milliseconds: 250)); // wait for animation
@@ -377,7 +377,7 @@ void main () {
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       await prepare(tester);
       await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
 
       await tester.tap(find.byType(BackButton));
       await tester.pump(Duration.zero); // tap the button
@@ -392,7 +392,7 @@ void main () {
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       await prepare(tester);
       await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
 
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration * 2;
       await chooseAccountWithEmail(tester, eg.otherAccount.email);
@@ -410,7 +410,7 @@ void main () {
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       await prepare(tester);
       await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
 
       // While still loading, choose a different account.
       await chooseAccountWithEmail(tester, eg.otherAccount.email);
@@ -432,7 +432,7 @@ void main () {
 
       await tester.pump(kTryAnotherAccountWaitPeriod);
       // While still loading the first account, choose a different account.
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
       await chooseAccountWithEmail(tester, eg.otherAccount.email);
       // User cannot go back because the navigator stack
       // was cleared after choosing an account.
@@ -443,7 +443,7 @@ void main () {
 
       await tester.pump(kTryAnotherAccountWaitPeriod);
       // While still loading the second account, choose a different account.
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
       await chooseAccountWithEmail(tester, thirdAccount.email);
       // User cannot go back because the navigator stack
       // was cleared after choosing an account.
@@ -460,7 +460,7 @@ void main () {
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       await prepare(tester);
       await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
 
       // Stall while on ChoooseAccountPage so that the account finished loading.
       await tester.pump(loadPerAccountDuration);
@@ -476,7 +476,7 @@ void main () {
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       await prepare(tester);
       await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapChooseAccount(tester);
+      await tapTryAnotherAccount(tester);
 
       // Stall while on ChoooseAccountPage so that the account finished loading.
       await tester.pump(loadPerAccountDuration);

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -291,8 +291,12 @@ void main () {
       await tapButtonAndAwaitTransition(tester, combinedFeedMenuIconFinder);
 
       // When we go back to the home page, the menu sheet should be gone.
+      final topBeforePop = topRoute;
+      check(topBeforePop).isNotNull().isA<MaterialAccountWidgetRoute>()
+        .page.isA<MessageListPage>().initNarrow.equals(CombinedFeedNarrow());
       (await ZulipApp.navigator).pop();
-      await tester.pump(const Duration(milliseconds: 350)); // wait for pop animation
+      await tester.pump((topBeforePop as TransitionRoute).reverseTransitionDuration);
+
       check(find.byType(BottomSheet)).findsNothing();
     });
 

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -128,10 +128,10 @@ void main () {
         foundOldest: true, messages: []).toJson());
       await tester.tap(find.byIcon(ZulipIcons.message_feed));
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 250));
       check(pushedRoutes).single.isA<WidgetRoute>().page
         .isA<MessageListPage>()
         .initNarrow.equals(const CombinedFeedNarrow());
+      await tester.pump(Duration.zero); // message-list fetch
     });
   });
 


### PR DESCRIPTION
This would fix some tests to allow an upstream change to land.

Discussion; see Greg's comment: https://github.com/flutter/flutter/pull/165832#issuecomment-2931857108
> We definitely have some tests in Zulip that wait a fixed number of ms when what they really want is "until the page transition finishes", and the real point of the test doesn't care whether that takes 300ms or 800ms or some other value. (I'd expect Zulip to be representative of a lot of apps out there in having some tests of this kind.) So where that's the case, the test would be cleaner if there were some value it could refer to instead.
> 
> It might be tricky to specify the value as a constant, though — different transitions may take different durations, right? So maybe the API that's needed is some way to look up the duration (or the remaining duration?) of the page transition that's currently in progress, or perhaps to get a Future that will complete when the transition finishes.

There are more places we use hard-coded durations, but those don't seem to be affected—the four test failures are all in `home_test.dart`.