### PR TITLE
Omit unread button unsubscribed

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -28,20 +28,7 @@ import Flutter
 
     UNUserNotificationCenter.current().delegate = self
 
-    // This is needed to get a push token from APNs.
-    // The user will be prompted for permission only the first time.
-    application.registerForRemoteNotifications()
-
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  // This method will be called when an app receives a notification in the foreground.
-  override func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    willPresent notification: UNNotification,
-    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-  ) {
-    completionHandler([.alert, .badge, .sound])
   }
 
   override func userNotificationCenter(

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -28,7 +28,20 @@ import Flutter
 
     UNUserNotificationCenter.current().delegate = self
 
+    // This is needed to get a push token from APNs.
+    // The user will be prompted for permission only the first time.
+    application.registerForRemoteNotifications()
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // This method will be called when an app receives a notification in the foreground.
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.alert, .badge, .sound])
   }
 
   override func userNotificationCenter(

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -606,7 +606,8 @@ void showMessageActionSheet({required BuildContext context, required Message mes
 
   final isMessageRead = message.flags.contains(MessageFlag.read);
   final markAsUnreadSupported = store.zulipFeatureLevel >= 155; // TODO(server-6)
-  final showMarkAsUnreadButton = markAsUnreadSupported && isMessageRead;
+  final showMarkAsUnreadButton = markAsUnreadSupported && isMessageRead
+  && (message is! StreamMessage || store.subscriptions[message.streamId] != null);
 
   final isSenderMuted = store.isUserMuted(message.senderId);
 


### PR DESCRIPTION
I am sorry for doing a pr on this , I already saw that someone was assigned and I saw that he hasn't done a pr yet so I am doing this basically I noticed that If store.subscriptions[message.streamId] returns null, it means the user is not subscribed to that stream. so I just fixed that , please ignore this if the pr is to be completed by the assignee Idk how this works im still learning 
im doing the table thing for the first time not sure if its needed but here goes
<table>
<thead>
<tr>
<th>Before (Subscribed Channel)</th>
<th>After (Unsubscribed Channel)</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img alt="A screenshot showing the message action sheet with a 'Mark as unread' option." src="https://github.com/user-attachments/assets/04c44d2f-e2bf-4906-ae4f-90bd57b5c8d2" width="294">
</td>
<td>
<img alt="A screenshot showing the message action sheet without the 'Mark as unread' option." src="https://github.com/user-attachments/assets/dfd7e7ac-e7d2-4b8b-a9d7-c0d05981d47a" width="286">
</td>
</tr>
</tbody>
</table>

