### PR TITLE
msglist: Friendlier placeholder text when narrow has no messages

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -31,6 +31,10 @@
   "@upgradeWelcomeDialogDismiss":  {
     "description":  "Label for button dismissing dialog shown on first upgrade from the legacy Zulip app."
   },
+  "learnMoreButtonLabel": "Learn more",
+  "@learnMoreButtonLabel":  {
+    "description":  "Label for a 'Learn more' button."
+  },
   "chooseAccountPageTitle": "Choose account",
   "@chooseAccountPageTitle": {
     "description": "Title for the page to choose between Zulip accounts."
@@ -528,6 +532,79 @@
     "description": "Message list page title for a DM group with others.",
     "placeholders": {
       "others": {"type": "String", "example": "Alice, Bob"}
+    }
+  },
+  "emptyMessageList": "There are no messages here.",
+  "@emptyMessageList": {
+    "description": "Placeholder for some message-list pages when there are no messages."
+  },
+  "emptyMessageListCombinedFeed": "There are no messages in your combined feed.",
+  "@emptyMessageListCombinedFeed": {
+    "description": "Placeholder for the 'Combined feed' page when there are no messages."
+  },
+  "emptyMessageListPrivateChannelNotSubscribed": "This channel is private.",
+  "@emptyMessageListPrivateChannelNotSubscribed": {
+    "description": "Placeholder for a channel page when there are no messages, the channel is private, and you are not subscribed."
+  },
+  "emptyMessageListChannelUnavailable": "This channel doesn’t exist, or you are not allowed to view it.",
+  "@emptyMessageListChannelUnavailable": {
+    "description": "Placeholder for a channel page when there are no messages and the channel does not exist or you don't have access to it."
+  },
+  "emptyMessageListSelfDm": "You have not sent any direct messages to yourself yet!",
+  "@emptyMessageListSelfDm": {
+    "description": "Placeholder for the self-DM page when there are no messages."
+  },
+  "emptyMessageListSelfDmExplanation": "Use this space for personal notes, or to test out Zulip features.",
+  "@emptyMessageListSelfDmExplanation": {
+    "description": "Extra detail in the placeholder for the self-DM page when there are no messages."
+  },
+  "emptyMessageListDm": "You have no direct messages with {person} yet.",
+  "@emptyMessageListDm": {
+    "description": "Placeholder for a 1:1 DM page when there are no messages.",
+    "placeholders": {
+      "person": {"type": "String", "example": "Alice"}
+    }
+  },
+  "emptyMessageListDmDeactivatedUser": "You have no direct messages with {person}.",
+  "@emptyMessageListDmDeactivatedUser": {
+    "description": "Placeholder for a 1:1 DM page when there are no messages and the other user is deactivated.",
+    "placeholders": {
+      "person": {"type": "String", "example": "Alice"}
+    }
+  },
+  "emptyMessageListDmUnknownUser": "You have no direct messages with this person.",
+  "@emptyMessageListDmUnknownUser": {
+    "description": "Placeholder for a 1:1 DM page when there are no messages and the other user's name is unavailable."
+  },
+  "emptyMessageListGroupDm": "You have no direct messages with these users yet.",
+  "@emptyMessageListGroupDm": {
+    "description": "Placeholder for a group DM page when there are no messages."
+  },
+  "emptyMessageListGroupDmDeactivatedUser": "You have no direct messages with these users.",
+  "@emptyMessageListGroupDmDeactivatedUser": {
+    "description": "Placeholder for a group DM page when there are no messages and one or more participants is deactivated."
+  },
+  "emptyMessageListDmStartConversation": "Why not start the conversation?",
+  "@emptyMessageListDmStartConversation": {
+    "description": "Extra detail in the placeholder for some DM pages when there are no messages."
+  },
+  "emptyMessageListMentions": "This view will show messages where you are mentioned.",
+  "@emptyMessageListMentions": {
+    "description": "Placeholder for the 'Mentions' page when there are no messages."
+  },
+  "emptyMessageListMentionsExplanation": "To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.",
+  "@emptyMessageListMentionsExplanation": {
+    "description": "Extra detail in the placeholder for the 'Mentions' page when there are no messages."
+  },
+  "emptyMessageListStarred": "You have no starred messages.",
+  "@emptyMessageListStarred": {
+    "description": "Placeholder for the 'Starred' page when there are no messages."
+  },
+  "emptyMessageListStarredExplanation": "Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “{button}.”",
+  "@emptyMessageListStarredExplanation": {
+    "description": "Extra detail in the placeholder for the 'Starred' page when there are no messages. The {button} placeholder will be the button's translated text.",
+    "placeholders": {
+      "button": {"type": "String", "example": "Star message"}
     }
   },
   "messageListGroupYouWithYourself": "Messages with yourself",

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -177,6 +177,12 @@ abstract class ZulipLocalizations {
   /// **'Let\'s go'**
   String get upgradeWelcomeDialogDismiss;
 
+  /// Label for a 'Learn more' button.
+  ///
+  /// In en, this message translates to:
+  /// **'Learn more'**
+  String get learnMoreButtonLabel;
+
   /// Title for the page to choose between Zulip accounts.
   ///
   /// In en, this message translates to:
@@ -844,6 +850,102 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'DMs with {others}'**
   String dmsWithOthersPageTitle(String others);
+
+  /// Placeholder for some message-list pages when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'There are no messages here.'**
+  String get emptyMessageList;
+
+  /// Placeholder for the 'Combined feed' page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'There are no messages in your combined feed.'**
+  String get emptyMessageListCombinedFeed;
+
+  /// Placeholder for a channel page when there are no messages, the channel is private, and you are not subscribed.
+  ///
+  /// In en, this message translates to:
+  /// **'This channel is private.'**
+  String get emptyMessageListPrivateChannelNotSubscribed;
+
+  /// Placeholder for a channel page when there are no messages and the channel does not exist or you don't have access to it.
+  ///
+  /// In en, this message translates to:
+  /// **'This channel doesn’t exist, or you are not allowed to view it.'**
+  String get emptyMessageListChannelUnavailable;
+
+  /// Placeholder for the self-DM page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'You have not sent any direct messages to yourself yet!'**
+  String get emptyMessageListSelfDm;
+
+  /// Extra detail in the placeholder for the self-DM page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'Use this space for personal notes, or to test out Zulip features.'**
+  String get emptyMessageListSelfDmExplanation;
+
+  /// Placeholder for a 1:1 DM page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no direct messages with {person} yet.'**
+  String emptyMessageListDm(String person);
+
+  /// Placeholder for a 1:1 DM page when there are no messages and the other user is deactivated.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no direct messages with {person}.'**
+  String emptyMessageListDmDeactivatedUser(String person);
+
+  /// Placeholder for a 1:1 DM page when there are no messages and the other user's name is unavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no direct messages with this person.'**
+  String get emptyMessageListDmUnknownUser;
+
+  /// Placeholder for a group DM page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no direct messages with these users yet.'**
+  String get emptyMessageListGroupDm;
+
+  /// Placeholder for a group DM page when there are no messages and one or more participants is deactivated.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no direct messages with these users.'**
+  String get emptyMessageListGroupDmDeactivatedUser;
+
+  /// Extra detail in the placeholder for some DM pages when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'Why not start the conversation?'**
+  String get emptyMessageListDmStartConversation;
+
+  /// Placeholder for the 'Mentions' page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'This view will show messages where you are mentioned.'**
+  String get emptyMessageListMentions;
+
+  /// Extra detail in the placeholder for the 'Mentions' page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.'**
+  String get emptyMessageListMentionsExplanation;
+
+  /// Placeholder for the 'Starred' page when there are no messages.
+  ///
+  /// In en, this message translates to:
+  /// **'You have no starred messages.'**
+  String get emptyMessageListStarred;
+
+  /// Extra detail in the placeholder for the 'Starred' page when there are no messages. The {button} placeholder will be the button's translated text.
+  ///
+  /// In en, this message translates to:
+  /// **'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “{button}.”'**
+  String emptyMessageListStarredExplanation(String button);
 
   /// Message list recipient header for a DM group that only includes yourself.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Let\'s go';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
@@ -432,6 +435,71 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DMs with $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Los gehts';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Konto auswählen';
 
   @override
@@ -447,6 +450,71 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DNs mit $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Let\'s go';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
@@ -432,6 +435,71 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DMs with $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Andiamo';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Scegli account';
 
   @override
@@ -443,6 +446,71 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'MD con $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Let\'s go';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'アカウントを選択';
 
   @override
@@ -432,6 +435,71 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DMs with $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Let\'s go';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
@@ -432,6 +435,71 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DMs with $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Zaczynajmy';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Wybierz konto';
 
   @override
@@ -441,6 +444,71 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DM z $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Приступим!';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Выберите учетную запись';
 
   @override
@@ -441,6 +444,71 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'ЛС с $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Let\'s go';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Zvoliť účet';
 
   @override
@@ -432,6 +435,71 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DMs with $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -34,6 +34,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Začnimo';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Izberite račun';
 
   @override
@@ -453,6 +456,71 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'Neposredna sporočila z $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Ходімо!';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Обрати обліковий запис';
 
   @override
@@ -443,6 +446,71 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'Особисті повідомлення з $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -35,6 +35,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get upgradeWelcomeDialogDismiss => 'Let\'s go';
 
   @override
+  String get learnMoreButtonLabel => 'Learn more';
+
+  @override
   String get chooseAccountPageTitle => 'Choose account';
 
   @override
@@ -432,6 +435,71 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   @override
   String dmsWithOthersPageTitle(String others) {
     return 'DMs with $others';
+  }
+
+  @override
+  String get emptyMessageList => 'There are no messages here.';
+
+  @override
+  String get emptyMessageListCombinedFeed =>
+      'There are no messages in your combined feed.';
+
+  @override
+  String get emptyMessageListPrivateChannelNotSubscribed =>
+      'This channel is private.';
+
+  @override
+  String get emptyMessageListChannelUnavailable =>
+      'This channel doesn’t exist, or you are not allowed to view it.';
+
+  @override
+  String get emptyMessageListSelfDm =>
+      'You have not sent any direct messages to yourself yet!';
+
+  @override
+  String get emptyMessageListSelfDmExplanation =>
+      'Use this space for personal notes, or to test out Zulip features.';
+
+  @override
+  String emptyMessageListDm(String person) {
+    return 'You have no direct messages with $person yet.';
+  }
+
+  @override
+  String emptyMessageListDmDeactivatedUser(String person) {
+    return 'You have no direct messages with $person.';
+  }
+
+  @override
+  String get emptyMessageListDmUnknownUser =>
+      'You have no direct messages with this person.';
+
+  @override
+  String get emptyMessageListGroupDm =>
+      'You have no direct messages with these users yet.';
+
+  @override
+  String get emptyMessageListGroupDmDeactivatedUser =>
+      'You have no direct messages with these users.';
+
+  @override
+  String get emptyMessageListDmStartConversation =>
+      'Why not start the conversation?';
+
+  @override
+  String get emptyMessageListMentions =>
+      'This view will show messages where you are mentioned.';
+
+  @override
+  String get emptyMessageListMentionsExplanation =>
+      'To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you’d like to mention from the list of suggestions.';
+
+  @override
+  String get emptyMessageListStarred => 'You have no starred messages.';
+
+  @override
+  String emptyMessageListStarredExplanation(String button) {
+    return 'Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, long-press it and tap “$button.”';
   }
 
   @override

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -2064,8 +2064,12 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
       case ChannelNarrow(:final streamId):
       case TopicNarrow(:final streamId):
         final channel = store.streams[streamId];
-        if (channel == null || !store.hasPostingPermission(inChannel: channel,
-            user: store.selfUser, byDate: DateTime.now())) {
+        if (
+          channel == null
+          || (channel.inviteOnly && channel is! Subscription)
+          || !store.hasPostingPermission(inChannel: channel,
+               user: store.selfUser, byDate: DateTime.now())
+        ) {
           return _ErrorBanner(getLabel: (zulipLocalizations) =>
             zulipLocalizations.errorBannerCannotPostInChannelLabel);
         }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart' hide TextDirection;
 
 import '../api/model/model.dart';
 import '../generated/l10n/zulip_localizations.dart';
+import '../model/binding.dart';
 import '../model/database.dart';
 import '../model/message.dart';
 import '../model/message_list.dart';
@@ -14,6 +15,7 @@ import '../model/typing_status.dart';
 import 'action_sheet.dart';
 import 'actions.dart';
 import 'app_bar.dart';
+import 'button.dart';
 import 'color.dart';
 import 'compose_box.dart';
 import 'content.dart';
@@ -790,6 +792,11 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   Widget build(BuildContext context) {
     if (!model.fetched) return const Center(child: CircularProgressIndicator());
 
+    if (model.haveNewest && model.haveOldest
+          && model.messages.isEmpty && model.outboxMessages.isEmpty) {
+      return NoMessagesPlaceholder(widget.narrow);
+    }
+
     // Pad the left and right insets, for small devices in landscape.
     return SafeArea(
       // Don't let this be the place we pad the bottom inset. When there's
@@ -995,6 +1002,114 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         final header = RecipientHeader(message: data.message, narrow: widget.narrow);
         return MessageItem(header: header, item: data);
     }
+  }
+}
+
+/// A "no messages here" message, for the body of the message-list page.
+///
+/// Pads the horizontal insets.
+@visibleForTesting
+class NoMessagesPlaceholder extends StatelessWidget {
+  const NoMessagesPlaceholder(this.narrow, {super.key});
+
+  final Narrow narrow;
+
+  @override
+  Widget build(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+    final designVariables = DesignVariables.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
+
+    final String message;
+    String? explanation;
+    Uri? learnMoreButtonUrl;
+    switch (narrow) {
+      case CombinedFeedNarrow():
+        message = zulipLocalizations.emptyMessageListCombinedFeed;
+      case ChannelNarrow(:final streamId) || TopicNarrow(:final streamId):
+        final channel = store.streams[streamId];
+        if (channel == null) {
+          message = zulipLocalizations.emptyMessageListChannelUnavailable;
+        } else if (channel.inviteOnly && channel is! Subscription) {
+          message = zulipLocalizations.emptyMessageListPrivateChannelNotSubscribed;
+          learnMoreButtonUrl = store.tryResolveUrl('/help/channel-permissions#private-channels');
+        } else {
+          message = zulipLocalizations.emptyMessageList;
+        }
+      case DmNarrow(:final otherRecipientIds) when otherRecipientIds.isEmpty:
+        message = zulipLocalizations.emptyMessageListSelfDm;
+        explanation = zulipLocalizations.emptyMessageListSelfDmExplanation;
+      case DmNarrow(:final otherRecipientIds) when otherRecipientIds.length == 1:
+        final user = store.getUser(otherRecipientIds.single);
+        switch (user) {
+          case null:
+            message = zulipLocalizations.emptyMessageListDmUnknownUser;
+          case User(isActive: false):
+            message = zulipLocalizations.emptyMessageListDmDeactivatedUser(
+              store.userDisplayName(user.userId));
+          case User():
+            message = zulipLocalizations.emptyMessageListDm(store.userDisplayName(user.userId));
+            if (!store.isUserMuted(user.userId)) {
+              explanation = zulipLocalizations.emptyMessageListDmStartConversation;
+            }
+        }
+      case DmNarrow(:final otherRecipientIds)
+          when otherRecipientIds.any((userId) {
+            final user = store.getUser(userId);
+            return user != null && !user.isActive;
+          }):
+        message = zulipLocalizations.emptyMessageListGroupDmDeactivatedUser;
+      case DmNarrow():
+        message = zulipLocalizations.emptyMessageListGroupDm;
+        explanation = zulipLocalizations.emptyMessageListDmStartConversation;
+      case MentionsNarrow():
+        message = zulipLocalizations.emptyMessageListMentions;
+        if (store.zulipFeatureLevel >= 224) { // TODO(server-8)
+          // This string mentions @topic, which is new in Server 8.
+
+          // TODO(#233) ...It also mentions user-group mentions,
+          //   so we'll just comment it out until that's implemented.
+          // explanation = zulipLocalizations.emptyMessageListMentionsExplanation;
+        }
+        // TODO(#233) as above, uncomment when user-group mentions are done
+        // learnMoreButtonUrl = store.tryResolveUrl('/help/mention-a-user-or-group');
+      case StarredMessagesNarrow():
+        message = zulipLocalizations.emptyMessageListStarred;
+        explanation = zulipLocalizations.emptyMessageListStarredExplanation(zulipLocalizations.actionSheetOptionStarMessage);
+        learnMoreButtonUrl = store.tryResolveUrl('/help/star-a-message');
+    }
+
+    final baseTextStyle = TextStyle(
+      color: designVariables.labelSearchPrompt,
+      fontSize: 17,
+      height: 23 / 17,
+    );
+
+    // TODO(design) This was based on [PageBodyEmptyContentPlaceholder];
+    //   we may need a separate design.
+    return SafeArea(
+      minimum: EdgeInsets.symmetric(horizontal: 24),
+      child: Padding(
+        padding: EdgeInsets.only(top: 48, bottom: 16),
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: Column(
+            spacing: 16,
+            children: [
+              Text(
+                textAlign: TextAlign.center,
+                style: baseTextStyle.merge(weightVariableTextStyle(context, wght: 500)),
+                message),
+              if (explanation != null)
+                Text(
+                  textAlign: TextAlign.center,
+                  style: baseTextStyle,
+                  explanation),
+              if (learnMoreButtonUrl != null)
+                ZulipWebUiKitButton(
+                  label: zulipLocalizations.learnMoreButtonLabel,
+                  onPressed: () => ZulipBinding.instance.launchUrl(learnMoreButtonUrl!)),
+            ]))));
   }
 }
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -125,6 +125,9 @@ void main() {
     return findScrollView(tester).controller;
   }
 
