### PR TITLE
edit-message: Show error dialog on edit-message request error

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -58,10 +58,15 @@ mixin MessageStore {
   /// Should only be called when there is no current edit request for [messageId],
   /// i.e., [getEditMessageErrorStatus] returns null for [messageId].
   ///
+  /// The returned [Future] settles when the edit-message response is received.
+  /// The [Future] resolves if the request succeeded and rejects if it failed,
+  /// unless the event already arrived or the message was deleted,
+  /// in which case it resolves.
+  ///
   /// See also:
   ///   * [getEditMessageErrorStatus]
   ///   * [takeFailedMessageEdit]
-  void editMessage({
+  Future<void> editMessage({
     required int messageId,
     required String originalRawContent,
     required String newContent,
@@ -104,7 +109,7 @@ mixin ProxyMessageStore on MessageStore {
     return messageStore.getEditMessageErrorStatus(messageId);
   }
   @override
-  void editMessage({
+  Future<void> editMessage({
     required int messageId,
     required String originalRawContent,
     required String newContent,
@@ -315,7 +320,7 @@ class MessageStoreImpl extends HasRealmStore with MessageStore, _OutboxMessageSt
   final Map<int, _EditMessageRequestStatus> _editMessageRequests = {};
 
   @override
-  void editMessage({
+  Future<void> editMessage({
     required int messageId,
     required String originalRawContent,
     required String newContent,
@@ -349,6 +354,7 @@ class MessageStoreImpl extends HasRealmStore with MessageStore, _OutboxMessageSt
       }
       status.hasError = true;
       _notifyMessageListViewsForOneMessage(messageId);
+      rethrow;
     }
   }
 

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -53,7 +53,7 @@ mixin MessageStore {
   /// and the update-message event hasn't arrived.
   bool? getEditMessageErrorStatus(int messageId);
 
-  /// Edit a message's content, via a request to the server.
+  /// Makes an edit-message request and starts an edit-outbox lifecycle.
   ///
   /// Should only be called when there is no current edit request for [messageId],
   /// i.e., [getEditMessageErrorStatus] returns null for [messageId].

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1815,11 +1815,13 @@ class _EditMessageBanner extends _Banner {
       return;
     }
 
-    store.editMessage(
-      messageId: controller.messageId,
-      originalRawContent: originalRawContent,
-      newContent: controller.content.textNormalized);
+    final messageId = controller.messageId;
+    final newContent = controller.content.textNormalized;
     composeBoxState.endEditInteraction();
+    store.editMessage(
+      messageId: messageId,
+      originalRawContent: originalRawContent,
+      newContent: newContent);
   }
 
   @override

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1821,7 +1821,7 @@ class _EditMessageBanner extends _Banner {
     store.editMessage(
       messageId: messageId,
       originalRawContent: originalRawContent,
-      newContent: newContent);
+      newContent: newContent).onError((_, _) {}); // TODO show error feedback
   }
 
   @override

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -7,6 +7,7 @@ import 'package:crypto/crypto.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/scaffolding.dart';
+import 'package:zulip/api/exception.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/submessage.dart';
@@ -603,8 +604,8 @@ void main() {
 
       connection.prepare(
         json: UpdateMessageResult().toJson(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content'));
       checkRequest(message.id,
         prevContent: 'old content',
         content: 'new content');
@@ -634,8 +635,8 @@ void main() {
 
       connection.prepare(
         json: UpdateMessageResult().toJson(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content'));
       checkRequest(message.id,
         prevContent: 'old content',
         content: 'new content');
@@ -647,8 +648,8 @@ void main() {
       check(store.getEditMessageErrorStatus(otherMessage.id)).isNull();
       connection.prepare(
         json: UpdateMessageResult().toJson(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: otherMessage.id,
-        originalRawContent: 'other message old content', newContent: 'other message new content');
+      unawaited(store.editMessage(messageId: otherMessage.id,
+        originalRawContent: 'other message old content', newContent: 'other message new content'));
       checkRequest(otherMessage.id,
         prevContent: 'other message old content',
         content: 'other message new content');
@@ -682,8 +683,8 @@ void main() {
       check(store.getEditMessageErrorStatus(message.id)).isNull();
 
       connection.prepare(apiException: eg.apiBadRequest(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(check(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content')).throws<ZulipApiException>());
       checkNotifiedOnce();
       async.elapse(Duration(seconds: 1));
       check(store.getEditMessageErrorStatus(message.id)).isNotNull().isTrue();
@@ -695,8 +696,8 @@ void main() {
       check(store.getEditMessageErrorStatus(message.id)).isNull();
 
       connection.prepare(apiException: eg.apiBadRequest(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(check(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content')).throws<ZulipApiException>());
       checkNotifiedOnce();
       async.elapse(Duration(seconds: 1));
       check(store.getEditMessageErrorStatus(message.id)).isNotNull().isTrue();
@@ -718,8 +719,8 @@ void main() {
 
       connection.prepare(
         json: UpdateMessageResult().toJson(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content'));
       async.elapse(Duration(milliseconds: 500));
       check(connection.takeRequests()).length.equals(1);
       checkNotifiedOnce();
@@ -738,8 +739,8 @@ void main() {
 
       connection.prepare(
         httpException: const SocketException('failed'), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content'));
       checkNotifiedOnce();
 
       async.elapse(Duration(milliseconds: 500));
@@ -760,8 +761,8 @@ void main() {
 
       connection.prepare(
         httpException: const SocketException('failed'), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(check(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content')).throws<NetworkException>());
       checkNotifiedOnce();
 
       async.elapse(Duration(seconds: 1));
@@ -781,8 +782,8 @@ void main() {
 
       connection.prepare(
         httpException: const SocketException('failed'), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(check(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content')).throws<NetworkException>());
       checkNotifiedOnce();
 
       async.elapse(Duration(seconds: 1));
@@ -801,8 +802,8 @@ void main() {
       check(store.getEditMessageErrorStatus(message.id)).isNull();
 
       connection.prepare(apiException: eg.apiBadRequest(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(check(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content')).throws<ZulipApiException>());
       checkNotifiedOnce();
       async.elapse(Duration(seconds: 1));
       check(store.getEditMessageErrorStatus(message.id)).isNotNull().isTrue();
@@ -818,8 +819,8 @@ void main() {
       check(store.getEditMessageErrorStatus(message.id)).isNull();
 
       connection.prepare(apiException: eg.apiBadRequest(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content'));
       checkNotifiedOnce();
 
       async.elapse(Duration(milliseconds: 500));
@@ -843,8 +844,8 @@ void main() {
 
       connection.prepare(
         json: UpdateMessageResult().toJson(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
-        originalRawContent: 'old content', newContent: 'new content');
+      unawaited(store.editMessage(messageId: message.id,
+        originalRawContent: 'old content', newContent: 'new content'));
       checkNotifiedOnce();
 
       async.elapse(Duration(milliseconds: 500));

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -1952,6 +1952,12 @@ void main() {
         await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
       }
 
+      Future<void> takeErrorDialogAndPump(WidgetTester tester) async {
+        final errorDialog = checkErrorDialog(tester, expectedTitle: 'Message not saved');
+        await tester.tap(find.byWidget(errorDialog));
+        await tester.pump();
+      }
+
       group('present/absent appropriately', () {
         /// Test whether the edit-message button is visible, given params.
         ///
@@ -2042,6 +2048,7 @@ void main() {
               connection.prepare(apiException: eg.apiBadRequest());
               await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Save'));
               await tester.pump(Duration.zero);
+              await takeErrorDialogAndPump(tester);
             } else if (errorStatus == false) {
               // We're testing the request-in-progress state. Prepare a delay,
               // tap Save, and wait through only part of the delay.

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1748,6 +1748,12 @@ void main() {
       await tester.pump(); // message list updates
     }
 
+    Future<void> takeErrorDialogAndPump(WidgetTester tester) async {
+      final errorDialog = checkErrorDialog(tester, expectedTitle: 'Message not saved');
+      await tester.tap(find.byWidget(errorDialog));
+      await tester.pump();
+    }
+
     /// Check that the compose box is in the "Preparing…" state,
     /// awaiting the fetch-raw-content request.
     Future<void> checkAwaitingRawMessageContent(WidgetTester tester) async {
@@ -1770,6 +1776,7 @@ void main() {
       await tester.tap(
         find.widgetWithText(ZulipWebUiKitButton, 'Save'), warnIfMissed: false);
       await tester.pump(Duration.zero);
+      checkNoDialog(tester);
       check(connection.lastRequest).equals(lastRequest);
     }
 
@@ -1788,6 +1795,7 @@ void main() {
       connection.prepare(apiException: eg.apiBadRequest());
       await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Save'));
       await tester.pump(Duration.zero);
+      await takeErrorDialogAndPump(tester);
       await tester.tap(find.text('EDIT NOT SAVED'));
       await tester.pump();
       connection.takeRequests();
@@ -1966,6 +1974,7 @@ void main() {
         await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Save'));
         connection.takeRequests();
         await tester.pump(Duration.zero);
+        await takeErrorDialogAndPump(tester);
         checkNotInEditingMode(tester, narrow: narrow);
         check(find.text('EDIT NOT SAVED')).findsOne();
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -2299,6 +2299,8 @@ void main() {
       await tester.pump(Duration.zero);
       checkEditInProgress(tester);
       await tester.pump(Duration(seconds: 1));
+      // (the error dialog is tested elsewhere;
+      // it's triggered in the "Save" tap handler, not store.editMessage)
       checkEditFailed(tester);
 
       connection.prepare(json: GetMessageResult(

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -9,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:zulip/api/exception.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
@@ -2274,9 +2276,9 @@ void main() {
         messages: [message]);
 
       connection.prepare(json: UpdateMessageResult().toJson());
-      store.editMessage(messageId: message.id,
+      unawaited(store.editMessage(messageId: message.id,
         originalRawContent: 'foo',
-        newContent: 'bar');
+        newContent: 'bar'));
       await tester.pump(Duration.zero);
       checkEditInProgress(tester);
       await store.handleEvent(eg.updateMessageEditEvent(message));
@@ -2291,9 +2293,9 @@ void main() {
         messages: [message]);
 
       connection.prepare(apiException: eg.apiBadRequest(), delay: Duration(seconds: 1));
-      store.editMessage(messageId: message.id,
+      unawaited(check(store.editMessage(messageId: message.id,
         originalRawContent: 'foo',
-        newContent: 'bar');
+        newContent: 'bar')).throws<ZulipApiException>());
       await tester.pump(Duration.zero);
       checkEditInProgress(tester);
       await tester.pump(Duration(seconds: 1));


### PR DESCRIPTION
With #188, the message-list UI for an unsubscribed channel will become more prominent, which calls for fixing at least the following glitch:

Since we don't get events when the self-user sends or edits a message in an unsubscribed channel, we'd like to refetch messages on success of those actions. Discussion: [#mobile > Message sending in unsubscribed channels @ 💬](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Message.20sending.20in.20unsubscribed.20channels/near/2233492) So, on the path to that, make `store.editMessage` similar to `store.sendMessage` in returning `Future<void>` instead of `void`, where the returned Future resolves or rejects with the API request, irrespective of the event.

While we're at it, show an error dialog when the edit fails, as we've been meaning to do, again for consistency with the send-message UX.

-----

Compare error feedback on _sending_ an invalid message (in `main` and unchanged here) vs. trying to _save_ an invalid message edit (new here; in `main` we show no dialog):

| Send | Edit |
| --- | --- |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/0c97530a-183b-4689-ab13-84f915532836" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/5c213d1b-8509-4faa-a4d2-e733a230768a" /> |

The outbox logic is unchanged. As in `main`, we show "MESSAGE NOT SENT" and "EDIT NOT SAVED" in the message list, and these are tappable to restore the composing session and try again.