### PR TITLE
KaTeX(5/n): Handle 'position' & 'top' property in KaTeX span inline style

### DIFF
--- a/lib/widgets/katex.dart
+++ b/lib/widgets/katex.dart
@@ -96,10 +96,10 @@ class _KatexSpan extends StatelessWidget {
     }
 
     final styles = node.styles;
-
-    // Currently, we expect `top` to be only present with the
-    // vlist inner row span, and parser handles that explicitly.
-    assert(styles.topEm == null);
+    if (styles.topEm != null) {
+      // The meaning of `top` would be different without `position: relative`.
+      assert(styles.position == KatexSpanPosition.relative);
+    }
 
     final fontFamily = styles.fontFamily;
     final fontSize = switch (styles.fontSizeEm) {
@@ -181,6 +181,18 @@ class _KatexSpan extends StatelessWidget {
     if (margin != null) {
       assert(margin.isNonNegative);
       widget = Padding(padding: margin, child: widget);
+    }
+
+    switch (styles.position) {
+      case KatexSpanPosition.relative:
+        if (styles.topEm case final topEm?) {
+          widget = Transform.translate(
+            offset: Offset(0, topEm * em),
+            child: widget);
+        }
+
+      case null:
+        break;
     }
 
     return widget;

--- a/test/model/katex_test.dart
+++ b/test/model/katex_test.dart
@@ -644,6 +644,62 @@ class KatexExample extends ContentExample {
       ]),
     ]);
 
