### PR TITLE
content: Include inline styles (italic etc.) in what we pass to WidgetSpans

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -805,7 +805,7 @@ class MathBlock extends StatelessWidget {
         child: SingleChildScrollViewWithScrollbar(
           scrollDirection: Axis.horizontal,
           child: KatexWidget(
-            textStyle: ContentTheme.of(context).textStylePlainParagraph,
+            ambientTextStyle: ContentTheme.of(context).textStylePlainParagraph,
             nodes: nodes))));
   }
 }
@@ -1130,7 +1130,7 @@ class _InlineContentBuilder {
           : WidgetSpan(
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
-              child: KatexWidget(textStyle: widget.style, nodes: nodes));
+              child: KatexWidget(ambientTextStyle: widget.style, nodes: nodes));
 
       case GlobalTimeNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1036,11 +1036,13 @@ class _InlineContentBuilder {
     _context = context;
     assert(_recognizer == widget.recognizer);
     assert(_recognizerStack == null || _recognizerStack!.isEmpty);
+    assert(_styleStack == null || _styleStack!.isEmpty);
     final result = _buildNodes(widget.nodes, style: widget.style);
     assert(identical(_context, context));
     _context = null;
     assert(_recognizer == widget.recognizer);
     assert(_recognizerStack == null || _recognizerStack!.isEmpty);
+    assert(_styleStack == null || _styleStack!.isEmpty);
     return result;
   }
 
@@ -1064,10 +1066,43 @@ class _InlineContentBuilder {
     _recognizer = _recognizerStack!.removeLast();
   }
 
-  InlineSpan _buildNodes(List<InlineContentNode> nodes, {required TextStyle? style}) {
+  /// A stack of the [TextStyle]s applied by ancestors of the node being built,
+  /// excluding the root [widget.style].
+  ///
+  /// Call [_resolveStyleStack] to merge [widget.style] and these styles
+  /// into one ambient style for the node being built.
+  ///
+  /// [widget.style] is excluded to avoid allocating an empty list
+  /// for unstyled paragraphs.
+  List<TextStyle>? _styleStack;
+
+  void _pushStyle(TextStyle style) {
+    if (identical(style, widget.style)) return;
+    (_styleStack ??= []).add(style);
+  }
+
+  void _popStyle(TextStyle style) {
+    if (identical(style, widget.style)) return;
+    _styleStack!.removeLast();
+  }
+
+  /// The merged result of [widget.style] and all styles on [_styleStack].
+  // In principle we could memoize this, but profiling suggests that's unnecessary:
+  //   https://github.com/zulip/zulip-flutter/pull/1821#discussion_r2608812752
+  TextStyle _resolveStyleStack() {
+    if (_styleStack == null || _styleStack!.isEmpty) return widget.style;
+    return _styleStack!.fold(widget.style,
+      (value, element) => value.merge(element));
+  }
+
+  InlineSpan _buildNodes(List<InlineContentNode> nodes, {required TextStyle style}) {
+    _pushStyle(style);
+    final children = nodes.map(_buildNode).toList(growable: false);
+    _popStyle(style);
+
     return TextSpan(
       style: style,
-      children: nodes.map(_buildNode).toList(growable: false));
+      children: children);
   }
 
   InlineSpan _buildNode(InlineContentNode node) {
@@ -1106,7 +1141,7 @@ class _InlineContentBuilder {
 
       case MentionNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
-          child: Mention(ambientTextStyle: widget.style, node: node));
+          child: Mention(ambientTextStyle: _resolveStyleStack(), node: node));
 
       case UnicodeEmojiNode():
         return TextSpan(text: node.emojiUnicode, recognizer: _recognizer,
@@ -1130,11 +1165,11 @@ class _InlineContentBuilder {
           : WidgetSpan(
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
-              child: KatexWidget(ambientTextStyle: widget.style, nodes: nodes));
+              child: KatexWidget(ambientTextStyle: _resolveStyleStack(), nodes: nodes));
 
       case GlobalTimeNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
-          child: GlobalTime(node: node, ambientTextStyle: widget.style));
+          child: GlobalTime(node: node, ambientTextStyle: _resolveStyleStack()));
 
       case UnimplementedInlineContentNode():
         return _errorUnimplemented(node, context: _context!);
