### PR TITLE
ci: Work around accidental desync of Flutter main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       # pubspec is satisfied.  It's uncommon for flutter/flutter to go
       # more than 100 commits between tags.  Fetch 1000 for good measure.
       run: |
-        git clone --depth=1000 -b main https://github.com/flutter/flutter ~/flutter
+        # TODO temp hack 2025-07-08 as Flutter's `main` is broken but `master` works:
+        #   https://github.com/zulip/zulip-flutter/pull/1688#issuecomment-3050661097
+        #   https://discord.com/channels/608014603317936148/608021351567065092/1392301750383415376
+        git clone --depth=1000 -b master https://github.com/flutter/flutter ~/flutter
         TZ=UTC git --git-dir ~/flutter/.git log -1 --format='%h | %ci | %s' --date=iso8601-local
         echo ~/flutter/bin >> "$GITHUB_PATH"
 
@@ -31,7 +34,7 @@ jobs:
         # (or "upstream/master"):
         #   https://github.com/flutter/flutter/issues/160626
         # TODO(upstream): make workaround unneeded
-        git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
+        # TODO, see temp hack above: git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
 
     - name: Download Flutter SDK artifacts (flutter precache)
       run: flutter precache --universal


### PR DESCRIPTION
This infra issue in Flutter is currently causing our CI to fail:
  https://github.com/zulip/zulip-flutter/pull/1688#issuecomment-3050661097
  https://discord.com/channels/608014603317936148/608021351567065092/1392301750383415376
