### PR TITLE
More error tolerance in migrating legacy data

### DIFF
--- a/lib/model/legacy_app_data.dart
+++ b/lib/model/legacy_app_data.dart
@@ -272,9 +272,13 @@ class LegacyAppDatabase {
       // Not sure how newlines get there into the data; but empirically
       // they do, after each 76 characters of `encodedSplit`.
       final encoded = encodedSplit.replaceAll('\n', '');
-      final compressedBytes = base64Decode(encoded);
-      final uncompressedBytes = zlib.decoder.convert(compressedBytes);
-      return utf8.decode(uncompressedBytes);
+      try {
+        final compressedBytes = base64Decode(encoded);
+        final uncompressedBytes = zlib.decoder.convert(compressedBytes);
+        return utf8.decode(uncompressedBytes);
+      } catch (_) {
+        return null; // TODO(log)
+      }
     }
     return item;
   }


### PR DESCRIPTION
In particular, if the legacy app's account list contains multiple entries with the same realm and user ID (though different emails), we'll drop all but the most-recently-used one because this app's accounts table keeps (realmUrl, userId) unique. With this change, we still drop the duplicates, but we catch the exception and proceed smoothly to the next account in the list.

Ideally these changes would be tested. We'll leave that as part of the followup issue #1593, which covers this whole file.
