### PR TITLE
home [nfc]: Clean up some dead safe-area code from before bottom-tabs

### DIFF
--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -168,9 +168,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         message: zulipLocalizations.inboxEmptyPlaceholder);
     }
 
-    return SafeArea(
-      // Don't pad the bottom here; we want the list content to do that.
-      bottom: false,
+    return SafeArea( // horizontal insets
       child: StickyHeaderListView.builder(
         itemCount: sections.length,
         itemBuilder: (context, index) {

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -64,9 +64,7 @@ class _RecentDmConversationsPageBodyState extends State<RecentDmConversationsPag
           PageBodyEmptyContentPlaceholder(
             message: zulipLocalizations.recentDmConversationsEmptyPlaceholder)
         else
-          SafeArea(
-            // Don't pad the bottom here; we want the list content to do that.
-            bottom: false,
+          SafeArea( // horizontal insets
             child: ListView.builder(
               padding: EdgeInsets.only(bottom: 90),
               itemCount: sorted.length,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -101,9 +101,7 @@ class _SubscriptionListPageBodyState extends State<SubscriptionListPageBody> wit
         message: zulipLocalizations.channelsEmptyPlaceholder);
     }
 
-    return SafeArea(
-      // Don't pad the bottom here; we want the list content to do that.
-      bottom: false,
+    return SafeArea( // horizontal insets
       child: CustomScrollView(
         slivers: [
           if (pinned.isNotEmpty) ...[
@@ -116,9 +114,6 @@ class _SubscriptionListPageBodyState extends State<SubscriptionListPageBody> wit
           ],
 
           // TODO(#188): add button leading to "All Streams" page with ability to subscribe
-
-          // This ensures last item in scrollable can settle in an unobstructed area.
-          const SliverSafeArea(sliver: SliverToBoxAdapter(child: SizedBox.shrink())),
         ]));
   }
 }


### PR DESCRIPTION
The responsibility for consuming the bottom inset is now external to all of these *PageBody widgets; it's handled by
Scaffold.bottomNavigationBar. So we don't need to forward a bottom-inset value down to descendants
(via `SafeArea.bottom: false`), and we don't need to add widgets to pad the bottom inset; the bottom-inset height in all these places is zero.