+  final contentInputFinder = find.byWidgetPredicate(
+    (widget) => widget is TextField && widget.controller is ComposeContentController);
+
   group('MessageListPage', () {
     testWidgets('ancestorOf finds page state from message', (tester) async {
       await setupMessageListPage(tester,
@@ -1633,9 +1636,6 @@ void main() {
     final topic = 'topic';
     final topicNarrow = eg.topicNarrow(stream.streamId, topic);
     const content = 'outbox message content';
-
-    final contentInputFinder = find.byWidgetPredicate(
-      (widget) => widget is TextField && widget.controller is ComposeContentController);
 
     Finder outboxMessageFinder = find.widgetWithText(
       OutboxMessageWithPossibleSender, content, skipOffstage: true);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -23,6 +23,7 @@ import 'package:zulip/model/store.dart';
 import 'package:zulip/model/typing_status.dart';
 import 'package:zulip/widgets/app_bar.dart';
 import 'package:zulip/widgets/autocomplete.dart';
+import 'package:zulip/widgets/button.dart';
 import 'package:zulip/widgets/color.dart';
 import 'package:zulip/widgets/compose_box.dart';
 import 'package:zulip/widgets/content.dart';
@@ -326,6 +327,208 @@ void main() {
         of: find.byType(TopicListPage),
         matching: find.text('channel foo')),
       ).findsOne();
+    });
+  });
+
+  group('no-messages placeholder', () {
+    final findPlaceholder = find.byType(NoMessagesPlaceholder);
+
+    Finder findTextInPlaceholder(String text) =>
+      find.descendant(of: findPlaceholder, matching: find.textContaining(text));
+
+    Future<void> checkLearnMoreButton(WidgetTester tester, Uri expectedUrl) async {
+      await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Learn more'));
+      final (url: url, mode: _) = testBinding.takeLaunchUrlCalls().single;
+      check(url).equals(expectedUrl);
+    }
+
+    testWidgets('Combined feed', (tester) async {
+      await setupMessageListPage(tester, narrow: CombinedFeedNarrow(), messages: []);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('combined feed')).findsOne();
+    });
+
+    testWidgets('Known, subscribed channel', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: ChannelNarrow(channel.streamId), messages: [], streams: [channel],
+        skipPumpAndSettle: true);
+
+      // The topic input is autofocused, triggering topic autocomplete.
+      connection.prepare(json: GetStreamTopicsResult(topics: []).toJson());
+      await tester.pumpAndSettle();
+
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('no messages')).findsOne();
+    });
+
+    testWidgets('Private, unsubscribed channel', (tester) async {
+      final channel = eg.stream(inviteOnly: true);
+      await setupMessageListPage(tester,
+        narrow: ChannelNarrow(channel.streamId), messages: [], streams: [channel]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('This channel is private.')).findsOne();
+      await checkLearnMoreButton(tester,
+        store.tryResolveUrl('/help/channel-permissions#private-channels')!);
+    });
+
+    testWidgets('Unknown channel', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: ChannelNarrow(channel.streamId), messages: [], streams: []);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('This channel doesn’t exist, or you are not allowed to view it.')).findsOne();
+    });
+
+    testWidgets('Topic in unknown channel', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: TopicNarrow(channel.streamId, eg.t('topic')), messages: [], streams: []);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('This channel doesn’t exist, or you are not allowed to view it.')).findsOne();
+    });
+
+    testWidgets('Topic in known, subscribed channel', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: TopicNarrow(channel.streamId, eg.t('topic')), messages: [], streams: [channel]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('no messages')).findsOne();
+    });
+
+    testWidgets('Topic in private, unsubscribed channel', (tester) async {
+      final channel = eg.stream(inviteOnly: true);
+      await setupMessageListPage(tester,
+        narrow: TopicNarrow(channel.streamId, eg.t('topic')), messages: [], streams: [channel]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('This channel is private.')).findsOne();
+      await checkLearnMoreButton(tester,
+        store.tryResolveUrl('/help/channel-permissions#private-channels')!);
+    });
+
+    testWidgets('Self-DM', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUser(selfUserId, selfUserId: selfUserId), messages: [], users: [eg.selfUser]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('yourself')).findsOne();
+      check(findTextInPlaceholder('Use this space')).findsOne();
+    });
+
+    testWidgets('1:1 DM', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      final user = eg.user();
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUser(user.userId, selfUserId: selfUserId), messages: [], users: [eg.selfUser, user]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder(user.fullName)).findsOne();
+      check(findTextInPlaceholder('yet.')).findsOne();
+      check(findTextInPlaceholder('Why not start the conversation?')).findsOne();
+    });
+
+    testWidgets('1:1 DM, muted user', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      final user = eg.user();
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUser(user.userId, selfUserId: selfUserId), messages: [], users: [eg.selfUser, user]);
+      await store.handleEvent(MutedUsersEvent(id: 1, mutedUsers: [MutedUserItem(id: user.userId)]));
+      await tester.pump();
+      check(store.isUserMuted(user.userId)).isTrue();
+      check(findPlaceholder).findsOne();
+
+      // Probably want to show their name, not "Muted user";
+      // this UI context is very much focused on the one user.
+      check(findTextInPlaceholder(user.fullName)).findsOne();
+      check(findTextInPlaceholder('Muted user')).findsNothing();
+
+      // No need to encourage starting a conversation though.
+      check(findTextInPlaceholder('Why not start the conversation?')).findsNothing();
+    });
+
+    testWidgets('1:1 DM, unknown user', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUser(eg.user().userId, selfUserId: selfUserId), messages: [], users: [eg.selfUser]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('this person')).findsOne();
+      check(findTextInPlaceholder('(unknown user)')).findsNothing();
+
+      // No need to encourage starting a conversation...right?
+      check(findTextInPlaceholder('yet.')).findsNothing();
+      check(findTextInPlaceholder('Why not start the conversation?')).findsNothing();
+    });
+
+    testWidgets('1:1 DM, deactivated user', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      final user = eg.user(isActive: false);
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUser(user.userId, selfUserId: selfUserId), messages: [], users: [eg.selfUser, user]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder(user.fullName)).findsOne();
+
+      // Sending messages isn't allowed; don't suggest that
+      check(findTextInPlaceholder('yet.')).findsNothing();
+      check(findTextInPlaceholder('Why not start the conversation?')).findsNothing();
+    });
+
+    testWidgets('Group DM', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      final user1 = eg.user();
+      final user2 = eg.user();
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUsers([user1.userId, user2.userId], selfUserId: selfUserId),
+        messages: [], users: [eg.selfUser, user1, user2]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('these users')).findsOne();
+      check(findTextInPlaceholder('yet.')).findsOne();
+      check(findTextInPlaceholder('Why not start the conversation?')).findsOne();
+    });
+
+    testWidgets('Group DM with a deactivated user', (tester) async {
+      final selfUserId = eg.selfUser.userId;
+      final user1 = eg.user(isActive: false);
+      final user2 = eg.user();
+      await setupMessageListPage(tester,
+        narrow: DmNarrow.withUsers([user1.userId, user2.userId], selfUserId: selfUserId),
+        messages: [], users: [eg.selfUser, user1, user2]);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('these users')).findsOne();
+
+      // Sending messages isn't allowed; don't suggest that
+      check(findTextInPlaceholder('yet.')).findsNothing();
+      check(findTextInPlaceholder('Why not start the conversation?')).findsNothing();
+    });
+
+    testWidgets('Mentions', (tester) async {
+      await setupMessageListPage(tester, narrow: MentionsNarrow(), messages: []);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('mentioned')).findsOne();
+    });
+
+    testWidgets('Starred', (tester) async {
+      await setupMessageListPage(tester, narrow: StarredMessagesNarrow(), messages: []);
+      check(findPlaceholder).findsOne();
+      check(findTextInPlaceholder('starred')).findsOne();
+      check(findTextInPlaceholder('tap “Star message.”')).findsOne();
+      await checkLearnMoreButton(tester,
+        store.tryResolveUrl('/help/star-a-message')!);
+    });
+
+    testWidgets('when `messages` empty but `outboxMessages` not empty, show outboxes, not placeholder', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: TopicNarrow(channel.streamId, eg.t('topic')),
+        streams: [channel],
+        messages: []);
+      check(findPlaceholder).findsOne();
+
+      connection.prepare(json: SendMessageResult(id: 1).toJson());
+      await tester.enterText(contentInputFinder, 'asdfjkl;');
+      await tester.tap(find.byIcon(ZulipIcons.send));
+      await tester.pump(kLocalEchoDebounceDuration);
+
+      check(findPlaceholder).findsNothing();
+      check(find.text('asdfjkl;')).findsOne();
     });
   });
 


