### PR TITLE
action_sheet: Add 'Channel feed' button to channel action sheet

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -116,6 +116,10 @@
   "@actionSheetOptionListOfTopics": {
     "description": "Label for navigating to a channel's topic-list page."
   },
+  "actionSheetOptionChannelFeed": "Channel feed",
+  "@actionSheetOptionChannelFeed": {
+    "description": "Label for navigating to a channel's channel-feed page."
+  },
   "actionSheetOptionUnsubscribe": "Unsubscribe",
   "@actionSheetOptionUnsubscribe": {
     "description": "Label in the channel action sheet for unsubscribing from the channel."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -275,7 +275,7 @@ abstract class ZulipLocalizations {
   /// **'To upload files, please grant Zulip additional permissions in Settings.'**
   String get permissionsDeniedReadExternalStorage;
 
-  /// Label in the channel context menu for subscribing to the channel.
+  /// Label in the channel action sheet for subscribing to the channel.
   ///
   /// In en, this message translates to:
   /// **'Subscribe'**
@@ -305,7 +305,13 @@ abstract class ZulipLocalizations {
   /// **'List of topics'**
   String get actionSheetOptionListOfTopics;
 
-  /// Label in the channel context menu for unsubscribing from the channel.
+  /// Label for navigating to a channel's channel-feed page.
+  ///
+  /// In en, this message translates to:
+  /// **'Channel feed'**
+  String get actionSheetOptionChannelFeed;
+
+  /// Label in the channel action sheet for unsubscribing from the channel.
   ///
   /// In en, this message translates to:
   /// **'Unsubscribe'**

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'List of topics';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -105,6 +105,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'Themenliste';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'List of topics';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'List of topics';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -104,6 +104,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'Elenco degli argomenti';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -102,6 +102,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'トピック一覧';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'List of topics';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -105,6 +105,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'Lista wątków';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -105,6 +105,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'Список тем';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'List of topics';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'Seznam tem';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -106,6 +106,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'Список тем';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -103,6 +103,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get actionSheetOptionListOfTopics => 'List of topics';
 
   @override
+  String get actionSheetOptionChannelFeed => 'Channel feed';
+
+  @override
   String get actionSheetOptionUnsubscribe => 'Unsubscribe';
 
   @override

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -239,11 +239,18 @@ enum BottomSheetDismissButtonStyle {
 /// Show a sheet of actions you can take on a channel.
 ///
 /// Needs a [PageRoot] ancestor.
+/// May or may not have a [MessageListPage] ancestor;
+/// some callers are on that page and some aren't.
 void showChannelActionSheet(BuildContext context, {
   required int channelId,
 }) {
   final pageContext = PageRoot.contextOf(context);
   final store = PerAccountStoreWidget.of(pageContext);
+  final messageListPageState = MessageListPage.maybeAncestorOf(pageContext);
+
+  final messageListPageNarrow = messageListPageState?.narrow;
+  final isOnChannelFeed = messageListPageNarrow is ChannelNarrow
+    && messageListPageNarrow.streamId == channelId;
 
   final unreadCount = store.unreads.countInChannelNarrow(channelId);
   final isSubscribed = store.subscriptions[channelId] != null;
@@ -255,6 +262,8 @@ void showChannelActionSheet(BuildContext context, {
       if (unreadCount > 0)
         MarkChannelAsReadButton(pageContext: pageContext, channelId: channelId),
       TopicListButton(pageContext: pageContext, channelId: channelId),
+      if (!isOnChannelFeed)
+        ChannelFeedButton(pageContext: pageContext, channelId: channelId),
       CopyChannelLinkButton(channelId: channelId, pageContext: pageContext)
     ],
     if (isSubscribed)
@@ -352,6 +361,30 @@ class TopicListButton extends ActionSheetMenuItemButton {
   void onPressed() {
     Navigator.push(pageContext,
       TopicListPage.buildRoute(context: pageContext, streamId: channelId));
+  }
+}
+
+class ChannelFeedButton extends ActionSheetMenuItemButton {
+  const ChannelFeedButton({
+    super.key,
+    required this.channelId,
+    required super.pageContext,
+  });
+
+  final int channelId;
+
+  @override
+  IconData get icon => ZulipIcons.message_feed;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.actionSheetOptionChannelFeed;
+  }
+
+  @override
+  void onPressed() {
+    Navigator.push(pageContext,
+      MessageListPage.buildRoute(context: pageContext, narrow: ChannelNarrow(channelId)));
   }
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -197,12 +197,28 @@ class MessageListPage extends StatefulWidget {
   ///
   /// Uses the inefficient [BuildContext.findAncestorStateOfType];
   /// don't call this in a build method.
-  // If we do find ourselves wanting this in a build method, it won't be hard
-  // to enable that: we'd just need to add an [InheritedWidget] here.
+  ///
+  /// See also:
+  ///  * [maybeAncestorOf], which returns null instead of throwing
+  ///    when an ancestor [MessageListPageState] is not found.
   static MessageListPageState ancestorOf(BuildContext context) {
-    final state = context.findAncestorStateOfType<_MessageListPageState>();
+    final state = maybeAncestorOf(context);
     assert(state != null, 'No MessageListPage ancestor');
     return state!;
+  }
+
+  /// The [MessageListPageState] above this context in the tree, if any.
+  ///
+  /// Uses the inefficient [BuildContext.findAncestorStateOfType];
+  /// don't call this in a build method.
+  ///
+  /// See also:
+  ///  * [ancestorOf], which throws instead of returning null
+  ///    when an ancestor [MessageListPageState] is not found.
+  // If we do find ourselves wanting this in a build method, it won't be hard
+  // to enable that: we'd just need to add an [InheritedWidget] here.
+  static MessageListPageState? maybeAncestorOf(BuildContext context) {
+    return context.findAncestorStateOfType<_MessageListPageState>();
   }
 
   final Narrow initNarrow;

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -33,6 +33,7 @@ import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:share_plus_platform_interface/method_channel/method_channel_share.dart';
 import 'package:zulip/widgets/subscription_list.dart';
+import 'package:zulip/widgets/topic_list.dart';
 import 'package:zulip/widgets/user.dart';
 import '../api/fake_api.dart';
 
@@ -197,7 +198,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 250));
     }
 
-    Future<void> showFromAppBar(WidgetTester tester, {
+    Future<void> showFromMsglistAppBar(WidgetTester tester, {
       ZulipStream? channel,
       required Narrow narrow,
     }) async {
@@ -239,6 +240,22 @@ void main() {
       await tester.pump(const Duration(milliseconds: 250));
     }
 
+    Future<void> showFromTopicListAppBar(WidgetTester tester) async {
+      final transitionDurationObserver = TransitionDurationObserver();
+
+      connection.prepare(json: GetStreamTopicsResult(topics: []).toJson());
+      await tester.pumpWidget(TestZulipApp(
+        navigatorObservers: [transitionDurationObserver],
+        accountId: eg.selfAccount.id,
+        child: TopicListPage(streamId: someChannel.streamId)));
+      await tester.pump();
+
+      await tester.longPress(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.text(someChannel.name)));
+      await transitionDurationObserver.pumpPastTransition(tester);
+    }
+
     final actionSheetFinder = find.byType(BottomSheet);
     Finder findButtonForLabel(String label) =>
       find.descendant(of: actionSheetFinder, matching: find.text(label));
@@ -277,23 +294,29 @@ void main() {
         check(findButtonForLabel('Mark channel as read')).findsNothing();
       });
 
-      testWidgets('show from app bar in channel narrow', (tester) async {
+      testWidgets('show from message-list app bar in channel narrow', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
         checkButtons();
       });
 
-      testWidgets('show from app bar in topic narrow', (tester) async {
+      testWidgets('show from message-list app bar in topic narrow', (tester) async {
         await prepare();
         final narrow = eg.topicNarrow(someChannel.streamId, someTopic);
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
         checkButtons();
       });
 
       testWidgets('show from recipient header', (tester) async {
         await prepare();
         await showFromRecipientHeader(tester, message: someMessage);
+        checkButtons();
+      });
+
+      testWidgets('show from topic-list app bar', (tester) async {
+        await prepare();
+        await showFromTopicListAppBar(tester);
         checkButtons();
       });
     });
@@ -308,7 +331,7 @@ void main() {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
         await store.removeSubscription(narrow.streamId);
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
         checkButton('Subscribe');
       });
 
@@ -316,7 +339,7 @@ void main() {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
         check(store.subscriptions[narrow.streamId]).isNotNull();
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
         checkNoButton('Subscribe');
       });
 
@@ -324,7 +347,7 @@ void main() {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
         await store.removeSubscription(narrow.streamId);
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
 
         connection.prepare(json: {});
         await tapButton(tester);
@@ -387,7 +410,7 @@ void main() {
 
     testWidgets('TopicListButton', (tester) async {
       await prepare();
-      await showFromAppBar(tester,
+      await showFromMsglistAppBar(tester,
         narrow: ChannelNarrow(someChannel.streamId));
 
       connection.prepare(json: GetStreamTopicsResult(topics: [
@@ -415,7 +438,7 @@ void main() {
       testWidgets('copies channel link to clipboard', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
 
         await tapCopyChannelLinkButton(tester);
         await tester.pump(Duration.zero);
@@ -435,7 +458,7 @@ void main() {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
         check(store.subscriptions[narrow.streamId]).isNotNull();
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
         checkButton('Unsubscribe');
       });
 
@@ -443,7 +466,7 @@ void main() {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
         await store.removeSubscription(narrow.streamId);
-        await showFromAppBar(tester, narrow: narrow);
+        await showFromMsglistAppBar(tester, narrow: narrow);
         checkNoButton('Unsubscribe');
       });
 
@@ -453,7 +476,7 @@ void main() {
         await store.addStream(channel);
         await store.addSubscription(eg.subscription(channel));
         final narrow = ChannelNarrow(channel.streamId);
-        await showFromAppBar(tester, channel: channel, narrow: narrow);
+        await showFromMsglistAppBar(tester, channel: channel, narrow: narrow);
 
         connection.prepare(json: {});
         await tapButton(tester);
@@ -475,7 +498,7 @@ void main() {
         await store.addStream(channel);
         await store.addSubscription(eg.subscription(channel));
         final narrow = ChannelNarrow(channel.streamId);
-        await showFromAppBar(tester, channel: channel, narrow: narrow);
+        await showFromMsglistAppBar(tester, channel: channel, narrow: narrow);
         connection.takeRequests();
 
         connection.prepare(json: {});

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -177,7 +177,9 @@ void main() {
     }
 
     Future<void> showFromInbox(WidgetTester tester) async {
+      transitionDurationObserver = TransitionDurationObserver();
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        navigatorObservers: [transitionDurationObserver],
         child: const HomePage()));
       await tester.pump();
       check(find.byType(InboxPageBody)).findsOne();
@@ -419,6 +421,61 @@ void main() {
       await tester.tap(findButtonForLabel('List of topics'));
       await tester.pumpAndSettle();
       check(find.text('some topic foo')).findsOne();
+    });
+
+    group('ChannelFeedButton', () {
+      Future<void> tapButtonAndPump(WidgetTester tester) async {
+        await tester.tap(findButtonForLabel('Channel feed'));
+        await tester.pump(); // [MenuItemButton.onPressed] called in a post-frame callback: flutter/flutter@e4a39fa2e
+      }
+
+      testWidgets('from inbox: visible ', (tester) async {
+        await prepare();
+        await showFromInbox(tester);
+        checkButton('Channel feed');
+      });
+
+      testWidgets('from subscription list: visible ', (tester) async {
+        await prepare();
+        await showFromInbox(tester);
+        checkButton('Channel feed');
+      });
+
+      testWidgets('from recipient header in combined feed: visible ', (tester) async {
+        await prepare();
+        await showFromRecipientHeader(tester);
+        checkButton('Channel feed');
+      });
+
+      testWidgets('from app bar on topic list: visible ', (tester) async {
+        await prepare();
+        await showFromTopicListAppBar(tester);
+        checkButton('Channel feed');
+      });
+
+      testWidgets('from msglist app bar on channel feed: not visible ', (tester) async {
+        await prepare();
+        await showFromMsglistAppBar(tester, narrow: ChannelNarrow(someChannel.streamId));
+        checkNoButton('Channel feed');
+      });
+
+      // (The channel action sheet isn't reached from a recipient header
+      // in the channel feed.)
+
+      testWidgets('navigates to channel feed', (tester) async {
+        await prepare();
+        await showFromInbox(tester);
+
+        connection.prepare(json: eg.newestGetMessagesResult(
+          foundOldest: true, messages: []).toJson());
+        // for topic autocomplete
+        connection.prepare(json: GetStreamTopicsResult(topics: []).toJson());
+        await tapButtonAndPump(tester);
+        await transitionDurationObserver.pumpPastTransition(tester);
+
+        final appBar = tester.widget(find.byType(MessageListAppBarTitle)) as MessageListAppBarTitle;
+        check(appBar.narrow).equals(ChannelNarrow(someChannel.streamId));
+      });
     });
 
     group('CopyChannelLinkButton', () {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -199,14 +199,17 @@ void main() {
 
     Future<void> showFromAppBar(WidgetTester tester, {
       ZulipStream? channel,
-      List<StreamMessage>? messages,
       required Narrow narrow,
     }) async {
       channel ??= someChannel;
-      messages ??= [someMessage];
 
       connection.prepare(json: eg.newestGetMessagesResult(
-        foundOldest: true, messages: messages).toJson());
+        foundOldest: true, messages: []).toJson());
+      if (narrow case ChannelNarrow()) {
+        // We auto-focus the topic input when there are no messages;
+        // this is for topic autocomplete.
+        connection.prepare(json: GetStreamTopicsResult(topics: []).toJson());
+      }
       await tester.pumpWidget(TestZulipApp(
         accountId: eg.selfAccount.id,
         child: MessageListPage(
@@ -446,13 +449,11 @@ void main() {
 
       testWidgets('smoke, public channel', (tester) async {
         final channel = eg.stream(inviteOnly: false);
-        final message = eg.streamMessage(stream: channel);
         await prepare();
         await store.addStream(channel);
         await store.addSubscription(eg.subscription(channel));
         final narrow = ChannelNarrow(channel.streamId);
-        await showFromAppBar(tester,
-          channel: channel, narrow: narrow, messages: [message]);
+        await showFromAppBar(tester, channel: channel, narrow: narrow);
 
         connection.prepare(json: {});
         await tapButton(tester);
@@ -470,13 +471,11 @@ void main() {
 
       testWidgets('smoke, private channel', (tester) async {
         final channel = eg.stream(inviteOnly: true);
-        final message = eg.streamMessage(stream: channel);
         await prepare();
         await store.addStream(channel);
         await store.addSubscription(eg.subscription(channel));
         final narrow = ChannelNarrow(channel.streamId);
-        await showFromAppBar(tester,
-          channel: channel, narrow: narrow, messages: [message]);
+        await showFromAppBar(tester, channel: channel, narrow: narrow);
         connection.takeRequests();
 
         connection.prepare(json: {});


### PR DESCRIPTION
Fixes #1705.

## Screenshots

### From channel feed (no button)

<img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/60782e79-9b7d-41bb-86fe-f063bb043041" />

### Not from channel feed (button)

<img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/1c4f5710-b113-46b9-8ec2-d13448153244" />

<img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/f92deb93-58f2-41de-aaf0-e4c1a0262e99" />
