### PR TITLE
presence: Dispose Presence object when store disposed

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -878,6 +878,7 @@ class PerAccountStore extends PerAccountStoreBase with
     recentDmConversationsView.dispose();
     unreads.dispose();
     _messages.dispose();
+    presence.dispose();
     typingStatus.dispose();
     typingNotifier.dispose();
     updateMachine?.dispose();


### PR DESCRIPTION
I happened to notice this message getting printed repeatedly in the debug logs (reformatted a bit):

    [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception:
      NetworkException: HTTP request failed. Client is already closed.
      (ClientException: HTTP request failed. Client is already closed.,
       uri=https://chat.zulip.org/api/v1/users/me/presence)
    #0      ApiConnection.send (package:zulip/api/core.dart:175)
    <asynchronous suspension>
    #1      Presence._maybePingAndRecordResponse (package:zulip/model/presence.dart:93)
    <asynchronous suspension>
    #2      Presence._poll (package:zulip/model/presence.dart:121)
    <asynchronous suspension>

That'd be a symptom of an old Presence continuing to run its polling loop after the ApiConnection has been closed, which happens when the PerAccountStore is disposed.  Looks like when we introduced Presence in 5d43df2be (#1619), we forgot to call its `dispose` method. Fix that now.

The presence model doesn't currently have any tests.  So rather than try to add a test for just this, we'll leave it as something to include when we write those tests, #1620.