### PR TITLE
katex: Remove renderKaTex experimental flag

### DIFF
--- a/lib/model/katex.dart
+++ b/lib/model/katex.dart
@@ -116,31 +116,27 @@ MathParserResult? parseMath(dom.Element element, { required bool block }) {
     // content parsing stage here, thus the `!` here.
     final globalStore = ZulipBinding.instance.getGlobalStoreSync()!;
     final globalSettings = globalStore.settings;
-    final flagRenderKatex =
-      globalSettings.getBool(BoolGlobalSetting.renderKatex);
     final flagForceRenderKatex =
       globalSettings.getBool(BoolGlobalSetting.forceRenderKatex);
 
     KatexParserHardFailReason? hardFailReason;
     KatexParserSoftFailReason? softFailReason;
     List<KatexNode>? nodes;
-    if (flagRenderKatex) {
-      final parser = _KatexParser();
-      try {
-        nodes = parser.parseKatexHtml(katexHtmlElement);
-      } on _KatexHtmlParseError catch (e, st) {
-        assert(debugLog('$e\n$st'));
-        hardFailReason = KatexParserHardFailReason(
-          message: e.message,
-          stackTrace: st);
-      }
+    final parser = _KatexParser();
+    try {
+      nodes = parser.parseKatexHtml(katexHtmlElement);
+    } on _KatexHtmlParseError catch (e, st) {
+      assert(debugLog('$e\n$st'));
+      hardFailReason = KatexParserHardFailReason(
+        message: e.message,
+        stackTrace: st);
+    }
 
-      if (parser.hasError && !flagForceRenderKatex) {
-        nodes = null;
-        softFailReason = KatexParserSoftFailReason(
-          unsupportedCssClasses: parser.unsupportedCssClasses,
-          unsupportedInlineCssProperties: parser.unsupportedInlineCssProperties);
-      }
+    if (parser.hasError && !flagForceRenderKatex) {
+      nodes = null;
+      softFailReason = KatexParserSoftFailReason(
+        unsupportedCssClasses: parser.unsupportedCssClasses,
+        unsupportedInlineCssProperties: parser.unsupportedInlineCssProperties);
     }
 
     return MathParserResult(

--- a/lib/model/settings.dart
+++ b/lib/model/settings.dart
@@ -177,9 +177,6 @@ enum BoolGlobalSetting {
   /// welcome dialog for upgrading from the legacy app.
   upgradeWelcomeDialogShown(GlobalSettingType.internal, false),
 
-  /// An experimental flag to toggle rendering KaTeX content in messages.
-  renderKatex(GlobalSettingType.experimentalFeatureFlag, true),
-
   /// An experimental flag to enable rendering KaTeX even when some
   /// errors are encountered.
   forceRenderKatex(GlobalSettingType.experimentalFeatureFlag, false),
@@ -187,6 +184,7 @@ enum BoolGlobalSetting {
   // Former settings which might exist in the database,
   // whose names should therefore not be reused:
   //   openFirstUnread  // v0.0.30
+  //   renderKatex      // v0.0.29 - v30.0.261
   ;
 
   const BoolGlobalSetting(this.type, this.default_);

--- a/test/model/katex_test.dart
+++ b/test/model/katex_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:zulip/model/settings.dart';
 import 'package:checks/checks.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test_api/scaffolding.dart';
@@ -571,9 +570,6 @@ class KatexExample extends ContentExample {
 
 void main() async {
   TestZulipBinding.ensureInitialized();
-
-  await testBinding.globalStore.settings.setBool(
-    BoolGlobalSetting.renderKatex, true);
 
   testParseExample(KatexExample.mathBlockKatexSizing);
   testParseExample(KatexExample.mathBlockKatexNestedSizing);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -566,15 +566,6 @@ void main() {
 
     testContentSmoke(ContentExample.mathBlock);
 
-    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
-
-      await prepareContent(tester, plainContent(ContentExample.mathBlock.html));
-      tester.widget(find.text(r'\lambda', findRichText: true));
-    });
-
     testWidgets('displays KaTeX content; experimental flag enabled', (tester) async {
       addTearDown(testBinding.reset);
       final globalSettings = testBinding.globalStore.settings;
@@ -583,6 +574,15 @@ void main() {
 
       await prepareContent(tester, plainContent(ContentExample.mathBlock.html));
       tester.widget(find.text('λ', findRichText: true));
+    });
+
+    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
+      addTearDown(testBinding.reset);
+      final globalSettings = testBinding.globalStore.settings;
+      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
+
+      await prepareContent(tester, plainContent(ContentExample.mathBlock.html));
+      tester.widget(find.text(r'\lambda', findRichText: true));
     });
   });
 
@@ -1039,15 +1039,6 @@ void main() {
         targetFontSizeFinder: mkTargetFontSizeFinderFromPattern(r'\lambda'));
     });
 
-    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
-
-      await prepareContent(tester, plainContent(ContentExample.mathInline.html));
-      tester.widget(find.text(r'\lambda', findRichText: true));
-    });
-
     testWidgets('displays KaTeX content; experimental flag enabled', (tester) async {
       addTearDown(testBinding.reset);
       final globalSettings = testBinding.globalStore.settings;
@@ -1056,6 +1047,15 @@ void main() {
 
       await prepareContent(tester, plainContent(ContentExample.mathInline.html));
       tester.widget(find.text('λ', findRichText: true));
+    });
+
+    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
+      addTearDown(testBinding.reset);
+      final globalSettings = testBinding.globalStore.settings;
+      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
+
+      await prepareContent(tester, plainContent(ContentExample.mathInline.html));
+      tester.widget(find.text(r'\lambda', findRichText: true));
     });
   });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1026,19 +1026,6 @@ void main() {
     });
 
     testWidgets('maintains font-size ratio with surrounding text, when showing TeX source', (tester) async {
-      const html = '<span class="katex">'
-        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
-          '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
-        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span>';
-      await checkFontSizeRatio(tester,
-        targetHtml: html,
-        targetFontSizeFinder: mkTargetFontSizeFinderFromPattern(r'λ'));
-    }, skip: true // TODO(#46): adapt this test
-                  //   (it needs a more complex targetFontSizeFinder;
-                  //    see other uses in this file for examples.)
-    );
-
-    testWidgets('maintains font-size ratio with surrounding text, when showing TeX source', (tester) async {
       addTearDown(testBinding.reset);
       final globalSettings = testBinding.globalStore.settings;
       await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -25,7 +25,6 @@ import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/content_test.dart';
-import '../model/store_checks.dart';
 import '../model/test_store.dart';
 import '../test_images.dart';
 import '../test_navigation.dart';
@@ -566,22 +565,13 @@ void main() {
 
     testContentSmoke(ContentExample.mathBlock);
 
-    testWidgets('displays KaTeX content; experimental flag enabled', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, true);
-      check(globalSettings).getBool(BoolGlobalSetting.renderKatex).isTrue();
-
+    testWidgets('displays KaTeX content', (tester) async {
       await prepareContent(tester, plainContent(ContentExample.mathBlock.html));
       tester.widget(find.text('λ', findRichText: true));
     });
 
-    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
-
-      await prepareContent(tester, plainContent(ContentExample.mathBlock.html));
+    testWidgets('fallback to displaying KaTeX source if unsupported KaTeX HTML', (tester) async {
+      await prepareContent(tester, plainContent(ContentExample.mathBlockUnknown.html));
       tester.widget(find.text(r'\lambda', findRichText: true));
     });
   });
@@ -1000,11 +990,6 @@ void main() {
     testContentSmoke(ContentExample.mathInline);
 
     testWidgets('maintains font-size ratio with surrounding text', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, true);
-      check(globalSettings.getBool(BoolGlobalSetting.renderKatex)).isTrue();
-
       const html = '<span class="katex">'
         '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
           '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
@@ -1025,37 +1010,27 @@ void main() {
         });
     });
 
