### PR TITLE
home: Add placeholder text for empty Inbox, Channels, and Direct messages

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -781,6 +781,10 @@
   "@inboxPageTitle": {
     "description": "Title for the page with unreads."
   },
+  "inboxEmptyPlaceholder": "There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.",
+  "@inboxEmptyPlaceholder": {
+    "description": "Centered text on the 'Inbox' page saying that there is no content to show."
+  },
   "recentDmConversationsPageTitle": "Direct messages",
   "@recentDmConversationsPageTitle": {
     "description": "Title for the page with a list of DM conversations."
@@ -788,6 +792,10 @@
   "recentDmConversationsSectionHeader": "Direct messages",
   "@recentDmConversationsSectionHeader": {
     "description": "Heading for direct messages section on the 'Inbox' message view."
+  },
+  "recentDmConversationsEmptyPlaceholder": "You have no direct messages yet! Why not start the conversation?",
+  "@recentDmConversationsEmptyPlaceholder": {
+    "description": "Centered text on the 'Direct messages' page saying that there is no content to show."
   },
   "combinedFeedPageTitle": "Combined feed",
   "@combinedFeedPageTitle": {
@@ -804,6 +812,10 @@
   "channelsPageTitle": "Channels",
   "@channelsPageTitle": {
     "description": "Title for the page with a list of subscribed channels."
+  },
+  "channelsEmptyPlaceholder": "You are not subscribed to any channels yet.",
+  "@channelsEmptyPlaceholder": {
+    "description": "Centered text on the 'Channels' page saying that there is no content to show."
   },
   "mainMenuMyProfile": "My profile",
   "@mainMenuMyProfile": {
@@ -832,10 +844,6 @@
   "unpinnedSubscriptionsLabel": "Unpinned",
   "@unpinnedSubscriptionsLabel": {
     "description": "Label for the list of unpinned subscribed channels."
-  },
-  "subscriptionListNoChannels": "No channels found",
-  "@subscriptionListNoChannels": {
-    "description": "Text to display on subscribed-channels page when there are no subscribed channels."
   },
   "notifSelfUser": "You",
   "@notifSelfUser": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1181,6 +1181,12 @@ abstract class ZulipLocalizations {
   /// **'Inbox'**
   String get inboxPageTitle;
 
+  /// Centered text on the 'Inbox' page saying that there is no content to show.
+  ///
+  /// In en, this message translates to:
+  /// **'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.'**
+  String get inboxEmptyPlaceholder;
+
   /// Title for the page with a list of DM conversations.
   ///
   /// In en, this message translates to:
@@ -1192,6 +1198,12 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Direct messages'**
   String get recentDmConversationsSectionHeader;
+
+  /// Centered text on the 'Direct messages' page saying that there is no content to show.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no direct messages yet! Why not start the conversation?'**
+  String get recentDmConversationsEmptyPlaceholder;
 
   /// Page title for the 'Combined feed' message view.
   ///
@@ -1216,6 +1228,12 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Channels'**
   String get channelsPageTitle;
+
+  /// Centered text on the 'Channels' page saying that there is no content to show.
+  ///
+  /// In en, this message translates to:
+  /// **'You are not subscribed to any channels yet.'**
+  String get channelsEmptyPlaceholder;
 
   /// Label for main-menu button leading to the user's own profile.
   ///
@@ -1252,12 +1270,6 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Unpinned'**
   String get unpinnedSubscriptionsLabel;
-
-  /// Text to display on subscribed-channels page when there are no subscribed channels.
-  ///
-  /// In en, this message translates to:
-  /// **'No channels found'**
-  String get subscriptionListNoChannels;
 
   /// Display name for the user themself, to show after replying in an Android notification
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -640,10 +640,18 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -656,6 +664,10 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Channels';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'My profile';
@@ -682,9 +694,6 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'You';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -640,10 +640,18 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -656,6 +664,10 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Channels';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'My profile';
@@ -682,9 +694,6 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'You';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -640,10 +640,18 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -656,6 +664,10 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Channels';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'My profile';
@@ -682,9 +694,6 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'You';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -640,10 +640,18 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -656,6 +664,10 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Channels';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'My profile';
@@ -682,9 +694,6 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'You';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -640,10 +640,18 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -656,6 +664,10 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Channels';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'My profile';
@@ -682,9 +694,6 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'You';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -649,10 +649,18 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get inboxPageTitle => 'Odebrane';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Wiadomości bezpośrednie';
 
   @override
   String get recentDmConversationsSectionHeader => 'Wiadomości bezpośrednie';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Mieszany widok';
@@ -665,6 +673,10 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Kanały';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'Mój profil';
@@ -691,9 +703,6 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Odpięte';
-
-  @override
-  String get subscriptionListNoChannels => 'Nie odnaleziono kanałów';
 
   @override
   String get notifSelfUser => 'Ty';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -653,10 +653,18 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get inboxPageTitle => 'Входящие';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Личные сообщения';
 
   @override
   String get recentDmConversationsSectionHeader => 'Личные сообщения';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Объединенная лента';
@@ -669,6 +677,10 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Каналы';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'Мой профиль';
@@ -695,9 +707,6 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Откреплены';
-
-  @override
-  String get subscriptionListNoChannels => 'Каналы не найдены';
 
   @override
   String get notifSelfUser => 'Вы';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -642,10 +642,18 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Priama správa';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Zlúčený kanál';
@@ -658,6 +666,10 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Kanály';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'Môj profil';
@@ -684,9 +696,6 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'Ty';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -652,10 +652,18 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get inboxPageTitle => 'Вхідні';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Особисті повідомлення';
 
   @override
   String get recentDmConversationsSectionHeader => 'Особисті повідомлення';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Об\'єднана стрічка';
@@ -668,6 +676,10 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Канали';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'Мій профіль';
@@ -694,9 +706,6 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Відкріплені';
-
-  @override
-  String get subscriptionListNoChannels => 'Канали не знайдено';
 
   @override
   String get notifSelfUser => 'Ви';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -640,10 +640,18 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
+  String get inboxEmptyPlaceholder =>
+      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholder =>
+      'You have no direct messages yet! Why not start the conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -656,6 +664,10 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
 
   @override
   String get channelsPageTitle => 'Channels';
+
+  @override
+  String get channelsEmptyPlaceholder =>
+      'You are not subscribed to any channels yet.';
 
   @override
   String get mainMenuMyProfile => 'My profile';
@@ -682,9 +694,6 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
 
   @override
   String get unpinnedSubscriptionsLabel => 'Unpinned';
-
-  @override
-  String get subscriptionListNoChannels => 'No channels found';
 
   @override
   String get notifSelfUser => 'You';

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -148,6 +148,40 @@ class _HomePageState extends State<HomePage> {
   }
 }
 
+/// A "no content here" message, for the Inbox, Subscriptions, and DMs pages.
+///
+/// This should go near the root of the "page body"'s widget subtree.
+/// In particular, it handles the horizontal device insets.
+/// (The vertical insets are handled externally, by the app bar and bottom nav.)
+class PageBodyEmptyContentPlaceholder extends StatelessWidget {
+  const PageBodyEmptyContentPlaceholder({super.key, required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    return SafeArea(
+      minimum: EdgeInsets.symmetric(horizontal: 24),
+      child: Padding(
+        padding: EdgeInsets.only(top: 48, bottom: 16),
+        child: Align(
+          alignment: Alignment.topCenter,
+          // TODO leading and trailing elements, like in Figma (given as SVGs):
+          //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=5957-167736&m=dev
+          child: Text(
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: designVariables.labelSearchPrompt,
+              fontSize: 17,
+              height: 23 / 17,
+            ).merge(weightVariableTextStyle(context, wght: 500)),
+            message))));
+  }
+}
+
+
 const kTryAnotherAccountWaitPeriod = Duration(seconds: 5);
 
 class _LoadingPlaceholderPage extends StatefulWidget {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -6,6 +6,7 @@ import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
 import 'action_sheet.dart';
+import 'home.dart';
 import 'icons.dart';
 import 'message_list.dart';
 import 'sticky_header.dart';
@@ -82,6 +83,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final store = PerAccountStoreWidget.of(context);
     final subscriptions = store.subscriptions;
 
@@ -158,6 +160,12 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         return bLastUnreadId.compareTo(aLastUnreadId);
       });
       sections.add(_StreamSectionData(streamId, countInStream, streamHasMention, topicItems));
+    }
+
+    if (sections.isEmpty) {
+      return PageBodyEmptyContentPlaceholder(
+        // TODO(#315) add e.g. "You might be interested in recent conversations."
+        message: zulipLocalizations.inboxEmptyPlaceholder);
     }
 
     return SafeArea(

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
+import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
 import 'content.dart';
+import 'home.dart';
 import 'icons.dart';
 import 'message_list.dart';
 import 'store.dart';
@@ -48,7 +50,14 @@ class _RecentDmConversationsPageBodyState extends State<RecentDmConversationsPag
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final sorted = model!.sorted;
+
+    if (sorted.isEmpty) {
+      return PageBodyEmptyContentPlaceholder(
+        message: zulipLocalizations.recentDmConversationsEmptyPlaceholder);
+    }
+
     return SafeArea(
       // Don't pad the bottom here; we want the list content to do that.
       bottom: false,

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -5,6 +5,7 @@ import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import '../model/unreads.dart';
 import 'action_sheet.dart';
+import 'home.dart';
 import 'icons.dart';
 import 'message_list.dart';
 import 'store.dart';
@@ -94,13 +95,17 @@ class _SubscriptionListPageBodyState extends State<SubscriptionListPageBody> wit
     _sortSubs(pinned);
     _sortSubs(unpinned);
 
+    if (pinned.isEmpty && unpinned.isEmpty) {
+      return PageBodyEmptyContentPlaceholder(
+        // TODO(#188) add e.g. "Go to 'All channels' and join some of them."
+        message: zulipLocalizations.channelsEmptyPlaceholder);
+    }
+
     return SafeArea(
       // Don't pad the bottom here; we want the list content to do that.
       bottom: false,
       child: CustomScrollView(
         slivers: [
-          if (pinned.isEmpty && unpinned.isEmpty)
-            const _NoSubscriptionsItem(),
           if (pinned.isNotEmpty) ...[
             _SubscriptionListHeader(label: zulipLocalizations.pinnedSubscriptionsLabel),
             _SubscriptionList(unreadsModel: unreadsModel, subscriptions: pinned),
@@ -115,27 +120,6 @@ class _SubscriptionListPageBodyState extends State<SubscriptionListPageBody> wit
           // This ensures last item in scrollable can settle in an unobstructed area.
           const SliverSafeArea(sliver: SliverToBoxAdapter(child: SizedBox.shrink())),
         ]));
-  }
-}
-
-class _NoSubscriptionsItem extends StatelessWidget {
-  const _NoSubscriptionsItem();
-
-  @override
-  Widget build(BuildContext context) {
-    final designVariables = DesignVariables.of(context);
-    final zulipLocalizations = ZulipLocalizations.of(context);
-
-    return SliverToBoxAdapter(
-      child: Padding(
-        padding: const EdgeInsets.all(10),
-        child: Text(zulipLocalizations.subscriptionListNoChannels,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: designVariables.subscriptionListHeaderText,
-            fontSize: 18,
-            height: (20 / 18),
-          ))));
   }
 }
 

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -164,6 +164,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     labelCounterUnread: const Color(0xff222222),
     labelEdited: const HSLColor.fromAHSL(0.35, 0, 0, 0).toColor(),
     labelMenuButton: const Color(0xff222222),
+    labelSearchPrompt: const Color(0xff000000).withValues(alpha: 0.5),
     mainBackground: const Color(0xfff0f0f0),
     textInput: const Color(0xff000000),
     title: const Color(0xff1a1a1a),
@@ -225,6 +226,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     labelCounterUnread: const Color(0xffffffff).withValues(alpha: 0.7),
     labelEdited: const HSLColor.fromAHSL(0.35, 0, 0, 1).toColor(),
     labelMenuButton: const Color(0xffffffff).withValues(alpha: 0.85),
+    labelSearchPrompt: const Color(0xffffffff).withValues(alpha: 0.5),
     mainBackground: const Color(0xff1d1d1d),
     textInput: const Color(0xffffffff).withValues(alpha: 0.9),
     title: const Color(0xffffffff).withValues(alpha: 0.9),
@@ -294,6 +296,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.labelCounterUnread,
     required this.labelEdited,
     required this.labelMenuButton,
+    required this.labelSearchPrompt,
     required this.mainBackground,
     required this.textInput,
     required this.title,
@@ -364,6 +367,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color labelCounterUnread;
   final Color labelEdited;
   final Color labelMenuButton;
+  final Color labelSearchPrompt;
   final Color mainBackground;
   final Color textInput;
   final Color title;
@@ -429,6 +433,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? labelCounterUnread,
     Color? labelEdited,
     Color? labelMenuButton,
+    Color? labelSearchPrompt,
     Color? mainBackground,
     Color? textInput,
     Color? title,
@@ -489,6 +494,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       labelCounterUnread: labelCounterUnread ?? this.labelCounterUnread,
       labelEdited: labelEdited ?? this.labelEdited,
       labelMenuButton: labelMenuButton ?? this.labelMenuButton,
+      labelSearchPrompt: labelSearchPrompt ?? this.labelSearchPrompt,
       mainBackground: mainBackground ?? this.mainBackground,
       textInput: textInput ?? this.textInput,
       title: title ?? this.title,
@@ -556,6 +562,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       labelCounterUnread: Color.lerp(labelCounterUnread, other.labelCounterUnread, t)!,
       labelEdited: Color.lerp(labelEdited, other.labelEdited, t)!,
       labelMenuButton: Color.lerp(labelMenuButton, other.labelMenuButton, t)!,
+      labelSearchPrompt: Color.lerp(labelSearchPrompt, other.labelSearchPrompt, t)!,
       mainBackground: Color.lerp(mainBackground, other.mainBackground, t)!,
       textInput: Color.lerp(textInput, other.textInput, t)!,
       title: Color.lerp(title, other.title, t)!,

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -196,6 +196,7 @@ void main() {
   group('InboxPage', () {
     testWidgets('page builds; empty', (tester) async {
       await setupPage(tester, unreadMessages: []);
+      check(find.textContaining('There are no unread messages in your inbox.')).findsOne();
     });
 
     // TODO more checks: ordering, etc.

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -1,6 +1,7 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
@@ -67,6 +68,12 @@ void main() {
     Finder findConversationItem(Narrow narrow) => find.byWidgetPredicate(
       (widget) => widget is RecentDmConversationsItem && widget.narrow == narrow,
     );
+
+    testWidgets('appearance when empty', (tester) async {
+      await setupPage(tester, users: [], dmMessages: []);
+      check(find.text('You have no direct messages yet! Why not start the conversation?'))
+        .findsOne();
+    });
 
     testWidgets('page builds; conversations appear in order', (tester) async {
       final user1 = eg.user(userId: 1);

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -57,11 +57,12 @@ void main() {
     return find.byType(SubscriptionItem).evaluate().length;
   }
 
-  testWidgets('smoke', (tester) async {
+  testWidgets('empty', (tester) async {
     await setupStreamListPage(tester, subscriptions: []);
     check(getItemCount()).equals(0);
     check(isPinnedHeaderInTree()).isFalse();
     check(isUnpinnedHeaderInTree()).isFalse();
+    check(find.text('You are not subscribed to any channels yet.')).findsOne();
   });
 
   testWidgets('basic subscriptions', (tester) async {


### PR DESCRIPTION
The "Direct messages" part of this was requested as part of #127 new-DM: it's item 0 in https://github.com/zulip/zulip-flutter/pull/1322#issuecomment-2917492437 . This should block on the rest of #127, because the empty "Direct messages" placeholder says "Why not start the conversation?", and there's no way to do that pre-#127.

Screenshots coming soon.

cc @alya

-----

The Figma has some graphics on all of these, but we'll leave that for later: see issue #1551.

Fixes: #385
Fixes: #386