### PR TITLE
Render KaTeX by default

### DIFF
--- a/lib/model/settings.dart
+++ b/lib/model/settings.dart
@@ -178,7 +178,7 @@ enum BoolGlobalSetting {
   upgradeWelcomeDialogShown(GlobalSettingType.internal, false),
 
   /// An experimental flag to toggle rendering KaTeX content in messages.
-  renderKatex(GlobalSettingType.experimentalFeatureFlag, false),
+  renderKatex(GlobalSettingType.experimentalFeatureFlag, true),
 
   /// An experimental flag to enable rendering KaTeX even when some
   /// errors are encountered.

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -512,7 +512,7 @@ class ContentExample {
   static final mathInline = ContentExample.inline(
     'inline math',
     r"$$ \lambda $$",
-    expectedText: r'\lambda',
+    expectedText: r'λ',
     '<p><span class="katex">'
       '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
         '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
@@ -532,7 +532,7 @@ class ContentExample {
   static const mathBlock = ContentExample(
     'math block',
     "```math\n\\lambda\n```",
-    expectedText: r'\lambda',
+    expectedText: r'λ',
     '<p><span class="katex-display"><span class="katex">'
       '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>λ</mi></mrow>'
         '<annotation encoding="application/x-tex">\\lambda</annotation></semantics></math></span>'

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -558,7 +558,11 @@ void main() {
   group('MathBlock', () {
     testContentSmoke(ContentExample.mathBlock);
 
-    testWidgets('displays KaTeX source; experimental flag default', (tester) async {
+    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
+      addTearDown(testBinding.reset);
+      final globalSettings = testBinding.globalStore.settings;
+      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
+
       await prepareContent(tester, plainContent(ContentExample.mathBlock.html));
       tester.widget(find.text(r'\lambda', findRichText: true));
     });
@@ -1108,10 +1112,31 @@ void main() {
         '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span>';
       await checkFontSizeRatio(tester,
         targetHtml: html,
+        targetFontSizeFinder: mkTargetFontSizeFinderFromPattern(r'λ'));
+    }, skip: true // TODO(#46): adapt this test
+                  //   (it needs a more complex targetFontSizeFinder;
+                  //    see other uses in this file for examples.)
+    );
+
+    testWidgets('maintains font-size ratio with surrounding text, when showing TeX source', (tester) async {
+      addTearDown(testBinding.reset);
+      final globalSettings = testBinding.globalStore.settings;
+      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
+
+      const html = '<span class="katex">'
+        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
+          '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
+        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span>';
+      await checkFontSizeRatio(tester,
+        targetHtml: html,
         targetFontSizeFinder: mkTargetFontSizeFinderFromPattern(r'\lambda'));
     });
 
-    testWidgets('displays KaTeX source; experimental flag default', (tester) async {
+    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
+      addTearDown(testBinding.reset);
+      final globalSettings = testBinding.globalStore.settings;
+      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
+
       await prepareContent(tester, plainContent(ContentExample.mathInline.html));
       tester.widget(find.text(r'\lambda', findRichText: true));
     });


### PR DESCRIPTION
Here's a version of the commit I've included in each release recently, atop (previous versions of) #1559, to enable our KaTeX support. Now that #1559 and its preceding PRs (#1698, and others before that) are merged to main, this is ready to go to main too.

This was a minimal version for the release, just flipping the flag's default to true. But in general we should remove experimental flags from the codebase as soon as they're no longer relevant, to keep complexity from building up. (See the doc on [GlobalSettingType.experimentalFeatureFlag].) @rajveermalviya would you write a follow-up commit that removes this flag entirely, and cleans up the logic elsewhere which that makes possible to clean up?

#### 5287d39b9 content: Render KaTeX by default, the way we have in recent releases

This is cherry-picked from commits we included in each of the last
several releases, starting with 8f3723768 in v0.0.31.
