### PR TITLE
Start using `rank` field on mention autocomplete

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -13,7 +13,6 @@ import 'compose.dart';
 import 'emoji.dart';
 import 'narrow.dart';
 import 'store.dart';
-import 'user.dart';
 
 extension ComposeContentAutocomplete on ComposeContentController {
   AutocompleteIntent<ComposeAutocompleteQuery>? autocompleteIntent() {
@@ -652,7 +651,7 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   }
 
   MentionAutocompleteResult? _testUser(MentionAutocompleteQuery query, User user) {
-    return query.testUser(user, store.autocompleteViewManager.autocompleteDataCache, store);
+    return query.testUser(user, store);
   }
 
   @override
@@ -757,10 +756,11 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
       wildcardOption: wildcardOption, rank: _rankWildcardResult);
   }
 
-  MentionAutocompleteResult? testUser(User user, AutocompleteDataCache cache, UserStore store) {
+  MentionAutocompleteResult? testUser(User user, PerAccountStore store) {
     if (!user.isActive) return null;
     if (store.isUserMuted(user.userId)) return null;
 
+    final cache = store.autocompleteViewManager.autocompleteDataCache;
     // TODO(#236) test email too, not just name
     if (!_testName(user, cache)) return null;
 

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -650,10 +650,7 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   }
 
   MentionAutocompleteResult? _testUser(MentionAutocompleteQuery query, User user) {
-    if (query.testUser(user, store.autocompleteViewManager.autocompleteDataCache, store)) {
-      return UserMentionAutocompleteResult(userId: user.userId);
-    }
-    return null;
+    return query.testUser(user, store.autocompleteViewManager.autocompleteDataCache, store);
   }
 
   @override
@@ -755,12 +752,14 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
       || wildcardOption.localizedCanonicalString(localizations).contains(_lowercase);
   }
 
-  bool testUser(User user, AutocompleteDataCache cache, UserStore store) {
-    if (!user.isActive) return false;
-    if (store.isUserMuted(user.userId)) return false;
+  MentionAutocompleteResult? testUser(User user, AutocompleteDataCache cache, UserStore store) {
+    if (!user.isActive) return null;
+    if (store.isUserMuted(user.userId)) return null;
 
     // TODO(#236) test email too, not just name
-    return _testName(user, cache);
+    if (!_testName(user, cache)) return null;
+
+    return UserMentionAutocompleteResult(userId: user.userId);
   }
 
   bool _testName(User user, AutocompleteDataCache cache) {

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -610,11 +610,10 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     if (query.silent) return;
 
     bool tryOption(WildcardMentionOption option) {
-      if (query.testWildcardOption(option, localizations: localizations)) {
-        results.add(WildcardMentionAutocompleteResult(wildcardOption: option));
-        return true;
-      }
-      return false;
+      final result = query.testWildcardOption(option, localizations: localizations);
+      if (result == null) return false;
+      results.add(result);
+      return true;
     }
 
     // Only one of the (all, everyone, channel, stream) channel wildcards are
@@ -745,11 +744,13 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
       store: store, localizations: localizations, narrow: narrow, query: this);
   }
 
-  bool testWildcardOption(WildcardMentionOption wildcardOption, {
+  WildcardMentionAutocompleteResult? testWildcardOption(WildcardMentionOption wildcardOption, {
       required ZulipLocalizations localizations}) {
     // TODO(#237): match insensitively to diacritics
-    return wildcardOption.canonicalString.contains(_lowercase)
+    final matches = wildcardOption.canonicalString.contains(_lowercase)
       || wildcardOption.localizedCanonicalString(localizations).contains(_lowercase);
+    if (!matches) return null;
+    return WildcardMentionAutocompleteResult(wildcardOption: wildcardOption);
   }
 
   MentionAutocompleteResult? testUser(User user, AutocompleteDataCache cache, UserStore store) {

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -517,9 +517,6 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     final dmsResult = compareByDms(userA, userB, store: store);
     if (dmsResult != 0) return dmsResult;
 
-    final botStatusResult = compareByBotStatus(userA, userB);
-    if (botStatusResult != 0) return botStatusResult;
-
     return compareByAlphabeticalOrder(userA, userB, store: store);
   }
 
@@ -584,16 +581,6 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
       (int(),     _) => 1,
       (_,     int()) => -1,
       _              => 0,
-    };
-  }
-
-  /// Comparator that puts non-bots before bots.
-  @visibleForTesting
-  static int compareByBotStatus(User userA, User userB) {
-    return switch ((userA.isBot, userB.isBot)) {
-      (false, true) => -1,
-      (true, false) => 1,
-      _             => 0,
     };
   }
 
