### PR TITLE
action_sheet: Put mark-channel-as-read button at top of action sheet

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -241,9 +241,7 @@ void showChannelActionSheet(BuildContext context, {
   final pageContext = PageRoot.contextOf(context);
   final store = PerAccountStoreWidget.of(pageContext);
 
-  final optionButtons = <ActionSheetMenuItemButton>[
-    TopicListButton(pageContext: pageContext, channelId: channelId),
-  ];
+  final optionButtons = <ActionSheetMenuItemButton>[];
 
   final unreadCount = store.unreads.countInChannelNarrow(channelId);
   if (unreadCount > 0) {
@@ -252,33 +250,12 @@ void showChannelActionSheet(BuildContext context, {
   }
 
   optionButtons.add(
+    TopicListButton(pageContext: pageContext, channelId: channelId));
+
+  optionButtons.add(
     CopyChannelLinkButton(channelId: channelId, pageContext: pageContext));
 
   _showActionSheet(pageContext, optionButtons: optionButtons);
-}
-
-class TopicListButton extends ActionSheetMenuItemButton {
-  const TopicListButton({
-    super.key,
-    required this.channelId,
-    required super.pageContext,
-  });
-
-  final int channelId;
-
-  @override
-  IconData get icon => ZulipIcons.topics;
-
-  @override
-  String label(ZulipLocalizations zulipLocalizations) {
-    return zulipLocalizations.actionSheetOptionListOfTopics;
-  }
-
-  @override
-  void onPressed() {
-    Navigator.push(pageContext,
-      TopicListPage.buildRoute(context: pageContext, streamId: channelId));
-  }
 }
 
 class MarkChannelAsReadButton extends ActionSheetMenuItemButton {
@@ -302,6 +279,30 @@ class MarkChannelAsReadButton extends ActionSheetMenuItemButton {
   void onPressed() async {
     final narrow = ChannelNarrow(channelId);
     await ZulipAction.markNarrowAsRead(pageContext, narrow);
+  }
+}
+
+class TopicListButton extends ActionSheetMenuItemButton {
+  const TopicListButton({
+    super.key,
+    required this.channelId,
+    required super.pageContext,
+  });
+
+  final int channelId;
+
+  @override
+  IconData get icon => ZulipIcons.topics;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.actionSheetOptionListOfTopics;
+  }
+
+  @override
+  void onPressed() {
+    Navigator.push(pageContext,
+      TopicListPage.buildRoute(context: pageContext, streamId: channelId));
   }
 }
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -247,8 +247,8 @@ void main() {
     group('showChannelActionSheet', () {
       void checkButtons() {
         check(actionSheetFinder).findsOne();
-        checkButton('List of topics');
         checkButton('Mark channel as read');
+        checkButton('List of topics');
         checkButton('Copy link to channel');
       }
 
@@ -289,19 +289,6 @@ void main() {
         await showFromRecipientHeader(tester, message: someMessage);
         checkButtons();
       });
-    });
-
-    testWidgets('TopicListButton', (tester) async {
-      await prepare();
-      await showFromAppBar(tester,
-        narrow: ChannelNarrow(someChannel.streamId));
-
-      connection.prepare(json: GetStreamTopicsResult(topics: [
-        eg.getStreamTopicsEntry(name: 'some topic foo'),
-      ]).toJson());
-      await tester.tap(findButtonForLabel('List of topics'));
-      await tester.pumpAndSettle();
-      check(find.text('some topic foo')).findsOne();
     });
 
     group('MarkChannelAsReadButton', () {
@@ -348,6 +335,19 @@ void main() {
         checkErrorDialog(tester,
           expectedTitle: "Mark as read failed");
       });
+    });
+
+    testWidgets('TopicListButton', (tester) async {
+      await prepare();
+      await showFromAppBar(tester,
+        narrow: ChannelNarrow(someChannel.streamId));
+
+      connection.prepare(json: GetStreamTopicsResult(topics: [
+        eg.getStreamTopicsEntry(name: 'some topic foo'),
+      ]).toJson());
+      await tester.tap(findButtonForLabel('List of topics'));
+      await tester.pumpAndSettle();
+      check(find.text('some topic foo')).findsOne();
     });
 
     group('CopyChannelLinkButton', () {


### PR DESCRIPTION
As in the Figma:
  https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=6812-34593&m=dev

-----

cc @alya 

| Before | After |
| --- | --- |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/cb824260-778e-414a-b3f9-288c31d36288" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/ef53221b-b48f-4dc2-9370-0bf6c2843d90" /> |