### PR TITLE
ci: Fetch 3000 commits from upstream, rather than 1000

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,17 @@ jobs:
       # so that Flutter knows its version and sees the constraint in our
       # pubspec is satisfied.  It's uncommon for flutter/flutter to go
       # more than 100 commits between tags.  Fetch 1000 for good measure.
+      # TODO(upstream): Around 2025-05, Flutter upstream stopped making
+      #   tags within the main/master branch.  Get that fixed:
+      #     https://github.com/zulip/zulip-flutter/issues/1710
+      #   Pending that, fetch more than 1000 commits.
       run: |
         # TODO temp hack 2025-07-08 as Flutter's `main` is broken but `master` works:
         #   https://github.com/zulip/zulip-flutter/pull/1688#issuecomment-3050661097
         #   https://discord.com/channels/608014603317936148/608021351567065092/1392301750383415376
         #   https://github.com/flutter/flutter/issues/171833
         #   (See also "temp hack" items below.)
-        git clone --depth=1000 -b master https://github.com/flutter/flutter ~/flutter
+        git clone --depth=3000 -b master https://github.com/flutter/flutter ~/flutter
         TZ=UTC git --git-dir ~/flutter/.git log -1 --format='%h | %ci | %s' --date=iso8601-local
         echo ~/flutter/bin >> "$GITHUB_PATH"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,7 @@ jobs:
       #     https://github.com/zulip/zulip-flutter/issues/1710
       #   Pending that, fetch more than 1000 commits.
       run: |
-        # TODO temp hack 2025-07-08 as Flutter's `main` is broken but `master` works:
-        #   https://github.com/zulip/zulip-flutter/pull/1688#issuecomment-3050661097
-        #   https://discord.com/channels/608014603317936148/608021351567065092/1392301750383415376
-        #   https://github.com/flutter/flutter/issues/171833
-        #   (See also "temp hack" items below.)
-        git clone --depth=3000 -b master https://github.com/flutter/flutter ~/flutter
+        git clone --depth=3000 -b main https://github.com/flutter/flutter ~/flutter
         TZ=UTC git --git-dir ~/flutter/.git log -1 --format='%h | %ci | %s' --date=iso8601-local
         echo ~/flutter/bin >> "$GITHUB_PATH"
 
@@ -40,7 +35,7 @@ jobs:
         # (or "upstream/master"):
         #   https://github.com/flutter/flutter/issues/160626
         # TODO(upstream): make workaround unneeded
-        # TODO, see temp hack above: git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
+        git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
 
     - name: Download Flutter SDK artifacts (flutter precache)
       run: flutter precache --universal
@@ -49,5 +44,4 @@ jobs:
       run: flutter pub get
 
     - name: Run tools/check
-      # TODO omitting flutter_version, see temp hack above
-      run: TERM=dumb tools/check --verbose --all-files analyze test build_runner l10n drift pigeon icons android shellcheck
+      run: TERM=dumb tools/check --all --verbose

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -29,8 +29,9 @@ jobs:
         # so that Flutter knows its version and sees the constraint in our
         # pubspec is satisfied.  It's uncommon for flutter/flutter to go
         # more than 100 commits between tags.  Fetch 1000 for good measure.
+        # TODO(upstream): See ci.yml for why we fetch more than 1000.
         run: |
-          git clone --depth=1000 -b main https://github.com/flutter/flutter ~/flutter
+          git clone --depth=3000 -b main https://github.com/flutter/flutter ~/flutter
           TZ=UTC git --git-dir ~/flutter/.git log -1 --format='%h | %ci | %s' --date=iso8601-local
           echo ~/flutter/bin >> "$GITHUB_PATH"
 


### PR DESCRIPTION
Fixes #1710.

This should work around the problem for a few more months.  If it doesn't get fixed upstream by then, we can figure something else out.

While we're here, also revert the temp hack we needed for a previous issue:

#### a3bbee9f0 ci: Revert temp hack for desync of Flutter main branch

This reverts commits 9cc34cd7e and 37af86db6 (#1691, #1690).

The operational issue in the upstream repo which this worked around has been fixed.