@@ -787,11 +774,13 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
   /// from 0 (best) to one less than [_numResultRanks].
   ///
   /// See also [_rankWildcardResult].
-  static int _rankUserResult(User user) => 1;
+  static int _rankUserResult(User user) {
+    return user.isBot ? 2 : 1;
+  }
 
   /// The number of possible values returned by
   /// [_rankWildcardResult] and [_rankUserResult].
-  static const _numResultRanks = 2;
+  static const _numResultRanks = 3;
 
   @override
   String toString() {

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -455,18 +455,23 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   }
 
   /// Compare the users the same way they would be sorted as
-  /// autocomplete candidates.
+  /// autocomplete candidates, given [query].
+  ///
+  /// The users must both match the query.
   ///
   /// This behaves the same as the comparator used for sorting in
-  /// [_usersByRelevance], but calling this for each comparison would be a bit
-  /// less efficient because some of the logic is independent of the users and
-  /// can be precomputed.
+  /// [_usersByRelevance], combined with the ranking applied at the end
+  /// of [computeResults].
   ///
   /// This is useful for tests in order to distinguish "A comes before B"
   /// from "A ranks equal to B, and the sort happened to put A before B",
   /// particularly because [List.sort] makes no guarantees about the order
   /// of items that compare equal.
   int debugCompareUsers(User userA, User userB) {
+    final rankA = query.testUser(userA, store)!.rank;
+    final rankB = query.testUser(userB, store)!.rank;
+    if (rankA != rankB) return rankA.compareTo(rankB);
+
     return _comparator(store: store, narrow: narrow)(userA, userB);
   }
 

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -770,7 +770,7 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
     if (!_testName(user, cache)) return null;
 
     return UserMentionAutocompleteResult(
-      userId: user.userId, rank: _rankUserResult);
+      userId: user.userId, rank: _rankUserResult(user));
   }
 
   bool _testName(User user, AutocompleteDataCache cache) {
@@ -787,7 +787,7 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
   /// from 0 (best) to one less than [_numResultRanks].
   ///
   /// See also [_rankWildcardResult].
-  static const _rankUserResult = 1;
+  static int _rankUserResult(User user) => 1;
 
   /// The number of possible values returned by
   /// [_rankWildcardResult] and [_rankUserResult].

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -8,6 +8,7 @@ import '../api/model/model.dart';
 import '../api/route/channels.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../widgets/compose_box.dart';
+import 'algorithms.dart';
 import 'compose.dart';
 import 'emoji.dart';
 import 'narrow.dart';
@@ -636,16 +637,18 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
 
   @override
   Future<List<MentionAutocompleteResult>?> computeResults() async {
-    final results = <MentionAutocompleteResult>[];
+    final unsorted = <MentionAutocompleteResult>[];
     // Give priority to wildcard mentions.
-    computeWildcardMentionResults(results: results,
+    computeWildcardMentionResults(results: unsorted,
       isComposingChannelMessage: narrow is ChannelNarrow || narrow is TopicNarrow);
 
     if (await filterCandidates(filter: _testUser,
-        candidates: sortedUsers, results: results)) {
+        candidates: sortedUsers, results: unsorted)) {
       return null;
     }
-    return results;
+
+    return bucketSort(unsorted,
+      (r) => r.rank, numBuckets: MentionAutocompleteQuery._numResultRanks);
   }
 
   MentionAutocompleteResult? _testUser(MentionAutocompleteQuery query, User user) {
@@ -750,7 +753,8 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
     final matches = wildcardOption.canonicalString.contains(_lowercase)
       || wildcardOption.localizedCanonicalString(localizations).contains(_lowercase);
     if (!matches) return null;
-    return WildcardMentionAutocompleteResult(wildcardOption: wildcardOption);
+    return WildcardMentionAutocompleteResult(
+      wildcardOption: wildcardOption, rank: _rankWildcardResult);
   }
 
   MentionAutocompleteResult? testUser(User user, AutocompleteDataCache cache, UserStore store) {
@@ -760,12 +764,29 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
     // TODO(#236) test email too, not just name
     if (!_testName(user, cache)) return null;
 
-    return UserMentionAutocompleteResult(userId: user.userId);
+    return UserMentionAutocompleteResult(
+      userId: user.userId, rank: _rankUserResult);
   }
 
   bool _testName(User user, AutocompleteDataCache cache) {
     return _testContainsQueryWords(cache.nameWordsForUser(user));
   }
+
+  /// A measure of a wildcard result's quality in the context of the query,
+  /// from 0 (best) to one less than [_numResultRanks].
+  ///
+  /// See also [_rankUserResult].
+  static const _rankWildcardResult = 0;
+
+  /// A measure of a user result's quality in the context of the query,
+  /// from 0 (best) to one less than [_numResultRanks].
+  ///
+  /// See also [_rankWildcardResult].
+  static const _rankUserResult = 1;
+
+  /// The number of possible values returned by
+  /// [_rankWildcardResult] and [_rankUserResult].
+  static const _numResultRanks = 2;
 
   @override
   String toString() {
@@ -853,20 +874,31 @@ class EmojiAutocompleteResult extends ComposeAutocompleteResult {
 /// This is abstract because there are several kinds of result
 /// that can all be offered in the same @-mention autocomplete interaction:
 /// a user, a wildcard, or a user group.
-sealed class MentionAutocompleteResult extends ComposeAutocompleteResult {}
+sealed class MentionAutocompleteResult extends ComposeAutocompleteResult {
+  /// A measure of the result's quality in the context of the query.
+  ///
+  /// Used internally by [MentionAutocompleteView] for ranking the results.
+  int get rank;
+}
 
 /// An autocomplete result for an @-mention of an individual user.
 class UserMentionAutocompleteResult extends MentionAutocompleteResult {
-  UserMentionAutocompleteResult({required this.userId});
+  UserMentionAutocompleteResult({required this.userId, required this.rank});
 
   final int userId;
+
+  @override
+  final int rank;
 }
 
 /// An autocomplete result for an @-mention of all the users in a conversation.
 class WildcardMentionAutocompleteResult extends MentionAutocompleteResult {
-  WildcardMentionAutocompleteResult({required this.wildcardOption});
+  WildcardMentionAutocompleteResult({required this.wildcardOption, required this.rank});
 
   final WildcardMentionOption wildcardOption;
+
+  @override
+  final int rank;
 }
 
 // TODO(#233): // class UserGroupMentionAutocompleteResult extends MentionAutocompleteResult {

--- a/test/model/autocomplete_checks.dart
+++ b/test/model/autocomplete_checks.dart
@@ -1,6 +1,7 @@
 import 'package:checks/checks.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/autocomplete.dart';
+import 'package:zulip/model/compose.dart';
 import 'package:zulip/widgets/compose_box.dart';
 
 extension ComposeContentControllerChecks on Subject<ComposeContentController> {
@@ -18,6 +19,10 @@ extension AutocompleteIntentChecks on Subject<AutocompleteIntent<AutocompleteQue
 
 extension UserMentionAutocompleteResultChecks on Subject<UserMentionAutocompleteResult> {
   Subject<int> get userId => has((r) => r.userId, 'userId');
+}
+
+extension WildcardMentionAutocompleteResultChecks on Subject<WildcardMentionAutocompleteResult> {
+  Subject<WildcardMentionOption> get wildcardOption => has((x) => x.wildcardOption, 'wildcardOption');
 }
 
 extension TopicAutocompleteResultChecks on Subject<TopicAutocompleteResult> {

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -409,7 +409,9 @@ void main() {
     void doCheck(String rawQuery, User user, bool expected) {
       final result = MentionAutocompleteQuery(rawQuery)
         .testUser(user, AutocompleteDataCache(), store);
-      expected ? check(result).isTrue() : check(result).isFalse();
+      expected
+        ? check(result).isA<UserMentionAutocompleteResult>()
+        : check(result).isNull();
     }
 
     test('user is always excluded when not active regardless of other criteria', () {

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -407,8 +407,7 @@ void main() {
     late PerAccountStore store;
 
     void doCheck(String rawQuery, User user, bool expected) {
-      final result = MentionAutocompleteQuery(rawQuery)
-        .testUser(user, AutocompleteDataCache(), store);
+      final result = MentionAutocompleteQuery(rawQuery).testUser(user, store);
       expected
         ? check(result).isA<UserMentionAutocompleteResult>()
         : check(result).isNull();

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -834,12 +834,11 @@ void main() {
       ];
 
       await prepare(users: users, messages: [
-        eg.streamMessage(id: 50, sender: users[1-1], stream: stream, topic: topic),
-        eg.streamMessage(id: 60, sender: users[5-1], stream: stream, topic: 'other $topic'),
-      ], dmConversations: [
-        RecentDmConversation(userIds: [4],    maxMessageId: 300),
-        RecentDmConversation(userIds: [1],    maxMessageId: 200),
-        RecentDmConversation(userIds: [1, 2], maxMessageId: 100),
+        eg.streamMessage(sender: users[1-1], stream: stream, topic: topic),
+        eg.streamMessage(sender: users[5-1], stream: stream, topic: 'other $topic'),
+        eg.dmMessage(from: users[1-1], to: [users[2-1], eg.selfUser]),
+        eg.dmMessage(from: users[1-1], to: [eg.selfUser]),
+        eg.dmMessage(from: users[4-1], to: [eg.selfUser]),
       ]);
 
       // Check the ranking of the full list of mentions.

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -403,66 +403,6 @@ void main() {
       ..not((results) => results.contains(11000));
   });
 
-  group('MentionAutocompleteQuery.testUser', () {
-    late PerAccountStore store;
-
-    void doCheck(String rawQuery, User user, bool expected) {
-      final result = MentionAutocompleteQuery(rawQuery).testUser(user, store);
-      expected
-        ? check(result).isA<UserMentionAutocompleteResult>()
-        : check(result).isNull();
-    }
-
-    test('user is always excluded when not active regardless of other criteria', () {
-      store = eg.store();
-
-      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: false), false);
-      // When active then other criteria will be checked
-      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: true), true);
-    });
-
-    test('user is always excluded when muted, regardless of other criteria', () async {
-      store = eg.store();
-      await store.setMutedUsers([1]);
-      doCheck('Full Name', eg.user(userId: 1, fullName: 'Full Name'), false);
-      // When not muted, then other criteria will be checked
-      doCheck('Full Name', eg.user(userId: 2, fullName: 'Full Name'), true);
-    });
-
-    test('user is included if fullname words match the query', () {
-      store = eg.store();
-
-      doCheck('', eg.user(fullName: 'Full Name'), true);
-      doCheck('', eg.user(fullName: ''), true); // Unlikely case, but should not crash
-      doCheck('Full Name', eg.user(fullName: 'Full Name'), true);
-      doCheck('full name', eg.user(fullName: 'Full Name'), true);
-      doCheck('Full Name', eg.user(fullName: 'full name'), true);
-      doCheck('Full', eg.user(fullName: 'Full Name'), true);
-      doCheck('Name', eg.user(fullName: 'Full Name'), true);
-      doCheck('Full Name', eg.user(fullName: 'Fully Named'), true);
-      doCheck('Full Four', eg.user(fullName: 'Full Name Four Words'), true);
-      doCheck('Name Words', eg.user(fullName: 'Full Name Four Words'), true);
-      doCheck('Full F', eg.user(fullName: 'Full Name Four Words'), true);
-      doCheck('F Four', eg.user(fullName: 'Full Name Four Words'), true);
-      doCheck('full full', eg.user(fullName: 'Full Full Name'), true);
-      doCheck('full full', eg.user(fullName: 'Full Name Full'), true);
-
-      doCheck('F', eg.user(fullName: ''), false); // Unlikely case, but should not crash
-      doCheck('Fully Named', eg.user(fullName: 'Full Name'), false);
-      doCheck('Full Name', eg.user(fullName: 'Full'), false);
-      doCheck('Full Name', eg.user(fullName: 'Name'), false);
-      doCheck('ull ame', eg.user(fullName: 'Full Name'), false);
-      doCheck('ull Name', eg.user(fullName: 'Full Name'), false);
-      doCheck('Full ame', eg.user(fullName: 'Full Name'), false);
-      doCheck('Full Full', eg.user(fullName: 'Full Name'), false);
-      doCheck('Name Name', eg.user(fullName: 'Full Name'), false);
-      doCheck('Name Full', eg.user(fullName: 'Full Name'), false);
-      doCheck('Name Four Full Words', eg.user(fullName: 'Full Name Four Words'), false);
-      doCheck('F Full', eg.user(fullName: 'Full Name Four Words'), false);
-      doCheck('Four F', eg.user(fullName: 'Full Name Four Words'), false);
-    });
-  });
-
   group('MentionAutocompleteView sorting users results', () {
     late PerAccountStore store;
 
@@ -953,6 +893,66 @@ void main() {
       check(getWildcardOptionsFor('topic',
           narrow: channelNarrow, zulipFeatureLevel: 223))
         .deepEquals([]);
+    });
+  });
+
+  group('MentionAutocompleteQuery.testUser', () {
+    late PerAccountStore store;
+
+    void doCheck(String rawQuery, User user, bool expected) {
+      final result = MentionAutocompleteQuery(rawQuery).testUser(user, store);
+      expected
+        ? check(result).isA<UserMentionAutocompleteResult>()
+        : check(result).isNull();
+    }
+
+    test('user is always excluded when not active regardless of other criteria', () {
+      store = eg.store();
+
+      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: false), false);
+      // When active then other criteria will be checked
+      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: true), true);
+    });
+
+    test('user is always excluded when muted, regardless of other criteria', () async {
+      store = eg.store();
+      await store.setMutedUsers([1]);
+      doCheck('Full Name', eg.user(userId: 1, fullName: 'Full Name'), false);
+      // When not muted, then other criteria will be checked
+      doCheck('Full Name', eg.user(userId: 2, fullName: 'Full Name'), true);
+    });
+
+    test('user is included if fullname words match the query', () {
+      store = eg.store();
+
+      doCheck('', eg.user(fullName: 'Full Name'), true);
+      doCheck('', eg.user(fullName: ''), true); // Unlikely case, but should not crash
+      doCheck('Full Name', eg.user(fullName: 'Full Name'), true);
+      doCheck('full name', eg.user(fullName: 'Full Name'), true);
+      doCheck('Full Name', eg.user(fullName: 'full name'), true);
+      doCheck('Full', eg.user(fullName: 'Full Name'), true);
+      doCheck('Name', eg.user(fullName: 'Full Name'), true);
+      doCheck('Full Name', eg.user(fullName: 'Fully Named'), true);
+      doCheck('Full Four', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('Name Words', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('Full F', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('F Four', eg.user(fullName: 'Full Name Four Words'), true);
+      doCheck('full full', eg.user(fullName: 'Full Full Name'), true);
+      doCheck('full full', eg.user(fullName: 'Full Name Full'), true);
+
+      doCheck('F', eg.user(fullName: ''), false); // Unlikely case, but should not crash
+      doCheck('Fully Named', eg.user(fullName: 'Full Name'), false);
+      doCheck('Full Name', eg.user(fullName: 'Full'), false);
+      doCheck('Full Name', eg.user(fullName: 'Name'), false);
+      doCheck('ull ame', eg.user(fullName: 'Full Name'), false);
+      doCheck('ull Name', eg.user(fullName: 'Full Name'), false);
+      doCheck('Full ame', eg.user(fullName: 'Full Name'), false);
+      doCheck('Full Full', eg.user(fullName: 'Full Name'), false);
+      doCheck('Name Name', eg.user(fullName: 'Full Name'), false);
+      doCheck('Name Full', eg.user(fullName: 'Full Name'), false);
+      doCheck('Name Four Full Words', eg.user(fullName: 'Full Name Four Words'), false);
+      doCheck('F Full', eg.user(fullName: 'Full Name Four Words'), false);
+      doCheck('Four F', eg.user(fullName: 'Full Name Four Words'), false);
     });
   });
 

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -972,6 +972,43 @@ void main() {
     });
   });
 
