### PR TITLE
store: Pass `dont_block` in first poll attempt after a failure

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -582,12 +582,12 @@ class PerAccountStore extends PerAccountStoreBase with
     _updateMachine = value;
   }
 
-  bool get isLoading => _isLoading;
-  bool _isLoading = false;
+  bool get isRecoveringEventStream => _isRecoveringEventStream;
+  bool _isRecoveringEventStream = false;
   @visibleForTesting
-  set isLoading(bool value) {
-    if (_isLoading == value) return;
-    _isLoading = value;
+  set isRecoveringEventStream(bool value) {
+    if (_isRecoveringEventStream == value) return;
+    _isRecoveringEventStream = value;
     notifyListeners();
   }
 
@@ -1511,7 +1511,7 @@ class UpdateMachine {
     // and failures, the successes themselves should space out the requests.
     _pollBackoffMachine = null;
 
-    store.isLoading = false;
+    store.isRecoveringEventStream = false;
     _accumulatedTransientFailureCount = 0;
     reportErrorToUserBriefly(null);
   }
@@ -1530,7 +1530,7 @@ class UpdateMachine {
   ///  * [_handlePollError], which handles errors from the rest of [poll]
   ///    and errors this method rethrows.
   Future<void> _handlePollRequestError(Object error, StackTrace stackTrace) async {
-    store.isLoading = true;
+    store.isRecoveringEventStream = true;
 
     if (error is! ApiRequestException) {
       // Some unexpected error, outside even making the HTTP request.
@@ -1588,7 +1588,7 @@ class UpdateMachine {
     // or an unexpected exception representing a bug in our code or the server.
     // Either way, the show must go on.  So reload server data from scratch.
 
-    store.isLoading = true;
+    store.isRecoveringEventStream = true;
 
     bool isUnexpected;
     // TODO(#1054): handle auth failure

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -79,7 +79,7 @@ class _ZulipAppBarBottom extends StatelessWidget implements PreferredSizeWidget 
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
-    if (!store.isLoading) return const SizedBox.shrink();
+    if (!store.isRecoveringEventStream) return const SizedBox.shrink();
     return LinearProgressIndicator(minHeight: 4.0, backgroundColor: backgroundColor);
   }
 }

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -45,7 +45,7 @@ extension GlobalStoreChecks on Subject<GlobalStore> {
 
 extension PerAccountStoreChecks on Subject<PerAccountStore> {
   Subject<ApiConnection> get connection => has((x) => x.connection, 'connection');
-  Subject<bool> get isLoading => has((x) => x.isLoading, 'isLoading');
+  Subject<bool> get isRecoveringEventStream => has((x) => x.isRecoveringEventStream, 'isRecoveringEventStream');
   Subject<Uri> get realmUrl => has((x) => x.realmUrl, 'realmUrl');
   Subject<String> get zulipVersion => has((x) => x.zulipVersion, 'zulipVersion');
   Subject<bool> get realmMandatoryTopics => has((x) => x.realmMandatoryTopics, 'realmMandatoryTopics');

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -841,7 +841,7 @@ void main() {
         await prepareError();
         updateMachine.debugAdvanceLoop();
         async.elapse(Duration.zero);
-        check(store).isLoading.isTrue();
+        check(store).isRecoveringEventStream.isTrue();
 
         if (expectBackoff) {
           // The reload doesn't happen immediately; there's a timer.
@@ -853,7 +853,7 @@ void main() {
         // The global store has a new store.
         check(globalStore.perAccountSync(store.accountId)).not((it) => it.identicalTo(store));
         updateFromGlobalStore();
-        check(store).isLoading.isFalse();
+        check(store).isRecoveringEventStream.isFalse();
 
         // The new UpdateMachine updates the new store.
         updateMachine.debugPauseLoop();
@@ -879,7 +879,7 @@ void main() {
         updateMachine.debugAdvanceLoop();
         async.elapse(Duration.zero);
         checkLastRequest(lastEventId: 1);
-        check(store).isLoading.isTrue();
+        check(store).isRecoveringEventStream.isTrue();
 
         // Polling doesn't resume immediately; there's a timer.
         check(async.pendingTimers).length.equals(1);
@@ -895,7 +895,7 @@ void main() {
         async.flushTimers();
         checkLastRequest(lastEventId: 1);
         check(updateMachine.lastEventId).equals(2);
-        check(store).isLoading.isFalse();
+        check(store).isRecoveringEventStream.isFalse();
       });
     }
 
@@ -1036,7 +1036,7 @@ void main() {
         updateMachine.debugAdvanceLoop();
         async.elapse(Duration.zero);
         if (shouldCheckRequest) checkLastRequest(lastEventId: 1);
-        check(store).isLoading.isTrue();
+        check(store).isRecoveringEventStream.isTrue();
       }
 
       Subject<String> checkReported(void Function() prepareError) {
@@ -1186,7 +1186,7 @@ void main() {
       globalStore.clearCachedApiConnections();
       updateMachine.debugAdvanceLoop();
       async.elapse(Duration.zero); // the bad-event-queue error arrives
-      check(store).isLoading.isTrue();
+      check(store).isRecoveringEventStream.isTrue();
     }
 
     test('user logged out before new store is loaded', () => awaitFakeAsync((async) async {

--- a/test/widgets/app_bar_test.dart
+++ b/test/widgets/app_bar_test.dart
@@ -31,7 +31,7 @@ void main() {
     await tester.pumpAndSettle();
     final rectBefore = tester.getRect(find.byType(ZulipAppBar));
     check(finder.evaluate()).isEmpty();
-    store.isLoading = true;
+    store.isRecoveringEventStream = true;
 
     await tester.pump();
     check(tester.getRect(find.byType(ZulipAppBar))).equals(rectBefore);


### PR DESCRIPTION
Fixes #979.

Discussion:
  https://github.com/zulip/zulip-flutter/issues/979#issuecomment-2993296322

------

Tested manually, with and without this change:

1. Log out from CZO (too active; events coming in frequently); connect to a not-very-active org

2. Make an artificial network error in the `getEvents` binding:

```diff
diff --git lib/api/route/events.dart lib/api/route/events.dart
index bd14521c7..da7bf4fea 100644
--- lib/api/route/events.dart
+++ lib/api/route/events.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import '../core.dart';
+import '../exception.dart';
 import '../model/events.dart';
 import '../model/initial_snapshot.dart';
 
@@ -27,6 +28,7 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection) {
 Future<GetEventsResult> getEvents(ApiConnection connection, {
   required String queueId, int? lastEventId, bool? dontBlock,
 }) {
+  throw NetworkException(routeName: 'foo', message: 'foo', cause: 'foo');
   return connection.get('getEvents', GetEventsResult.fromJson, 'events', {
     'queue_id': RawParameter(queueId),
     if (lastEventId != null) 'last_event_id': lastEventId,
```

3. Watch the logs to see retries going by
4. Comment out the `throw NetworkException` line and do a hot-reload
5. Watch the logs for `dont_block` in the `GET /events`, and watch the app to see if the loading indicator goes away quickly
   - Without the change, I don't see `dont_block`, and the loading indicator doesn't go away until the next event comes in
   - With the change, I see `dont_block`, and the loading indicator goes away quickly