### PR DESCRIPTION
    msglist: Friendlier placeholder text when narrow has no messages
    
    Fixes #1555.
    
    A "no-messages-here" placeholder will be important for search, #252.
    Might as well implement it properly for the various possible cases,
    using web as a guide; see web/src/narrow_banner.ts in zulip/zulip.

### Screenshots

<img width="490" alt="Screenshot 2025-06-26 at 5 28 34 PM" src="https://github.com/user-attachments/assets/aca16fa1-de3d-492d-9171-ebfc1b4f457e" />

Starred messages: "Learn more" button opens `/help/star-a-message`
<img width="490" alt="Screenshot 2025-06-26 at 5 32 00 PM" src="https://github.com/user-attachments/assets/fb80d20d-c0a7-4225-942b-05f908aa8e72" />

<img width="490" alt="Screenshot 2025-06-26 at 5 31 52 PM" src="https://github.com/user-attachments/assets/1c8b9859-ab46-4fb1-b838-488d75c57b44" />

Group DM:
<img width="490" alt="Screenshot 2025-06-26 at 5 31 32 PM" src="https://github.com/user-attachments/assets/d8b3b32b-0617-4e6f-ac49-f43345b3c8b3" />

Group DM with a deactivated user:
<img width="490" alt="Screenshot 2025-06-26 at 9 52 33 PM" src="https://github.com/user-attachments/assets/1abfabf3-9c11-4323-9b3c-a2685692a80b" />

