### PR TITLE
content: Inline audio preview

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1087,6 +1087,22 @@ class _ZulipInlineContentParser {
       return GlobalTimeNode(datetime: datetime, debugHtmlNode: debugHtmlNode);
     }
 
+    if (localName == 'audio' && className.isEmpty) {
+      final srcAttr = element.attributes['src'];
+      if (srcAttr == null) return unimplemented();
+
+      final String title = switch (element.attributes) {
+        {'title': final titleAttr} => titleAttr,
+        _ => Uri.tryParse(srcAttr)?.pathSegments.lastOrNull ?? srcAttr,
+      };
+
+      final link = LinkNode(
+        url: srcAttr,
+        nodes: [TextNode(title)]);
+      (_linkNodes ??= []).add(link);
+      return link;
+    }
+
     if (localName == 'span' && className == 'katex') {
       return parseInlineMath(element) ?? unimplemented();
     }

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -1327,6 +1327,24 @@ class ContentExample {
     InlineVideoNode(srcUrl: '/user_uploads/2/78/_KoRecCHZTFrVtyTKCkIh5Hq/Big-Buck-Bunny.webm'),
   ]);
 
+  static const audioInline = ContentExample(
+    'audio inline',
+    '![crab-rave.mp3](/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3)',
+    '<p><audio controls preload="metadata" src="/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3" title="crab-rave.mp3"></audio></p>', [
+    ParagraphNode(links: null, nodes: [
+      LinkNode(url: '/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3', nodes: [TextNode('crab-rave.mp3')]),
+    ]),
+  ]);
+
+  static const audioInlineNoTitle = ContentExample(
+    'audio inline no title',
+    '![](/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3)',
+    '<p><audio controls preload="metadata" src="/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3"></audio></p>', [
+    ParagraphNode(links: null, nodes: [
+      LinkNode(url: '/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3', nodes: [TextNode('crab-rave.mp3')]),
+    ]),
+  ]);
+
   static const websitePreviewSmoke = ContentExample(
     'website preview smoke',
     'https://pub-14f7b5e1308d42b69c4a46608442a50c.r2.dev/image+title+description.html',
@@ -1989,6 +2007,9 @@ void main() async {
   testParseExample(ContentExample.videoEmbedVimeoClassesFlipped);
   testParseExample(ContentExample.videoInline);
   testParseExample(ContentExample.videoInlineClassesFlipped);
+
+  testParseExample(ContentExample.audioInline);
+  testParseExample(ContentExample.audioInlineNoTitle);
 
   testParseExample(ContentExample.websitePreviewSmoke);
   testParseExample(ContentExample.websitePreviewWithoutTitle);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1167,6 +1167,26 @@ void main() {
     });
   });
 
+  group('InlineAudio', () {
+    Future<void> prepare(WidgetTester tester, String html) async {
+      await prepareContent(tester, plainContent(html),
+        // We try to resolve relative links on the self-account's realm.
+        wrapWithPerAccountStoreWidget: true);
+    }
+
+    testWidgets('tapping on audio link opens it in browser', (tester) async {
+      final url = eg.realmUrl.resolve('/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/crab-rave.mp3');
+      await prepare(tester, ContentExample.audioInline.html);
+
+      await tapText(tester, find.text('crab-rave.mp3'));
+
+      final expectedLaunchMode = defaultTargetPlatform == TargetPlatform.iOS ?
+        LaunchMode.externalApplication : LaunchMode.inAppBrowserView;
+      check(testBinding.takeLaunchUrlCalls())
+        .single.equals((url: url, mode: expectedLaunchMode));
+    }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
+  });
+
   group('MessageImageEmoji', () {
     Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContent(tester, plainContent(html),


### PR DESCRIPTION
Fixes #1665.

The first commit is ready, which just displays the source URL of `<audio>` element. Later commit adds the actual inline audio player which currently is minimal implementation using [`package:just_audio`](https://pub.dev/packages/just_audio), as I was unsure about the required behaviour and design.