### PR TITLE
Fix/toggle dimensions 1636

### DIFF
--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -225,7 +225,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.2),
     bgMenuButtonSelected: Colors.black.withValues(alpha: 0.25),
-    bgMessageRegular: const HSLColor.fromAHSL(1, 0, 0, 0.11).toColor(),
+    bgMessageRegular: const Color(0xFF1D1D1D),
     bgTopBar: const Color(0xff242424),
     borderBar: const Color(0xffffffff).withValues(alpha: 0.1),
     borderMenuButtonSelected: Colors.white.withValues(alpha: 0.1),


### PR DESCRIPTION
Fixes: #1636

This pull request resolves the issue where the "Invisible mode" toggle switch did not match the Figma design specifications. The standard Flutter Switch widget does not provide the necessary customization options to achieve the required dimensions.
to address this, this PR introduces a new custom widget, FigmaSwitch, which is built from the ground up to precisely match the specified dimensions for both its on and off states.

Changes I made""

New FigmaSwitch Widget:  highly-customizable w, highly-customizable switch widget that accurately reflects the Figma design for the "Invisible mode" toggle.

New FigmaSwitchListTile Widget: A ListTile that incorporates the FigmaSwitch for easy integration into settings pages.

Settings Page Integration: The "Invisible mode" setting now uses the new FigmaSwitchListTile to ensure it matches the design.

Testing""

Navigate to the settings page.

See the "Invisible mode" toggle switch.

Verify that its dimensions match the Figma specifications in both the "on" and "off" states.

On: 28px by 48px, with a 10px radius thumb.

Off: 26px by 46px, with a 7px radius thumb.

Confirm that the toggle switch functions correctly, updating the user's presence setting.             

Hope this resolves the issue 

also attaching before and after screenshots 

BEFORE
<img width="295" height="639" alt="BEFORE" src="https://github.com/user-attachments/assets/588a64fb-dcef-4042-9e10-7bcf8ec178cf" />


AFTER
<img width="291" height="639" alt="AFTER" src="https://github.com/user-attachments/assets/b16aa227-e707-4087-a298-b68838508d85" />