-    testWidgets('maintains font-size ratio with surrounding text, when showing TeX source', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
-
-      const html = '<span class="katex">'
+    testWidgets('maintains font-size ratio with surrounding text, when falling back to TeX source', (tester) async {
+      const unsupportedHtml = '<span class="katex">'
         '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
           '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
-        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span>';
+        '<span class="katex-html" aria-hidden="true">'
+          '<span class="base unknown">' // Server doesn't generate this 'unknown' class.
+          '<span class="strut" style="height:0.6944em;"></span>'
+          '<span class="mord mathnormal">λ</span></span></span></span>';
       await checkFontSizeRatio(tester,
-        targetHtml: html,
+        targetHtml: unsupportedHtml,
         targetFontSizeFinder: mkTargetFontSizeFinderFromPattern(r'\lambda'));
     });
 
-    testWidgets('displays KaTeX content; experimental flag enabled', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, true);
-      check(globalSettings.getBool(BoolGlobalSetting.renderKatex)).isTrue();
-
+    testWidgets('displays KaTeX content', (tester) async {
       await prepareContent(tester, plainContent(ContentExample.mathInline.html));
       tester.widget(find.text('λ', findRichText: true));
     });
 
-    testWidgets('displays KaTeX source; experimental flag disabled', (tester) async {
-      addTearDown(testBinding.reset);
-      final globalSettings = testBinding.globalStore.settings;
-      await globalSettings.setBool(BoolGlobalSetting.renderKatex, false);
-
-      await prepareContent(tester, plainContent(ContentExample.mathInline.html));
-      tester.widget(find.text(r'\lambda', findRichText: true));
+    testWidgets('fallback to displaying KaTeX source if unsupported KaTeX HTML', (tester) async {
+      await prepareContent(tester, plainContent(ContentExample.mathInlineUnknown.html));
+      tester.widget(find.text(r'\lambda'));
     });
   });
 

--- a/test/widgets/katex_test.dart
+++ b/test/widgets/katex_test.dart
@@ -2,12 +2,10 @@ import 'package:checks/checks.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:zulip/model/settings.dart';
 import 'package:zulip/widgets/katex.dart';
 
 import '../model/binding.dart';
 import '../model/katex_test.dart';
-import '../model/store_checks.dart';
 import 'content_test.dart';
 
 void main() {
@@ -80,11 +78,6 @@ void main() {
       for (final testCase in testCases) {
         testWidgets(testCase.$1.description, (tester) async {
           await _loadKatexFonts();
-
-          addTearDown(testBinding.reset);
-          final globalSettings = testBinding.globalStore.settings;
-          await globalSettings.setBool(BoolGlobalSetting.renderKatex, true);
-          check(globalSettings).getBool(BoolGlobalSetting.renderKatex).isTrue();
 
           await prepareContent(tester, plainContent(testCase.$1.html));
 

--- a/tools/content/unimplemented_katex_test.dart
+++ b/tools/content/unimplemented_katex_test.dart
@@ -10,15 +10,12 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/model/content.dart';
-import 'package:zulip/model/settings.dart';
 
 import '../../test/model/binding.dart';
 import 'model.dart';
 
 void main() async {
   TestZulipBinding.ensureInitialized();
-  await testBinding.globalStore.settings.setBool(
-    BoolGlobalSetting.renderKatex, true);
 
   Future<void> checkForKatexFailuresInFile(File file) async {
     int totalMessageCount = 0;


### PR DESCRIPTION
This flag has been enabled since v0.0.29 (beta) release, and we don't plan to disable it. So remove the flag completely, simplifying related code.

Fixes: #1728 