+  static final bigOperators = KatexExample.block(
+    r'big operators: \int',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2240766
+    r'\int',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mo>∫</mo></mrow><annotation encoding="application/x-tex">\\int</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:2.2222em;vertical-align:-0.8622em;"></span>'
+            '<span class="mop op-symbol large-op" style="margin-right:0.44445em;position:relative;top:-0.0011em;">∫</span></span></span></span></span></p>', [
+      KatexSpanNode(nodes: [
+        KatexStrutNode(heightEm: 2.2222, verticalAlignEm: -0.8622),
+        KatexSpanNode(
+          styles: KatexSpanStyles(
+            topEm: -0.0011,
+            marginRightEm: 0.44445,
+            fontFamily: 'KaTeX_Size2',
+            position: KatexSpanPosition.relative),
+          text: '∫'),
+      ]),
+    ]);
+
+  static final colonEquals = KatexExample.block(
+    r'\colonequals relation',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2244936
+    r'\colonequals',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mo><mi mathvariant="normal">≔</mi></mo></mrow><annotation encoding="application/x-tex">\\colonequals</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.4306em;"></span>'
+            '<span class="mrel">'
+              '<span class="mrel">'
+                '<span class="mop" style="position:relative;top:-0.0347em;">:</span></span>'
+              '<span class="mrel">'
+                '<span class="mspace" style="margin-right:-0.0667em;"></span></span>'
+              '<span class="mrel">=</span></span></span></span></span></span></p>', [
+      KatexSpanNode(nodes: [
+        KatexStrutNode(heightEm: 0.4306, verticalAlignEm: null),
+        KatexSpanNode(nodes: [
+          KatexSpanNode(nodes: [
+            KatexSpanNode(
+              styles: KatexSpanStyles(topEm: -0.0347, position: KatexSpanPosition.relative),
+              text: ':'),
+          ]),
+          KatexSpanNode(nodes: [
+            KatexSpanNode(nodes: []),
+            KatexNegativeMarginNode(leftOffsetEm: -0.0667, nodes: []),
+          ]),
+          KatexSpanNode(text: '='),
+        ]),
+      ]),
+    ]);
+
   static final nulldelimiter = KatexExample.block(
     r'null delimiters, like `\left.`',
     // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2205534
@@ -695,6 +751,8 @@ void main() async {
   testParseExample(KatexExample.textColor);
   testParseExample(KatexExample.customColorMacro);
   testParseExample(KatexExample.phantom);
+  testParseExample(KatexExample.bigOperators);
+  testParseExample(KatexExample.colonEquals);
   testParseExample(KatexExample.nulldelimiter);
 
   group('parseCssHexColor', () {

--- a/test/widgets/katex_test.dart
+++ b/test/widgets/katex_test.dart
@@ -73,6 +73,10 @@ void main() {
         ('X', Offset(0.00, 7.04), Size(17.03, 25.00)),
         ('n', Offset(17.03, 15.90), Size(8.63, 17.00)),
       ]),
+      (KatexExample.colonEquals, skip: false, [
+        (':', Offset(0.00, 3.45), Size(5.72, 25.00)),
+        ('=', Offset(5.72, 3.92), Size(16.00, 25.00)),
+      ]),
       (KatexExample.nulldelimiter, skip: false, [
         ('a', Offset(2.47, 3.36), Size(10.88, 25.00)),
         ('b', Offset(15.81, 3.36), Size(8.82, 25.00)),


### PR DESCRIPTION
| Flutter | Web |
| - | - |
| <img width="1542" height="340" alt="image" src="https://github.com/user-attachments/assets/a8d03ba4-dd23-4d64-b2f3-b94a6ac12534" /> | <img width="1774" height="306" alt="image" src="https://github.com/user-attachments/assets/b370710f-accf-4799-8c65-3c8dd245ac88" /> |

#### Survey results

```diff
-  …, 31380 of them were KaTeX containing messages and 3817 of those failed.
-  There were 1075 math block nodes out of which 614 failed.
-  There were 164014 math inline nodes out of which 6470 failed.
-  Because of hard fail: unsupported inline CSS property: top:
-    1546 messages failed.
-  Because of unsupported inline css property: position:
-    1356 messages failed.
+  …, 31380 of them were KaTeX containing messages and 2801 of those failed.
+  There were 1075 math block nodes out of which 538 failed.
+  There were 164014 math inline nodes out of which 4710 failed.
   Because of hard fail: unexpected CSS class for vlist inner span: svg-align:
-    644 messages failed.
-  Because of unsupported css class: accent:
-    609 messages failed.
+    648 messages failed.
   Because of unsupported inline css property: border-bottom-width:
-    605 messages failed.
+    631 messages failed.
+  Because of unsupported css class: accent:
+    614 messages failed.
   Because of unsupported css class: op-limits:
-    517 messages failed.
+    521 messages failed.
   Because of unsupported css class: fix:
-    473 messages failed.
+    488 messages failed.
   Because of unsupported css class: inner:
-    473 messages failed.
-  Because of unsupported css class: accent-body:
-    455 messages failed.
-  Because of unsupported inline css property: left:
-    455 messages failed.
+    488 messages failed.
   Because of unsupported css class: rlap:
-    450 messages failed.
+    465 messages failed.
   Because of unsupported css class: thinbox:
-    448 messages failed.
+    463 messages failed.
   Because of unsupported css class: vbox:
-    448 messages failed.
+    463 messages failed.
   Because of unsupported css class: nulldelimiter:
-    437 messages failed.
+    461 messages failed.
+  Because of unsupported css class: accent-body:
+    460 messages failed.
+  Because of unsupported inline css property: left:
+    460 messages failed.
   Because of unsupported css class: mfrac:
-    410 messages failed.
+    433 messages failed.
   Because of unsupported css class: frac-line:
-    389 messages failed.
+    416 messages failed.
   Because of unsupported css class: x-arrow:
-    389 messages failed.
+    392 messages failed.
   Because of unsupported css class: x-arrow-pad:
-    380 messages failed.
+    383 messages failed.
+  Because of hard fail: unsupported inline CSS property "top", when "position: null":
+    235 messages failed.
   Because of unsupported css class: delimcenter:
-    226 messages failed.
+    235 messages failed.
   Because of unsupported css class: mtable:
     209 messages failed.
@@ -53,9 +51,9 @@
     86 messages failed.
   Because of unsupported css class: col-align-r:
-    80 messages failed.
+    83 messages failed.
+  Because of hard fail: unsupported html node:
+    78 messages failed.
   Because of unsupported css class: arraycolsep:
     77 messages failed.
-  Because of hard fail: unsupported html node:
-    75 messages failed.
   Because of unsupported css class: sqrt:
     75 messages failed.
@@ -74,10 +72,10 @@
   Because of hard fail: unsupported html node: svg:
     28 messages failed.
+  Because of unsupported css class: newline:
+    28 messages failed.
   Because of unsupported css class: overlay:
     28 messages failed.
   Because of unsupported css class: llap:
     26 messages failed.
-  Because of unsupported css class: newline:
-    25 messages failed.
   Because of unsupported css class: cjk_fallback:
     20 messages failed.
@@ -127,3 +125,3 @@
     1 messages failed.                                                                                                                                                       
```

Fixes: #1671