### PR TITLE
theme: Set visualDensity to standard, even on desktop

### DIFF
--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -59,6 +59,13 @@ ThemeData zulipThemeData(BuildContext context) {
     brightness: brightness,
     typography: zulipTypography(context),
     extensions: themeExtensions,
+
+    // Use "standard" visual density (the default for mobile platforms)
+    // on all platforms.  That helps the desktop builds of the app be faithful
+    // previews of how the app behaves on mobile -- which is the only purpose
+    // we use the desktop builds for.
+    visualDensity: VisualDensity.standard,
+
     iconButtonTheme: IconButtonThemeData(style: IconButton.styleFrom(
       foregroundColor: designVariables.icon,
     )),


### PR DESCRIPTION
This also fixes an assert in ZulipMenuItemButton when running desktop builds of the app.

In particular that assert prevents the buttons in an action sheet from appearing, so I ran into it while using a desktop build to test https://github.com/zulip/zulip-flutter/pull/1706#discussion_r2252435627 .
