### PR TITLE
For uploads, use verbatim URL string from server

### DIFF
--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -315,10 +315,11 @@ Future<UploadFileResult> uploadFile(
 
 @JsonSerializable(fieldRename: FieldRename.snake)
 class UploadFileResult {
-  final String uri;
+  @JsonKey(name: 'uri')
+  final String url;
 
   UploadFileResult({
-    required this.uri,
+    required this.url,
   });
 
   factory UploadFileResult.fromJson(Map<String, dynamic> json) =>

--- a/lib/api/route/messages.g.dart
+++ b/lib/api/route/messages.g.dart
@@ -50,10 +50,10 @@ Map<String, dynamic> _$UpdateMessageResultToJson(
 ) => <String, dynamic>{};
 
 UploadFileResult _$UploadFileResultFromJson(Map<String, dynamic> json) =>
-    UploadFileResult(uri: json['uri'] as String);
+    UploadFileResult(url: json['uri'] as String);
 
 Map<String, dynamic> _$UploadFileResultToJson(UploadFileResult instance) =>
-    <String, dynamic>{'uri': instance.uri};
+    <String, dynamic>{'uri': instance.url};
 
 UpdateMessageFlagsResult _$UpdateMessageFlagsResultFromJson(
   Map<String, dynamic> json,

--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -188,7 +188,7 @@ String wildcardMention(WildcardMentionOption wildcardOption, {
 /// result may be surprising.
 ///
 /// The part between "(" and ")" is just a "link destination" (no "link title").
-/// That destination is the string [destination], if provided.
+/// That destination is the string [destination].
 /// If [destination] has parentheses in it, the result may be surprising.
 // TODO: Try harder to guarantee output that creates an inline link,
 //   and in particular, the intended one. We could help with this by escaping
@@ -199,8 +199,8 @@ String wildcardMention(WildcardMentionOption wildcardOption, {
 //   > Backtick code spans, autolinks, and raw HTML tags bind more tightly
 //   > than the brackets in link text. Thus, for example, [foo`]` could not be
 //   > a link text, since the second ] is part of a code span.
-String inlineLink(String visibleText, String? destination) {
-  return '[$visibleText](${destination ?? ''})';
+String inlineLink(String visibleText, String destination) {
+  return '[$visibleText]($destination)';
 }
 
 /// What we show while fetching the target message's raw Markdown.

--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -188,8 +188,8 @@ String wildcardMention(WildcardMentionOption wildcardOption, {
 /// result may be surprising.
 ///
 /// The part between "(" and ")" is just a "link destination" (no "link title").
-/// That destination is simply the stringified [destination], if provided.
-/// If that has parentheses in it, the result may be surprising.
+/// That destination is the string [destination], if provided.
+/// If [destination] has parentheses in it, the result may be surprising.
 // TODO: Try harder to guarantee output that creates an inline link,
 //   and in particular, the intended one. We could help with this by escaping
 //   square brackets, perhaps with HTML character references:
@@ -199,8 +199,8 @@ String wildcardMention(WildcardMentionOption wildcardOption, {
 //   > Backtick code spans, autolinks, and raw HTML tags bind more tightly
 //   > than the brackets in link text. Thus, for example, [foo`]` could not be
 //   > a link text, since the second ] is part of a code span.
-String inlineLink(String visibleText, Uri? destination) {
-  return '[$visibleText](${destination?.toString() ?? ''})';
+String inlineLink(String visibleText, String? destination) {
+  return '[$visibleText](${destination ?? ''})';
 }
 
 /// What we show while fetching the target message's raw Markdown.
@@ -213,7 +213,7 @@ String quoteAndReplyPlaceholder(
     SendableNarrow.ofMessage(message, selfUserId: store.selfUserId),
     nearMessageId: message.id);
   return '${userMentionFromMessage(message, silent: true, users: store)} '
-    '${inlineLink('said', url)}: ' // TODO(#1285)
+    '${inlineLink('said', url.toString())}: ' // TODO(#1285)
     '*${zulipLocalizations.composeBoxLoadingMessage(message.id)}*\n';
 }
 
@@ -237,6 +237,6 @@ String quoteAndReply(PerAccountStore store, {
   // and the extra noise won't much matter with the already probably-long
   // message link in there too.
   return '${userMentionFromMessage(message, silent: true, users: store)} '
-    '${inlineLink('said', url)}:\n' // TODO(#1285)
+    '${inlineLink('said', url.toString())}:\n' // TODO(#1285)
     '${wrapWithBacktickFence(content: rawContent, infoString: 'quote')}';
 }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -372,7 +372,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
 
     value = value.replaced(
       replacementRange,
-      url == null ? '' : inlineLink(filename, url));
+      url == null ? '' : inlineLink(filename, url.toString()));
     _uploads.remove(tag);
     notifyListeners(); // _uploads change could affect validationErrors
   }

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -359,9 +359,9 @@ class ComposeContentController extends ComposeController<ContentValidationError>
 
   /// Tells the controller that a file upload has ended, with success or error.
   ///
-  /// To indicate success, pass the URL to be used for the Markdown link.
+  /// To indicate success, pass the URL string to be used for the Markdown link.
   /// If `url` is null, failure is assumed.
-  void registerUploadEnd(int tag, Uri? url) {
+  void registerUploadEnd(int tag, String? url) {
     final val = _uploads[tag];
     assert(val != null, 'registerUploadEnd called twice for same tag');
     final (:filename, :placeholder) = val!;
@@ -372,7 +372,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
 
     value = value.replaced(
       replacementRange,
-      url == null ? '' : inlineLink(filename, url.toString()));
+      url == null ? '' : inlineLink(filename, url));
     _uploads.remove(tag);
     notifyListeners(); // _uploads change could affect validationErrors
   }
@@ -971,7 +971,7 @@ Future<void> _uploadFiles({
 
   for (final (tag, file) in uploadsInProgress) {
     final _File(:content, :length, :filename, :mimeType) = file;
-    Uri? url;
+    String? url;
     try {
       final result = await uploadFile(store.connection,
         content: content,
@@ -979,7 +979,7 @@ Future<void> _uploadFiles({
         filename: filename,
         contentType: mimeType,
       );
-      url = Uri.parse(result.url);
+      url = result.url;
     } catch (e) {
       if (!context.mounted) return;
       // TODO(#741): Specifically handle `413 Payload Too Large`

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -350,7 +350,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
     final tag = _nextUploadTag;
     _nextUploadTag += 1;
     final linkText = zulipLocalizations.composeBoxUploadingFilename(filename);
-    final placeholder = inlineLink(linkText, null);
+    final placeholder = inlineLink(linkText, '');
     _uploads[tag] = (filename: filename, placeholder: placeholder);
     notifyListeners(); // _uploads change could affect validationErrors
     value = value.replaced(insertionIndex(), '$placeholder\n\n');

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -979,7 +979,7 @@ Future<void> _uploadFiles({
         filename: filename,
         contentType: mimeType,
       );
-      url = Uri.parse(result.uri);
+      url = Uri.parse(result.url);
     } catch (e) {
       if (!context.mounted) return;
       // TODO(#741): Specifically handle `413 Payload Too Large`

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -567,7 +567,7 @@ void main() {
       required String? contentType,
     }) async {
       connection.prepare(json:
-        UploadFileResult(uri: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/$filename').toJson());
+        UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/$filename').toJson());
       await uploadFile(connection,
         content: Stream.fromIterable(content),
         length: length,

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -320,7 +320,7 @@ hello
 
   test('inlineLink', () {
     check(inlineLink('CZO', 'https://chat.zulip.org/')).equals('[CZO](https://chat.zulip.org/)');
-    check(inlineLink('Uploading file.txt…', null)).equals('[Uploading file.txt…]()');
+    check(inlineLink('Uploading file.txt…', '')).equals('[Uploading file.txt…]()');
     check(inlineLink('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png'))
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
   });

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -319,9 +319,9 @@ hello
   });
 
   test('inlineLink', () {
-    check(inlineLink('CZO', Uri.parse('https://chat.zulip.org/'))).equals('[CZO](https://chat.zulip.org/)');
+    check(inlineLink('CZO', 'https://chat.zulip.org/')).equals('[CZO](https://chat.zulip.org/)');
     check(inlineLink('Uploading file.txt…', null)).equals('[Uploading file.txt…]()');
-    check(inlineLink('IMG_2488.png', Uri.parse('/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png')))
+    check(inlineLink('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png'))
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
   });
 

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1070,7 +1070,7 @@ void main() {
           size: 12345,
         )]);
         connection.prepare(delay: const Duration(seconds: 1), json:
-          UploadFileResult(uri: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
+          UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
 
         await tester.tap(find.byIcon(ZulipIcons.image));
         await tester.pump();
@@ -1129,7 +1129,7 @@ void main() {
           path: '/private/var/mobile/Containers/Data/Application/foo/tmp/image.jpg',
         );
         connection.prepare(delay: const Duration(seconds: 1), json:
-          UploadFileResult(uri: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
+          UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
 
         await tester.tap(find.byIcon(ZulipIcons.camera));
         await tester.pump();
@@ -1833,7 +1833,7 @@ void main() {
         testBinding.pickFilesResult = FilePickerResult([
           PlatformFile(name: 'file.jpg', size: 1000, readStream: Stream.fromIterable(['asdf'.codeUnits]))]);
         connection.prepare(json:
-          UploadFileResult(uri: '/path/file.jpg').toJson());
+          UploadFileResult(url: '/path/file.jpg').toJson());
         await tester.tap(find.byIcon(ZulipIcons.attach_file), warnIfMissed: false);
         await tester.pump(Duration.zero);
         checkNoErrorDialog(tester);


### PR DESCRIPTION
Fixes #1709.

## Commit messages

#### 314c83c09 api [nfc]: Rename field UploadFileResult.url from "uri"

Like elsewhere in our codebase, use the standard term "URL":
  https://github.com/zulip/zulip-mobile/blob/main/docs/style.md#url-not-uri



#### c7f336c1e compose [nfc]: Take a URL string at inlineLink, rather than a Uri object

This way this function is a more faithful wrapper of constructing
the actual Markdown syntax.  The Markdown will have a URL string,
after all, so it's for the best to put this function's caller in
control of exactly what string that is.



#### 2e06a67ff compose: For uploads, use verbatim URL string from server

Fixes #1709.

Round-tripping through `Uri.parse` and `.toString()` had the effect
of percent-encoding any non-ASCII characters in the given URL string.
The server expects, reasonably enough, that the client will refer to
the upload using the same URL string the server provided at upload
time; so do that.



#### 6a35cc47f compose [nfc]: Simplify inlineLink by dropping null destination

Now that the caller is passing a string instead of a Uri object, the
caller that wants an empty string here can just pass an empty string.

