### PR TITLE
docs: Add missing project board link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ and describing your progress.
 
 [your first codebase contribution]: https://zulip.readthedocs.io/en/latest/contributing/contributing.html#your-first-codebase-contribution
 [what makes a great Zulip contributor]: https://zulip.readthedocs.io/en/latest/contributing/contributing.html#what-makes-a-great-zulip-contributor
+[project board]: https://github.com/orgs/zulip/projects/5/views/4
 [picking an issue to work on]: https://zulip.readthedocs.io/en/latest/contributing/contributing.html#picking-an-issue-to-work-on
 
 


### PR DESCRIPTION
This adds back the definition for the
project board link that was dropped as
a part of d3d77215508cc0a281de8d2b84292e4bc3394339.

Discussion: https://chat.zulip.org/#narrow/channel/19-documentation/topic/Missing.20project.20board.20link.20in.20flutter.20readme