### PR TITLE
Set status page adjustments

### DIFF
--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -554,10 +554,8 @@ class _EmojiPickerState extends State<EmojiPicker> with PerAccountStoreAwareStat
               padding: const EdgeInsets.symmetric(horizontal: 8),
               splashFactory: NoSplash.splashFactory,
               foregroundColor: designVariables.contextMenuItemText,
-            ).copyWith(backgroundColor: WidgetStateColor.resolveWith((states) =>
-              states.contains(WidgetState.pressed)
-                ? designVariables.contextMenuItemBg.withFadedAlpha(0.20)
-                : Colors.transparent)),
+              overlayColor: Colors.transparent,
+            ),
             child: Text(zulipLocalizations.dialogCancel,
               style: const TextStyle(fontSize: 20, height: 30 / 20))),
         ])),

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -193,6 +193,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
               // [SingleChildScrollView.padding] below.
               bottom: 0),
             child: Row(
+              spacing: 4,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 IconButton(

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -250,10 +250,10 @@ class _SetStatusPageState extends State<SetStatusPage> {
               ]),
           ),
           Expanded(child: InsetShadowBox(
-            top: 6, bottom: 6,
+            top: 6,
             color: designVariables.mainBackground,
             child: SingleChildScrollView(
-              padding: EdgeInsets.symmetric(vertical: 6),
+              padding: EdgeInsets.only(top: 6),
               child: Column(children: [
                 for (final status in suggestions)
                   StatusSuggestionsListEntry(

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -8,7 +8,6 @@ import '../basic.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../log.dart';
 import 'app_bar.dart';
-import 'color.dart';
 import 'emoji_reaction.dart';
 import 'icons.dart';
 import 'inset_shadow.dart';
@@ -316,16 +315,9 @@ class StatusSuggestionsListEntry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final designVariables = DesignVariables.of(context);
-
-    return InkWell(
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: onTap,
-      splashFactory: NoSplash.splashFactory,
-      overlayColor: WidgetStateColor.resolveWith(
-        (states) => states.any((e) => e == WidgetState.pressed)
-          ? designVariables.contextMenuItemBg.withFadedAlpha(0.20)
-          : Colors.transparent,
-      ),
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: 7, horizontal: 16),
         child: Row(

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -189,7 +189,10 @@ class _SetStatusPageState extends State<SetStatusPage> {
             // In Figma design, this is 16px, but we compensate for that in
             // the icon button below.
             start: 8,
-            top: 8, end: 10,
+            top: 8,
+            // In Figma design, this is 10px, but to be consistent with other
+            // page content, we use 8px.
+            end: 8,
             // In Figma design, this is 4px, be we compensate for that in
             // [SingleChildScrollView.padding] below.
             bottom: 0),

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -182,88 +182,85 @@ class _SetStatusPageState extends State<SetStatusPage> {
             }),
         ],
       ),
-      body: Column(children: [
-        Padding(
-          padding: const EdgeInsetsDirectional.only(
-            // In Figma design, this is 16px, but we compensate for that in
-            // the icon button below.
-            start: 8,
-            top: 8,
-            // In Figma design, this is 10px, but to be consistent with other
-            // page content, we use 8px.
-            end: 8,
-            // In Figma design, this is 4px, be we compensate for that in
-            // [SingleChildScrollView.padding] below.
-            bottom: 0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              IconButton(
-                onPressed: chooseStatusEmoji,
-                style: IconButton.styleFrom(
-                  splashFactory: NoSplash.splashFactory,
-                  foregroundColor: designVariables.icon,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  padding: EdgeInsets.symmetric(
-                    vertical: 8,
-                    // In Figma design, there is no horizontal padding, but we
-                    // provide it in order to create a proper tap target size.
-                    horizontal: 8)),
-                icon: Row(spacing: 4, children: [
-                  ValueListenableBuilder(
-                    valueListenable: statusChange,
-                    builder: (_, change, _) {
-                      final emoji = change.emoji.or(oldStatus.emoji);
-                      return emoji == null
-                        ? const Icon(ZulipIcons.smile, size: 24)
-                        : UserStatusEmoji(emoji: emoji, size: 24, neverAnimate: false);
-                    }),
-                  Icon(ZulipIcons.chevron_down, size: 16),
-                ]),
-              ),
-              Expanded(child: TextField(
-                controller: statusTextController,
-                minLines: 1,
-                maxLines: 2,
-                // The limit on the size of the status text is 60 characters.
-                // See: https://zulip.com/api/update-status#parameter-status_text
-                maxLength: 60,
-                cursorColor: designVariables.textInput,
-                textCapitalization: TextCapitalization.sentences,
-                style: TextStyle(fontSize: 19, height: 24 / 19),
-                decoration: InputDecoration(
-                  // TODO: display a counter as suggested in CZO discussion:
-                  //   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Set.20user.20status/near/2224549
-                  counterText: '',
-                  hintText: localizations.statusTextHint,
-                  hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    vertical: 8,
-                    // Subtracting 4 pixels to account for the internal
-                    // 4-pixel horizontal padding.
-                    horizontal: 10 - 4,
-                  ),
-                  filled: true,
-                  fillColor: designVariables.bgSearchInput,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(10),
-                    borderSide: BorderSide.none,
-                  )))),
-            ]),
-        ),
-        Expanded(child: InsetShadowBox(
-          top: 6, bottom: 6,
-          color: designVariables.mainBackground,
-          child: SingleChildScrollView(
-            padding: EdgeInsets.symmetric(vertical: 6),
-            child: Column(children: [
-              for (final status in suggestions)
-                StatusSuggestionsListEntry(
-                  status: status,
-                  onTap: () => chooseStatusSuggestion(status)),
-            ])))),
-      ]),
+      body: SafeArea(
+        bottom: false,
+        minimum: EdgeInsets.symmetric(horizontal: 8),
+        child: Column(children: [
+          Padding(
+            padding: const EdgeInsetsDirectional.only(
+              top: 8,
+              // In Figma design, this is 4px, be we compensate for that in
+              // [SingleChildScrollView.padding] below.
+              bottom: 0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                IconButton(
+                  onPressed: chooseStatusEmoji,
+                  style: IconButton.styleFrom(
+                    splashFactory: NoSplash.splashFactory,
+                    foregroundColor: designVariables.icon,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    padding: EdgeInsets.symmetric(
+                      vertical: 8,
+                      // In Figma design, there is no horizontal padding, but we
+                      // provide it in order to create a proper tap target size.
+                      horizontal: 8)),
+                  icon: Row(spacing: 4, children: [
+                    ValueListenableBuilder(
+                      valueListenable: statusChange,
+                      builder: (_, change, _) {
+                        final emoji = change.emoji.or(oldStatus.emoji);
+                        return emoji == null
+                          ? const Icon(ZulipIcons.smile, size: 24)
+                          : UserStatusEmoji(emoji: emoji, size: 24, neverAnimate: false);
+                      }),
+                    Icon(ZulipIcons.chevron_down, size: 16),
+                  ]),
+                ),
+                Expanded(child: TextField(
+                  controller: statusTextController,
+                  minLines: 1,
+                  maxLines: 2,
+                  // The limit on the size of the status text is 60 characters.
+                  // See: https://zulip.com/api/update-status#parameter-status_text
+                  maxLength: 60,
+                  cursorColor: designVariables.textInput,
+                  textCapitalization: TextCapitalization.sentences,
+                  style: TextStyle(fontSize: 19, height: 24 / 19),
+                  decoration: InputDecoration(
+                    // TODO: display a counter as suggested in CZO discussion:
+                    //   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Set.20user.20status/near/2224549
+                    counterText: '',
+                    hintText: localizations.statusTextHint,
+                    hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
+                    isDense: true,
+                    contentPadding: EdgeInsets.symmetric(
+                      vertical: 8,
+                      // Subtracting 4 pixels to account for the internal
+                      // 4-pixel horizontal padding.
+                      horizontal: 10 - 4,
+                    ),
+                    filled: true,
+                    fillColor: designVariables.bgSearchInput,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10),
+                      borderSide: BorderSide.none,
+                    )))),
+              ]),
+          ),
+          Expanded(child: InsetShadowBox(
+            top: 6, bottom: 6,
+            color: designVariables.mainBackground,
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Column(children: [
+                for (final status in suggestions)
+                  StatusSuggestionsListEntry(
+                    status: status,
+                    onTap: () => chooseStatusSuggestion(status)),
+              ])))),
+        ])),
     );
   }
 }
