### PR TITLE
style: Set correct dark-theme message background color

### DIFF
--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -225,7 +225,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.2),
     bgMenuButtonSelected: Colors.black.withValues(alpha: 0.25),
-    bgMessageRegular: const HSLColor.fromAHSL(1, 0, 0, 0.11).toColor(),
+    bgMessageRegular: const Color(0xFF1D1D1D),
     bgTopBar: const Color(0xff242424),
     borderBar: const Color(0xffffffff).withValues(alpha: 0.1),
     borderMenuButtonSelected: Colors.white.withValues(alpha: 0.1),


### PR DESCRIPTION
Fixes #1685.

The DesignVariables.bgMessageRegular color was slightly incorrect in dark mode. The previous value, const HSLColor.fromAHSL(1, 0, 0, 0.11).toColor(), resulted in a background color of #1C1C1C, which created a noticeable contrast with the main background. This value might have been a legacy from a previous design iteration.

The Figma design clearly specifies #1D1D1D for the bg-message-regular variable in dark mode. This change updates the value to match the design specification, ensuring a consistent and uniform background for messages.

Before 
<img width="632" height="1268" alt="unnamed-2" src="https://github.com/user-attachments/assets/3c9cff9b-c147-43cd-925f-67a797eb2e9e" />

After
<img width="576" height="1224" alt="unnamed" src="https://github.com/user-attachments/assets/0dacbbd5-3aca-4d47-94a3-dc553ec02f60" />
