### PR TITLE
Make read-receipts and view-reactions draggable-scrollable

### DIFF
--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1460,10 +1460,10 @@ class UpdateMachine {
   }
 
   void _reportToUserErrorConnectingToServer(Object error) {
-    final localizations = GlobalLocalizations.zulipLocalizations;
+    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
     reportErrorToUserBriefly(
-      localizations.errorConnectingToServerShort,
-      details: localizations.errorConnectingToServerDetails(
+      zulipLocalizations.errorConnectingToServerShort,
+      details: zulipLocalizations.errorConnectingToServerDetails(
         store.realmUrl.toString(), error.toString()));
   }
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -504,11 +504,11 @@ class CopyChannelLinkButton extends ActionSheetMenuItemButton {
 
   @override
   void onPressed() async {
-    final localizations = ZulipLocalizations.of(pageContext);
+    final zulipLocalizations = ZulipLocalizations.of(pageContext);
     final store = PerAccountStoreWidget.of(pageContext);
 
     PlatformActions.copyWithPopup(context: pageContext,
-      successContent: Text(localizations.successChannelLinkCopied),
+      successContent: Text(zulipLocalizations.successChannelLinkCopied),
       data: ClipboardData(text: narrowLink(store, ChannelNarrow(channelId)).toString()));
   }
 }
@@ -915,11 +915,11 @@ class CopyTopicLinkButton extends ActionSheetMenuItemButton {
   }
 
   @override void onPressed() async {
-    final localizations = ZulipLocalizations.of(pageContext);
+    final zulipLocalizations = ZulipLocalizations.of(pageContext);
     final store = PerAccountStoreWidget.of(pageContext);
 
     PlatformActions.copyWithPopup(context: pageContext,
-      successContent: Text(localizations.successTopicLinkCopied),
+      successContent: Text(zulipLocalizations.successTopicLinkCopied),
       data: ClipboardData(text: narrowLink(store, narrow).toString()));
   }
 }

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -112,7 +112,7 @@ class ZulipApp extends StatefulWidget {
       return;
     }
 
-    final localizations = ZulipLocalizations.of(navigatorKey.currentContext!);
+    final zulipLocalizations = ZulipLocalizations.of(navigatorKey.currentContext!);
     final newSnackBar = scaffoldMessenger!.showSnackBar(
       snackBarAnimationStyle: AnimationStyle(
         duration: const Duration(milliseconds: 200),
@@ -120,9 +120,9 @@ class ZulipApp extends StatefulWidget {
       SnackBar(
         content: Text(message),
         action: (details == null) ? null : SnackBarAction(
-          label: localizations.snackBarDetails,
+          label: zulipLocalizations.snackBarDetails,
           onPressed: () => showErrorDialog(context: navigatorKey.currentContext!,
-            title: localizations.errorDialogTitle,
+            title: zulipLocalizations.errorDialogTitle,
             message: details))));
 
     _snackBarCount++;

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -178,8 +178,8 @@ class ComposeAutocomplete extends AutocompleteField<ComposeAutocompleteQuery, Co
   @override
   ComposeAutocompleteView initViewModel(BuildContext context, ComposeAutocompleteQuery query) {
     final store = PerAccountStoreWidget.of(context);
-    final localizations = ZulipLocalizations.of(context);
-    return query.initViewModel(store: store, localizations: localizations,
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    return query.initViewModel(store: store, localizations: zulipLocalizations,
       narrow: narrow);
   }
 
@@ -273,18 +273,18 @@ class MentionAutocompleteItem extends StatelessWidget {
   }) {
     final isDmNarrow = narrow is DmNarrow;
     final isChannelWildcardAvailable = store.zulipFeatureLevel >= 247; // TODO(server-9)
-    final localizations = ZulipLocalizations.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
     return switch (wildcardOption) {
       WildcardMentionOption.all || WildcardMentionOption.everyone => isDmNarrow
-        ? localizations.wildcardMentionAllDmDescription
+        ? zulipLocalizations.wildcardMentionAllDmDescription
         : isChannelWildcardAvailable
-            ? localizations.wildcardMentionChannelDescription
-            : localizations.wildcardMentionStreamDescription,
-      WildcardMentionOption.channel => localizations.wildcardMentionChannelDescription,
+            ? zulipLocalizations.wildcardMentionChannelDescription
+            : zulipLocalizations.wildcardMentionStreamDescription,
+      WildcardMentionOption.channel => zulipLocalizations.wildcardMentionChannelDescription,
       WildcardMentionOption.stream => isChannelWildcardAvailable
-        ? localizations.wildcardMentionChannelDescription
-        : localizations.wildcardMentionStreamDescription,
-      WildcardMentionOption.topic => localizations.wildcardMentionTopicDescription,
+        ? zulipLocalizations.wildcardMentionChannelDescription
+        : zulipLocalizations.wildcardMentionStreamDescription,
+      WildcardMentionOption.topic => zulipLocalizations.wildcardMentionTopicDescription,
     };
   }
 

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -1030,6 +1030,7 @@ class ViewReactionsUserList extends StatelessWidget {
       label: zulipLocalizations.seeWhoReactedSheetUserListLabel(emojiName, userIds.length),
       role: SemanticsRole.tabPanel,
       container: true,
+      explicitChildNodes: true,
       child: result);
   }
 }