@@ -1414,7 +1449,7 @@ class GlobalTime extends StatelessWidget {
                 size: ambientTextStyle.fontSize!,
                 // (When GlobalTime appears in a link, it should be blue
                 // like the text.)
-                color: DefaultTextStyle.of(context).style.color!,
+                color: ambientTextStyle.color,
                 ZulipIcons.clock),
               // Ad-hoc spacing adjustment per feedback:
               //   https://chat.zulip.org/#narrow/stream/101-design/topic/clock.20icons/near/1729345

--- a/lib/widgets/katex.dart
+++ b/lib/widgets/katex.dart
@@ -6,7 +6,6 @@ import 'package:flutter/rendering.dart';
 
 import '../model/content.dart';
 import '../model/katex.dart';
-import 'content.dart';
 
 /// Creates a base text style for rendering KaTeX content.
 ///
@@ -16,7 +15,7 @@ import 'content.dart';
 ///   https://github.com/KaTeX/KaTeX/blob/613c3da8/src/styles/katex.scss#L13-L15
 ///
 /// Requires the [ambientStyle.fontSize] to be non-null.
-TextStyle mkBaseKatexTextStyle(TextStyle ambientStyle, Color baseColor) {
+TextStyle mkBaseKatexTextStyle(TextStyle ambientStyle) {
   return ambientStyle.copyWith(
     ////// Overrides of our own styles:
 
@@ -24,9 +23,6 @@ TextStyle mkBaseKatexTextStyle(TextStyle ambientStyle, Color baseColor) {
     // Just for completeness, remove "wght", but it wouldn't do anything anyway
     // since KaTeX_Main is not a variable-weight font.
     fontVariations: [],
-    // Remove link color, but
-    // TODO(#1823) do we want to do that? Web doesn't.
-    color: baseColor,
     // Italic is removed below.
 
     // Strikethrough is removed below, which affects formatting of rendered
@@ -68,8 +64,7 @@ class KatexWidget extends StatelessWidget {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: DefaultTextStyle(
-        style: mkBaseKatexTextStyle(ambientTextStyle,
-          ContentTheme.of(context).textStylePlainParagraph.color!),
+        style: mkBaseKatexTextStyle(ambientTextStyle),
         child: widget));
   }
 }

--- a/lib/widgets/katex.dart
+++ b/lib/widgets/katex.dart
@@ -15,9 +15,9 @@ import 'content.dart';
 /// and applies the CSS styles defined in .katex class in katex.scss :
 ///   https://github.com/KaTeX/KaTeX/blob/613c3da8/src/styles/katex.scss#L13-L15
 ///
-/// Requires the [style.fontSize] to be non-null.
-TextStyle mkBaseKatexTextStyle(TextStyle style, Color baseColor) {
-  return style.copyWith(
+/// Requires the [ambientStyle.fontSize] to be non-null.
+TextStyle mkBaseKatexTextStyle(TextStyle ambientStyle, Color baseColor) {
+  return ambientStyle.copyWith(
     ////// Overrides of our own styles:
 
     // Bold formatting is removed below by setting FontWeight.normal…
@@ -39,7 +39,7 @@ TextStyle mkBaseKatexTextStyle(TextStyle style, Color baseColor) {
 
     ////// From the .katex class in katex.scss:
 
-    fontSize: style.fontSize! * 1.21,
+    fontSize: ambientStyle.fontSize! * 1.21,
     fontFamily: 'KaTeX_Main',
     height: 1.2,
     fontWeight: FontWeight.normal,
@@ -54,11 +54,11 @@ TextStyle mkBaseKatexTextStyle(TextStyle style, Color baseColor) {
 class KatexWidget extends StatelessWidget {
   const KatexWidget({
     super.key,
-    required this.textStyle,
+    required this.ambientTextStyle,
     required this.nodes,
   });
 
-  final TextStyle textStyle;
+  final TextStyle ambientTextStyle;
   final List<KatexNode> nodes;
 
   @override
@@ -68,7 +68,7 @@ class KatexWidget extends StatelessWidget {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: DefaultTextStyle(
-        style: mkBaseKatexTextStyle(textStyle,
+        style: mkBaseKatexTextStyle(ambientTextStyle,
           ContentTheme.of(context).textStylePlainParagraph.color!),
         child: widget));
   }

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1462,13 +1462,22 @@ void main() {
 
     testContentSmoke(ContentExample.mathInline);
 
+    final mathInlineHtml = '<span class="katex">'
+      '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
+        '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
+      '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span>';
+
+    testWidgets('is link-colored in link span', (tester) async {
+      // Regression test for: https://github.com/zulip/zulip-flutter/issues/1823
+      await prepareContent(tester,
+        plainContent('<p><a href="https://example/">$mathInlineHtml</a></p>'));
+      final style = mergedStyleOf(tester, 'λ');
+      check(style!.color).equals(const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor());
+    });
+
     testWidgets('maintains font-size ratio with surrounding text', (tester) async {
-      const html = '<span class="katex">'
-        '<span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>λ</mi></mrow>'
-          '<annotation encoding="application/x-tex"> \\lambda </annotation></semantics></math></span>'
-        '<span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">λ</span></span></span></span>';
       await checkFontSizeRatio(tester,
-        targetHtml: html,
+        targetHtml: mathInlineHtml,
         targetFontSizeFinder: (rootSpan) {
           late final double result;
           rootSpan.visitChildren((span) {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1043,6 +1043,15 @@ void main() {
         });
     });
 
+    testWidgets('is italic in italic span', (tester) async {
+      // Regression test for: https://github.com/zulip/zulip-flutter/issues/1813
+      await prepareContent(tester,
+        wrapWithPerAccountStoreWidget: true,
+        plainContent('<p><em><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></em></p>'));
+      final style = mergedStyleOf(tester, '@Chris Bobbe');
+      check(style!.fontStyle).equals(FontStyle.italic);
+    });
+
     testFontWeight('silent or non-self mention in plain paragraph',
       expectedWght: 400,
       // @_**Greg Price**
@@ -1553,7 +1562,19 @@ void main() {
       check(find.textContaining(renderedTextRegexpTwelveHour)).findsOne();
     });
 
-    void testIconAndTextSameColor(String description, String html) {
+    testWidgets('is italic in italic span', (tester) async {
+      // Regression test for: https://github.com/zulip/zulip-flutter/issues/1813
+      await prepareContent(tester,
+        // We use the self-account's time-format setting.
+        wrapWithPerAccountStoreWidget: true,
+        initialSnapshot: eg.initialSnapshot(),
+        plainContent('<p><em>$timeSpanHtml</em></p>'));
+      final style = mergedStyleOf(tester,
+        findAncestor: find.byType(GlobalTime), renderedTextRegexp);
+      check(style!.fontStyle).equals(FontStyle.italic);
+    });
+
+    void testIconAndTextSameColor(String description, String html, {Color? expectedColor}) {
       testWidgets('clock icon and text are the same color: $description', (tester) async {
         await prepareContent(tester,
           // We use the self-account's time-format setting.
@@ -1569,11 +1590,16 @@ void main() {
         check(textColor).isNotNull();
 
         check(icon).color.isNotNull().isSameColorAs(textColor!);
+        if (expectedColor != null) {
+          check(icon).color.equals(expectedColor);
+        }
       });
     }
 
     testIconAndTextSameColor('common case', '<p>$timeSpanHtml</p>');
-    testIconAndTextSameColor('inside link', '<p><a href="https://example/">$timeSpanHtml</a></p>');
+    // Regression test for: https://github.com/zulip/zulip-flutter/issues/1819
+    testIconAndTextSameColor('inside link', '<p><a href="https://example/">$timeSpanHtml</a></p>',
+      expectedColor: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor());
 
     group('maintains font-size ratio with surrounding text', () {
       Future<void> doCheck(WidgetTester tester, double Function(GlobalTime widget) sizeFromWidget) async {


### PR DESCRIPTION
Fixes #1813.
Fixes #1819.
Fixes #1823.

I've left out further testing because we have other pressing priorities; please let me know if something's missing or not well-explained.

-----

| Before | After |
| --- | --- |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/b9b7a5eb-91f1-4a15-b6ab-2aa37a4cd0bc" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/24250f76-beb2-48a8-b7c3-9e406111cc7c" /> |