### PR TITLE
compose [nfc]: Use ComposeBoxController.uploadFiles in _AttachUploadsButton

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1024,11 +1024,10 @@ abstract class _AttachUploadsButton extends StatelessWidget {
       return;
     }
 
-    await _uploadFiles(
+    await controller.uploadFiles(
       context: context,
-      contentController: controller.content,
-      contentFocusNode: controller.contentFocusNode,
-      files: files);
+      files: files,
+      shouldRequestFocus: true);
   }
 
   @override


### PR DESCRIPTION
In e4deccbdc ComposeBoxController started exposing uploadFiles method, which is now used by Share-to-Zulip implementation. So use that for _AttachUploadsButton too, using the same implementation between Share-to-Zulip and compose box upload buttons.