### PR TITLE
msglist: In keyword search narrow, highlight keywords in message content

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -913,6 +913,10 @@ class GlobalTimeNode extends InlineContentNode {
   }
 }
 
+class HighlightNode extends InlineContainerNode {
+  const HighlightNode({super.debugHtmlNode, required super.nodes});
+}
+
 ////////////////////////////////////////////////////////////////
 
 /// Parser for the inline-content subtrees within Zulip content HTML.
@@ -1085,6 +1089,10 @@ class _ZulipInlineContentParser {
       if (!datetime.isUtc) return unimplemented();
 
       return GlobalTimeNode(datetime: datetime, debugHtmlNode: debugHtmlNode);
+    }
+
+    if (localName == 'span' && className == 'highlight') {
+      return HighlightNode(nodes: nodes(), debugHtmlNode: debugHtmlNode);
     }
 
     if (localName == 'audio' && className.isEmpty) {

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -48,6 +48,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.2, 240, 0.7, 0.7).toColor(),
       colorGlobalTimeBackground: const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor(),
       colorGlobalTimeBorder: const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor(),
+      colorHighlightBackground: const Color(0xfffcef9f),
       colorLink: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
@@ -82,6 +83,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.25, 240, 0.52, 0.6).toColor(),
       colorGlobalTimeBackground: const HSLColor.fromAHSL(0.2, 0, 0, 0).toColor(),
       colorGlobalTimeBorder: const HSLColor.fromAHSL(0.4, 0, 0, 0).toColor(),
+      colorHighlightBackground: const Color(0xffffe757).withValues(alpha: 0.35),
       colorLink: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor(), // the same as light in Web
       colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
@@ -115,6 +117,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.colorDirectMentionBackground,
     required this.colorGlobalTimeBackground,
     required this.colorGlobalTimeBorder,
+    required this.colorHighlightBackground,
     required this.colorLink,
     required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
@@ -148,6 +151,10 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final Color colorDirectMentionBackground;
   final Color colorGlobalTimeBackground;
   final Color colorGlobalTimeBorder;
+
+  // From Figma: https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=10904-102278&m=dev
+  final Color colorHighlightBackground;
+
   final Color colorLink;
   final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
@@ -209,6 +216,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     Color? colorDirectMentionBackground,
     Color? colorGlobalTimeBackground,
     Color? colorGlobalTimeBorder,
+    Color? colorHighlightBackground,
     Color? colorLink,
     Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
@@ -232,6 +240,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorDirectMentionBackground: colorDirectMentionBackground ?? this.colorDirectMentionBackground,
       colorGlobalTimeBackground: colorGlobalTimeBackground ?? this.colorGlobalTimeBackground,
       colorGlobalTimeBorder: colorGlobalTimeBorder ?? this.colorGlobalTimeBorder,
+      colorHighlightBackground: colorHighlightBackground ?? this.colorHighlightBackground,
       colorLink: colorLink ?? this.colorLink,
       colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
@@ -262,6 +271,7 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorDirectMentionBackground: Color.lerp(colorDirectMentionBackground, other.colorDirectMentionBackground, t)!,
       colorGlobalTimeBackground: Color.lerp(colorGlobalTimeBackground, other.colorGlobalTimeBackground, t)!,
       colorGlobalTimeBorder: Color.lerp(colorGlobalTimeBorder, other.colorGlobalTimeBorder, t)!,
+      colorHighlightBackground: Color.lerp(colorHighlightBackground, other.colorHighlightBackground, t)!,
       colorLink: Color.lerp(colorLink, other.colorLink, t)!,
       colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,
@@ -1277,6 +1287,10 @@ class _InlineContentBuilder {
       case GlobalTimeNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
           child: GlobalTime(node: node, ambientTextStyle: widget.style));
+
+      case HighlightNode():
+        return _buildNodes(node.nodes,
+          style: TextStyle(backgroundColor: ContentTheme.of(_context!).colorHighlightBackground));
 
       case UnimplementedInlineContentNode():
         return _errorUnimplemented(node, context: _context!);

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -261,6 +261,13 @@ class ContentExample {
     GlobalTimeNode(
       datetime: DateTime.parse("2024-03-07T23:00:00Z")));
 
+  static final highlight = ContentExample.inline(
+    'highlight (for search)',
+    null, // keyword highlighting is done by the server; no Markdown representation
+    expectedText: 'keyword',
+    '<p><span class="highlight">keyword</span></p>',
+    const HighlightNode(nodes: [TextNode('keyword')]));
+
   static final messageLink = ContentExample.inline(
     'message link',
     '#**api design>notation for near links@1972281**',
@@ -1822,6 +1829,8 @@ void main() async {
       inlineUnimplemented('<time datetime="2024-01-30T17:33:00">2024-01-30T17:33:00</time>'),
     );
   });
+
+  testParseExample(ContentExample.highlight);
 
   //
   // Block content.

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1167,6 +1167,8 @@ void main() {
     });
   });
 
+  testContentSmoke(ContentExample.highlight);
+
   group('InlineAudio', () {
     Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContent(tester, plainContent(html),


### PR DESCRIPTION
Fixes #1692.

Still TODO:

- Tests (model and widget tests for the message list? maybe just model tests)
- Resolve a slightly annoying rebase conflict with #1624 

~~But otherwise I think this is ready.~~

—Oh no, hmm, the code-blocks issue #1695 might need to block this after all; it's ugly when there's a match in a code block:

<img width="559" alt="image" src="https://github.com/user-attachments/assets/b47d6bf4-50ce-44af-817d-6e0b82b61377" />

Figma for what highlighting should look like: https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=10904-102304&m=dev

-----

| Light | Dark |
| --- | --- |
| <img width="559" alt="image" src="https://github.com/user-attachments/assets/b0461e9c-729e-4995-b134-ee8f5e613afb" /> | <img width="559" alt="image" src="https://github.com/user-attachments/assets/3f716578-85dd-4f1d-bdb8-1f6034eed6cd" /> |

cc @alya to look at the screenshots.