### PR TITLE
Refactor KaTeX parsing of inline styles and vlists; normalize survey output a bit more

### DIFF
--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -13,7 +13,6 @@ import 'package:wakelock_plus/wakelock_plus.dart' as wakelock_plus;
 import '../host/android_notifications.dart';
 import '../host/notifications.dart' as notif_pigeon;
 import '../log.dart';
-import '../widgets/store.dart';
 import 'store.dart';
 
 export 'package:file_picker/file_picker.dart' show FilePickerResult, FileType, PlatformFile;

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -312,7 +312,6 @@ class _KatexParser {
 
               var styles = _parseSpanInlineStyles(innerSpan);
               if (styles == null) throw _KatexHtmlParseError();
-              if (styles.verticalAlignEm != null) throw _KatexHtmlParseError();
               final topEm = styles.topEm ?? 0;
 
               styles = styles.filter(topEm: false);
@@ -374,10 +373,6 @@ class _KatexParser {
 
     final inlineStyles = _parseSpanInlineStyles(element);
     if (inlineStyles != null) {
-      // We expect `vertical-align` inline style to be only present on a
-      // `strut` span, for which we emit `KatexStrutNode` separately.
-      if (inlineStyles.verticalAlignEm != null) throw _KatexHtmlParseError();
-
       // Currently, we expect `top` to only be inside a vlist, and
       // we handle that case separately above.
       if (inlineStyles.topEm != null) {
@@ -668,7 +663,6 @@ class _KatexParser {
     final result = KatexSpanStyles(
       heightEm: _takeStyleEm(declarations, 'height'),
       topEm: _takeStyleEm(declarations, 'top'),
-      verticalAlignEm: _takeStyleEm(declarations, 'vertical-align'),
       marginRightEm: _takeStyleEm(declarations, 'margin-right'),
       marginLeftEm: _takeStyleEm(declarations, 'margin-left'),
       // TODO handle more CSS properties
@@ -758,7 +752,10 @@ enum KatexSpanTextAlign {
 @immutable
 class KatexSpanStyles {
   final double? heightEm;
-  final double? verticalAlignEm;
+
+  // We expect `vertical-align` inline style to be only present on a
+  // `strut` span, for which we emit `KatexStrutNode` separately.
+  // final double? verticalAlignEm;
 
   final double? topEm;
 
@@ -773,7 +770,6 @@ class KatexSpanStyles {
 
   const KatexSpanStyles({
     this.heightEm,
-    this.verticalAlignEm,
     this.topEm,
     this.marginRightEm,
     this.marginLeftEm,
@@ -788,7 +784,6 @@ class KatexSpanStyles {
   int get hashCode => Object.hash(
     'KatexSpanStyles',
     heightEm,
-    verticalAlignEm,
     topEm,
     marginRightEm,
     marginLeftEm,
@@ -803,7 +798,6 @@ class KatexSpanStyles {
   bool operator ==(Object other) {
     return other is KatexSpanStyles &&
       other.heightEm == heightEm &&
-      other.verticalAlignEm == verticalAlignEm &&
       other.topEm == topEm &&
       other.marginRightEm == marginRightEm &&
       other.marginLeftEm == marginLeftEm &&
@@ -818,7 +812,6 @@ class KatexSpanStyles {
   String toString() {
     final args = <String>[];
     if (heightEm != null) args.add('heightEm: $heightEm');
-    if (verticalAlignEm != null) args.add('verticalAlignEm: $verticalAlignEm');
     if (topEm != null) args.add('topEm: $topEm');
     if (marginRightEm != null) args.add('marginRightEm: $marginRightEm');
     if (marginLeftEm != null) args.add('marginLeftEm: $marginLeftEm');
@@ -840,7 +833,6 @@ class KatexSpanStyles {
   KatexSpanStyles merge(KatexSpanStyles other) {
     return KatexSpanStyles(
       heightEm: other.heightEm ?? heightEm,
-      verticalAlignEm: other.verticalAlignEm ?? verticalAlignEm,
       topEm: other.topEm ?? topEm,
       marginRightEm: other.marginRightEm ?? marginRightEm,
       marginLeftEm: other.marginLeftEm ?? marginLeftEm,
@@ -866,7 +858,6 @@ class KatexSpanStyles {
   }) {
     return KatexSpanStyles(
       heightEm: heightEm ? this.heightEm : null,
-      verticalAlignEm: verticalAlignEm ? this.verticalAlignEm : null,
       topEm: topEm ? this.topEm : null,
       marginRightEm: marginRightEm ? this.marginRightEm : null,
       marginLeftEm: marginLeftEm ? this.marginLeftEm : null,

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -308,11 +308,15 @@ class _KatexParser {
                   'vlist inner span: ${innerSpan.className}');
               }
 
-              var styles = _parseSpanInlineStyles(innerSpan);
-              if (styles == null) throw _KatexHtmlParseError();
-              final topEm = styles.topEm ?? 0;
-
-              styles = styles.filter(topEm: false);
+              final inlineStyles = _parseInlineStyles(innerSpan);
+              if (inlineStyles == null) throw _KatexHtmlParseError();
+              final styles = KatexSpanStyles(
+                heightEm: _takeStyleEm(inlineStyles, 'height'),
+                marginLeftEm: _takeStyleEm(inlineStyles, 'margin-left'),
+                marginRightEm: _takeStyleEm(inlineStyles, 'margin-right'),
+              );
+              final topEm = _takeStyleEm(inlineStyles, 'top');
+              if (inlineStyles.isNotEmpty) throw _KatexHtmlParseError();
 
               final pstrutStyles = _parseInlineStyles(pstrutSpan);
               if (pstrutStyles == null) throw _KatexHtmlParseError();
@@ -345,7 +349,7 @@ class _KatexParser {
               }
 
               rows.add(KatexVlistRowNode(
-                verticalOffsetEm: topEm + pstrutHeightEm,
+                verticalOffsetEm: (topEm ?? 0) + pstrutHeightEm,
                 debugHtmlNode: kDebugMode ? innerSpan : null,
                 node: innerSpanNode));
             } else {

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -680,12 +680,8 @@ class _KatexParser {
       // TODO handle more CSS properties
     );
 
-    for (final declaration in declarations.entries) {
-      final property = declaration.key;
-      final expression = declaration.value;
-
-      assert(debugLog('KaTeX: Unsupported CSS expression:'
-        ' ${expression.toDebugString()}'));
+    for (final property in declarations.keys) {
+      assert(debugLog('KaTeX: Unexpected inline CSS property: $property'));
       unsupportedInlineCssProperties.add(property);
       _hasError = true;
     }

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -311,7 +311,6 @@ class _KatexParser {
               final inlineStyles = _parseInlineStyles(innerSpan);
               if (inlineStyles == null) throw _KatexHtmlParseError();
               final styles = KatexSpanStyles(
-                heightEm: _takeStyleEm(inlineStyles, 'height'),
                 marginLeftEm: _takeStyleEm(inlineStyles, 'margin-left'),
                 marginRightEm: _takeStyleEm(inlineStyles, 'margin-right'),
               );

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -265,9 +265,8 @@ class _KatexParser {
           // a "height" inline style which we ignore, because it doesn't seem
           // to have any effect in rendering on the web.
           // But also make sure there aren't any other inline styles present.
-          final vlistStyles = _parseSpanInlineStyles(vlist);
-          if (vlistStyles != null
-            && vlistStyles.filter(heightEm: false) != const KatexSpanStyles()) {
+          final vlistStyles = _parseInlineStyles(vlist);
+          if (vlistStyles != null && vlistStyles.keys.any((p) => p != 'height')) {
             throw _KatexHtmlParseError();
           }
         } else {
@@ -288,9 +287,8 @@ class _KatexParser {
           // because it doesn't seem to have any effect in rendering on
           // the web.
           // But also make sure there aren't any other inline styles present.
-          final vlistStyles = _parseSpanInlineStyles(vlist);
-          if (vlistStyles != null
-            && vlistStyles.filter(heightEm: false) != const KatexSpanStyles()) {
+          final vlistStyles = _parseInlineStyles(vlist);
+          if (vlistStyles != null && vlistStyles.keys.any((p) => p != 'height')) {
             throw _KatexHtmlParseError();
           }
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -314,14 +314,11 @@ class _KatexParser {
 
               styles = styles.filter(topEm: false);
 
-              final pstrutStyles = _parseSpanInlineStyles(pstrutSpan);
+              final pstrutStyles = _parseInlineStyles(pstrutSpan);
               if (pstrutStyles == null) throw _KatexHtmlParseError();
-              if (pstrutStyles.filter(heightEm: false)
-                  != const KatexSpanStyles()) {
-                throw _KatexHtmlParseError();
-              }
-              final pstrutHeightEm = pstrutStyles.heightEm;
+              final pstrutHeightEm = _takeStyleEm(pstrutStyles, 'height');
               if (pstrutHeightEm == null) throw _KatexHtmlParseError();
+              if (pstrutStyles.isNotEmpty) throw _KatexHtmlParseError();
 
               final KatexSpanNode innerSpanNode;
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -723,6 +723,10 @@ enum KatexSpanTextAlign {
 
 @immutable
 class KatexSpanStyles {
+  // TODO(#1674) does height actually appear on generic spans?
+  //   In a corpus, the only occurrences that we don't already handle separately
+  //   (i.e. occurrences other than on struts, vlists, etc) seem to be within
+  //   accents; so after #1674 we might be handling those separately too.
   final double? heightEm;
 
   // We expect `vertical-align` inline style to be only present on a

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -329,7 +329,7 @@ class _KatexParser {
                   != const KatexSpanStyles()) {
                 throw _KatexHtmlParseError();
               }
-              final pstrutHeight = pstrutStyles.heightEm ?? 0;
+              final pstrutHeightEm = pstrutStyles.heightEm ?? 0;
 
               final KatexSpanNode innerSpanNode;
 
@@ -356,7 +356,7 @@ class _KatexParser {
               }
 
               rows.add(KatexVlistRowNode(
-                verticalOffsetEm: topEm + pstrutHeight,
+                verticalOffsetEm: topEm + pstrutHeightEm,
                 debugHtmlNode: kDebugMode ? innerSpan : null,
                 node: innerSpanNode));
             } else {

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -653,32 +653,32 @@ class _KatexParser {
   ///
   /// To interpret the resulting map, consider [_takeStyleEm].
   static Map<String, css_visitor.Expression>? _parseInlineStyles(dom.Element element) {
-    if (element.attributes case {'style': final styleStr}) {
-      // `package:csslib` doesn't seem to have a way to parse inline styles:
-      //   https://github.com/dart-lang/tools/issues/1173
-      // So, work around that by wrapping it in a universal declaration.
-      final stylesheet = css_parser.parse('*{$styleStr}');
-      if (stylesheet.topLevels case [css_visitor.RuleSet() && final ruleSet]) {
-        final result = <String, css_visitor.Expression>{};
-        for (final declaration in ruleSet.declarationGroup.declarations) {
-          if (declaration case css_visitor.Declaration(
-            :final property,
-            expression: css_visitor.Expressions(
-              expressions: [css_visitor.Expression() && final expression]),
-          )) {
-            result.update(property, ifAbsent: () => expression,
-              (_) => throw _KatexHtmlParseError(
-                'duplicate inline CSS property: $property'));
-          } else {
-            throw _KatexHtmlParseError('unexpected shape of inline CSS');
-          }
+    final styleStr = element.attributes['style'];
+    if (styleStr == null) return null;
+
+    // `package:csslib` doesn't seem to have a way to parse inline styles:
+    //   https://github.com/dart-lang/tools/issues/1173
+    // So, work around that by wrapping it in a universal declaration.
+    final stylesheet = css_parser.parse('*{$styleStr}');
+    if (stylesheet.topLevels case [css_visitor.RuleSet() && final ruleSet]) {
+      final result = <String, css_visitor.Expression>{};
+      for (final declaration in ruleSet.declarationGroup.declarations) {
+        if (declaration case css_visitor.Declaration(
+          :final property,
+          expression: css_visitor.Expressions(
+            expressions: [css_visitor.Expression() && final expression]),
+        )) {
+          result.update(property, ifAbsent: () => expression,
+            (_) => throw _KatexHtmlParseError(
+              'duplicate inline CSS property: $property'));
+        } else {
+          throw _KatexHtmlParseError('unexpected shape of inline CSS');
         }
-        return result;
-      } else {
-        throw _KatexHtmlParseError();
       }
+      return result;
+    } else {
+      throw _KatexHtmlParseError();
     }
-    return null;
   }
 
   /// Remove the given property from the given style map,

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -329,7 +329,8 @@ class _KatexParser {
                   != const KatexSpanStyles()) {
                 throw _KatexHtmlParseError();
               }
-              final pstrutHeightEm = pstrutStyles.heightEm ?? 0;
+              final pstrutHeightEm = pstrutStyles.heightEm;
+              if (pstrutHeightEm == null) throw _KatexHtmlParseError();
 
               final KatexSpanNode innerSpanNode;
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -230,18 +230,12 @@ class _KatexParser {
     if (element.className == 'strut') {
       if (element.nodes.isNotEmpty) throw _KatexHtmlParseError();
 
-      final styles = _parseSpanInlineStyles(element);
+      final styles = _parseInlineStyles(element);
       if (styles == null) throw _KatexHtmlParseError();
-
-      final heightEm = styles.heightEm;
+      final heightEm = _takeStyleEm(styles, 'height');
       if (heightEm == null) throw _KatexHtmlParseError();
-      final verticalAlignEm = styles.verticalAlignEm;
-
-      // Ensure only `height` and `vertical-align` inline styles are present.
-      if (styles.filter(heightEm: false, verticalAlignEm: false)
-          != const KatexSpanStyles()) {
-        throw _KatexHtmlParseError();
-      }
+      final verticalAlignEm = _takeStyleEm(styles, 'vertical-align');
+      if (styles.isNotEmpty) throw _KatexHtmlParseError();
 
       return KatexStrutNode(
         heightEm: heightEm,

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -386,7 +386,9 @@ class _KatexParser {
 
       // Currently, we expect `top` to only be inside a vlist, and
       // we handle that case separately above.
-      if (inlineStyles.topEm != null) throw _KatexHtmlParseError();
+      if (inlineStyles.topEm != null) {
+        throw _KatexHtmlParseError('unsupported inline CSS property: top');
+      }
     }
 
     // Aggregate the CSS styles that apply, in the same order as the CSS
@@ -586,7 +588,7 @@ class _KatexParser {
             'size4' => 'KaTeX_Size4',
             'mult' =>
               // TODO handle nested spans with `.delim-size{1,4}` class.
-              throw _KatexHtmlParseError(),
+              throw _KatexHtmlParseError('unimplemented CSS class pair: .delimsizing.mult'),
             _ => throw _KatexHtmlParseError(),
           };
 
@@ -705,7 +707,7 @@ class _KatexParser {
             unsupportedInlineCssProperties.add(property);
             _hasError = true;
           } else {
-            throw _KatexHtmlParseError();
+            throw _KatexHtmlParseError('unexpected shape of inline CSS');
           }
         }
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -18,11 +18,11 @@ import 'settings.dart';
 /// a specific node.
 class KatexParserHardFailReason {
   const KatexParserHardFailReason({
-    required this.error,
+    required this.message,
     required this.stackTrace,
   });
 
-  final String error;
+  final String? message;
   final StackTrace stackTrace;
 }
 
@@ -132,7 +132,7 @@ MathParserResult? parseMath(dom.Element element, { required bool block }) {
       } on _KatexHtmlParseError catch (e, st) {
         assert(debugLog('$e\n$st'));
         hardFailReason = KatexParserHardFailReason(
-          error: e.message ?? 'unknown',
+          message: e.message,
           stackTrace: st);
       }
 

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -369,15 +369,6 @@ class _KatexParser {
       }
     }
 
-    final inlineStyles = _parseSpanInlineStyles(element);
-    if (inlineStyles != null) {
-      // Currently, we expect `top` to only be inside a vlist, and
-      // we handle that case separately above.
-      if (inlineStyles.topEm != null) {
-        throw _KatexHtmlParseError('unsupported inline CSS property: top');
-      }
-    }
-
     // Aggregate the CSS styles that apply, in the same order as the CSS
     // classes specified for this span, mimicking the behaviour on web.
     //
@@ -621,13 +612,23 @@ class _KatexParser {
           _hasError = true;
       }
     }
-    final styles = KatexSpanStyles(
+    final classStyles = KatexSpanStyles(
       fontFamily: fontFamily,
       fontSizeEm: fontSizeEm,
       fontWeight: fontWeight,
       fontStyle: fontStyle,
       textAlign: textAlign,
     );
+    final inlineStyles = _parseSpanInlineStyles(element);
+    if (inlineStyles != null) {
+      // Currently, we expect `top` to only be inside a vlist, and
+      // we handle that case separately above.
+      if (inlineStyles.topEm != null) {
+        throw _KatexHtmlParseError('unsupported inline CSS property: top');
+      }
+    }
+    final styles = inlineStyles == null ? classStyles
+      : classStyles.merge(inlineStyles);
 
     String? text;
     List<KatexNode>? spans;
@@ -639,9 +640,7 @@ class _KatexParser {
     if (text == null && spans == null) throw _KatexHtmlParseError();
 
     return KatexSpanNode(
-      styles: inlineStyles != null
-        ? styles.merge(inlineStyles)
-        : styles,
+      styles: styles,
       text: text,
       nodes: spans,
       debugHtmlNode: debugHtmlNode);

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:csslib/parser.dart' as css_parser;
 import 'package:csslib/visitor.dart' as css_visitor;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:html/dom.dart' as dom;
 
 import '../log.dart';

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -310,9 +310,13 @@ class _KatexParser {
 
               final inlineStyles = _parseInlineStyles(innerSpan);
               if (inlineStyles == null) throw _KatexHtmlParseError();
+              final marginLeftEm = _takeStyleEm(inlineStyles, 'margin-left');
+              final marginLeftIsNegative = marginLeftEm?.isNegative ?? false;
+              final marginRightEm = _takeStyleEm(inlineStyles, 'margin-right');
+              if (marginRightEm?.isNegative ?? false) throw _KatexHtmlParseError();
               final styles = KatexSpanStyles(
-                marginLeftEm: _takeStyleEm(inlineStyles, 'margin-left'),
-                marginRightEm: _takeStyleEm(inlineStyles, 'margin-right'),
+                marginLeftEm: marginLeftIsNegative ? null : marginLeftEm,
+                marginRightEm: marginRightEm,
               );
               final topEm = _takeStyleEm(inlineStyles, 'top');
               if (inlineStyles.isNotEmpty) throw _KatexHtmlParseError();
@@ -325,19 +329,14 @@ class _KatexParser {
 
               final KatexSpanNode innerSpanNode;
 
-              final marginRightEm = styles.marginRightEm;
-              final marginLeftEm = styles.marginLeftEm;
-              if (marginRightEm != null && marginRightEm.isNegative) {
-                throw _KatexHtmlParseError();
-              }
-              if (marginLeftEm != null && marginLeftEm.isNegative) {
+              if (marginLeftIsNegative) {
                 innerSpanNode = KatexSpanNode(
                   styles: KatexSpanStyles(),
                   text: null,
                   nodes: [KatexNegativeMarginNode(
-                    leftOffsetEm: marginLeftEm,
+                    leftOffsetEm: marginLeftEm!,
                     nodes: [KatexSpanNode(
-                      styles: styles.filter(marginLeftEm: false),
+                      styles: styles,
                       text: null,
                       nodes: _parseChildSpans(otherSpans))])]);
               } else {

--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -327,29 +327,24 @@ class _KatexParser {
               if (pstrutHeightEm == null) throw _KatexHtmlParseError();
               if (pstrutStyles.isNotEmpty) throw _KatexHtmlParseError();
 
-              final KatexSpanNode innerSpanNode;
+              KatexSpanNode child = KatexSpanNode(
+                styles: styles,
+                text: null,
+                nodes: _parseChildSpans(otherSpans));
 
               if (marginLeftIsNegative) {
-                innerSpanNode = KatexSpanNode(
+                child = KatexSpanNode(
                   styles: KatexSpanStyles(),
                   text: null,
                   nodes: [KatexNegativeMarginNode(
                     leftOffsetEm: marginLeftEm!,
-                    nodes: [KatexSpanNode(
-                      styles: styles,
-                      text: null,
-                      nodes: _parseChildSpans(otherSpans))])]);
-              } else {
-                innerSpanNode = KatexSpanNode(
-                  styles: styles,
-                  text: null,
-                  nodes: _parseChildSpans(otherSpans));
+                    nodes: [child])]);
               }
 
               rows.add(KatexVlistRowNode(
                 verticalOffsetEm: (topEm ?? 0) + pstrutHeightEm,
                 debugHtmlNode: kDebugMode ? innerSpan : null,
-                node: innerSpanNode));
+                node: child));
             } else {
               throw _KatexHtmlParseError();
             }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -922,10 +922,6 @@ class _KatexSpan extends StatelessWidget {
     }
 
     final styles = node.styles;
-    // We expect vertical-align to be only present with the
-    // `strut` span, for which parser explicitly emits `KatexStrutNode`.
-    // So, this should always be null for non `strut` spans.
-    assert(styles.verticalAlignEm == null);
 
     // Currently, we expect `top` to be only present with the
     // vlist inner row span, and parser handles that explicitly.

--- a/tools/content/unimplemented_katex_test.dart
+++ b/tools/content/unimplemented_katex_test.dart
@@ -103,9 +103,13 @@ void main() async {
     buf.writeln('There were $totalMathInlineNodes math inline nodes out of which $failedMathInlineNodes failed.');
     buf.writeln();
 
-    for (final MapEntry(key: reason, value: messageIds) in failedMessageIdsByReason.entries.sorted(
-      (a, b) => b.value.length.compareTo(a.value.length),
-    )) {
+    for (final MapEntry(key: reason, value: messageIds)
+         in failedMessageIdsByReason.entries.sorted((a, b) {
+           // Sort by number of failed messages descending, then by reason.
+           final r = - a.value.length.compareTo(b.value.length);
+           if (r != 0) return r;
+           return a.key.compareTo(b.key);
+         })) {
       final failedMathNodes = failedMathNodesByReason[reason]!.toList();
       failedMathNodes.shuffle();
       final oldestId = messageIds.reduce(min);

--- a/tools/content/unimplemented_katex_test.dart
+++ b/tools/content/unimplemented_katex_test.dart
@@ -59,8 +59,9 @@ void main() async {
       int failureCount = 0;
 
       if (hardFailReason != null) {
-        final firstLine = hardFailReason.stackTrace.toString().split('\n').first;
-        final reason = 'hard fail: ${hardFailReason.error} "$firstLine"';
+        final message = hardFailReason.message
+          ?? 'unknown reason at ${_inmostFrame(hardFailReason.stackTrace)}';
+        final reason = 'hard fail: $message';
         (failedMessageIdsByReason[reason] ??= {}).add(messageId);
         (failedMathNodesByReason[reason] ??= {}).add(value);
         failureCount++;
@@ -154,6 +155,16 @@ void main() async {
       test(file.path, () => checkForKatexFailuresInFile(file));
     }
   });
+}
+
+/// The innermost frame of the given stack trace,
+/// e.g. the line where an exception was thrown.
+///
+/// Inevitably this is a bit heuristic, given the lack of any API guarantees
+/// on the structure of [StackTrace].
+String _inmostFrame(StackTrace stackTrace) {
+  final firstLine = stackTrace.toString().split('\n').first;
+  return firstLine.replaceFirst(RegExp(r'^#\d+\s+'), '');
 }
 
 const String _corpusDirPath = String.fromEnvironment('corpusDir');


### PR DESCRIPTION
Now that the KaTeX support we've had in recent releases is merged into main (with #1559) (*), I've gone and made a number of the refactors that I'd been contemplating for this code but hadn't wanted to do before those were merged. In this branch:
* Parse each element's inline styles in a more direct way, letting the parsing logic for different types of elements apply their respective context of what styles are expected. This also means less building and copying of generic KatexSpanStyles objects.
* Simplify some of the vlist parsing code, notably around margins.
* Split the parsing of struts and vlists into their own respective methods.
* At the start of the branch, a few adjustments to make the output of `tools/content/check-features katex-check` more stable and easier to compare across changes to the implementation. This helped me validate that on an empirical corpus, none of the above changes caused any KaTeX expressions to stop being successfully parsed.

In particular I ran `tools/content/check-features katex-check` near the start of the branch, after the first three commits:
8c4106d84 katex [nfc]: Show line numbers only on unknown hard-fails, not others
d2696287f katex [nfc]: Add messages for remaining hard-fail cases seen in corpus
e74557bba tools/content [nfc]: Tie-break on reason text when number of failures equal

and again at the end of the branch. I then compared the output with commands like:
```
$ diff -U2 <(grep -P 'failed|Because' tmp/tex.old) \
           <(grep -P 'failed|Because' tmp/tex.new)
```

There were no changes in the total number of messages or KaTeX expressions where the parser failed. For a small number of expressions, there were changes in the set of soft failures reported before reaching a hard failure; the reasons for those are in a couple of individual commit messages. The full diff was (with a denominator of "28109 of them were KaTeX containing messages and 3370 of those failed"):
```
@@ -38,4 +38,6 @@
   Because of unsupported css class: frac-line:
     335 messages failed.
+  Because of unsupported css class: delimcenter:
+    184 messages failed.
   Because of unsupported css class: mtable:
     177 messages failed.
@@ -90,6 +92,4 @@
   Because of unsupported css class: cd-arrow-pad:
     8 messages failed.
-  Because of unsupported inline css property: border-right-width:
-    5 messages failed.
   Because of unsupported css class: boxpad:
     4 messages failed.
@@ -102,4 +102,6 @@
   Because of unsupported css class: rule:
     3 messages failed.
+  Because of unsupported inline css property: border-right-width:
+    3 messages failed.
   Because of unsupported inline css property: border-top-width:
     3 messages failed.
@@ -120,5 +122,5 @@
   Because of unsupported css class: textup:
     2 messages failed.
-  Because of unsupported inline css property: border-right-style:
+  Because of unsupported css class: vertical-separator:
     2 messages failed.
   Because of unsupported css class: mover:
```

(*) One change is still outstanding, in #1720. But it won't much interact with the main logic.


## Selected commit messages

#### 8c4106d84 katex [nfc]: Show line numbers only on unknown hard-fails, not others

This makes the output of the survey script more stable as our KaTeX
parser gets refactored and otherwise edited.



#### d2696287f katex [nfc]: Add messages for remaining hard-fail cases seen in corpus



#### e74557bba tools/content [nfc]: Tie-break on reason text when number of failures equal

This helps make the output more stable from run to run, so that
it's easier to spot changes (or confirm the absence of changes)
when editing the code.



#### 16deb86bb katex [nfc]: Cut stray import of widgets library

This was here only for a reference in a doc.  In general we try to
avoid imports of widgets from model code; it's an inversion of layers.


#### 46c74e706 katex [nfc]: Fix a variable name to specify its units, namely em



#### e223229e5 katex: Require height on pstrut spans

If this were missing, it's not clear to me that zero would be an
appropriate default.

In any case, in an empirical corpus, it's always present.
So just require that.



#### b62979c58 katex [nfc]: Separate _parseInlineStyles from constructing a KatexSpanStyles

Also document the existing _parseSpanInlineStyles method, and
describe our plan for eliminating most of its call sites.



#### a88de1450 katex [nfc]: Push more parsing into _parseInlineStyles; return Map

This has a small effect on the survey script's list of failure
reasons: in the rare case that the "unexpected shape of inline CSS"
error appears, it now fires before any of the CSS properties in the
same inline style are processed.  That can mean fewer entries added
to unsupportedInlineCssProperties.

This difference is only possible, though, on a KaTeX expression that
is going to reach the same hard failure either way.  So it has no
effect on behavior seen by a user.



#### ade7f6662 katex: Fix a misleading log line: unexpected CSS property, not value

Until the previous commit, this bit of code was handling both the case
where the value was unexpected (for which this message was accurate)
and the case where the property itself was unexpected (for which it
wasn't).  Now the first case is handled elsewhere, so fix the
remaining case.


#### 9c32bd6b6 katex [nfc]: Skip building whole KatexSpanStyles for struts' two properties

We know at this spot that there are just two specific CSS properties
we expect to see, and we'll end up handling them directly rather than
through a KatexSpanStyles object.  So parse them directly, rather
than build a whole KatexSpanStyles object (and then another one
with `.filter()`).



#### 6c2e55cb7 katex [nfc]: Cut vertical-align from generic style properties

All the remaining call sites of _parseSpanInlineStyles would throw
anyway if this property were actually found.  We only expect it
in a specific context, namely a strut.



#### f12c749f4 katex [nfc]: Check "only has height" directly, without making KatexSpanStyles

This lets us skip allocating these objects (two in each case -- the
second one comes from `.filter()`).  We also get to skip parsing the
value of `height`, since we don't intend to use it.



#### e1a2c9c21 katex [nfc]: Get pstrut height directly, without making KatexSpanStyles



#### 7443e1ae6 katex [nfc]: Directly handle expected inline styles on vlist child

There's only a handful of specific properties we expect to see on this
type of span; so handle those explicitly.

In fact, making this list explicit brings to light that there's one
property here which doesn't actually appear on KaTeX's vlist children:
height.  We'll cut that in a separate non-NFC commit.

This will also open up ways to simplify the interaction between this
and the margin-handling logic below.



#### 8e059b3c6 katex: Don't expect height on vlist child spans

These spans are highly structured; the only properties that go
into their inline styles are top, margin-left, and margin-right.



#### e61c6c7c4 katex [nfc]: Consolidate logic for computing overall styles of KatexSpanNode

This just pulls these three pieces of closely-related logic next to
each other.  That will make it easier to refactor them further.

This causes one change in the survey script's list of failure reasons:
when the `delimcenter` class occurs with an inline `top` property, we
now record the unsupported class before reaching the hard fail for the
unsupported property.  This has no user-visible effect, though,
because it can only happen when the expression is going to reach that
hard failure either way.



#### 77b1c2fd4 katex [nfc]: Inline remaining/main use of _parseSpanInlineStyles

And inline the effect of the `merge` method, eliminating that
method too.

This way we get to construct just one KatexSpanStyles object, rather
than constructing three of them when inline styles are present.



#### 636ac6af7 katex [nfc]: Construct vlist child's styles directly, without filter



#### c744e4579 katex [nfc]: Note that heightEm might turn out not to be needed



#### 26ac991aa katex [nfc]: Split out _parseStrut, _parseVlist, _parseGenericSpan

Each of these swathes of logic has no interaction with the others.
Splitting them into their own methods makes that structure easy for
the reader to see.

