### PR TITLE
fix: Adjust emoji picker layout

### DIFF
--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -599,10 +599,9 @@ class EmojiPickerListEntry extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(spacing: 4, children: [
-          if (glyph != null)
             Padding(
               padding: const EdgeInsets.all(10),
-              child: glyph),
+              child: glyph ?? SizedBox(width: _emojiSize, height: _emojiSize)),
           Flexible(child: Text(label,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -599,9 +599,13 @@ class EmojiPickerListEntry extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(spacing: 4, children: [
-            Padding(
-              padding: const EdgeInsets.all(10),
-              child: glyph ?? SizedBox(width: _emojiSize, height: _emojiSize)),
+            if (glyph != null)
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: glyph,
+                  ),
+            if (glyph == null)
+                SizedBox(width: _emojiSize + 20, height: _emojiSize + 20),
           Flexible(child: Text(label,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| **Plain-text emoji overflow** | **Layout corrected** |
| ![Simulator Screenshot - iPhone 16e - 2025-07-26 at 10 46 10](https://github.com/user-attachments/assets/e4348ff2-9422-4bff-a077-af956e47168c) | ![Simulator Screenshot - iPhone 16e - 2025-07-26 at 10 45 37](https://github.com/user-attachments/assets/8556923e-f968-4c61-a8e7-ea4f52542fc4) |

