### PR TITLE
compose: Don't show compose box for private, unsubscribed channels

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -2064,8 +2064,12 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
       case ChannelNarrow(:final streamId):
       case TopicNarrow(:final streamId):
         final channel = store.streams[streamId];
-        if (channel == null || !store.hasPostingPermission(inChannel: channel,
-            user: store.selfUser, byDate: DateTime.now())) {
+        if (
+          channel == null
+          || (channel.inviteOnly && channel is! Subscription)
+          || !store.hasPostingPermission(inChannel: channel,
+               user: store.selfUser, byDate: DateTime.now())
+        ) {
           return _ErrorBanner(getLabel: (zulipLocalizations) =>
             zulipLocalizations.errorBannerCannotPostInChannelLabel);
         }

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -125,6 +125,9 @@ void main() {
     return findScrollView(tester).controller;
   }
 
+  final contentInputFinder = find.byWidgetPredicate(
+    (widget) => widget is TextField && widget.controller is ComposeContentController);
+
   group('MessageListPage', () {
     testWidgets('ancestorOf finds page state from message', (tester) async {
       await setupMessageListPage(tester,
@@ -1633,9 +1636,6 @@ void main() {
     final topic = 'topic';
     final topicNarrow = eg.topicNarrow(stream.streamId, topic);
     const content = 'outbox message content';
-
-    final contentInputFinder = find.byWidgetPredicate(
-      (widget) => widget is TextField && widget.controller is ComposeContentController);
 
     Finder outboxMessageFinder = find.widgetWithText(
       OutboxMessageWithPossibleSender, content, skipOffstage: true);


### PR DESCRIPTION
I noticed this while working on #1555.

Fixes #1651.