<img width="490" alt="Screenshot 2025-06-26 at 5 30 27 PM" src="https://github.com/user-attachments/assets/f88ea87a-fee3-4f84-b04c-b3fb45ff7e40" />

DM with muted user:
<img width="490" alt="Screenshot 2025-06-26 at 9 48 02 PM" src="https://github.com/user-attachments/assets/aecbab62-0146-4b23-b549-c914231e734e" />

DM with deactivated user:
<img width="490" alt="Screenshot 2025-06-26 at 9 51 07 PM" src="https://github.com/user-attachments/assets/91c5f740-cf5b-4af6-9848-57076ce38f85" />

<img width="490" alt="Screenshot 2025-06-26 at 5 30 11 PM" src="https://github.com/user-attachments/assets/49ddddda-992e-4c28-8d63-1450084284b8" />
<img width="490" alt="Screenshot 2025-06-26 at 5 29 57 PM" src="https://github.com/user-attachments/assets/4c1b6de1-8025-41fd-a191-68b1f2b579d2" />
<img width="490" alt="Screenshot 2025-06-26 at 5 28 46 PM" src="https://github.com/user-attachments/assets/a05810ba-ffc7-48c1-8e4c-192a79d58fd4" />

Unknown channel (unknown because I'm not allowed to know about it):
<img width="490" alt="Screenshot 2025-06-26 at 9 43 11 PM" src="https://github.com/user-attachments/assets/b43abe45-f057-4bf3-9e9c-0929945a0caa" />

Private channel I'm not subscribed to: "Learn more" button goes to `/help/channel-permissions#private-channels`
(The error banner replacing the compose box is also new in this PR. It's the same as the one above, for unknown channels, which is in `main`.)
<img width="490" alt="Screenshot 2025-06-26 at 9 36 12 PM" src="https://github.com/user-attachments/assets/440d98f8-e803-4bb4-a780-6d0d00a5a658" />