### PR TITLE
Translate About page labels into Japanese

### DIFF
--- a/assets/l10n/app_ja.arb
+++ b/assets/l10n/app_ja.arb
@@ -1,20 +1,50 @@
 {
+  "aboutPageTitle": "Zulipについて",
+  "@aboutPageTitle": {
+    "description": "Title for About Zulip page."
+  },
+  "aboutPageAppVersion": "アプリバージョン",
+  "@aboutPageAppVersion": {
+    "description": "Label for Zulip app version in About Zulip page"
+  },
+  "aboutPageOpenSourceLicenses": "オープンソースライセンス",
+  "@aboutPageOpenSourceLicenses": {
+    "description": "Item title in About Zulip page to navigate to Licenses page"
+  },
   "chooseAccountPageTitle": "アカウントを選択",
-  "@chooseAccountPageTitle": {},
+  "@chooseAccountPageTitle": {
+    "description": "Title for the page to choose between Zulip accounts."
+  },
   "chooseAccountButtonAddAnAccount": "新しいアカウントを追加",
-  "@chooseAccountButtonAddAnAccount": {},
+  "@chooseAccountButtonAddAnAccount": {
+    "description": "Label for ChooseAccountPage button to add an account"
+  },
   "profileButtonSendDirectMessage": "ダイレクトメッセージを送信",
-  "@profileButtonSendDirectMessage": {},
+  "@profileButtonSendDirectMessage": {
+    "description": "Label for button in profile screen to navigate to DMs with the shown user."
+  },
   "userRoleOwner": "オーナー",
-  "@userRoleOwner": {},
+  "@userRoleOwner": {
+    "description": "Label for UserRole.owner"
+  },
   "userRoleAdministrator": "管理者",
-  "@userRoleAdministrator": {},
+  "@userRoleAdministrator": {
+    "description": "Label for UserRole.administrator"
+  },
   "userRoleModerator": "モデレータ",
-  "@userRoleModerator": {},
+  "@userRoleModerator": {
+    "description": "Label for UserRole.moderator"
+  },
   "userRoleMember": "メンバー",
-  "@userRoleMember": {},
+  "@userRoleMember": {
+    "description": "Label for UserRole.member"
+  },
   "userRoleGuest": "ゲスト",
-  "@userRoleGuest": {},
+  "@userRoleGuest": {
+    "description": "Label for UserRole.guest"
+  },
   "userRoleUnknown": "不明",
-  "@userRoleUnknown": {}
+  "@userRoleUnknown": {
+    "description": "Label for UserRole.unknown"
+  }
 }


### PR DESCRIPTION
This is my first Pull Request to the Zulip project.

I've translated a few strings on the About page into Japanese in the `app_ja.arb` file.

If there's anything I should improve or if this overlaps with another PR, please let me know.  
I appreciate your guidance!

Related to issue #277 (already closed).

Here's a screenshot of the translated labels on the About page.
The red boxes indicate the strings I updated in this PR.

<img width="189" alt="about-page-button-ja" src="https://github.com/user-attachments/assets/92d1caaa-e63e-44e5-8a2d-cd920cc96e78" />
<img width="189" alt="about-page-ja" src="https://github.com/user-attachments/assets/4e156068-9ac5-4fd9-b3d2-bc73b63fb8f7" />

In addition to translating the Japanese strings, I also added description fields to existing entries where they were previously missing, for consistency with the English source file.

Please let me know if this approach is appropriate, or if you'd recommend a different way.