### PR TITLE
content: Handle keyword highlighting in code blocks

### DIFF
--- a/lib/model/code_block.dart
+++ b/lib/model/code_block.dart
@@ -8,6 +8,11 @@ enum CodeBlockSpanType {
   unknown,
   /// A run of unstyled text in a code block.
   text,
+  /// A code-block span with CSS class `highlight`.
+  ///
+  /// This span is emitted by server for content matching
+  /// used for displaying keyword search highlighting.
+  highlight,
   /// A code-block span with CSS class `hll`.
   ///
   /// Unlike most `CodeBlockSpanToken` values, this does not correspond to
@@ -174,6 +179,7 @@ enum CodeBlockSpanType {
 
 CodeBlockSpanType codeBlockSpanTypeFromClassName(String className) {
   return switch (className) {
+    'highlight' => CodeBlockSpanType.highlight,
     'hll' => CodeBlockSpanType.highlightedLines,
     'w' => CodeBlockSpanType.whitespace,
     'esc' => CodeBlockSpanType.escape,

--- a/lib/widgets/code_block.dart
+++ b/lib/widgets/code_block.dart
@@ -19,6 +19,10 @@ class CodeBlockTextStyles {
           height: 1.4))
         .merge(weightVariableTextStyle(context)),
 
+      // .highlight { background-color: hsl(51deg 100% 79%); }
+      // See https://github.com/zulip/zulip/blob/f87479703/web/styles/rendered_markdown.css#L1037-L1039
+      highlight: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 51, 1, 0.79).toColor()),
+
       // .hll { background-color: hsl(60deg 100% 90%); }
       hll: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 60, 1, 0.90).toColor()),
 
@@ -258,6 +262,10 @@ class CodeBlockTextStyles {
           fontSize: 0.825 * kBaseFontSize,
           height: 1.4))
         .merge(weightVariableTextStyle(context)),
+
+      // .highlight { background-color: hsl(51deg 100% 23%); }
+      // See https://github.com/zulip/zulip/blob/f87479703/web/styles/dark_theme.css#L410-L412
+      highlight: TextStyle(backgroundColor: const HSLColor.fromAHSL(1, 51, 1, 0.23).toColor()),
 
       // .hll { background-color: #49483e; }
       hll: const TextStyle(backgroundColor: Color(0xff49483e)),
