### PR TITLE
msglist test: Fix a state leak from mutating eg.selfUser

### DIFF
--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1693,15 +1693,18 @@ void main() {
         }
       }
 
+      final user = eg.user();
+
       Future<void> handleNewAvatarEventAndPump(WidgetTester tester, String avatarUrl) async {
-        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: eg.selfUser.userId, avatarUrl: avatarUrl));
+        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId, avatarUrl: avatarUrl));
         await tester.pump();
       }
 
       prepareBoringImageHttpClient();
 
-      await setupMessageListPage(tester, messageCount: 10);
-      checkResultForSender(eg.selfUser.avatarUrl);
+      await setupMessageListPage(tester, users: [user],
+        messages: [eg.streamMessage(sender: user)]);
+      checkResultForSender(user.avatarUrl);
 
       await handleNewAvatarEventAndPump(tester, '/foo.png');
       checkResultForSender('/foo.png');


### PR DESCRIPTION
Fixes #1712.

Our CI has been failing in this test file since yesterday; this change fixes that.

This test had been having the store handle a RealmUserUpdateEvent affecting `eg.selfUser`.  That means the store mutates the actual User object it has... which, in this test context, means the value that `eg.selfUser` is bound to as a final variable.

As a result, when the test gets cleaned up with testBinding.reset, the store gets discarded as usual so that the next test will get a fresh store... but the User object at `eg.selfUser` is still the one that's been mutated by this test.

That's buggy in principle.  Concretely, here, it causes the self-user to have a non-null avatar.  When a later test sends a message and causes an outbox-message to appear in the tree, that results in a NetworkImage.  And that throws an error, because no HttpClient provider has been set, because that latter test wasn't expecting to create any `NetworkImage`s.  That's the failure we've been seeing in CI.

It's still a bit mysterious why this had previously been working (or anyway these tests hadn't been failing).  It started failing with an upstream change merged yesterday, which makes changes to NetworkImage that look innocuous: its `==` and `hashCode` become
finer-grained, and its `toString` more detailed.   In any case,
the bug is ours to fix.

It'd also be good to follow up here by systematically preventing this sort of state leak between tests.  But that comes after getting our CI passing again.