+  group('MentionAutocompleteQuery ranking', () {
+    // This gets filled lazily, but never reset.
+    // We're counting on this group's tests never doing anything to mutate it.
+    PerAccountStore? store;
+
+    int? rankOf(String queryStr, Object candidate) {
+      final query = MentionAutocompleteQuery(queryStr);
+      final result = switch (candidate) {
+        WildcardMentionOption() => query.testWildcardOption(candidate,
+          localizations: GlobalLocalizations.zulipLocalizations),
+        User() => query.testUser(candidate, (store ??= eg.store())),
+        _ => throw StateError('invalid candidate'),
+      };
+      return result?.rank;
+    }
+
+    void checkPrecedes(String query, Object a, Object b) {
+      check(rankOf(query, a)!).isLessThan(rankOf(query, b)!);
+    }
+
+    void checkSameRank(String query, Object a, Object b) {
+      check(rankOf(query, a)!).equals(rankOf(query, b)!);
+    }
+
+    test('wildcards, then users', () {
+      checkSameRank('', WildcardMentionOption.all, WildcardMentionOption.topic);
+      checkPrecedes('', WildcardMentionOption.topic, eg.user());
+      checkSameRank('', eg.user(), eg.user());
+    });
+
+    test('wildcard-vs-user more significant than match quality', () {
+      // Make the query an exact match for the user's name.
+      final user = eg.user(fullName: 'Ann');
+      checkPrecedes(user.fullName, WildcardMentionOption.channel, user);
+    });
+  });
+
   group('ComposeTopicAutocomplete.autocompleteIntent', () {
     void doTest(String markedText, TopicAutocompleteQuery? expectedQuery) {
       final parsed = parseMarkedText(markedText);


### PR DESCRIPTION
Stacked atop #1745. This makes some refactors to the tests for the ordering of autocomplete results, and then demonstrates changing that ordering by moving the human-vs-bot distinction into the "ranking" layer, as suggested in #1745.

Now that I've spelled that out, complete with its consequences as seen in the tests, it doesn't actually sound desirable as a product change: if there's a bot participating in the current thread and I start typing its name, wouldn't we want that as a top result? The distinctions in the "ranking" layer take priority over those in the initial sorting of candidates, so this change causes bots to always come after all other matches.

Anyway, this demonstrates how such a change would work out in the tests, though. And if that really is the behavior that web has, then we should probably just do it — in order to minimize avoidable differences from web's logic, to better clear the way to proceeding with user groups as autocomplete results, #233 — and consider coming back and changing it on both platforms later.
