### PR TITLE
notif: Use a different channel ID from previous values of zulip-mobile

### DIFF
--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -37,11 +37,12 @@ enum NotificationSound {
 class NotificationChannelManager {
   /// The channel ID we use for our one notification channel, which we use for
   /// all notifications.
-  // TODO(launch) check this doesn't match zulip-mobile's current or previous
-  //   channel IDs
-  // Previous values: 'messages-1'
+  // Previous values from Zulip Flutter Beta:
+  //   'messages-1'
+  // Previous values from Zulip Mobile:
+  //   'default', "messages-1', (alpha-only: 'messages-2'), 'messages-3'
   @visibleForTesting
-  static const kChannelId = 'messages-2';
+  static const kChannelId = 'messages-4';
 
   @visibleForTesting
   static const kDefaultNotificationSound = NotificationSound.chime3;


### PR DESCRIPTION
Previous values list is sourced from here:
      https://github.com/zulip/zulip-mobile/blob/eb8505c4a/android/app/src/main/java/com/zulipmobile/notifications/NotificationChannelManager.kt#L22-L24
