### PR TITLE
analyze: Fix new lints on latest Flutter main

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1172,10 +1172,7 @@ class UpdateMessageFlagsRemoveEvent extends UpdateMessageFlagsEvent {
   factory UpdateMessageFlagsRemoveEvent.fromJson(Map<String, dynamic> json) {
     final result = _$UpdateMessageFlagsRemoveEventFromJson(json);
     // Crunchy-shell validation
-    if (
-      result.flag == MessageFlag.read
-      && true // (we assume `event_types` has `message` and `update_message_flags`)
-    ) {
+    if (result.flag == MessageFlag.read) {
       result.messageDetails as Map<int, UpdateMessageFlagsMessageDetail>;
     }
     return result;

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -153,9 +153,10 @@ mixin ChannelStore on UserStore {
       case ChannelPostPolicy.any:             return true;
       case ChannelPostPolicy.fullMembers:     {
         if (!role.isAtLeast(UserRole.member)) return false;
-        return role == UserRole.member
-          ? hasPassedWaitingPeriod(user, byDate: byDate)
-          : true;
+        if (role == UserRole.member) {
+          return hasPassedWaitingPeriod(user, byDate: byDate);
+        }
+        return true;
       }
       case ChannelPostPolicy.moderators:      return role.isAtLeast(UserRole.moderator);
       case ChannelPostPolicy.administrators:  return role.isAtLeast(UserRole.administrator);


### PR DESCRIPTION
`flutter analyze` has started giving the following, which breaks CI:

   info • Unnecessary comparison to a boolean literal • lib/api/model/events.dart:1177:10 •
          no_literal_bool_comparisons
   info • Unnecessary comparison to a boolean literal • lib/model/channel.dart:158:13 •
          no_literal_bool_comparisons

Fixed.