### PR TITLE
login: Reject earlier (at get-server-settings) when server is too old

### DIFF
--- a/lib/model/server_support.dart
+++ b/lib/model/server_support.dart
@@ -1,0 +1,56 @@
+import '../api/core.dart';
+import '../api/exception.dart';
+import '../api/model/initial_snapshot.dart';
+import 'database.dart';
+
+/// The fields 'zulip_version', 'zulip_merge_base', and 'zulip_feature_level'
+/// from a /register response.
+class ZulipVersionData {
+  const ZulipVersionData({
+    required this.zulipVersion,
+    required this.zulipMergeBase,
+    required this.zulipFeatureLevel,
+  });
+
+  factory ZulipVersionData.fromInitialSnapshot(InitialSnapshot initialSnapshot) =>
+    ZulipVersionData(
+      zulipVersion: initialSnapshot.zulipVersion,
+      zulipMergeBase: initialSnapshot.zulipMergeBase,
+      zulipFeatureLevel: initialSnapshot.zulipFeatureLevel);
+
+  /// Make a [ZulipVersionData] from a [MalformedServerResponseException],
+  /// if the body was readable/valid JSON and contained the data, else null.
+  ///
+  /// If there's a zulip_version but no zulip_feature_level,
+  /// we infer it's indeed a Zulip server,
+  /// just an ancient one before feature levels were introduced in Zulip 3.0,
+  /// and we set 0 for zulipFeatureLevel.
+  static ZulipVersionData? fromMalformedServerResponseException(MalformedServerResponseException e) {
+    try {
+      final data = e.data!;
+      return ZulipVersionData(
+        zulipVersion: data['zulip_version'] as String,
+        zulipMergeBase: data['zulip_merge_base'] as String?,
+        zulipFeatureLevel: data['zulip_feature_level'] as int? ?? 0);
+    } catch (inner) {
+      return null;
+    }
+  }
+
+  final String zulipVersion;
+  final String? zulipMergeBase;
+  final int zulipFeatureLevel;
+
+  bool matchesAccount(Account account) =>
+    zulipVersion == account.zulipVersion
+    && zulipMergeBase == account.zulipMergeBase
+    && zulipFeatureLevel == account.zulipFeatureLevel;
+
+  bool get isUnsupported => zulipFeatureLevel < kMinSupportedZulipFeatureLevel;
+}
+
+class ServerVersionUnsupportedException implements Exception {
+  final ZulipVersionData data;
+
+  ServerVersionUnsupportedException(this.data);
+}

--- a/lib/model/server_support.dart
+++ b/lib/model/server_support.dart
@@ -1,16 +1,23 @@
 import '../api/core.dart';
 import '../api/exception.dart';
 import '../api/model/initial_snapshot.dart';
+import '../api/route/realm.dart';
 import 'database.dart';
 
 /// The fields 'zulip_version', 'zulip_merge_base', and 'zulip_feature_level'
