### PR TITLE
deps: Upgrade Flutter to 3.33.0-1.0.pre.1149

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -714,10 +714,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -1079,26 +1079,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: "direct dev"
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -1355,5 +1355,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.9.0-293.0.dev <4.0.0"
-  flutter: ">=3.33.0-1.0.pre.832"
+  dart: ">=3.10.0-28.0.dev <4.0.0"
+  flutter: ">=3.33.0-1.0.pre.1149"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.9.0-293.0.dev <4.0.0'
-  flutter: '>=3.33.0-1.0.pre.832'  # d35bde5363d5e25b71d69a81e8c93b0ee3272609
+  sdk: '>=3.10.0-28.0.dev <4.0.0'
+  flutter: '>=3.33.0-1.0.pre.1149'  # 053c8a55f1e933ecd57e6cadcddf3bdd8b6c6b2c
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
And update Flutter's supporting libraries to match.

With this upgrade, we can now use the route transition duration in tests to wait the minimum amount of time needed for the route animation to complete.

Related upstream PR: https://github.com/flutter/flutter/pull/171109