--- a/lib/widgets/inset_shadow.dart
+++ b/lib/widgets/inset_shadow.dart
@@ -48,12 +48,6 @@ class InsetShadowBox extends StatelessWidget {
 
   final Widget child;
 
-  BoxDecoration _shadowFrom(AlignmentGeometry begin) {
-    return BoxDecoration(gradient: LinearGradient(
-      begin: begin, end: -begin,
-      colors: [color, color.withValues(alpha: 0)]));
-  }
-
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -63,13 +57,32 @@ class InsetShadowBox extends StatelessWidget {
       children: [
         child,
         if (top != 0) Positioned(top: 0, height: top, left: 0, right: 0,
-          child: DecoratedBox(decoration: _shadowFrom(Alignment.topCenter))),
+          child: DecoratedBox(
+            decoration: fadeToTransparencyDecoration(FadeToTransparencyDirection.down, color))),
         if (bottom != 0) Positioned(bottom: 0, height: bottom, left: 0, right: 0,
-          child: DecoratedBox(decoration: _shadowFrom(Alignment.bottomCenter))),
+          child: DecoratedBox(
+            decoration: fadeToTransparencyDecoration(FadeToTransparencyDirection.up, color))),
         if (start != 0) PositionedDirectional(start: 0, width: start, top: 0, bottom: 0,
-          child: DecoratedBox(decoration: _shadowFrom(AlignmentDirectional.centerStart))),
+          child: DecoratedBox(
+            decoration: fadeToTransparencyDecoration(FadeToTransparencyDirection.end, color))),
         if (end != 0) PositionedDirectional(end: 0, width: end, top: 0, bottom: 0,
-          child: DecoratedBox(decoration: _shadowFrom(AlignmentDirectional.centerEnd))),
+          child: DecoratedBox(
+            decoration: fadeToTransparencyDecoration(FadeToTransparencyDirection.start, color))),
       ]);
   }
