### PR TITLE
KaTeX(7/n): Handle 'op-limits' KaTeX CSS

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -429,6 +429,37 @@ class KatexStrutNode extends KatexNode {
   }
 }
 
+class KatexVlistNode extends KatexNode {
+  const KatexVlistNode({
+    required this.rows,
+    super.debugHtmlNode,
+  });
+
+  final List<KatexVlistRowNode> rows;
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return rows.map((row) => row.toDiagnosticsNode()).toList();
+  }
+}
+
+class KatexVlistRowNode extends ContentNode {
+  const KatexVlistRowNode({
+    required this.verticalOffsetEm,
+    required this.node,
+    super.debugHtmlNode,
+  });
+
+  final double verticalOffsetEm;
+  final KatexSpanNode node;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('verticalOffsetEm', verticalOffsetEm));
+  }
+}
+
 class MathBlockNode extends MathNode implements BlockContentNode {
   const MathBlockNode({
     super.debugHtmlNode,

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -411,6 +411,24 @@ class KatexSpanNode extends KatexNode {
   }
 }
 
+class KatexStrutNode extends KatexNode {
+  const KatexStrutNode({
+    required this.heightEm,
+    required this.verticalAlignEm,
+    super.debugHtmlNode,
+  });
+
+  final double heightEm;
+  final double? verticalAlignEm;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('heightEm', heightEm));
+    properties.add(DoubleProperty('verticalAlignEm', verticalAlignEm));
+  }
+}
+
 class MathBlockNode extends MathNode implements BlockContentNode {
   const MathBlockNode({
     super.debugHtmlNode,

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -460,6 +460,28 @@ class KatexVlistRowNode extends ContentNode {
   }
 }
 
+class KatexNegativeMarginNode extends KatexNode {
+  const KatexNegativeMarginNode({
+    required this.leftOffsetEm,
+    required this.nodes,
+    super.debugHtmlNode,
+  }) : assert(leftOffsetEm < 0);
+
+  final double leftOffsetEm;
+  final List<KatexNode> nodes;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('leftOffsetEm', leftOffsetEm));
+  }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return nodes.map((node) => node.toDiagnosticsNode()).toList();
+  }
+}
+
 class MathBlockNode extends MathNode implements BlockContentNode {
   const MathBlockNode({
     super.debugHtmlNode,

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -247,13 +247,17 @@ class _KatexParser {
             for (final innerSpan in vlist.nodes) {
               if (innerSpan case dom.Element(
                 localName: 'span',
-                className: '',
                 nodes: [
                   dom.Element(localName: 'span', className: 'pstrut') &&
                       final pstrutSpan,
                   ...final otherSpans,
                 ],
               )) {
+                if (innerSpan.className != '') {
+                  throw _KatexHtmlParseError('unexpected CSS class for '
+                    'vlist inner span: ${innerSpan.className}');
+                }
+
                 var styles = _parseSpanInlineStyles(innerSpan)!;
                 final topEm = styles.topEm ?? 0;
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -493,6 +493,7 @@ class _KatexParser {
       if (stylesheet.topLevels case [css_visitor.RuleSet() && final rule]) {
         double? heightEm;
         double? verticalAlignEm;
+        double? topEm;
         double? marginRightEm;
         double? marginLeftEm;
 
@@ -510,6 +511,10 @@ class _KatexParser {
               case 'vertical-align':
                 verticalAlignEm = _getEm(expression);
                 if (verticalAlignEm != null) continue;
+
+              case 'top':
+                topEm = _getEm(expression);
+                if (topEm != null) continue;
 
               case 'margin-right':
                 marginRightEm = _getEm(expression);
@@ -538,6 +543,7 @@ class _KatexParser {
 
         return KatexSpanStyles(
           heightEm: heightEm,
+          topEm: topEm,
           verticalAlignEm: verticalAlignEm,
           marginRightEm: marginRightEm,
           marginLeftEm: marginLeftEm,
@@ -579,6 +585,8 @@ class KatexSpanStyles {
   final double? heightEm;
   final double? verticalAlignEm;
 
+  final double? topEm;
+
   final double? marginRightEm;
   final double? marginLeftEm;
 
@@ -591,6 +599,7 @@ class KatexSpanStyles {
   const KatexSpanStyles({
     this.heightEm,
     this.verticalAlignEm,
+    this.topEm,
     this.marginRightEm,
     this.marginLeftEm,
     this.fontFamily,
@@ -605,6 +614,7 @@ class KatexSpanStyles {
     'KatexSpanStyles',
     heightEm,
     verticalAlignEm,
+    topEm,
     marginRightEm,
     marginLeftEm,
     fontFamily,
@@ -619,6 +629,7 @@ class KatexSpanStyles {
     return other is KatexSpanStyles &&
       other.heightEm == heightEm &&
       other.verticalAlignEm == verticalAlignEm &&
+      other.topEm == topEm &&
       other.marginRightEm == marginRightEm &&
       other.marginLeftEm == marginLeftEm &&
       other.fontFamily == fontFamily &&
@@ -633,6 +644,7 @@ class KatexSpanStyles {
     final args = <String>[];
     if (heightEm != null) args.add('heightEm: $heightEm');
     if (verticalAlignEm != null) args.add('verticalAlignEm: $verticalAlignEm');
+    if (topEm != null) args.add('topEm: $topEm');
     if (marginRightEm != null) args.add('marginRightEm: $marginRightEm');
     if (marginLeftEm != null) args.add('marginLeftEm: $marginLeftEm');
     if (fontFamily != null) args.add('fontFamily: $fontFamily');
@@ -654,6 +666,7 @@ class KatexSpanStyles {
     return KatexSpanStyles(
       heightEm: other.heightEm ?? heightEm,
       verticalAlignEm: other.verticalAlignEm ?? verticalAlignEm,
+      topEm: other.topEm ?? topEm,
       marginRightEm: other.marginRightEm ?? marginRightEm,
       marginLeftEm: other.marginLeftEm ?? marginLeftEm,
       fontFamily: other.fontFamily ?? fontFamily,
@@ -667,6 +680,7 @@ class KatexSpanStyles {
   KatexSpanStyles filter({
     bool heightEm = true,
     bool verticalAlignEm = true,
+    bool topEm = true,
     bool marginRightEm = true,
     bool marginLeftEm = true,
     bool fontFamily = true,
@@ -678,6 +692,7 @@ class KatexSpanStyles {
     return KatexSpanStyles(
       heightEm: heightEm ? this.heightEm : null,
       verticalAlignEm: verticalAlignEm ? this.verticalAlignEm : null,
+      topEm: topEm ? this.topEm : null,
       marginRightEm: marginRightEm ? this.marginRightEm : null,
       marginLeftEm: marginLeftEm ? this.marginLeftEm : null,
       fontFamily: fontFamily ? this.fontFamily : null,

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -327,10 +327,21 @@ class _KatexParser {
               }
             }
 
-            return KatexVlistNode(
+            final result = KatexVlistNode(
               rows: rows,
               debugHtmlNode: kDebugMode ? vlistT : null,
             );
+
+            if (_ancestorClasses.any(
+              (classes) => classes.split(' ').contains('op-limits'),
+            )) {
+              return KatexSpanNode(
+                styles: KatexSpanStyles(textAlign: KatexSpanTextAlign.center),
+                text: null,
+                nodes: [result]);
+            }
+
+            return result;
           } else {
             throw _KatexHtmlParseError();
           }
@@ -562,6 +573,10 @@ class _KatexParser {
             'large-op' => 'KaTeX_Size2',
             _ => throw _KatexHtmlParseError(),
           };
+
+        case 'op-limits':
+          // .op-limits > .vlist-t { text-align: center; }
+          // We handle this above while parsing the vlist.
 
         // TODO handle more classes from katex.scss
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -493,6 +493,8 @@ class _KatexParser {
       if (stylesheet.topLevels case [css_visitor.RuleSet() && final rule]) {
         double? heightEm;
         double? verticalAlignEm;
+        double? marginRightEm;
+        double? marginLeftEm;
 
         for (final declaration in rule.declarationGroup.declarations) {
           if (declaration case css_visitor.Declaration(
@@ -508,6 +510,20 @@ class _KatexParser {
               case 'vertical-align':
                 verticalAlignEm = _getEm(expression);
                 if (verticalAlignEm != null) continue;
+
+              case 'margin-right':
+                marginRightEm = _getEm(expression);
+                if (marginRightEm != null) {
+                  if (marginRightEm < 0) throw _KatexHtmlParseError();
+                  continue;
+                }
+
+              case 'margin-left':
+                marginLeftEm = _getEm(expression);
+                if (marginLeftEm != null) {
+                  if (marginLeftEm < 0) throw _KatexHtmlParseError();
+                  continue;
+                }
             }
 
             // TODO handle more CSS properties
@@ -523,6 +539,8 @@ class _KatexParser {
         return KatexSpanStyles(
           heightEm: heightEm,
           verticalAlignEm: verticalAlignEm,
+          marginRightEm: marginRightEm,
+          marginLeftEm: marginLeftEm,
         );
       } else {
         throw _KatexHtmlParseError();
@@ -561,6 +579,9 @@ class KatexSpanStyles {
   final double? heightEm;
   final double? verticalAlignEm;
 
+  final double? marginRightEm;
+  final double? marginLeftEm;
+
   final String? fontFamily;
   final double? fontSizeEm;
   final KatexSpanFontWeight? fontWeight;
@@ -570,6 +591,8 @@ class KatexSpanStyles {
   const KatexSpanStyles({
     this.heightEm,
     this.verticalAlignEm,
+    this.marginRightEm,
+    this.marginLeftEm,
     this.fontFamily,
     this.fontSizeEm,
     this.fontWeight,
@@ -582,6 +605,8 @@ class KatexSpanStyles {
     'KatexSpanStyles',
     heightEm,
     verticalAlignEm,
+    marginRightEm,
+    marginLeftEm,
     fontFamily,
     fontSizeEm,
     fontWeight,
@@ -594,6 +619,8 @@ class KatexSpanStyles {
     return other is KatexSpanStyles &&
       other.heightEm == heightEm &&
       other.verticalAlignEm == verticalAlignEm &&
+      other.marginRightEm == marginRightEm &&
+      other.marginLeftEm == marginLeftEm &&
       other.fontFamily == fontFamily &&
       other.fontSizeEm == fontSizeEm &&
       other.fontWeight == fontWeight &&
@@ -606,6 +633,8 @@ class KatexSpanStyles {
     final args = <String>[];
     if (heightEm != null) args.add('heightEm: $heightEm');
     if (verticalAlignEm != null) args.add('verticalAlignEm: $verticalAlignEm');
+    if (marginRightEm != null) args.add('marginRightEm: $marginRightEm');
+    if (marginLeftEm != null) args.add('marginLeftEm: $marginLeftEm');
     if (fontFamily != null) args.add('fontFamily: $fontFamily');
     if (fontSizeEm != null) args.add('fontSizeEm: $fontSizeEm');
     if (fontWeight != null) args.add('fontWeight: $fontWeight');
@@ -625,6 +654,8 @@ class KatexSpanStyles {
     return KatexSpanStyles(
       heightEm: other.heightEm ?? heightEm,
       verticalAlignEm: other.verticalAlignEm ?? verticalAlignEm,
+      marginRightEm: other.marginRightEm ?? marginRightEm,
+      marginLeftEm: other.marginLeftEm ?? marginLeftEm,
       fontFamily: other.fontFamily ?? fontFamily,
       fontSizeEm: other.fontSizeEm ?? fontSizeEm,
       fontStyle: other.fontStyle ?? fontStyle,
@@ -636,6 +667,8 @@ class KatexSpanStyles {
   KatexSpanStyles filter({
     bool heightEm = true,
     bool verticalAlignEm = true,
+    bool marginRightEm = true,
+    bool marginLeftEm = true,
     bool fontFamily = true,
     bool fontSizeEm = true,
     bool fontWeight = true,
@@ -645,6 +678,8 @@ class KatexSpanStyles {
     return KatexSpanStyles(
       heightEm: heightEm ? this.heightEm : null,
       verticalAlignEm: verticalAlignEm ? this.verticalAlignEm : null,
+      marginRightEm: marginRightEm ? this.marginRightEm : null,
+      marginLeftEm: marginLeftEm ? this.marginLeftEm : null,
       fontFamily: fontFamily ? this.fontFamily : null,
       fontSizeEm: fontSizeEm ? this.fontSizeEm : null,
       fontWeight: fontWeight ? this.fontWeight : null,

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -161,6 +161,8 @@ class _KatexParser {
   final unsupportedCssClasses = <String>[];
   final unsupportedInlineCssProperties = <String>[];
 
+  final List<String> _ancestorClasses = [];
+
   List<KatexNode> parseKatexHtml(dom.Element element) {
     assert(element.localName == 'span');
     assert(element.className == 'katex-html');
@@ -177,7 +179,9 @@ class _KatexParser {
             : 'unsupported html node');
       }
 
+      _ancestorClasses.add(node.className);
       final span = _parseSpan(node);
+      assert(_ancestorClasses.removeLast() == node.className);
 
       if (span is KatexSpanNode) {
         final marginRightEm = span.styles.marginRightEm;

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -881,6 +881,7 @@ class _KatexNodeList extends StatelessWidget {
             data: MediaQueryData(textScaler: TextScaler.noScaling),
             child: switch (e) {
               KatexSpanNode() => _KatexSpan(e),
+              KatexStrutNode() => _KatexStrut(e),
             }));
       }))));
   }
@@ -958,6 +959,30 @@ class _KatexSpan extends StatelessWidget {
         ? styles.heightEm! * (fontSize ?? em)
         : null,
       child: widget);
+  }
+}
+
+class _KatexStrut extends StatelessWidget {
+  const _KatexStrut(this.node);
+
+  final KatexStrutNode node;
+
+  @override
+  Widget build(BuildContext context) {
+    final em = DefaultTextStyle.of(context).style.fontSize!;
+
+    final verticalAlignEm = node.verticalAlignEm;
+    if (verticalAlignEm == null) {
+      return SizedBox(height: node.heightEm * em);
+    }
+
+    return SizedBox(
+      height: node.heightEm * em,
+      child: Baseline(
+        baseline: (verticalAlignEm + node.heightEm) * em,
+        baselineType: TextBaseline.alphabetic,
+        child: const Text('')),
+    );
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -954,7 +954,30 @@ class _KatexSpan extends StatelessWidget {
         child: widget);
     }
 
-    return SizedBox(
+    final marginRight = switch (styles.marginRightEm) {
+      double marginRightEm => marginRightEm * em,
+      null => null,
+    };
+    final marginLeft = switch (styles.marginLeftEm) {
+      double marginLeftEm => marginLeftEm * em,
+      null => null,
+    };
+
+    EdgeInsets? margin;
+    if (marginRight != null || marginLeft != null) {
+      margin = EdgeInsets.zero;
+      if (marginRight != null) {
+        assert(marginRight >= 0);
+        margin += EdgeInsets.only(right: marginRight);
+      }
+      if (marginLeft != null) {
+        assert(marginLeft >= 0);
+        margin += EdgeInsets.only(left: marginLeft);
+      }
+    }
+
+    return Container(
+      margin: margin,
       height: styles.heightEm != null
         ? styles.heightEm! * (fontSize ?? em)
         : null,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1027,11 +1027,20 @@ class _KatexVlist extends StatelessWidget {
   Widget build(BuildContext context) {
     final em = DefaultTextStyle.of(context).style.fontSize!;
 
-    return Stack(children: List.unmodifiable(node.rows.map((row) {
-      return Transform.translate(
-        offset: Offset(0, row.verticalOffsetEm * em),
-        child: _KatexSpan(row.node));
-    })));
+    return IntrinsicWidth(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        textBaseline: TextBaseline.alphabetic,
+        children: List.unmodifiable(node.rows.map((row) {
+          return SizedBox(
+            height: 0,
+            child: OverflowBox(
+              maxHeight: double.infinity,
+              child: Transform.translate(
+                offset: Offset(0, row.verticalOffsetEm * em),
+                child: _KatexSpan(row.node),
+              )));
+        }))));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -823,7 +823,7 @@ class MathBlock extends StatelessWidget {
     return Center(
       child: SingleChildScrollViewWithScrollbar(
         scrollDirection: Axis.horizontal,
-        child: _Katex(
+        child: Katex(
           textStyle: ContentTheme.of(context).textStylePlainParagraph,
           nodes: nodes)));
   }
@@ -844,8 +844,9 @@ TextStyle mkBaseKatexTextStyle(TextStyle style) {
     fontStyle: FontStyle.normal);
 }
 
-class _Katex extends StatelessWidget {
-  const _Katex({
+class Katex extends StatelessWidget {
+  const Katex({
+    super.key,
     required this.textStyle,
     required this.nodes,
   });
@@ -882,6 +883,7 @@ class _KatexNodeList extends StatelessWidget {
             child: switch (e) {
               KatexSpanNode() => _KatexSpan(e),
               KatexStrutNode() => _KatexStrut(e),
+              KatexVlistNode() => _KatexVlist(e),
             }));
       }))));
   }
@@ -1009,6 +1011,23 @@ class _KatexStrut extends StatelessWidget {
         baselineType: TextBaseline.alphabetic,
         child: const Text('')),
     );
+  }
+}
+
+class _KatexVlist extends StatelessWidget {
+  const _KatexVlist(this.node);
+
+  final KatexVlistNode node;
+
+  @override
+  Widget build(BuildContext context) {
+    final em = DefaultTextStyle.of(context).style.fontSize!;
+
+    return Stack(children: List.unmodifiable(node.rows.map((row) {
+      return Transform.translate(
+        offset: Offset(0, row.verticalOffsetEm * em),
+        child: _KatexSpan(row.node));
+    })));
   }
 }
 
@@ -1330,7 +1349,7 @@ class _InlineContentBuilder {
           : WidgetSpan(
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
-              child: _Katex(textStyle: widget.style, nodes: nodes));
+              child: Katex(textStyle: widget.style, nodes: nodes));
 
       case GlobalTimeNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -22,6 +22,7 @@ import 'code_block.dart';
 import 'dialog.dart';
 import 'icons.dart';
 import 'inset_shadow.dart';
+import 'katex.dart';
 import 'lightbox.dart';
 import 'message_list.dart';
 import 'poll.dart';
@@ -884,6 +885,7 @@ class _KatexNodeList extends StatelessWidget {
               KatexSpanNode() => _KatexSpan(e),
               KatexStrutNode() => _KatexStrut(e),
               KatexVlistNode() => _KatexVlist(e),
+              KatexNegativeMarginNode() => _KatexNegativeMargin(e),
             }));
       }))));
   }
@@ -957,23 +959,21 @@ class _KatexSpan extends StatelessWidget {
     }
 
     final marginRight = switch (styles.marginRightEm) {
-      double marginRightEm => marginRightEm * em,
-      null => null,
+      double marginRightEm when marginRightEm >= 0 => marginRightEm * em,
+      _ => null,
     };
     final marginLeft = switch (styles.marginLeftEm) {
-      double marginLeftEm => marginLeftEm * em,
-      null => null,
+      double marginLeftEm when marginLeftEm >= 0 => marginLeftEm * em,
+      _ => null,
     };
 
     EdgeInsets? margin;
     if (marginRight != null || marginLeft != null) {
       margin = EdgeInsets.zero;
       if (marginRight != null) {
-        assert(marginRight >= 0);
         margin += EdgeInsets.only(right: marginRight);
       }
       if (marginLeft != null) {
-        assert(marginLeft >= 0);
         margin += EdgeInsets.only(left: marginLeft);
       }
     }
@@ -1028,6 +1028,21 @@ class _KatexVlist extends StatelessWidget {
         offset: Offset(0, row.verticalOffsetEm * em),
         child: _KatexSpan(row.node));
     })));
+  }
+}
+
+class _KatexNegativeMargin extends StatelessWidget {
+  const _KatexNegativeMargin(this.node);
+
+  final KatexNegativeMarginNode node;
+
+  @override
+  Widget build(BuildContext context) {
+    final em = DefaultTextStyle.of(context).style.fontSize!;
+
+    return NegativeLeftOffset(
+      leftOffset: node.leftOffsetEm * em,
+      child: _KatexNodeList(nodes: node.nodes));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -826,6 +826,7 @@ class MathBlock extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         child: Katex(
           textStyle: ContentTheme.of(context).textStylePlainParagraph,
+          textAlign: TextAlign.center,
           nodes: nodes)));
   }
 }
@@ -849,10 +850,12 @@ class Katex extends StatelessWidget {
   const Katex({
     super.key,
     required this.textStyle,
+    this.textAlign,
     required this.nodes,
   });
 
   final TextStyle textStyle;
+  final TextAlign? textAlign;
   final List<KatexNode> nodes;
 
   @override
@@ -863,6 +866,7 @@ class Katex extends StatelessWidget {
       textDirection: TextDirection.ltr,
       child: DefaultTextStyle.merge(
         style: mkBaseKatexTextStyle(textStyle),
+        textAlign: textAlign,
         child: widget));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -824,22 +824,33 @@ class MathBlock extends StatelessWidget {
       child: SingleChildScrollViewWithScrollbar(
         scrollDirection: Axis.horizontal,
         child: _Katex(
+          textStyle: ContentTheme.of(context).textStylePlainParagraph,
           nodes: nodes)));
   }
 }
 
-// Base text style from .katex class in katex.scss :
-//   https://github.com/KaTeX/KaTeX/blob/613c3da8/src/styles/katex.scss#L13-L15
-const kBaseKatexTextStyle = TextStyle(
-  fontSize: kBaseFontSize * 1.21,
-  fontFamily: 'KaTeX_Main',
-  height: 1.2);
+/// Creates a base text style for rendering KaTeX content.
+///
+/// This applies the CSS styles defined in .katex class in katex.scss :
+///   https://github.com/KaTeX/KaTeX/blob/613c3da8/src/styles/katex.scss#L13-L15
+///
+/// Requires the [style.fontSize] to be non-null.
+TextStyle mkBaseKatexTextStyle(TextStyle style) {
+  return style.copyWith(
+    fontSize: style.fontSize! * 1.21,
+    fontFamily: 'KaTeX_Main',
+    height: 1.2,
+    fontWeight: FontWeight.normal,
+    fontStyle: FontStyle.normal);
+}
 
 class _Katex extends StatelessWidget {
   const _Katex({
+    required this.textStyle,
     required this.nodes,
   });
 
+  final TextStyle textStyle;
   final List<KatexNode> nodes;
 
   @override
@@ -848,9 +859,8 @@ class _Katex extends StatelessWidget {
 
     return Directionality(
       textDirection: TextDirection.ltr,
-      child: DefaultTextStyle(
-        style: kBaseKatexTextStyle.copyWith(
-          color: ContentTheme.of(context).textStylePlainParagraph.color),
+      child: DefaultTextStyle.merge(
+        style: mkBaseKatexTextStyle(textStyle),
         child: widget));
   }
 }
@@ -867,9 +877,11 @@ class _KatexNodeList extends StatelessWidget {
         return WidgetSpan(
           alignment: PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: switch (e) {
-            KatexSpanNode() => _KatexSpan(e),
-          });
+          child: MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.noScaling),
+            child: switch (e) {
+              KatexSpanNode() => _KatexSpan(e),
+            }));
       }))));
   }
 }
@@ -1267,7 +1279,7 @@ class _InlineContentBuilder {
           : WidgetSpan(
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
-              child: _Katex(nodes: nodes));
+              child: _Katex(textStyle: widget.style, nodes: nodes));
 
       case GlobalTimeNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -981,6 +981,9 @@ class _KatexSpan extends StatelessWidget {
       height: styles.heightEm != null
         ? styles.heightEm! * (fontSize ?? em)
         : null,
+      transform: styles.topEm != null
+        ? Matrix4.translationValues(0, styles.topEm! * em, 0)
+        : null,
       child: widget);
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -820,7 +820,11 @@ class MathBlock extends StatelessWidget {
           children: [TextSpan(text: node.texSource)])));
     }
 
-    return _Katex(inline: false, nodes: nodes);
+    return Center(
+      child: SingleChildScrollViewWithScrollbar(
+        scrollDirection: Axis.horizontal,
+        child: _Katex(
+          nodes: nodes)));
   }
 }
 
@@ -833,23 +837,14 @@ const kBaseKatexTextStyle = TextStyle(
 
 class _Katex extends StatelessWidget {
   const _Katex({
-    required this.inline,
     required this.nodes,
   });
 
-  final bool inline;
   final List<KatexNode> nodes;
 
   @override
   Widget build(BuildContext context) {
     Widget widget = _KatexNodeList(nodes: nodes);
-
-    if (!inline) {
-      widget = Center(
-        child: SingleChildScrollViewWithScrollbar(
-          scrollDirection: Axis.horizontal,
-          child: widget));
-    }
 
     return Directionality(
       textDirection: TextDirection.ltr,
@@ -1272,7 +1267,7 @@ class _InlineContentBuilder {
           : WidgetSpan(
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
-              child: _Katex(inline: true, nodes: nodes));
+              child: _Katex(nodes: nodes));
 
       case GlobalTimeNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/katex.dart
+++ b/lib/widgets/katex.dart
@@ -1,0 +1,199 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/rendering.dart';
+
+class NegativeLeftOffset extends SingleChildRenderObjectWidget {
+  NegativeLeftOffset({super.key, required this.leftOffset, super.child})
+    : assert(leftOffset.isNegative),
+      _padding = EdgeInsets.only(left: leftOffset);
+
+  final double leftOffset;
+  final EdgeInsetsGeometry _padding;
+
+  @override
+  RenderNegativePadding createRenderObject(BuildContext context) {
+    return RenderNegativePadding(
+      padding: _padding,
+      textDirection: Directionality.maybeOf(context));
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderNegativePadding renderObject,
+  ) {
+    renderObject
+      ..padding = _padding
+      ..textDirection = Directionality.maybeOf(context);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', _padding));
+  }
+}
+
+// Like [RenderPadding] but only supports negative values.
+// TODO(upstream): give Padding an option to accept negative padding (at cost of hit-testing not working)
+class RenderNegativePadding extends RenderShiftedBox {
+  RenderNegativePadding({
+    required EdgeInsetsGeometry padding,
+    TextDirection? textDirection,
+    RenderBox? child,
+  }) : assert(!padding.isNonNegative),
+       _textDirection = textDirection,
+       _padding = padding,
+       super(child);
+
+  EdgeInsets? _resolvedPaddingCache;
+  EdgeInsets get _resolvedPadding {
+    final EdgeInsets returnValue = _resolvedPaddingCache ??= padding.resolve(textDirection);
+    return returnValue;
+  }
+
+  void _markNeedResolution() {
+    _resolvedPaddingCache = null;
+    markNeedsLayout();
+  }
+
+  /// The amount to pad the child in each dimension.
+  ///
+  /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]
+  /// must not be null.
+  EdgeInsetsGeometry get padding => _padding;
+  EdgeInsetsGeometry _padding;
+  set padding(EdgeInsetsGeometry value) {
+    assert(!value.isNonNegative);
+    if (_padding == value) {
+      return;
+    }
+    _padding = value;
+    _markNeedResolution();
+  }
+
+  /// The text direction with which to resolve [padding].
+  ///
+  /// This may be changed to null, but only after the [padding] has been changed
+  /// to a value that does not depend on the direction.
+  TextDirection? get textDirection => _textDirection;
+  TextDirection? _textDirection;
+  set textDirection(TextDirection? value) {
+    if (_textDirection == value) {
+      return;
+    }
+    _textDirection = value;
+    _markNeedResolution();
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    final EdgeInsets padding = _resolvedPadding;
+    if (child != null) {
+      // Relies on double.infinity absorption.
+      return child!.getMinIntrinsicWidth(math.max(0.0, height - padding.vertical)) +
+          padding.horizontal;
+    }
+    return padding.horizontal;
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    final EdgeInsets padding = _resolvedPadding;
+    if (child != null) {
+      // Relies on double.infinity absorption.
+      return child!.getMaxIntrinsicWidth(math.max(0.0, height - padding.vertical)) +
+          padding.horizontal;
+    }
+    return padding.horizontal;
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    final EdgeInsets padding = _resolvedPadding;
+    if (child != null) {
+      // Relies on double.infinity absorption.
+      return child!.getMinIntrinsicHeight(math.max(0.0, width - padding.horizontal)) +
+          padding.vertical;
+    }
+    return padding.vertical;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    final EdgeInsets padding = _resolvedPadding;
+    if (child != null) {
+      // Relies on double.infinity absorption.
+      return child!.getMaxIntrinsicHeight(math.max(0.0, width - padding.horizontal)) +
+          padding.vertical;
+    }
+    return padding.vertical;
+  }
+
+  @override
+  @protected
+  Size computeDryLayout(covariant BoxConstraints constraints) {
+    final EdgeInsets padding = _resolvedPadding;
+    if (child == null) {
+      return constraints.constrain(Size(padding.horizontal, padding.vertical));
+    }
+    final BoxConstraints innerConstraints = constraints.deflate(padding);
+    final Size childSize = child!.getDryLayout(innerConstraints);
+    return constraints.constrain(
+      Size(padding.horizontal + childSize.width, padding.vertical + childSize.height),
+    );
+  }
+
+  @override
+  double? computeDryBaseline(covariant BoxConstraints constraints, TextBaseline baseline) {
+    final RenderBox? child = this.child;
+    if (child == null) {
+      return null;
+    }
+    final EdgeInsets padding = _resolvedPadding;
+    final BoxConstraints innerConstraints = constraints.deflate(padding);
+    final BaselineOffset result =
+        BaselineOffset(child.getDryBaseline(innerConstraints, baseline)) + padding.top;
+    return result.offset;
+  }
+
+  @override
+  void performLayout() {
+    final BoxConstraints constraints = this.constraints;
+    final EdgeInsets padding = _resolvedPadding;
+    if (child == null) {
+      size = constraints.constrain(Size(padding.horizontal, padding.vertical));
+      return;
+    }
+    final BoxConstraints innerConstraints = constraints.deflate(padding);
+    child!.layout(innerConstraints, parentUsesSize: true);
+    final BoxParentData childParentData = child!.parentData! as BoxParentData;
+    childParentData.offset = Offset(padding.left, padding.top);
+    size = constraints.constrain(
+      Size(padding.horizontal + child!.size.width, padding.vertical + child!.size.height),
+    );
+  }
+
+  @override
+  void debugPaintSize(PaintingContext context, Offset offset) {
+    super.debugPaintSize(context, offset);
+    assert(() {
+      final Rect outerRect = offset & size;
+      debugPaintPadding(
+        context.canvas,
+        outerRect,
+        child != null ? _resolvedPaddingCache!.deflateRect(outerRect) : null,
+      );
+      return true;
+    }());
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding));
+    properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
+  }
+}

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -884,6 +884,387 @@ class ContentExample {
         ]),
     ]);
 
+  static const mathBlockKatexVertical1 = ContentExample(
+    'math block katex vertical 1',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2176734
+    '```math\na\'\n```',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><msup><mi>a</mi><mo mathvariant="normal" lspace="0em" rspace="0em">′</mo></msup></mrow>'
+          '<annotation encoding="application/x-tex">a&#x27;</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.8019em;"></span>'
+            '<span class="mord">'
+              '<span class="mord mathnormal">a</span>'
+              '<span class="msupsub">'
+                '<span class="vlist-t">'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.8019em;">'
+                      '<span style="top:-3.113em;margin-right:0.05em;">'
+                        '<span class="pstrut" style="height:2.7em;"></span>'
+                        '<span class="sizing reset-size6 size3 mtight">'
+                          '<span class="mord mtight">'
+                            '<span class="mord mtight">′</span></span></span></span></span></span></span></span></span></span></span></span></span></p>',
+    [
+      MathBlockNode(
+        texSource: 'a\'',
+        nodes: [
+          KatexSpanNode(
+            styles: KatexSpanStyles(),
+            text: null,
+            nodes: [
+              KatexStrutNode(heightEm: 0.8019, verticalAlignEm: null),
+              KatexSpanNode(
+                styles: KatexSpanStyles(),
+                text: null,
+                nodes: [
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(
+                      fontFamily: 'KaTeX_Math',
+                      fontStyle: KatexSpanFontStyle.italic),
+                    text: 'a',
+                    nodes: null),
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(textAlign: KatexSpanTextAlign.left),
+                    text: null,
+                    nodes: [
+                      KatexVlistNode(
+                        rows: [
+                          KatexVlistRowNode(
+                            verticalOffsetEm: -3.113 + 2.7,
+                            node: KatexSpanNode(
+                              styles: KatexSpanStyles(marginRightEm: 0.05),
+                              text: null,
+                              nodes: [
+                                KatexSpanNode(
+                                  styles: KatexSpanStyles(fontSizeEm: 0.7),
+                                  text: null,
+                                  nodes: [
+                                    KatexSpanNode(
+                                      styles: KatexSpanStyles(),
+                                      text: null,
+                                      nodes: [
+                                        KatexSpanNode(
+                                          styles: KatexSpanStyles(),
+                                          text: '′',
+                                          nodes: null),
+                                      ]),
+                                  ]),
+                              ])),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+    ]);
+
+  static const mathBlockKatexVertical2 = ContentExample(
+    'math block katex vertical 2',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2176735
+    '```math\nx_n\n```',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><msub><mi>x</mi><mi>n</mi></msub></mrow>'
+          '<annotation encoding="application/x-tex">x_n</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.5806em;vertical-align:-0.15em;"></span>'
+            '<span class="mord">'
+              '<span class="mord mathnormal">x</span>'
+              '<span class="msupsub">'
+                '<span class="vlist-t vlist-t2">'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.1514em;">'
+                      '<span style="top:-2.55em;margin-left:0em;margin-right:0.05em;">'
+                        '<span class="pstrut" style="height:2.7em;"></span>'
+                        '<span class="sizing reset-size6 size3 mtight">'
+                          '<span class="mord mathnormal mtight">n</span></span></span></span>'
+                    '<span class="vlist-s">​</span></span>'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.15em;"><span></span></span></span></span></span></span></span></span></span></span></p>',
+    [
+      MathBlockNode(
+        texSource: 'x_n',
+        nodes: [
+          KatexSpanNode(
+            styles: KatexSpanStyles(),
+            text: null,
+            nodes: [
+              KatexStrutNode(heightEm: 0.5806, verticalAlignEm: -0.15),
+              KatexSpanNode(
+                styles: KatexSpanStyles(),
+                text: null,
+                nodes: [
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(
+                      fontFamily: 'KaTeX_Math',
+                      fontStyle: KatexSpanFontStyle.italic),
+                    text: 'x',
+                    nodes: null),
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(textAlign: KatexSpanTextAlign.left),
+                    text: null,
+                    nodes: [
+                      KatexVlistNode(
+                        rows: [
+                          KatexVlistRowNode(
+                            verticalOffsetEm: -2.55 + 2.7,
+                            node: KatexSpanNode(
+                              styles: KatexSpanStyles(
+                                marginLeftEm: 0,
+                                marginRightEm: 0.05),
+                              text: null,
+                              nodes: [
+                                KatexSpanNode(
+                                  styles: KatexSpanStyles(fontSizeEm: 0.7),
+                                  text: null,
+                                  nodes: [
+                                    KatexSpanNode(
+                                      styles: KatexSpanStyles(
+                                        fontFamily: 'KaTeX_Math',
+                                        fontStyle: KatexSpanFontStyle.italic),
+                                      text: 'n',
+                                      nodes: null),
+                                  ]),
+                              ])),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+    ]);
+
+  static const mathBlockKatexVertical3 = ContentExample(
+    'math block katex vertical 3',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2176737
+    '```math\ne^x\n```',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><msup><mi>e</mi><mi>x</mi></msup></mrow>'
+          '<annotation encoding="application/x-tex">e^x</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.7144em;"></span>'
+            '<span class="mord"><span class="mord mathnormal">e</span>'
+            '<span class="msupsub">'
+              '<span class="vlist-t">'
+                '<span class="vlist-r">'
+                  '<span class="vlist" style="height:0.7144em;">'
+                    '<span style="top:-3.113em;margin-right:0.05em;">'
+                      '<span class="pstrut" style="height:2.7em;"></span>'
+                      '<span class="sizing reset-size6 size3 mtight">'
+                        '<span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></p>',
+    [
+      MathBlockNode(
+        texSource: 'e^x',
+        nodes: [
+          KatexSpanNode(
+            styles: KatexSpanStyles(),
+            text: null,
+            nodes: [
+              KatexStrutNode(heightEm: 0.7144, verticalAlignEm: null),
+              KatexSpanNode(
+                styles: KatexSpanStyles(),
+                text: null,
+                nodes: [
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(
+                      fontFamily: 'KaTeX_Math',
+                      fontStyle: KatexSpanFontStyle.italic),
+                    text: 'e',
+                    nodes: null),
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(textAlign: KatexSpanTextAlign.left),
+                    text: null,
+                    nodes: [
+                      KatexVlistNode(
+                        rows: [
+                          KatexVlistRowNode(
+                            verticalOffsetEm: -3.113 + 2.7,
+                            node: KatexSpanNode(
+                              styles: KatexSpanStyles(marginRightEm: 0.05),
+                              text: null,
+                              nodes: [
+                                KatexSpanNode(
+                                  styles: KatexSpanStyles(fontSizeEm: 0.7),
+                                  text: null,
+                                  nodes: [
+                                    KatexSpanNode(
+                                      styles: KatexSpanStyles(
+                                        fontFamily: 'KaTeX_Math',
+                                        fontStyle: KatexSpanFontStyle.italic),
+                                      text: 'x',
+                                      nodes: null),
+                                  ]),
+                              ])),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+    ]);
+
+  static const mathBlockKatexVertical4 = ContentExample(
+    'math block katex vertical 4',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2176738
+    '```math\n_u^o\n```',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><msubsup><mrow></mrow><mi>u</mi><mi>o</mi></msubsup></mrow>'
+          '<annotation encoding="application/x-tex">_u^o</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.9614em;vertical-align:-0.247em;"></span>'
+            '<span class="mord">'
+              '<span></span>'
+              '<span class="msupsub">'
+                '<span class="vlist-t vlist-t2">'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.7144em;">'
+                      '<span style="top:-2.453em;margin-right:0.05em;">'
+                        '<span class="pstrut" style="height:2.7em;"></span>'
+                        '<span class="sizing reset-size6 size3 mtight">'
+                          '<span class="mord mathnormal mtight">u</span></span></span>'
+                      '<span style="top:-3.113em;margin-right:0.05em;">'
+                        '<span class="pstrut" style="height:2.7em;"></span>'
+                        '<span class="sizing reset-size6 size3 mtight">'
+                          '<span class="mord mathnormal mtight">o</span></span></span></span>'
+                    '<span class="vlist-s">​</span></span>'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.247em;"><span></span></span></span></span></span></span></span></span></span></span></p>',
+    [
+      MathBlockNode(
+        texSource: "_u^o",
+        nodes: [
+          KatexSpanNode(
+            styles: KatexSpanStyles(),
+            text: null,
+            nodes: [
+              KatexStrutNode(heightEm: 0.9614, verticalAlignEm: -0.247),
+              KatexSpanNode(
+                styles: KatexSpanStyles(),
+                text: null,
+                nodes: [
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(),
+                    text: null,
+                    nodes: []),
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(textAlign: KatexSpanTextAlign.left),
+                    text: null,
+                    nodes: [
+                      KatexVlistNode(
+                        rows: [
+                          KatexVlistRowNode(
+                            verticalOffsetEm: -2.453 + 2.7,
+                            node: KatexSpanNode(
+                              styles: KatexSpanStyles(marginRightEm: 0.05),
+                              text: null,
+                              nodes: [
+                                KatexSpanNode(
+                                  styles: KatexSpanStyles(fontSizeEm: 0.7),
+                                  text: null,
+                                  nodes: [
+                                    KatexSpanNode(
+                                      styles: KatexSpanStyles(
+                                        fontFamily: 'KaTeX_Math',
+                                        fontStyle: KatexSpanFontStyle.italic),
+                                      text: 'u',
+                                      nodes: null),
+                                  ]),
+                              ])),
+                          KatexVlistRowNode(
+                            verticalOffsetEm: -3.113 + 2.7,
+                            node: KatexSpanNode(
+                              styles: KatexSpanStyles(marginRightEm: 0.05),
+                              text: null,
+                              nodes: [
+                                KatexSpanNode(
+                                  styles: KatexSpanStyles(fontSizeEm: 0.7),
+                                  text: null,
+                                  nodes: [
+                                    KatexSpanNode(
+                                      styles: KatexSpanStyles(
+                                        fontFamily: 'KaTeX_Math',
+                                        fontStyle: KatexSpanFontStyle.italic),
+                                      text: 'o',
+                                      nodes: null),
+                                  ]),
+                              ])),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+    ]);
+
+  static const mathBlockKatexVertical5 = ContentExample(
+    'math block katex vertical 5',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Rajesh/near/2176739
+    '```math\na\\raisebox{0.25em}{\$b\$}c\n```',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>a</mi><mpadded voffset="0.25em"><mstyle scriptlevel="0" displaystyle="false"><mstyle scriptlevel="0" displaystyle="false"><mi>b</mi></mstyle></mstyle></mpadded><mi>c</mi></mrow>'
+          '<annotation encoding="application/x-tex">a\\raisebox{0.25em}{\$b\$}c</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.9444em;"></span>'
+            '<span class="mord mathnormal">a</span>'
+            '<span class="vlist-t">'
+              '<span class="vlist-r">'
+                '<span class="vlist" style="height:0.9444em;">'
+                  '<span style="top:-3.25em;">'
+                    '<span class="pstrut" style="height:3em;"></span>'
+                    '<span class="mord">'
+                      '<span class="mord mathnormal">b</span></span></span></span></span></span>'
+            '<span class="mord mathnormal">c</span></span></span></span></span></p>',
+    [
+      MathBlockNode(
+        texSource: 'a\\raisebox{0.25em}{\$b\$}c',
+        nodes: [
+          KatexSpanNode(
+            styles: KatexSpanStyles(),
+            text: null,
+            nodes: [
+              KatexStrutNode(heightEm: 0.9444, verticalAlignEm: null),
+              KatexSpanNode(
+                styles: KatexSpanStyles(
+                  fontFamily: 'KaTeX_Math',
+                  fontStyle: KatexSpanFontStyle.italic),
+                text: 'a',
+                nodes: null),
+              KatexVlistNode(
+                rows: [
+                  KatexVlistRowNode(
+                    verticalOffsetEm: -3.25 + 3,
+                    node: KatexSpanNode(
+                      styles: KatexSpanStyles(),
+                      text: null,
+                      nodes: [
+                        KatexSpanNode(
+                          styles: KatexSpanStyles(),
+                          text: null,
+                          nodes: [
+                            KatexSpanNode(
+                              styles: KatexSpanStyles(
+                                fontFamily: 'KaTeX_Math',
+                                fontStyle: KatexSpanFontStyle.italic),
+                              text: 'b',
+                              nodes: null),
+                          ]),
+                      ])),
+                ]),
+              KatexSpanNode(
+                styles: KatexSpanStyles(
+                  fontFamily: 'KaTeX_Math',
+                  fontStyle: KatexSpanFontStyle.italic),
+                text: 'c',
+                nodes: null),
+            ]),
+        ]),
+    ]);
+
   static const imageSingle = ContentExample(
     'single image',
     // https://chat.zulip.org/#narrow/stream/7-test-here/topic/Thumbnails/near/1900103
@@ -1955,6 +2336,11 @@ void main() async {
   testParseExample(ContentExample.mathBlockKatexSizing);
   testParseExample(ContentExample.mathBlockKatexNestedSizing);
   testParseExample(ContentExample.mathBlockKatexDelimSizing);
+  testParseExample(ContentExample.mathBlockKatexVertical1);
+  testParseExample(ContentExample.mathBlockKatexVertical2);
+  testParseExample(ContentExample.mathBlockKatexVertical3);
+  testParseExample(ContentExample.mathBlockKatexVertical4);
+  testParseExample(ContentExample.mathBlockKatexVertical5);
 
   testParseExample(ContentExample.imageSingle);
   testParseExample(ContentExample.imageSingleNoDimensions);

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -519,7 +519,7 @@ class ContentExample {
       '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></p>',
     MathInlineNode(texSource: r'\lambda', nodes: [
       KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-        KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.6944), text: null, nodes: []),
+        KatexStrutNode(heightEm: 0.6944, verticalAlignEm: null),
         KatexSpanNode(
           styles: KatexSpanStyles(
             fontFamily: 'KaTeX_Math',
@@ -539,7 +539,7 @@ class ContentExample {
       '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span></span></p>',
     [MathBlockNode(texSource: r'\lambda', nodes: [
       KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-        KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.6944), text: null, nodes: []),
+        KatexStrutNode(heightEm: 0.6944, verticalAlignEm: null),
         KatexSpanNode(
           styles: KatexSpanStyles(
             fontFamily: 'KaTeX_Math',
@@ -564,7 +564,7 @@ class ContentExample {
         '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">b</span></span></span></span></span></p>', [
       MathBlockNode(texSource: 'a', nodes: [
         KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-          KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.4306), text: null, nodes: []),
+          KatexStrutNode(heightEm: 0.4306, verticalAlignEm: null),
           KatexSpanNode(
             styles: KatexSpanStyles(
               fontFamily: 'KaTeX_Math',
@@ -575,7 +575,7 @@ class ContentExample {
       ]),
       MathBlockNode(texSource: 'b', nodes: [
         KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-          KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.6944), text: null, nodes: []),
+          KatexStrutNode(heightEm: 0.6944, verticalAlignEm: null),
           KatexSpanNode(
             styles: KatexSpanStyles(
               fontFamily: 'KaTeX_Math',
@@ -603,7 +603,7 @@ class ContentExample {
     [QuotationNode([
       MathBlockNode(texSource: r'\lambda', nodes: [
         KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-          KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.6944), text: null, nodes: []),
+          KatexStrutNode(heightEm: 0.6944, verticalAlignEm: null),
           KatexSpanNode(
             styles: KatexSpanStyles(
               fontFamily: 'KaTeX_Math',
@@ -632,7 +632,7 @@ class ContentExample {
     [QuotationNode([
       MathBlockNode(texSource: 'a', nodes: [
         KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-          KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.4306), text: null, nodes: []),
+          KatexStrutNode(heightEm: 0.4306, verticalAlignEm: null),
           KatexSpanNode(
             styles: KatexSpanStyles(
               fontFamily: 'KaTeX_Math',
@@ -643,7 +643,7 @@ class ContentExample {
       ]),
       MathBlockNode(texSource: 'b', nodes: [
         KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-          KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.6944), text: null, nodes: []),
+          KatexStrutNode(heightEm: 0.6944, verticalAlignEm: null),
           KatexSpanNode(
             styles: KatexSpanStyles(
               fontFamily: 'KaTeX_Math',
@@ -681,7 +681,7 @@ class ContentExample {
       ]),
       MathBlockNode(texSource: 'a', nodes: [
         KatexSpanNode(styles: KatexSpanStyles(), text: null, nodes: [
-          KatexSpanNode(styles: KatexSpanStyles(heightEm: 0.4306),text: null, nodes: []),
+          KatexStrutNode(heightEm: 0.4306, verticalAlignEm: null),
           KatexSpanNode(
             styles: KatexSpanStyles(
               fontFamily: 'KaTeX_Math',
@@ -731,10 +731,7 @@ class ContentExample {
             styles: KatexSpanStyles(),
             text: null,
             nodes: [
-              KatexSpanNode(
-                styles: KatexSpanStyles(heightEm: 1.6034),
-                text: null,
-                nodes: []),
+              KatexStrutNode(heightEm: 1.6034, verticalAlignEm: null),
               KatexSpanNode(
                 styles: KatexSpanStyles(fontSizeEm: 2.488), // .reset-size6.size11
                 text: '1',
@@ -800,10 +797,7 @@ class ContentExample {
             styles: KatexSpanStyles(),
             text: null,
             nodes: [
-              KatexSpanNode(
-                styles: KatexSpanStyles(heightEm: 1.6034),
-                text: null,
-                nodes: []),
+              KatexStrutNode(heightEm: 1.6034, verticalAlignEm: null),
               KatexSpanNode(
                 styles: KatexSpanStyles(fontSizeEm: 0.5), // reset-size6 size1
                 text: null,
@@ -845,10 +839,7 @@ class ContentExample {
             styles: KatexSpanStyles(),
             text: null,
             nodes: [
-              KatexSpanNode(
-                styles: KatexSpanStyles(heightEm: 3.0),
-                text: null,
-                nodes: []),
+              KatexStrutNode(heightEm: 3, verticalAlignEm: -1.25),
               KatexSpanNode(
                 styles: KatexSpanStyles(),
                 text: '⟨',
@@ -1963,10 +1954,7 @@ void main() async {
   testParseExample(ContentExample.mathBlockBetweenImages);
   testParseExample(ContentExample.mathBlockKatexSizing);
   testParseExample(ContentExample.mathBlockKatexNestedSizing);
-  // TODO: Re-enable this test after adding support for parsing
-  //       `vertical-align` in inline styles. Currently it fails
-  //       because `strut` span has `vertical-align`.
-  testParseExample(ContentExample.mathBlockKatexDelimSizing, skip: true);
+  testParseExample(ContentExample.mathBlockKatexDelimSizing);
 
   testParseExample(ContentExample.imageSingle);
   testParseExample(ContentExample.imageSingleNoDimensions);

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -1265,6 +1265,141 @@ class ContentExample {
         ]),
     ]);
 
+  static const mathBlockKatexNegativeMargins = ContentExample(
+    'math block katex negative margins',
+    '```math\n\\KaTeX\n```',
+    '<p>'
+      '<span class="katex-display"><span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mtext>KaTeX</mtext></mrow>'
+          '<annotation encoding="application/x-tex">\\KaTeX</annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base">'
+            '<span class="strut" style="height:0.8988em;vertical-align:-0.2155em;"></span>'
+            '<span class="mord text">'
+              '<span class="mord textrm">K</span>'
+              '<span class="mspace" style="margin-right:-0.17em;"></span>'
+              '<span class="vlist-t"><span class="vlist-r">'
+                '<span class="vlist" style="height:0.6833em;">'
+                  '<span style="top:-2.905em;">'
+                    '<span class="pstrut" style="height:2.7em;"></span>'
+                    '<span class="mord">'
+                      '<span class="mord textrm mtight sizing reset-size6 size3">A</span></span></span></span></span></span>'
+              '<span class="mspace" style="margin-right:-0.15em;"></span>'
+              '<span class="mord text">'
+                '<span class="mord textrm">T</span>'
+                '<span class="mspace" style="margin-right:-0.1667em;"></span>'
+                '<span class="vlist-t vlist-t2">'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.4678em;">'
+                      '<span style="top:-2.7845em;">'
+                        '<span class="pstrut" style="height:3em;"></span>'
+                        '<span class="mord">'
+                          '<span class="mord textrm">E</span></span></span></span>'
+                    '<span class="vlist-s">​</span></span>'
+                  '<span class="vlist-r">'
+                    '<span class="vlist" style="height:0.2155em;"><span></span></span></span></span>'
+                '<span class="mspace" style="margin-right:-0.125em;"></span>'
+                '<span class="mord textrm">X</span></span></span></span></span></span></span></p>',
+    [
+      MathBlockNode(
+        texSource: '\\KaTeX',
+        nodes: [
+          KatexSpanNode(
+            styles: KatexSpanStyles(),
+            text: null,
+            nodes: [
+              KatexStrutNode(heightEm: 0.8988, verticalAlignEm: -0.2155),
+              KatexSpanNode(
+                styles: KatexSpanStyles(),
+                text: null,
+                nodes: [
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(fontFamily: 'KaTeX_Main'),
+                    text: 'K',
+                    nodes: null),
+                  KatexSpanNode(
+                    styles: KatexSpanStyles(marginRightEm: -0.17),
+                    text: null,
+                    nodes: []),
+                  KatexNegativeMarginNode(
+                    leftOffsetEm: -0.17,
+                    nodes: [
+                      KatexVlistNode(
+                        rows: [
+                          KatexVlistRowNode(
+                            verticalOffsetEm: -2.905 + 2.7,
+                            node: KatexSpanNode(
+                              styles: KatexSpanStyles(),
+                              text: null,
+                              nodes: [
+                                KatexSpanNode(
+                                  styles: KatexSpanStyles(
+                                    fontFamily: 'KaTeX_Main',
+                                    fontSizeEm: 0.7),
+                                  text: 'A',
+                                  nodes: null),
+                              ])),
+                        ]),
+                      KatexSpanNode(
+                        styles: KatexSpanStyles(marginRightEm: -0.15),
+                        text: null,
+                        nodes: []),
+                      KatexNegativeMarginNode(
+                        leftOffsetEm: -0.15,
+                        nodes: [
+                          KatexSpanNode(
+                            styles: KatexSpanStyles(),
+                            text: null,
+                            nodes: [
+                              KatexSpanNode(
+                                styles: KatexSpanStyles(
+                                  fontFamily: 'KaTeX_Main'),
+                                text: 'T',
+                                nodes: null),
+                              KatexSpanNode(
+                                styles: KatexSpanStyles(marginRightEm: -0.1667),
+                                text: null,
+                                nodes: []),
+                              KatexNegativeMarginNode(
+                                leftOffsetEm: -0.1667,
+                                nodes: [
+                                  KatexVlistNode(
+                                    rows: [
+                                      KatexVlistRowNode(
+                                        verticalOffsetEm: -2.7845 + 3,
+                                        node: KatexSpanNode(
+                                          styles: KatexSpanStyles(),
+                                          text: null,
+                                          nodes: [
+                                            KatexSpanNode(
+                                              styles: KatexSpanStyles(
+                                                fontFamily: 'KaTeX_Main'),
+                                              text: 'E',
+                                              nodes: null),
+                                          ])),
+                                    ]),
+                                  KatexSpanNode(
+                                    styles: KatexSpanStyles(marginRightEm: -0.125),
+                                    text: null,
+                                    nodes: []),
+                                  KatexNegativeMarginNode(
+                                    leftOffsetEm: -0.125,
+                                    nodes: [
+                                      KatexSpanNode(
+                                        styles: KatexSpanStyles(
+                                          fontFamily: 'KaTeX_Main'),
+                                        text: 'X',
+                                        nodes: null),
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+    ]);
+
   static const imageSingle = ContentExample(
     'single image',
     // https://chat.zulip.org/#narrow/stream/7-test-here/topic/Thumbnails/near/1900103
@@ -2341,6 +2476,7 @@ void main() async {
   testParseExample(ContentExample.mathBlockKatexVertical3);
   testParseExample(ContentExample.mathBlockKatexVertical4);
   testParseExample(ContentExample.mathBlockKatexVertical5);
+  testParseExample(ContentExample.mathBlockKatexNegativeMargins);
 
   testParseExample(ContentExample.imageSingle);
   testParseExample(ContentExample.imageSingleNoDimensions);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -697,6 +697,13 @@ void main() {
           ('b', Offset(10.88, -0.66), Size(8.82, 25.0)),
           ('c', Offset(19.70, 4.16), Size(8.90, 25.0)),
         ]),
+        (ContentExample.mathBlockKatexNegativeMargins, [
+          ('K', Offset(0.0, 8.64), Size(16.0, 25.0)),
+          ('A', Offset(12.50, 10.85), Size(10.79, 17.0)),
+          ('T', Offset(20.21, 9.36), Size(14.85, 25.0)),
+          ('E', Offset(31.63, 14.52), Size(14.0, 25.0)),
+          ('X', Offset(43.06, 9.85), Size(15.42, 25.0)),
+        ]),
       ];
 
       for (final testCase in testCases) {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -671,9 +671,7 @@ void main() {
           fontSize: baseTextStyle.fontSize!,
           fontHeight: baseTextStyle.height!);
       }
-    }, skip: true); // TODO: Re-enable this test after adding support for parsing
-                    // `vertical-align` in inline styles. Currently it fails
-                    // because `strut` span has `vertical-align`.
+    });
   });
 
   /// Make a [TargetFontSizeFinder] to pass to [checkFontSizeRatio],

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -595,16 +595,20 @@ void main() {
       final content = ContentExample.mathBlockKatexSizing;
       await prepareContent(tester, plainContent(content.html));
 
+      final context = tester.element(find.byType(MathBlock));
+      final baseTextStyle =
+        mkBaseKatexTextStyle(ContentTheme.of(context).textStylePlainParagraph);
+
       final mathBlockNode = content.expectedNodes.single as MathBlockNode;
       final baseNode = mathBlockNode.nodes!.single as KatexSpanNode;
       final nodes = baseNode.nodes!.skip(1); // Skip .strut node.
       for (var katexNode in nodes) {
         katexNode = katexNode as KatexSpanNode;
-        final fontSize = katexNode.styles.fontSizeEm! * kBaseKatexTextStyle.fontSize!;
+        final fontSize = katexNode.styles.fontSizeEm! * baseTextStyle.fontSize!;
         checkKatexText(tester, katexNode.text!,
           fontFamily: 'KaTeX_Main',
           fontSize: fontSize,
-          fontHeight: kBaseKatexTextStyle.height!);
+          fontHeight: baseTextStyle.height!);
       }
     });
 
@@ -617,17 +621,21 @@ void main() {
       final content = ContentExample.mathBlockKatexNestedSizing;
       await prepareContent(tester, plainContent(content.html));
 
-      var fontSize = 0.5 * kBaseKatexTextStyle.fontSize!;
+      final context = tester.element(find.byType(MathBlock));
+      final baseTextStyle =
+        mkBaseKatexTextStyle(ContentTheme.of(context).textStylePlainParagraph);
+
+      var fontSize = 0.5 * baseTextStyle.fontSize!;
       checkKatexText(tester, '1',
         fontFamily: 'KaTeX_Main',
         fontSize: fontSize,
-        fontHeight: kBaseKatexTextStyle.height!);
+        fontHeight: baseTextStyle.height!);
 
       fontSize = 4.976 * fontSize;
       checkKatexText(tester, '2',
         fontFamily: 'KaTeX_Main',
         fontSize: fontSize,
-        fontHeight: kBaseKatexTextStyle.height!);
+        fontHeight: baseTextStyle.height!);
     });
 
     testWidgets('displays KaTeX content with different delimiter sizing', (tester) async {
@@ -643,13 +651,15 @@ void main() {
       final baseNode = mathBlockNode.nodes!.single as KatexSpanNode;
       var nodes = baseNode.nodes!.skip(1); // Skip .strut node.
 
-      final fontSize = kBaseKatexTextStyle.fontSize!;
+      final context = tester.element(find.byType(MathBlock));
+      final baseTextStyle =
+        mkBaseKatexTextStyle(ContentTheme.of(context).textStylePlainParagraph);
 
       final firstNode = nodes.first as KatexSpanNode;
       checkKatexText(tester, firstNode.text!,
         fontFamily: 'KaTeX_Main',
-        fontSize: fontSize,
-        fontHeight: kBaseKatexTextStyle.height!);
+        fontSize: baseTextStyle.fontSize!,
+        fontHeight: baseTextStyle.height!);
       nodes = nodes.skip(1);
 
       for (var katexNode in nodes) {
@@ -658,8 +668,8 @@ void main() {
         final fontFamily = katexNode.styles.fontFamily!;
         checkKatexText(tester, katexNode.text!,
           fontFamily: fontFamily,
-          fontSize: fontSize,
-          fontHeight: kBaseKatexTextStyle.height!);
+          fontSize: baseTextStyle.fontSize!,
+          fontHeight: baseTextStyle.height!);
       }
     }, skip: true); // TODO: Re-enable this test after adding support for parsing
                     // `vertical-align` in inline styles. Currently it fails

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -677,32 +677,32 @@ void main() {
     group('characters render at specific offsets with specific size: ', () {
       final testCases = [
         (ContentExample.mathBlockKatexVertical1, [
-          ('a', Offset(0.0, 5.28), Size(10.88, 25.0)),
-          ('′', Offset(10.88, 1.13), Size(3.96, 17.0)),
+          ('a', Offset(0.0, 4.36), Size(10.88, 25.0)),
+          ('′', Offset(10.87, 0.26), Size(3.96, 17.0))
         ]),
         (ContentExample.mathBlockKatexVertical2, [
-          ('x', Offset(0.0, 5.28), Size(11.76, 25.0)),
-          ('n', Offset(11.76, 13.65), Size(8.63, 17.0)),
+          ('x', Offset(0.0, 4.36), Size(11.76, 25.0)),
+          ('n', Offset(11.76, 12.79), Size(8.63, 17.0))
         ]),
         (ContentExample.mathBlockKatexVertical3, [
-          ('e', Offset(0.0, 5.28), Size(9.58, 25.0)),
-          ('x', Offset(9.58, 2.07), Size(8.23, 17.0)),
+          ('e', Offset(0.0, 4.36), Size(9.58, 25.0)),
+          ('x', Offset(9.58, 1.20), Size(8.23, 17.0))
         ]),
         (ContentExample.mathBlockKatexVertical4, [
-          ('u', Offset(0.0, 15.65), Size(8.23, 17.0)),
-          ('o', Offset(0.0, 2.07), Size(6.98, 17.0)),
+          ('u', Offset(0.0, 14.82), Size(8.23, 17.0)),
+          ('o', Offset(0.0, 1.24), Size(6.98, 17.0))
         ]),
         (ContentExample.mathBlockKatexVertical5, [
-          ('a', Offset(0.0, 4.16), Size(10.88, 25.0)),
-          ('b', Offset(10.88, -0.66), Size(8.82, 25.0)),
-          ('c', Offset(19.70, 4.16), Size(8.90, 25.0)),
+          ('a', Offset(0.0, 4.24), Size(10.88, 25.0)),
+          ('b', Offset(10.87, -0.57), Size(8.82, 25.0)),
+          ('c', Offset(19.69, 4.24), Size(8.9, 25.0))
         ]),
         (ContentExample.mathBlockKatexNegativeMargins, [
-          ('K', Offset(0.0, 8.64), Size(16.0, 25.0)),
-          ('A', Offset(12.50, 10.85), Size(10.79, 17.0)),
-          ('T', Offset(20.21, 9.36), Size(14.85, 25.0)),
-          ('E', Offset(31.63, 14.52), Size(14.0, 25.0)),
-          ('X', Offset(43.06, 9.85), Size(15.42, 25.0)),
+          ('K', Offset(0.0, 7.75), Size(16.0, 25.0)),
+          ('A', Offset(12.50, 9.97), Size(10.79, 17.0)),
+          ('T', Offset(20.20, 8.48), Size(14.85, 25.0)),
+          ('E', Offset(31.62, 13.64), Size(14.0, 25.0)),
+          ('X', Offset(43.05, 8.96), Size(15.42, 25.0)),
         ]),
       ];
 
@@ -726,9 +726,9 @@ void main() {
 
             final rect = tester.getRect(find.text(character));
             check(rect.topLeft - baseRect.topLeft)
-              .within(distance: 0.02, from: topLeftOffset);
+              .within(distance: 0.05, from: topLeftOffset);
             check(rect.size)
-              .within(distance: 0.02, from: size);
+              .within(distance: 0.05, from: size);
           }
         });
       }


### PR DESCRIPTION
Stacked on top of #1559.

Currently a draft because there are some vertical height differences in the tests, after f10a0783646f95593ae381c3bd0caae8f92ae694 that I still need to figure out. But otherwise when seeing the content side-by-side with Web, I wasn't able to see any differences.