### PR TITLE
Visually disable Save button on validation error.

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1799,14 +1799,24 @@ class _EditMessageBanner extends _Banner {
   @override
   Widget buildTrailing(context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
+    final controller = composeBoxState.controller as EditMessageComposeBoxController;
     return Row(mainAxisSize: MainAxisSize.min, spacing: 8, children: [
       ZulipWebUiKitButton(label: zulipLocalizations.composeBoxBannerButtonCancel,
         onPressed: composeBoxState.endEditInteraction),
-      // TODO(#1481) disabled appearance when there are validation errors
-      //   or the original raw content hasn't loaded yet
-      ZulipWebUiKitButton(label: zulipLocalizations.composeBoxBannerButtonSave,
-        attention: ZulipWebUiKitButtonAttention.high,
-        onPressed: () => _handleTapSave(context)),
+      ValueListenableBuilder<bool>(
+        valueListenable: controller.content.hasValidationErrors,
+        builder: (context, hasErrors, child) {
+          final bool disabled = hasErrors || controller.originalRawContent == null;
+          return Opacity(
+            opacity: disabled ? 0.5 : 1.0,
+            child: ZulipWebUiKitButton(
+              label: zulipLocalizations.composeBoxBannerButtonSave,
+              attention: ZulipWebUiKitButtonAttention.high,
+              onPressed: disabled ? () {} : () => _handleTapSave(context),
+            ),
+          );
+        },
+      ),
     ]);
   }
 }


### PR DESCRIPTION
**Fixes: #1481**

This change implements the disabled visual state for the "Save" button in the edit-message compose box, providing immediate feedback to the user when the content is invalid.
also
**The Problem:**

Previously, when editing a message, if the user entered content that was too long (exceeding the server's character limit), the "Save" button remained visually active. Although tapping it would correctly show a validation error dialog and prevent saving, the button itself did not appear disabled. This could lead to a confusing user experience, as there was no visual cue that the save action was invalid.

**The Solution:**

This PR resolves the issue by wrapping the "Save" button (`ZulipWebUiKitButton`) inside a `ValueListenableBuilder`.

- The `ValueListenableBuilder` listens to the `hasValidationErrors` notifier on the `ComposeContentController`.
- When `hasValidationErrors` is `true`, or when the original message content is still loading, the button is now visually disabled in two ways:
    1. It is wrapped in an `Opacity` widget to give it a faded appearance.
    2. The `onPressed` callback is set to an empty function `() {}`, preventing any action on tap and satisfying the non-nullable requirement of the button's API.

This ensures the UI reacts instantly to the validation state of the text input, providing clear and correct feedback to the user.

**Testing:**

I have manually tested this change with the following scenarios:

1.  **Edit a message and enter content that exceeds the 10,000 character limit.**
    - **Result:** The "Save" button correctly fades out and becomes unresponsive.
2.  **Delete characters to bring the content back within the valid limit.**
    - **Result:** The "Save" button correctly becomes fully opaque and active again.
3.  **Edit a message and delete all content.**
    - **Result:** The "Save" button correctly remains enabled, preserving the ability to delete a message's content by saving an empty edit.

The fix works as expected and resolves the visual inconsistency.        
I hope this solves the error 