+}
+
+enum FadeToTransparencyDirection { down, up, end, start }
+
+BoxDecoration fadeToTransparencyDecoration(FadeToTransparencyDirection direction, Color color) {
+  final begin = switch (direction) {
+    FadeToTransparencyDirection.down => Alignment.topCenter,
+    FadeToTransparencyDirection.up => Alignment.bottomCenter,
+    FadeToTransparencyDirection.end => AlignmentDirectional.centerStart,
+    FadeToTransparencyDirection.start => AlignmentDirectional.centerEnd,
+  };
+
+  return BoxDecoration(gradient: LinearGradient(
+    begin: begin, end: -begin,
+    colors: [color, color.withValues(alpha: 0)]));
 }

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -252,15 +252,15 @@ class _SetStatusButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localizations = ZulipLocalizations.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final store = PerAccountStoreWidget.of(context);
     final userStatus = store.getUserStatus(store.selfUserId);
 
     return ZulipMenuItemButton(
       style: ZulipMenuItemButtonStyle.list,
       label: userStatus == UserStatus.zero
-        ? localizations.statusButtonLabelStatusUnset
-        : localizations.statusButtonLabelStatusSet,
+        ? zulipLocalizations.statusButtonLabelStatusUnset
+        : zulipLocalizations.statusButtonLabelStatusSet,
       subLabel: userStatus == UserStatus.zero ? null : TextSpan(children: [
         UserStatusEmoji.asWidgetSpan(
           userId: store.selfUserId,
@@ -270,7 +270,7 @@ class _SetStatusButton extends StatelessWidget {
           neverAnimate: false,
         ),
         userStatus.text == null
-          ? TextSpan(text: localizations.noStatusText,
+          ? TextSpan(text: zulipLocalizations.noStatusText,
               style: TextStyle(fontStyle: FontStyle.italic))
           : TextSpan(text: userStatus.text),
       ]),

--- a/lib/widgets/read_receipts.dart
+++ b/lib/widgets/read_receipts.dart
@@ -80,15 +80,33 @@ class _ReadReceiptsState extends State<ReadReceipts> with PerAccountStoreAwareSt
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
     // TODO could pull out this layout/appearance code,
     //   focusing this widget only on state management
+
+    final content = switch (status) {
+      FetchStatus.loading => BottomSheetEmptyContentPlaceholder(loading: true),
+      FetchStatus.error   => BottomSheetEmptyContentPlaceholder(
+        message: zulipLocalizations.actionSheetReadReceiptsErrorReadCount),
+      FetchStatus.success => userIds.isEmpty
+        ? BottomSheetEmptyContentPlaceholder(
+            message: zulipLocalizations.actionSheetReadReceiptsZeroReadCount)
+        : InsetShadowBox(
+            top: 8, bottom: 8,
+            color: DesignVariables.of(context).bgContextMenu,
+            child: ListView.builder(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              itemCount: userIds.length,
+              itemBuilder: (context, index) =>
+                ReadReceiptsUserItem(userId: userIds[index])))
+    };
 
     return SizedBox(
       height: 500, // TODO(design) tune
       child: Column(
         children: [
           _ReadReceiptsHeader(receiptCount: userIds.length, status: status),
-          Expanded(child: _ReadReceiptsUserList(userIds: userIds, status: status)),
+          Expanded(child: content),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: const BottomSheetDismissButton(style: BottomSheetDismissButtonStyle.close))
@@ -126,35 +144,6 @@ class _ReadReceiptsHeader extends StatelessWidget {
       child: BottomSheetHeader(
         title: zulipLocalizations.actionSheetReadReceipts,
         buildMessage: headerMessageBuilder));
-  }
-}
-
-class _ReadReceiptsUserList extends StatelessWidget {
-  const _ReadReceiptsUserList({required this.userIds, required this.status});
-
-  final List<int> userIds;
-  final FetchStatus status;
-
-  @override
-  Widget build(BuildContext context) {
-    final zulipLocalizations = ZulipLocalizations.of(context);
-
-    return switch(status) {
-      FetchStatus.loading => BottomSheetEmptyContentPlaceholder(loading: true),
-      FetchStatus.error   => BottomSheetEmptyContentPlaceholder(
-        message: zulipLocalizations.actionSheetReadReceiptsErrorReadCount),
-      FetchStatus.success => userIds.isEmpty
-        ? BottomSheetEmptyContentPlaceholder(
-            message: zulipLocalizations.actionSheetReadReceiptsZeroReadCount)
-        : InsetShadowBox(
-            top: 8, bottom: 8,
-            color: DesignVariables.of(context).bgContextMenu,
-            child: ListView.builder(
-              padding: EdgeInsets.symmetric(vertical: 8),
-              itemCount: userIds.length,
-              itemBuilder: (context, index) =>
-                ReadReceiptsUserItem(userId: userIds[index])))
-    };
   }
 }
 

--- a/lib/widgets/read_receipts.dart
+++ b/lib/widgets/read_receipts.dart
@@ -6,7 +6,6 @@ import '../generated/l10n/zulip_localizations.dart';
 import 'action_sheet.dart';
 import 'actions.dart';
 import 'color.dart';
-import 'inset_shadow.dart';
 import 'profile.dart';
 import 'store.dart';
 import 'text.dart';
@@ -81,36 +80,26 @@ class _ReadReceiptsState extends State<ReadReceipts> with PerAccountStoreAwareSt
   @override
   Widget build(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
-    // TODO could pull out this layout/appearance code,
-    //   focusing this widget only on state management
+    final receiptCount = userIds.length;
 
     final content = switch (status) {
-      FetchStatus.loading => BottomSheetEmptyContentPlaceholder(loading: true),
-      FetchStatus.error   => BottomSheetEmptyContentPlaceholder(
-        message: zulipLocalizations.actionSheetReadReceiptsErrorReadCount),
+      FetchStatus.loading => SliverToBoxAdapter(
+        child: BottomSheetEmptyContentPlaceholder(loading: true)),
+      FetchStatus.error   => SliverToBoxAdapter(
+        child: BottomSheetEmptyContentPlaceholder(
+          message: zulipLocalizations.actionSheetReadReceiptsErrorReadCount)),
       FetchStatus.success => userIds.isEmpty
-        ? BottomSheetEmptyContentPlaceholder(
-            message: zulipLocalizations.actionSheetReadReceiptsZeroReadCount)
-        : InsetShadowBox(
-            top: 8, bottom: 8,
-            color: DesignVariables.of(context).bgContextMenu,
-            child: ListView.builder(
-              padding: EdgeInsets.symmetric(vertical: 8),
-              itemCount: userIds.length,
-              itemBuilder: (context, index) =>
-                ReadReceiptsUserItem(userId: userIds[index])))
+        ? SliverToBoxAdapter(
+            child: BottomSheetEmptyContentPlaceholder(
+              message: zulipLocalizations.actionSheetReadReceiptsZeroReadCount))
+        : SliverList.builder(
+            itemCount: receiptCount,
+            itemBuilder: (_, index) => ReadReceiptsUserItem(userId: userIds[index])),
     };
 
-    return SizedBox(
-      height: 500, // TODO(design) tune
-      child: Column(
-        children: [
-          _ReadReceiptsHeader(receiptCount: userIds.length, status: status),
-          Expanded(child: content),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: const BottomSheetDismissButton(style: BottomSheetDismissButtonStyle.close))
-        ]));
+    return DraggableScrollableModalBottomSheet(
+      header: _ReadReceiptsHeader(receiptCount: receiptCount, status: status),
+      contentSliver: content);
   }
 }
 

--- a/lib/widgets/read_receipts.dart
+++ b/lib/widgets/read_receipts.dart
@@ -137,15 +137,15 @@ class _ReadReceiptsUserList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final localizations = ZulipLocalizations.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
 
     return switch(status) {
       FetchStatus.loading => BottomSheetEmptyContentPlaceholder(loading: true),
       FetchStatus.error   => BottomSheetEmptyContentPlaceholder(
-        message: localizations.actionSheetReadReceiptsErrorReadCount),
+        message: zulipLocalizations.actionSheetReadReceiptsErrorReadCount),
       FetchStatus.success => userIds.isEmpty
         ? BottomSheetEmptyContentPlaceholder(
-            message: localizations.actionSheetReadReceiptsZeroReadCount)
+            message: zulipLocalizations.actionSheetReadReceiptsZeroReadCount)
         : InsetShadowBox(
             top: 8, bottom: 8,
             color: DesignVariables.of(context).bgContextMenu,

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -84,16 +84,16 @@ class _SetStatusPageState extends State<SetStatusPage> {
 
   List<UserStatus> statusSuggestions(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
-    final localizations = ZulipLocalizations.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
 
     final values = [
-      ('1f6e0', localizations.userStatusBusy),
-      ('1f4c5', localizations.userStatusInAMeeting),
-      ('1f68c', localizations.userStatusCommuting),
-      ('1f912', localizations.userStatusOutSick),
-      ('1f334', localizations.userStatusVacationing),
-      ('1f3e0', localizations.userStatusWorkingRemotely),
-      ('1f3e2', localizations.userStatusAtTheOffice),
+      ('1f6e0', zulipLocalizations.userStatusBusy),
+      ('1f4c5', zulipLocalizations.userStatusInAMeeting),
+      ('1f68c', zulipLocalizations.userStatusCommuting),
+      ('1f912', zulipLocalizations.userStatusOutSick),
+      ('1f334', zulipLocalizations.userStatusVacationing),
+      ('1f3e0', zulipLocalizations.userStatusWorkingRemotely),
+      ('1f3e2', zulipLocalizations.userStatusAtTheOffice),
     ];
     return [
       for (final (emojiCode, statusText) in values)
@@ -114,7 +114,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
 
   Future<void> handleStatusSave() async {
     final store = PerAccountStoreWidget.of(context);
-    final localizations = ZulipLocalizations.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
 
     Navigator.pop(context);
     if (newStatus == oldStatus) return;
@@ -122,7 +122,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
     try {
       await updateStatus(store.connection, change: statusChange.value);
     } catch (e) {
-      reportErrorToUserBriefly(localizations.updateStatusErrorTitle);
+      reportErrorToUserBriefly(zulipLocalizations.updateStatusErrorTitle);
     }
   }
 
@@ -151,18 +151,18 @@ class _SetStatusPageState extends State<SetStatusPage> {
   @override
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
-    final localizations = ZulipLocalizations.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
 
     final suggestions = statusSuggestions(context);
 
     return Scaffold(
-      appBar: ZulipAppBar(title: Text(localizations.setStatusPageTitle),
+      appBar: ZulipAppBar(title: Text(zulipLocalizations.setStatusPageTitle),
         actions: [
           ValueListenableBuilder(
             valueListenable: statusChange,
             builder: (_, _, _) {
               return _ActionButton(
-                label: localizations.statusClearButtonLabel,
+                label: zulipLocalizations.statusClearButtonLabel,
                 icon: ZulipIcons.remove,
                 onPressed: newStatus == UserStatus.zero
                   ? null
@@ -173,7 +173,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
             valueListenable: statusChange,
             builder: (_, change, _) {
               return _ActionButton(
-                label: localizations.statusSaveButtonLabel,
+                label: zulipLocalizations.statusSaveButtonLabel,
                 icon: ZulipIcons.check,
                 onPressed: switch ((change.text, change.emoji)) {
                   (OptionNone(), OptionNone()) => null,
@@ -233,7 +233,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
                     // TODO: display a counter as suggested in CZO discussion:
                     //   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Set.20user.20status/near/2224549
                     counterText: '',
-                    hintText: localizations.statusTextHint,
+                    hintText: zulipLocalizations.statusTextHint,
                     hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
                     isDense: true,
                     contentPadding: EdgeInsets.symmetric(

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -446,13 +446,13 @@ void main() {
   });
 
   group('user status', () {
-    final localizations = GlobalLocalizations.zulipLocalizations;
+    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
 
     Finder findStatusButton({required bool statusSet}) {
       return find.widgetWithText(ZulipMenuItemButton,
         statusSet
-          ? localizations.statusButtonLabelStatusSet
-          : localizations.statusButtonLabelStatusUnset);
+          ? zulipLocalizations.statusButtonLabelStatusSet
+          : zulipLocalizations.statusButtonLabelStatusUnset);
     }
 
     testWidgets('non-self profile, status set: no status button, status info appears', (tester) async {
@@ -514,7 +514,7 @@ void main() {
 
         final statusButtonFinder = findStatusButton(statusSet: true);
         final textPlaceholderFinder = findText(
-          includePlaceholders: false, localizations.noStatusText);
+          includePlaceholders: false, zulipLocalizations.noStatusText);
 
         check(statusButtonFinder).findsOne();
         check(textPlaceholderFinder).findsOne();


### PR DESCRIPTION
For manual testing, ideally use a real device, to see the fling and drag responses faithfully to what most users will experience :)

Screenshots coming soon.

Selected commit messages:

-----

ead_receipts: Improve UX by making the sheet draggable-scrollable

The Figma asks that the sheet be expandable to fill the screen:
  https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=11367-21131&m=dev
and that's implemented here.

Compare f8ddff2f3, where we removed an earlier implementation. I
hadn't tried to bring that back yet because I wanted to support
triggering resize from a drag handle at the top, and I couldn't
figure out how to do that. IIRC I could only get the drag handle to
respond to drag-down gestures (via `enableDrag: true`) by shifting
the sheet's position downward. That worked as a way to dismiss the
sheet, but it was frustratingly different from the gesture handling
on the scrollable list:
- The slide-to-dismiss looked different from the shrink-and-dismiss,
  an awkward inconsistency
- The list would respond to upward drags, too (by growing and
  showing more content)

I've managed it here, modulo with a header instead of a drag handle,
by making sure the scrollable area extends through the top of the
sheet. (Done with a CustomScrollView, pinning the header to the
viewport top.)

-----

emoji_reaction: Use DraggableScrollableModalBottomSheet for view-reactions

Like we did for read-receipts in a recent commit. I *think* this
behavior is implied in the Figma, but it's not as explicit:
  https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=5878-19207&m=dev
...anyway, helpful to be consistent with read-receipts, I think,
which is similarly a read-only view that might have a long list to
show.

I thought this would be more complicated than it turned out to be --
thanks to SliverSemantics, I can actually wrap the list of voters in
a labeled container node, because
DraggableScrollableModalBottomSheet's API takes a sliver for the
content.