-/// from a /register response.
+/// from a /server_settings or /register response.
 class ZulipVersionData {
   const ZulipVersionData({
     required this.zulipVersion,
     required this.zulipMergeBase,
     required this.zulipFeatureLevel,
   });
+
+  factory ZulipVersionData.fromServerSettings(GetServerSettingsResult serverSettings) =>
+    ZulipVersionData(
+      zulipVersion: serverSettings.zulipVersion,
+      zulipMergeBase: serverSettings.zulipMergeBase,
+      zulipFeatureLevel: serverSettings.zulipFeatureLevel);
 
   factory ZulipVersionData.fromInitialSnapshot(InitialSnapshot initialSnapshot) =>
     ZulipVersionData(
@@ -20,6 +27,8 @@ class ZulipVersionData {
 
   /// Make a [ZulipVersionData] from a [MalformedServerResponseException],
   /// if the body was readable/valid JSON and contained the data, else null.
+  ///
+  /// May be used for the /server_settings or the /register response.
   ///
   /// If there's a zulip_version but no zulip_feature_level,
   /// we infer it's indeed a Zulip server,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -184,9 +184,8 @@ class _AddAccountPageState extends State<AddAccountPage> {
           connection.close();
         }
       } catch (e) {
-        if (!context.mounted) {
-          return;
-        }
+        if (!context.mounted) return;
+
         // TODO(#105) give more helpful feedback; see `fetchServerSettings`
         //   in zulip-mobile's src/message/fetchActions.js.
         showErrorDialog(context: context,
@@ -194,11 +193,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
           message: zulipLocalizations.errorLoginCouldNotConnect(url.toString()));
         return;
       }
-      // https://github.com/dart-lang/linter/issues/4007
-      // ignore: use_build_context_synchronously
-      if (!context.mounted) {
-        return;
-      }
+      if (!context.mounted) return;
 
       unawaited(Navigator.push(context,
         LoginPage.buildRoute(serverSettings: serverSettings)));

--- a/test/api/route/route_checks.dart
+++ b/test/api/route/route_checks.dart
@@ -1,12 +1,18 @@
 import 'package:checks/checks.dart';
 import 'package:zulip/api/route/messages.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/api/route/saved_snippets.dart';
 
 extension SendMessageResultChecks on Subject<SendMessageResult> {
   Subject<int> get id => has((e) => e.id, 'id');
 }
+
 extension CreateSavedSnippetResultChecks on Subject<CreateSavedSnippetResult> {
   Subject<int> get savedSnippetId => has((e) => e.savedSnippetId, 'savedSnippetId');
+}
+
+extension GetServerSettingsResultChecks on Subject<GetServerSettingsResult> {
+  Subject<Uri> get realmUrl => has((e) => e.realmUrl, 'realmUrl');
 }
 
 // TODO add similar extensions for other classes in api/route/*.dart

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -6,6 +6,7 @@ import 'package:zulip/model/autocomplete.dart';
 import 'package:zulip/model/binding.dart';
 import 'package:zulip/model/database.dart';
 import 'package:zulip/model/recent_dm_conversations.dart';
+import 'package:zulip/model/server_support.dart';
 import 'package:zulip/model/settings.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/model/unreads.dart';

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -17,6 +17,7 @@ import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/log.dart';
 import 'package:zulip/model/actions.dart';
 import 'package:zulip/model/presence.dart';
+import 'package:zulip/model/server_support.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/notifications/receive.dart';
 

--- a/test/widgets/checks.dart
+++ b/test/widgets/checks.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/widgets.dart';
+import 'package:zulip/api/route/realm.dart';
 
 import 'package:zulip/model/emoji.dart';
 import 'package:zulip/model/narrow.dart';
@@ -8,6 +9,7 @@ import 'package:zulip/widgets/compose_box.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/emoji.dart';
 import 'package:zulip/widgets/emoji_reaction.dart';
+import 'package:zulip/widgets/login.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/profile.dart';
@@ -72,6 +74,10 @@ extension WidgetRouteChecks<T> on Subject<WidgetRoute<T>> {
 
 extension AccountRouteChecks<T> on Subject<AccountRoute<T>> {
   Subject<int> get accountId => has((x) => x.accountId, 'accountId');
+}
+
+extension LoginPageChecks on Subject<LoginPage> {
+  Subject<GetServerSettingsResult> get serverSettings => has((x) => x.serverSettings, 'serverSettings');
 }
 
 extension ProfilePageChecks on Subject<ProfilePage> {

--- a/test/widgets/dialog_test.dart
+++ b/test/widgets/dialog_test.dart
@@ -7,7 +7,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:zulip/model/settings.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/dialog.dart';
-import 'package:zulip/widgets/store.dart';
 
 import '../model/binding.dart';
 import 'dialog_checks.dart';


### PR DESCRIPTION
Stacked atop #1782, which is an improvement to the tests that I found while working this (actually while pairing with @sm-sayedi 🙂) plus a fix for something we overlooked in #1017.

-----

There's a planned change to make zulipMergeBase required in
GetServerSettingsResult (see #904). When we do that, we'd otherwise
just treat a missing zulipMergeBase on an ancient server the same
way we treat any malformed response. Better to check if the server
is an ancient one we don't support, just like when the /register
response is malformed.