@@ -319,7 +316,7 @@ class StatusSuggestionsListEntry extends StatelessWidget {
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 7, horizontal: 16),
+        padding: EdgeInsets.symmetric(vertical: 7, horizontal: 8),
         child: Row(
           spacing: 8,
           children: [


### PR DESCRIPTION
Fixes: #1769
Fixes: #1770
Fixes: #1771

<details>
<summary>Screenshots</summary>

### Landscape mode
| Before | After |
| --- | --- |
| <img width="974" height="606" alt="Landscape - before" src="https://github.com/user-attachments/assets/811f325f-bf61-40d1-b09f-6cec7d9ad07d" /> | <img width="974" height="606" alt="Landscape - after" src="https://github.com/user-attachments/assets/55947bb7-0332-4f1c-9ebc-5290fab4aafa" /> |

### Consistent horizontal padding
| Before | After |
| --- | --- |
| <img width="544" height="1036" alt="Consistent padding - before" src="https://github.com/user-attachments/assets/be67e4bd-1ea4-4e9a-9584-3307ca3489df" /> | <img width="544" height="1036" alt="Consistent padding - after" src="https://github.com/user-attachments/assets/4f4b91c6-9bca-40b3-8032-9d3b0675de98" /> |

### Status-suggestion touch feedback
| Before | After (no feedback) |
| --- | --- |
| <img width="1206" height="2622" alt="item touch feedback - before" src="https://github.com/user-attachments/assets/33759da5-70d0-490c-8dcd-aa872b2f67b1" /> | <img width="1206" height="2622" alt="item touch feedback - after" src="https://github.com/user-attachments/assets/8ee46b57-a840-49a3-bd4b-b990710f2482" /> |

### Bottom shadow
| Before | After |
| --- | --- |
| <img width="974" height="606" alt="Bottom shadow - before" src="https://github.com/user-attachments/assets/f63f5376-3001-482e-991c-8ddc42e6bc4a" /> | <img width="974" height="606" alt="Bottom shadow - after" src="https://github.com/user-attachments/assets/d693edd4-5c28-4faf-a0d8-ed3128d88c12" /> |

### Space between emoji button and text input
#### Emoji button pressed
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Spacing pressed - before" src="https://github.com/user-attachments/assets/0083fa23-ecce-4d82-b327-28d8de9f86af" /> | <img width="1206" height="2622" alt="Spacing pressed - after" src="https://github.com/user-attachments/assets/9be32770-0188-407c-bfbb-c9bdfa584f77" /> |

#### Emoji button not pressed
| Before | After |
| --- | --- |
| <img width="544" height="1036" alt="Spacing - Before" src="https://github.com/user-attachments/assets/f8d675ff-9d62-40ca-be56-7f3ca01f4a43" /> | <img width="544" height="1036" alt="Spacing - after" src="https://github.com/user-attachments/assets/9fa0c28c-c853-4f93-a7bf-acf1a3c17464" /> |
</details>