@@ -500,6 +508,7 @@ class CodeBlockTextStyles {
 
   CodeBlockTextStyles._({
     required this.plain,
+    required TextStyle highlight,
     required TextStyle hll,
     required TextStyle c,
     required TextStyle err,
@@ -580,6 +589,7 @@ class CodeBlockTextStyles {
     required TextStyle? vm,
     required TextStyle il,
   }) :
+    _highlight = highlight,
     _hll = hll,
     _c = c,
     _err = err,
@@ -663,6 +673,7 @@ class CodeBlockTextStyles {
   /// The baseline style that the [forSpan] styles get applied on top of.
   final TextStyle plain;
 
+  final TextStyle _highlight;
   final TextStyle _hll;
   final TextStyle _c;
   final TextStyle _err;
@@ -751,6 +762,7 @@ class CodeBlockTextStyles {
   TextStyle? forSpan(CodeBlockSpanType type) {
     return switch (type) {
       CodeBlockSpanType.text => null, // A span with type of text is always unstyled.
+      CodeBlockSpanType.highlight => _highlight,
       CodeBlockSpanType.highlightedLines => _hll,
       CodeBlockSpanType.comment => _c,
       CodeBlockSpanType.error => _err,
@@ -839,6 +851,7 @@ class CodeBlockTextStyles {
 
     return CodeBlockTextStyles._(
       plain: TextStyle.lerp(a.plain, b.plain, t)!,
+      highlight: TextStyle.lerp(a._highlight, b._highlight, t)!,
       hll: TextStyle.lerp(a._hll, b._hll, t)!,
       c: TextStyle.lerp(a._c, b._c, t)!,
       err: TextStyle.lerp(a._err, b._err, t)!,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -764,14 +764,27 @@ class CodeBlock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final styles = ContentTheme.of(context).codeBlockTextStyles;
+    final codeBlockTextStyles = ContentTheme.of(context).codeBlockTextStyles;
+
+    TextSpan buildNode(CodeBlockSpanNode child) {
+      final style = codeBlockTextStyles.forSpan(child.type);
+
+      if (child.text != null) {
+        return TextSpan(
+          style: style,
+          text: child.text!);
+      }
+
+      return TextSpan(
+        style: style,
+        children: List.unmodifiable(child.spans!.map(buildNode)));
+    }
+
     return _CodeBlockContainer(
       borderColor: Colors.transparent,
       child: Text.rich(TextSpan(
-        style: styles.plain,
-        children: node.spans
-          .map((node) => TextSpan(style: styles.forSpan(node.type), text: node.text))
-          .toList(growable: false))));
+        style: codeBlockTextStyles.plain,
+        children: List.unmodifiable(node.spans.map(buildNode)))));
   }
 }
 

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -500,13 +500,18 @@ class ContentExample {
           '<span class="gu">## llo</span>\n'
           '<span class="hll">'
             '<span class="gu">### world</span>\n</span></code></pre></div>', [
-      // TODO: Fix this, see comment under `CodeBlockSpanType.highlightedLines` case in lib/model/content.dart.
-      blockUnimplemented('<div class="codehilite"><pre>'
-        '<span></span><code>::markdown hl_lines=&quot;2 4&quot;\n'
-        '<span class="hll"><span class="gh"># he</span>\n'
-        '</span><span class="gu">## llo</span>\n'
-        '<span class="hll"><span class="gu">### world</span>\n'
-        '</span></code></pre></div>'),
+      CodeBlockNode([
+        CodeBlockSpanNode(text: '::markdown hl_lines="2 4"\n', type: CodeBlockSpanType.text),
+        CodeBlockSpanNode(type: CodeBlockSpanType.highlightedLines, spans: [
+          CodeBlockSpanNode(text: '# he', type: CodeBlockSpanType.genericHeading),
+          CodeBlockSpanNode(text: '\n', type: CodeBlockSpanType.text),
+        ]),
+        CodeBlockSpanNode(text: '## llo', type: CodeBlockSpanType.genericSubheading),
+        CodeBlockSpanNode(text: '\n', type: CodeBlockSpanType.text),
+        CodeBlockSpanNode(type: CodeBlockSpanType.highlightedLines, spans: [
+          CodeBlockSpanNode(text: '### world', type: CodeBlockSpanType.genericSubheading),
+        ]),
+      ]),
     ]);
 
   static final codeBlockWithUnknownSpanType = ContentExample(

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -536,6 +536,82 @@ class ContentExample {
       ParagraphNode(links: null, nodes: [TextNode("some content")]),
     ]);
 
+  static const codeBlockKeywordHighlight = ContentExample(
+    'code block, search highlight',
+    '```dart\nclass A {}\n```',
+    '<div class="codehilite" data-code-language="Dart">'
+      '<pre><span></span>'
+        '<code>'
+          '<span class="kd">'
+            '<span class="highlight">class</span></span>'
+          '<span class="w"> </span>'
+          '<span class="nc">A</span>'
+          '<span class="w"> </span>'
+          '<span class="p">{}</span>\n</code></pre></div>', [
+      CodeBlockNode([
+        CodeBlockSpanNode(type: CodeBlockSpanType.keywordDeclaration, spans: [
+          CodeBlockSpanNode(text: 'class', type: CodeBlockSpanType.highlight),
+        ]),
+        CodeBlockSpanNode(text: ' ', type: CodeBlockSpanType.whitespace),
+        CodeBlockSpanNode(text: 'A', type: CodeBlockSpanType.nameClass),
+        CodeBlockSpanNode(text: ' ', type: CodeBlockSpanType.whitespace),
+        CodeBlockSpanNode(text: '{}', type: CodeBlockSpanType.punctuation),
+      ]),
+    ]);
+
+  static const codeBlockKeywordHighlightBetweenText = ContentExample(
+    'code block, search highlight between text',
+    '```console\n# postgresql\nThe World\'s Most Advanced Open Source Relational Database\n```',
+    '<div class="codehilite" data-code-language="Bash Session">'
+      '<pre><span></span>'
+        '<code>'
+          '<span class="gp"># </span>postgresql\n'
+          '<span class="go">'
+            'The '
+            '<span class="highlight">World</span>'
+            '\'s Most Advanced Open Source Relational Database</span>\n</code></pre></div>', [
+      CodeBlockNode([
+        CodeBlockSpanNode(text: '# ', type: CodeBlockSpanType.genericPrompt),
+        CodeBlockSpanNode(text: "postgresql\n", type: CodeBlockSpanType.text),
+        CodeBlockSpanNode(type: CodeBlockSpanType.genericOutput, spans: [
+          CodeBlockSpanNode(text: 'The ', type: CodeBlockSpanType.text),
+          CodeBlockSpanNode(text: 'World', type: CodeBlockSpanType.highlight),
+          CodeBlockSpanNode(text: '\'s Most Advanced Open Source Relational Database', type: CodeBlockSpanType.text),
+        ]),
+      ]),
+    ]);
+
+  static const codeBlockWithHighlightedLinesAndKeywordHighlight = ContentExample(
+    'code block with highlighted lines and keyword highlight',
+     '```\n::markdown hl_lines="2 4"\n# he\n## llo\n### world\n```',
+    '<div class="codehilite">'
+      '<pre><span></span>'
+        '<code>'
+          '::markdown hl_lines=&quot;2 4&quot;\n'
+          '<span class="hll">'
+            '<span class="gh"># he</span>\n</span>'
+          '<span class="gu">## llo</span>\n'
+          '<span class="hll">'
+            '<span class="gu">'
+              '### '
+              '<span class="highlight">world</span></span>\n</span></code></pre></div>', [
+      CodeBlockNode([
+        CodeBlockSpanNode(text: '::markdown hl_lines="2 4"\n', type: CodeBlockSpanType.text),
+        CodeBlockSpanNode(type: CodeBlockSpanType.highlightedLines, spans: [
+          CodeBlockSpanNode(text: '# he', type: CodeBlockSpanType.genericHeading),
+          CodeBlockSpanNode(text: '\n', type: CodeBlockSpanType.text),
+        ]),
+        CodeBlockSpanNode(text: '## llo', type: CodeBlockSpanType.genericSubheading),
+        CodeBlockSpanNode(text: '\n', type: CodeBlockSpanType.text),
+        CodeBlockSpanNode(type: CodeBlockSpanType.highlightedLines, spans: [
+          CodeBlockSpanNode(type: CodeBlockSpanType.genericSubheading, spans: [
+            CodeBlockSpanNode(text: '### ', type: CodeBlockSpanType.text),
+            CodeBlockSpanNode(text: 'world', type: CodeBlockSpanType.highlight),
+          ]),
+        ]),
+      ]),
+    ]);
+
   static final mathInline = ContentExample.inline(
     'inline math',
     r"$$ \lambda $$",
@@ -1799,6 +1875,9 @@ void main() async {
   testParseExample(ContentExample.codeBlockWithHighlightedLines);
   testParseExample(ContentExample.codeBlockWithUnknownSpanType);
   testParseExample(ContentExample.codeBlockFollowedByMultipleLineBreaks);
+  testParseExample(ContentExample.codeBlockKeywordHighlight);
+  testParseExample(ContentExample.codeBlockKeywordHighlightBetweenText);
+  testParseExample(ContentExample.codeBlockWithHighlightedLinesAndKeywordHighlight);
 
   // The math examples in this file are about how math blocks and spans fit
   // into the context of a Zulip message.

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -379,7 +379,9 @@ class ContentExample {
     'code block without syntax highlighting',
     "```\nverb\natim\n```",
     expectedText: 'verb\natim',
-    '<div class="codehilite"><pre><span></span><code>verb\natim\n</code></pre></div>', [
+    '<div class="codehilite">'
+      '<pre><span></span>'
+        '<code>verb\natim\n</code></pre></div>', [
       CodeBlockNode([
         CodeBlockSpanNode(text: 'verb\natim', type: CodeBlockSpanType.text),
       ]),
@@ -389,10 +391,14 @@ class ContentExample {
     'code block with syntax highlighting',
     "```dart\nclass A {}\n```",
     expectedText: 'class A {}',
-    '<div class="codehilite" data-code-language="Dart"><pre>'
-        '<span></span><code><span class="kd">class</span><span class="w"> </span>'
-        '<span class="nc">A</span><span class="w"> </span><span class="p">{}</span>'
-        '\n</code></pre></div>', [
+    '<div class="codehilite" data-code-language="Dart">'
+      '<pre><span></span>'
+        '<code>'
+          '<span class="kd">class</span>'
+          '<span class="w"> </span>'
+          '<span class="nc">A</span>'
+          '<span class="w"> </span>'
+          '<span class="p">{}</span>\n</code></pre></div>', [
       CodeBlockNode([
         CodeBlockSpanNode(text: 'class', type: CodeBlockSpanType.keywordDeclaration),
         CodeBlockSpanNode(text: ' ', type: CodeBlockSpanType.whitespace),
@@ -406,15 +412,27 @@ class ContentExample {
     'code block, multiline, with syntax highlighting',
     '```rust\nfn main() {\n    print!("Hello ");\n\n    print!("world!\\n");\n}\n```',
     expectedText: 'fn main() {\n    print!("Hello ");\n\n    print!("world!\\n");\n}',
-    '<div class="codehilite" data-code-language="Rust"><pre>'
-        '<span></span><code><span class="k">fn</span> <span class="nf">main</span>'
-        '<span class="p">()</span><span class="w"> </span><span class="p">{</span>\n'
-        '<span class="w">    </span><span class="fm">print!</span><span class="p">(</span>'
-        '<span class="s">"Hello "</span><span class="p">);</span>\n\n'
-        '<span class="w">    </span><span class="fm">print!</span><span class="p">(</span>'
-        '<span class="s">"world!</span><span class="se">\\n</span><span class="s">"</span>'
-        '<span class="p">);</span>\n<span class="p">}</span>\n'
-        '</code></pre></div>', [
+    '<div class="codehilite" data-code-language="Rust">'
+      '<pre><span></span>'
+        '<code>'
+          '<span class="k">fn</span> '
+          '<span class="nf">main</span>'
+          '<span class="p">()</span>'
+          '<span class="w"> </span>'
+          '<span class="p">{</span>\n'
+          '<span class="w">    </span>'
+          '<span class="fm">print!</span>'
+          '<span class="p">(</span>'
+          '<span class="s">"Hello "</span>'
+          '<span class="p">);</span>\n\n'
+          '<span class="w">    </span>'
+          '<span class="fm">print!</span>'
+          '<span class="p">(</span>'
+          '<span class="s">"world!</span>'
+          '<span class="se">\\n</span>'
+          '<span class="s">"</span>'
+          '<span class="p">);</span>\n'
+          '<span class="p">}</span>\n</code></pre></div>', [
       CodeBlockNode([
         CodeBlockSpanNode(text: 'fn', type: CodeBlockSpanType.keyword),
         CodeBlockSpanNode(text: ' ', type: CodeBlockSpanType.text),
@@ -447,10 +465,11 @@ class ContentExample {
     expectedText: '- item',
     // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Greg/near/1949014
     '<div class="codehilite" data-code-language="YAML">'
-        '<pre><span></span><code><span class="p p-Indicator">-</span>'
-        '<span class="w"> </span>'
-        '<span class="l l-Scalar l-Scalar-Plain">item</span>\n'
-        '</code></pre></div>', [
+      '<pre><span></span>'
+        '<code>'
+          '<span class="p p-Indicator">-</span>'
+          '<span class="w"> </span>'
+          '<span class="l l-Scalar l-Scalar-Plain">item</span>\n</code></pre></div>', [
       CodeBlockNode([
         CodeBlockSpanNode(text: "-", type: CodeBlockSpanType.punctuation),
         CodeBlockSpanNode(text: " ", type: CodeBlockSpanType.whitespace),
@@ -472,12 +491,15 @@ class ContentExample {
   static final codeBlockWithHighlightedLines = ContentExample(
     'code block, with syntax highlighting and highlighted lines',
     '```\n::markdown hl_lines="2 4"\n# he\n## llo\n### world\n```',
-    '<div class="codehilite"><pre>'
-        '<span></span><code>::markdown hl_lines=&quot;2 4&quot;\n'
-        '<span class="hll"><span class="gh"># he</span>\n'
-        '</span><span class="gu">## llo</span>\n'
-        '<span class="hll"><span class="gu">### world</span>\n'
-        '</span></code></pre></div>', [
+    '<div class="codehilite">'
+      '<pre><span></span>'
+        '<code>'
+          '::markdown hl_lines=&quot;2 4&quot;\n'
+          '<span class="hll">'
+            '<span class="gh"># he</span>\n</span>'
+          '<span class="gu">## llo</span>\n'
+          '<span class="hll">'
+            '<span class="gu">### world</span>\n</span></code></pre></div>', [
       // TODO: Fix this, see comment under `CodeBlockSpanType.highlightedLines` case in lib/model/content.dart.
       blockUnimplemented('<div class="codehilite"><pre>'
         '<span></span><code>::markdown hl_lines=&quot;2 4&quot;\n'


### PR DESCRIPTION
Take 2 of #1707

Fixes: #1695

Screenshots when commits based on top of #1694:
| Flutter | Web |
| - | - |
| <img width="1788" height="2252" alt="image" src="https://github.com/user-attachments/assets/6d8087a6-87c3-4435-8616-fcb1db5bc486" /> | <img width="1788" height="2522" alt="image" src="https://github.com/user-attachments/assets/79e7c63f-a387-42c0-bf4e-636e7f0538bd" /> |

