### PR TITLE
fix for unread button on unsubscribed channels #1641

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -606,7 +606,8 @@ void showMessageActionSheet({required BuildContext context, required Message mes
 
   final isMessageRead = message.flags.contains(MessageFlag.read);
   final markAsUnreadSupported = store.zulipFeatureLevel >= 155; // TODO(server-6)
-  final showMarkAsUnreadButton = markAsUnreadSupported && isMessageRead;
+  final showMarkAsUnreadButton = markAsUnreadSupported && isMessageRead &&
+  (message is! StreamMessage || store.subscriptions[message.streamId] != null);
 
   final isSenderMuted = store.isUserMuted(message.senderId);
 


### PR DESCRIPTION



Fixes: #1641

---

### Before & After

| Before | After |
| :---: | :---: |
| The button was incorrectly shown for unsubscribed channels. | The button is now not there. |
| <img width="290" alt="A screenshot showing the message action sheet with the 'Mark as unread from here' button visible." src="https://github.com/user-attachments/assets/3d7febfa-dfc2-48df-9782-e31f402800e7" /> | <img width="289" alt="A screenshot showing the message action sheet without the 'Mark as unread from here' button." src="https://github.com/user-attachments/assets/1e4b0e54-a74e-49d2-bce3-174184543730" /> |