### PR TITLE
settings [nfc]: Suppress some new deprecation warnings

### DIFF
--- a/lib/widgets/settings.dart
+++ b/lib/widgets/settings.dart
@@ -53,7 +53,10 @@ class _ThemeSetting extends StatelessWidget {
               themeSetting: themeSettingOption,
               zulipLocalizations: zulipLocalizations)),
             value: themeSettingOption,
+            // TODO(#1545) stop using the deprecated members
+            // ignore: deprecated_member_use
             groupValue: globalSettings.themeSetting,
+            // ignore: deprecated_member_use
             onChanged: (newValue) => _handleChange(context, newValue)),
       ]);
   }

--- a/test/flutter_checks.dart
+++ b/test/flutter_checks.dart
@@ -251,5 +251,7 @@ extension SwitchListTileChecks<T> on Subject<SwitchListTile> {
 }
 
 extension RadioListTileChecks<T> on Subject<RadioListTile<T>> {
+  // TODO(#1545) stop using the deprecated member
+  // ignore: deprecated_member_use
   Subject<bool> get checked => has((x) => x.checked, 'checked');
 }


### PR DESCRIPTION
See #1546 for a PR that would resolve them, and why we're not doing that just now (it would require upgrading Flutter past a breaking change).