### PR TITLE
Group-based permissions

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -34,7 +34,10 @@ sealed class Event {
         switch (json['op'] as String) {
           case 'add': return UserGroupAddEvent.fromJson(json);
           case 'update': return UserGroupUpdateEvent.fromJson(json);
-          // TODO(#1687): add_members, remove_members, add_subgroups, remove_subgroups
+          case 'add_members': return UserGroupAddMembersEvent.fromJson(json);
+          case 'remove_members': return UserGroupRemoveMembersEvent.fromJson(json);
+          case 'add_subgroups': return UserGroupAddSubgroupsEvent.fromJson(json);
+          case 'remove_subgroups': return UserGroupRemoveSubgroupsEvent.fromJson(json);
           case 'remove': return UserGroupRemoveEvent.fromJson(json);
           default: return UnexpectedEvent.fromJson(json);
         }
@@ -278,6 +281,78 @@ class UserGroupUpdateData {
   factory UserGroupUpdateData.fromJson(Map<String, dynamic> json) => _$UserGroupUpdateDataFromJson(json);
 
   Map<String, dynamic> toJson() => _$UserGroupUpdateDataToJson(this);
+}
+
+/// A [UserGroupEvent] with op `add_members`: https://zulip.com/api/get-events#user_group-add_members
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UserGroupAddMembersEvent extends UserGroupEvent {
+  @override
+  @JsonKey(includeToJson: true)
+  String get op => 'add_members';
+
+  final int groupId;
+  final List<int> userIds;
+
+  UserGroupAddMembersEvent({required super.id, required this.groupId, required this.userIds});
+
+  factory UserGroupAddMembersEvent.fromJson(Map<String, dynamic> json) => _$UserGroupAddMembersEventFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$UserGroupAddMembersEventToJson(this);
+}
+
+/// A [UserGroupEvent] with op `remove_members`: https://zulip.com/api/get-events#user_group-remove_members
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UserGroupRemoveMembersEvent extends UserGroupEvent {
+  @override
+  @JsonKey(includeToJson: true)
+  String get op => 'remove_members';
+
+  final int groupId;
+  final List<int> userIds;
+
+  UserGroupRemoveMembersEvent({required super.id, required this.groupId, required this.userIds});
+
+  factory UserGroupRemoveMembersEvent.fromJson(Map<String, dynamic> json) => _$UserGroupRemoveMembersEventFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$UserGroupRemoveMembersEventToJson(this);
+}
+
+/// A [UserGroupEvent] with op `add_subgroups`: https://zulip.com/api/get-events#user_group-add_subgroups
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UserGroupAddSubgroupsEvent extends UserGroupEvent {
+  @override
+  @JsonKey(includeToJson: true)
+  String get op => 'add_subgroups';
+
+  final int groupId;
+  final List<int> directSubgroupIds;
+
+  UserGroupAddSubgroupsEvent({required super.id, required this.groupId, required this.directSubgroupIds});
+
+  factory UserGroupAddSubgroupsEvent.fromJson(Map<String, dynamic> json) => _$UserGroupAddSubgroupsEventFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$UserGroupAddSubgroupsEventToJson(this);
+}
+
+/// A [UserGroupEvent] with op `remove_subgroups`: https://zulip.com/api/get-events#user_group-remove_subgroups
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UserGroupRemoveSubgroupsEvent extends UserGroupEvent {
+  @override
+  @JsonKey(includeToJson: true)
+  String get op => 'remove_subgroups';
+
+  final int groupId;
+  final List<int> directSubgroupIds;
+
+  UserGroupRemoveSubgroupsEvent({required super.id, required this.groupId, required this.directSubgroupIds});
+
+  factory UserGroupRemoveSubgroupsEvent.fromJson(Map<String, dynamic> json) => _$UserGroupRemoveSubgroupsEventFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$UserGroupRemoveSubgroupsEventToJson(this);
 }
 
 /// A [UserGroupEvent] with op `remove`: https://zulip.com/api/get-events#user_group-remove

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -674,6 +674,9 @@ class ChannelUpdateEvent extends ChannelEvent {
         return value as int?;
       case ChannelPropertyName.channelPostPolicy:
         return ChannelPostPolicy.fromApiValue(value as int);
+      case ChannelPropertyName.canAddSubscribersGroup:
+      case ChannelPropertyName.canSubscribeGroup:
+        return GroupSettingValue.fromJson(value);
       case ChannelPropertyName.streamWeeklyTraffic:
         return value as int?;
       case null:

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -134,6 +134,86 @@ Map<String, dynamic> _$UserGroupUpdateDataToJson(
   'deactivated': instance.deactivated,
 };
 
+UserGroupAddMembersEvent _$UserGroupAddMembersEventFromJson(
+  Map<String, dynamic> json,
+) => UserGroupAddMembersEvent(
+  id: (json['id'] as num).toInt(),
+  groupId: (json['group_id'] as num).toInt(),
+  userIds: (json['user_ids'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$UserGroupAddMembersEventToJson(
+  UserGroupAddMembersEvent instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': instance.type,
+  'op': instance.op,
+  'group_id': instance.groupId,
+  'user_ids': instance.userIds,
+};
+
+UserGroupRemoveMembersEvent _$UserGroupRemoveMembersEventFromJson(
+  Map<String, dynamic> json,
+) => UserGroupRemoveMembersEvent(
+  id: (json['id'] as num).toInt(),
+  groupId: (json['group_id'] as num).toInt(),
+  userIds: (json['user_ids'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$UserGroupRemoveMembersEventToJson(
+  UserGroupRemoveMembersEvent instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': instance.type,
+  'op': instance.op,
+  'group_id': instance.groupId,
+  'user_ids': instance.userIds,
+};
+
+UserGroupAddSubgroupsEvent _$UserGroupAddSubgroupsEventFromJson(
+  Map<String, dynamic> json,
+) => UserGroupAddSubgroupsEvent(
+  id: (json['id'] as num).toInt(),
+  groupId: (json['group_id'] as num).toInt(),
+  directSubgroupIds: (json['direct_subgroup_ids'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$UserGroupAddSubgroupsEventToJson(
+  UserGroupAddSubgroupsEvent instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': instance.type,
+  'op': instance.op,
+  'group_id': instance.groupId,
+  'direct_subgroup_ids': instance.directSubgroupIds,
+};
+
+UserGroupRemoveSubgroupsEvent _$UserGroupRemoveSubgroupsEventFromJson(
+  Map<String, dynamic> json,
+) => UserGroupRemoveSubgroupsEvent(
+  id: (json['id'] as num).toInt(),
+  groupId: (json['group_id'] as num).toInt(),
+  directSubgroupIds: (json['direct_subgroup_ids'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$UserGroupRemoveSubgroupsEventToJson(
+  UserGroupRemoveSubgroupsEvent instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': instance.type,
+  'op': instance.op,
+  'group_id': instance.groupId,
+  'direct_subgroup_ids': instance.directSubgroupIds,
+};
+
 UserGroupRemoveEvent _$UserGroupRemoveEventFromJson(
   Map<String, dynamic> json,
 ) => UserGroupRemoveEvent(

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -461,6 +461,8 @@ const _$ChannelPropertyNameEnumMap = {
   ChannelPropertyName.inviteOnly: 'invite_only',
   ChannelPropertyName.messageRetentionDays: 'message_retention_days',
   ChannelPropertyName.channelPostPolicy: 'stream_post_policy',
+  ChannelPropertyName.canAddSubscribersGroup: 'can_add_subscribers_group',
+  ChannelPropertyName.canSubscribeGroup: 'can_subscribe_group',
   ChannelPropertyName.streamWeeklyTraffic: 'stream_weekly_traffic',
 };
 

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -109,6 +109,9 @@ class InitialSnapshot {
   @JsonKey(readValue: _readUsersIsActiveFallbackTrue)
   final List<User> crossRealmBots;
 
+  // TODO(server): Get this API stabilized, to replace [SupportedPermissionSettings.fixture].
+  // final SupportedPermissionSettings? serverSupportedPermissionSettings;
+
   // TODO etc., etc.
   // If adding fields, keep them all in the order they appear in the API docs.
 
@@ -388,4 +391,115 @@ class UnreadHuddleSnapshot {
     _$UnreadHuddleSnapshotFromJson(json);
 
   Map<String, dynamic> toJson() => _$UnreadHuddleSnapshotToJson(this);
+}
+
+/// Metadata about how to interpret the various group-based permission settings.
+///
+/// This is the type that [InitialSnapshot.serverSupportedPermissionSettings]
+/// would have, according to the API as it exists as of 2025-08;
+/// but that API is documented as unstable and subject to change.
+///
+/// For a useful value of this type, see [SupportedPermissionSettings.fixture].
+///
+/// For docs, search for "d_perm" in: https://zulip.com/api/register-queue
+@JsonSerializable(fieldRename: FieldRename.snake)
+class SupportedPermissionSettings {
+  final Map<String, PermissionSettingsItem> realm;
+  final Map<String, PermissionSettingsItem> stream;
+  final Map<String, PermissionSettingsItem> group;
+
+  /// Metadata about how to interpret certain group-based permission settings,
+  /// including all those that this client uses, based on "current" servers.
+  ///
+  /// "Current" here means as of when this code was written, or last updated;
+  /// details in comments below.  Naturally it'd be better to have an API to
+  /// get this information from the actual server.
+  ///
+  /// Effectively we're counting on it being uncommon for the metadata for a
+  /// given permission to ever change from one server version to the next,
+  /// so that the values we take from one server version usually remain valid
+  /// for all past and future server versions that have the corresponding
+  /// permission at all.
+  ///
+  /// TODO(server): Stabilize [InitialSnapshot.serverSupportedPermissionSettings]
+  ///   or a similar API, and switch to using that.  See thread:
+  ///     https://chat.zulip.org/#narrow/channel/378-api-design/topic/server_supported_permission_settings/near/2247549
+  static SupportedPermissionSettings fixture = SupportedPermissionSettings(
+    realm: {}, // Please go ahead and fill this in when we come to need it.
+    group: {}, // Please go ahead and fill this in when we come to need it.
+    stream: {
+      // From the server's Stream.stream_permission_group_settings,
+      // in zerver/models/streams.py.  Current as of f9dc13014, 2025-08.
+      "can_add_subscribers_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: false,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+      "can_administer_channel_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: false,
+          // default_group_name="stream_creator_or_nobody",
+      ),
+      "can_delete_any_message_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+      "can_delete_own_message_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+      "can_move_messages_out_of_channel_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+      "can_move_messages_within_channel_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+      "can_remove_subscribers_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.ADMINISTRATORS,
+      ),
+      "can_send_message_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.EVERYONE,
+      ),
+      "can_subscribe_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: false,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+      "can_resolve_topics_group": PermissionSettingsItem(
+          // allow_nobody_group=True,
+          allowEveryoneGroup: true,
+          // default_group_name=SystemGroups.NOBODY,
+      ),
+    },
+  );
+
+  SupportedPermissionSettings({required this.realm, required this.stream, required this.group});
+
+  factory SupportedPermissionSettings.fromJson(Map<String, dynamic> json) =>
+    _$SupportedPermissionSettingsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SupportedPermissionSettingsToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class PermissionSettingsItem {
+  final bool allowEveryoneGroup;
+  // also other fields not yet used
+
+  PermissionSettingsItem({required this.allowEveryoneGroup});
+
+  factory PermissionSettingsItem.fromJson(Map<String, dynamic> json) =>
+    _$PermissionSettingsItemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PermissionSettingsItemToJson(this);
 }

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -355,3 +355,38 @@ Map<String, dynamic> _$UnreadHuddleSnapshotToJson(
   'user_ids_string': instance.userIdsString,
   'unread_message_ids': instance.unreadMessageIds,
 };
+
+SupportedPermissionSettings _$SupportedPermissionSettingsFromJson(
+  Map<String, dynamic> json,
+) => SupportedPermissionSettings(
+  realm: (json['realm'] as Map<String, dynamic>).map(
+    (k, e) =>
+        MapEntry(k, PermissionSettingsItem.fromJson(e as Map<String, dynamic>)),
+  ),
+  stream: (json['stream'] as Map<String, dynamic>).map(
+    (k, e) =>
+        MapEntry(k, PermissionSettingsItem.fromJson(e as Map<String, dynamic>)),
+  ),
+  group: (json['group'] as Map<String, dynamic>).map(
+    (k, e) =>
+        MapEntry(k, PermissionSettingsItem.fromJson(e as Map<String, dynamic>)),
+  ),
+);
+
+Map<String, dynamic> _$SupportedPermissionSettingsToJson(
+  SupportedPermissionSettings instance,
+) => <String, dynamic>{
+  'realm': instance.realm,
+  'stream': instance.stream,
+  'group': instance.group,
+};
+
+PermissionSettingsItem _$PermissionSettingsItemFromJson(
+  Map<String, dynamic> json,
+) => PermissionSettingsItem(
+  allowEveryoneGroup: json['allow_everyone_group'] as bool,
+);
+
+Map<String, dynamic> _$PermissionSettingsItemToJson(
+  PermissionSettingsItem instance,
+) => <String, dynamic>{'allow_everyone_group': instance.allowEveryoneGroup};

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -358,8 +358,8 @@ class UserGroup {
   final int id;
 
   // TODO(#1687) to maintain members, also act on user deactivation: https://github.com/zulip/zulip-flutter/issues/662#issuecomment-2405845356
-  // List<int> members; // TODO(#1687) track group members
-  // List<int> directSubgroupIds; // TODO(#1687) track group members
+  final Set<int> members;
+  final Set<int> directSubgroupIds;
 
   String name;
   String description;
@@ -377,6 +377,8 @@ class UserGroup {
 
   UserGroup({
     required this.id,
+    required this.members,
+    required this.directSubgroupIds,
     required this.name,
     required this.description,
     required this.isSystemGroup,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -641,7 +641,8 @@ class ZulipStream {
   ChannelPostPolicy channelPostPolicy;
   // final bool isAnnouncementOnly; // deprecated for `channelPostPolicy`; ignore
 
-  // GroupSettingsValue canRemoveSubscribersGroup; // TODO(#814)
+  GroupSettingValue? canAddSubscribersGroup; // TODO(server-10)
+  GroupSettingValue? canSubscribeGroup; // TODO(server-10)
 
   // TODO(server-8): added in FL 199, was previously only on [Subscription] objects
   int? streamWeeklyTraffic;
@@ -658,6 +659,8 @@ class ZulipStream {
     required this.historyPublicToSubscribers,
     required this.messageRetentionDays,
     required this.channelPostPolicy,
+    required this.canAddSubscribersGroup,
+    required this.canSubscribeGroup,
     required this.streamWeeklyTraffic,
   });
 
@@ -675,6 +678,8 @@ class ZulipStream {
       historyPublicToSubscribers: subscription.historyPublicToSubscribers,
       messageRetentionDays: subscription.messageRetentionDays,
       channelPostPolicy: subscription.channelPostPolicy,
+      canAddSubscribersGroup: subscription.canAddSubscribersGroup,
+      canSubscribeGroup: subscription.canSubscribeGroup,
       streamWeeklyTraffic: subscription.streamWeeklyTraffic,
     );
   }
@@ -705,8 +710,8 @@ enum ChannelPropertyName {
   messageRetentionDays,
   @JsonValue('stream_post_policy')
   channelPostPolicy,
-  // canRemoveSubscribersGroup, // TODO(#814)
-  // canRemoveSubscribersGroupId, // TODO(#814) handle // TODO(server-8) remove
+  canAddSubscribersGroup,
+  canSubscribeGroup,
   streamWeeklyTraffic;
 
   /// Get a [ChannelPropertyName] from a raw, snake-case string we recognize, else null.
@@ -786,6 +791,8 @@ class Subscription extends ZulipStream {
     required super.historyPublicToSubscribers,
     required super.messageRetentionDays,
     required super.channelPostPolicy,
+    required super.canAddSubscribersGroup,
+    required super.canSubscribeGroup,
     required super.streamWeeklyTraffic,
     required this.desktopNotifications,
     required this.emailNotifications,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -357,7 +357,6 @@ enum Emojiset {
 class UserGroup {
   final int id;
 
-  // TODO(#1687) to maintain members, also act on user deactivation: https://github.com/zulip/zulip-flutter/issues/662#issuecomment-2405845356
   final Set<int> members;
   final Set<int> directSubgroupIds;
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -12,6 +12,50 @@ export 'reaction.dart';
 
 part 'model.g.dart';
 
+/// A Zulip "group-setting value": https://zulip.com/api/group-setting-values
+sealed class GroupSettingValue {
+  const GroupSettingValue();
+
+  factory GroupSettingValue.fromJson(Object? json) {
+    return switch (json) {
+      int() => GroupSettingValueNamed.fromJson(json),
+      Map<String, dynamic>() => GroupSettingValueNameless.fromJson(json),
+      _ => throw FormatException(),
+    };
+  }
+
+  Object? toJson();
+}
+
+class GroupSettingValueNamed extends GroupSettingValue {
+  final int groupId;
+
+  const GroupSettingValueNamed(this.groupId);
+
+  factory GroupSettingValueNamed.fromJson(int json) => GroupSettingValueNamed(json);
+
+  @override
+  int toJson() => groupId;
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class GroupSettingValueNameless extends GroupSettingValue {
+  // TODO(server): The API docs say these should be "direct_member_ids" and
+  //   "direct_subgroup_ids", but empirically they're "direct_members"
+  //   and "direct_subgroups".  Discussion:
+  //     https://chat.zulip.org/#narrow/channel/378-api-design/topic/groups.20redesign/near/2247218
+  final List<int> directMembers;
+  final List<int> directSubgroups;
+
+  GroupSettingValueNameless({required this.directMembers, required this.directSubgroups});
+
+  factory GroupSettingValueNameless.fromJson(Map<String, dynamic> json) =>
+    _$GroupSettingValueNamelessFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$GroupSettingValueNamelessToJson(this);
+}
+
 /// As in [InitialSnapshot.customProfileFields].
 ///
 /// For docs, search for "custom_profile_fields:"

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -250,6 +250,12 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
     _$ChannelPostPolicyEnumMap,
     json['stream_post_policy'],
   ),
+  canAddSubscribersGroup: json['can_add_subscribers_group'] == null
+      ? null
+      : GroupSettingValue.fromJson(json['can_add_subscribers_group']),
+  canSubscribeGroup: json['can_subscribe_group'] == null
+      ? null
+      : GroupSettingValue.fromJson(json['can_subscribe_group']),
   streamWeeklyTraffic: (json['stream_weekly_traffic'] as num?)?.toInt(),
 );
 
@@ -266,6 +272,8 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.channelPostPolicy,
+      'can_add_subscribers_group': instance.canAddSubscribersGroup,
+      'can_subscribe_group': instance.canSubscribeGroup,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
     };
 
@@ -292,6 +300,12 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
     _$ChannelPostPolicyEnumMap,
     json['stream_post_policy'],
   ),
+  canAddSubscribersGroup: json['can_add_subscribers_group'] == null
+      ? null
+      : GroupSettingValue.fromJson(json['can_add_subscribers_group']),
+  canSubscribeGroup: json['can_subscribe_group'] == null
+      ? null
+      : GroupSettingValue.fromJson(json['can_subscribe_group']),
   streamWeeklyTraffic: (json['stream_weekly_traffic'] as num?)?.toInt(),
   desktopNotifications: json['desktop_notifications'] as bool?,
   emailNotifications: json['email_notifications'] as bool?,
@@ -316,6 +330,8 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
       'stream_post_policy': instance.channelPostPolicy,
+      'can_add_subscribers_group': instance.canAddSubscribersGroup,
+      'can_subscribe_group': instance.canSubscribeGroup,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
       'desktop_notifications': instance.desktopNotifications,
       'email_notifications': instance.emailNotifications,
@@ -475,6 +491,8 @@ const _$ChannelPropertyNameEnumMap = {
   ChannelPropertyName.inviteOnly: 'invite_only',
   ChannelPropertyName.messageRetentionDays: 'message_retention_days',
   ChannelPropertyName.channelPostPolicy: 'stream_post_policy',
+  ChannelPropertyName.canAddSubscribersGroup: 'can_add_subscribers_group',
+  ChannelPropertyName.canSubscribeGroup: 'can_subscribe_group',
   ChannelPropertyName.streamWeeklyTraffic: 'stream_weekly_traffic',
 };
 

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -8,6 +8,24 @@ part of 'model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+GroupSettingValueNameless _$GroupSettingValueNamelessFromJson(
+  Map<String, dynamic> json,
+) => GroupSettingValueNameless(
+  directMembers: (json['direct_members'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+  directSubgroups: (json['direct_subgroups'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$GroupSettingValueNamelessToJson(
+  GroupSettingValueNameless instance,
+) => <String, dynamic>{
+  'direct_members': instance.directMembers,
+  'direct_subgroups': instance.directSubgroups,
+};
+
 CustomProfileField _$CustomProfileFieldFromJson(Map<String, dynamic> json) =>
     CustomProfileField(
       id: (json['id'] as num).toInt(),

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -96,6 +96,12 @@ Map<String, dynamic> _$RealmEmojiItemToJson(RealmEmojiItem instance) =>
 
 UserGroup _$UserGroupFromJson(Map<String, dynamic> json) => UserGroup(
   id: (json['id'] as num).toInt(),
+  members: (json['members'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toSet(),
+  directSubgroupIds: (json['direct_subgroup_ids'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toSet(),
   name: json['name'] as String,
   description: json['description'] as String,
   isSystemGroup: json['is_system_group'] as bool,
@@ -104,6 +110,8 @@ UserGroup _$UserGroupFromJson(Map<String, dynamic> json) => UserGroup(
 
 Map<String, dynamic> _$UserGroupToJson(UserGroup instance) => <String, dynamic>{
   'id': instance.id,
+  'members': instance.members.toList(),
+  'direct_subgroup_ids': instance.directSubgroupIds.toList(),
   'name': instance.name,
   'description': instance.description,
   'is_system_group': instance.isSystemGroup,

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -337,6 +337,10 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
             stream.messageRetentionDays = event.value as int?;
           case ChannelPropertyName.channelPostPolicy:
             stream.channelPostPolicy = event.value as ChannelPostPolicy;
+          case ChannelPropertyName.canAddSubscribersGroup:
+            stream.canAddSubscribersGroup = event.value as GroupSettingValue;
+          case ChannelPropertyName.canSubscribeGroup:
+            stream.canSubscribeGroup = event.value as GroupSettingValue;
           case ChannelPropertyName.streamWeeklyTraffic:
             stream.streamWeeklyTraffic = event.value as int?;
         }

--- a/lib/model/realm.dart
+++ b/lib/model/realm.dart
@@ -4,6 +4,7 @@ import '../api/model/events.dart';
 import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
 import 'store.dart';
+import 'user_group.dart';
 
 /// The portion of [PerAccountStore] for realm settings, server settings,
 /// and similar data about the whole realm or server.
@@ -11,7 +12,10 @@ import 'store.dart';
 /// See also:
 ///  * [RealmStoreImpl] for the implementation of this that does the work.
 ///  * [HasRealmStore] for an implementation useful for other substores.
-mixin RealmStore on PerAccountStoreBase {
+mixin RealmStore on PerAccountStoreBase, UserGroupStore {
+  @protected
+  UserGroupStore get userGroupStore;
+
   //|//////////////////////////////////////////////////////////////
   // Server settings, explicitly so named.
 
@@ -159,9 +163,9 @@ mixin ProxyRealmStore on RealmStore {
 
 /// A base class for [PerAccountStore] substores that need access to [RealmStore]
 /// as well as to [CorePerAccountStore].
-abstract class HasRealmStore extends PerAccountStoreBase with RealmStore, ProxyRealmStore {
+abstract class HasRealmStore extends HasUserGroupStore with RealmStore, ProxyRealmStore {
   HasRealmStore({required RealmStore realm})
-    : realmStore = realm, super(core: realm.core);
+    : realmStore = realm, super(groups: realm.userGroupStore);
 
   @protected
   @override
@@ -169,9 +173,9 @@ abstract class HasRealmStore extends PerAccountStoreBase with RealmStore, ProxyR
 }
 
 /// The implementation of [RealmStore] that does the work.
-class RealmStoreImpl extends PerAccountStoreBase with RealmStore {
+class RealmStoreImpl extends HasUserGroupStore with RealmStore {
   RealmStoreImpl({
-    required super.core,
+    required super.groups,
     required InitialSnapshot initialSnapshot,
   }) :
     serverPresencePingIntervalSeconds = initialSnapshot.serverPresencePingIntervalSeconds,

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -496,15 +496,16 @@ class PerAccountStore extends PerAccountStoreBase with
       throw Exception("bad initial snapshot: self-user missing from user list");
     }
 
-    final realm = RealmStoreImpl(core: core, initialSnapshot: initialSnapshot);
+    final groups = UserGroupStoreImpl(core: core,
+      groups: initialSnapshot.realmUserGroups);
+    final realm = RealmStoreImpl(groups: groups, initialSnapshot: initialSnapshot);
     final users = UserStoreImpl(realm: realm, initialSnapshot: initialSnapshot,
       userMap: userMap);
     final channels = ChannelStoreImpl(users: users,
       initialSnapshot: initialSnapshot);
     return PerAccountStore._(
       core: core,
-      groups: UserGroupStoreImpl(core: core,
-        groups: initialSnapshot.realmUserGroups),
+      groups: groups,
       realm: realm,
       emoji: EmojiStoreImpl(core: core,
         allRealmEmoji: initialSnapshot.realmEmoji),

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -498,7 +498,8 @@ class PerAccountStore extends PerAccountStoreBase with
 
     final groups = UserGroupStoreImpl(core: core,
       groups: initialSnapshot.realmUserGroups);
-    final realm = RealmStoreImpl(groups: groups, initialSnapshot: initialSnapshot);
+    final realm = RealmStoreImpl(groups: groups, initialSnapshot: initialSnapshot,
+      selfUser: selfUser);
     final users = UserStoreImpl(realm: realm, initialSnapshot: initialSnapshot,
       userMap: userMap);
     final channels = ChannelStoreImpl(users: users,
@@ -759,6 +760,7 @@ class PerAccountStore extends PerAccountStoreBase with
       case RealmUserUpdateEvent():
         assert(debugLog("server event: realm_user/update"));
         _groups.handleRealmUserUpdateEvent(event);
+        _realm.handleRealmUserUpdateEvent(event);
         _users.handleRealmUserEvent(event);
         autocompleteViewManager.handleRealmUserUpdateEvent(event);
         notifyListeners();

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -757,6 +757,7 @@ class PerAccountStore extends PerAccountStoreBase with
 
       case RealmUserUpdateEvent():
         assert(debugLog("server event: realm_user/update"));
+        _groups.handleRealmUserUpdateEvent(event);
         _users.handleRealmUserEvent(event);
         autocompleteViewManager.handleRealmUserUpdateEvent(event);
         notifyListeners();

--- a/lib/model/user_group.dart
+++ b/lib/model/user_group.dart
@@ -74,6 +74,12 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
         if (data.name != null)        group.name        = data.name!;
         if (data.description != null) group.description = data.description!;
         if (data.deactivated != null) group.deactivated = data.deactivated!;
+
+      case UserGroupAddMembersEvent():
+      case UserGroupRemoveMembersEvent():
+      case UserGroupAddSubgroupsEvent():
+      case UserGroupRemoveSubgroupsEvent():
+        break; // TODO(#1687): update group memberships on event
     }
   }
 }

--- a/lib/model/user_group.dart
+++ b/lib/model/user_group.dart
@@ -39,6 +39,15 @@ mixin ProxyUserGroupStore on UserGroupStore {
     => userGroupStore.selfInGroupSetting(value);
 }
 
+abstract class HasUserGroupStore extends PerAccountStoreBase with UserGroupStore, ProxyUserGroupStore {
+  HasUserGroupStore({required UserGroupStore groups})
+    : userGroupStore = groups, super(core: groups.core);
+
+  @protected
+  @override
+  final UserGroupStore userGroupStore;
+}
+
 /// The implementation of [UserGroupStore] that does the work.
 class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
   UserGroupStoreImpl({required super.core, required List<UserGroup> groups})

--- a/lib/model/user_group.dart
+++ b/lib/model/user_group.dart
@@ -63,7 +63,7 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
   }
 
   @override
-  bool selfInGroupSetting(GroupSettingValue value) { // TODO(#1687) test
+  bool selfInGroupSetting(GroupSettingValue value) {
     return switch (value) {
       GroupSettingValueNamed() =>
         _selfInGroup(value.groupId),
@@ -106,7 +106,6 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
         if (data.description != null) group.description = data.description!;
         if (data.deactivated != null) group.deactivated = data.deactivated!;
 
-      // TODO(#1687): test handling the four membership-related events
       case UserGroupAddMembersEvent():
         final group = _expectGroup(event.groupId);
         if (group == null) return;
@@ -131,7 +130,6 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
 
   void handleRealmUserUpdateEvent(RealmUserUpdateEvent event) {
     if (event.isActive == false) {
-      // TODO(#1687): test handling user deactivation
       for (final group in _groups.values) {
         group.members.remove(event.userId);
       }

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -445,10 +445,11 @@ void showChannelActionSheet(BuildContext context, {
     && messageListPageNarrow.streamId == channelId;
 
   final unreadCount = store.unreads.countInChannelNarrow(channelId);
-  final isSubscribed = store.subscriptions[channelId] != null;
+  final channel = store.streams[channelId];
+  final isSubscribed = channel is Subscription;
   final buttonSections = [
-    if (!isSubscribed)
-      // TODO(#1786) check group-based can-subscribe permission
+    if (!isSubscribed
+        && channel != null && store.selfHasContentAccess(channel))
       [SubscribeButton(pageContext: pageContext, channelId: channelId)],
     [
       if (unreadCount > 0)

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -443,6 +443,8 @@ ZulipStream stream({
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
   ChannelPostPolicy? channelPostPolicy,
+  GroupSettingValue? canAddSubscribersGroup,
+  GroupSettingValue? canSubscribeGroup,
   int? streamWeeklyTraffic,
 }) {
   _checkPositive(streamId, 'stream ID');
@@ -462,6 +464,8 @@ ZulipStream stream({
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
     channelPostPolicy: channelPostPolicy ?? ChannelPostPolicy.any,
+    canAddSubscribersGroup: canAddSubscribersGroup ?? GroupSettingValueNamed(nobodyGroup.id),
+    canSubscribeGroup: canSubscribeGroup ?? GroupSettingValueNamed(nobodyGroup.id),
     streamWeeklyTraffic: streamWeeklyTraffic,
   );
 }
@@ -500,6 +504,8 @@ Subscription subscription(
     historyPublicToSubscribers: stream.historyPublicToSubscribers,
     messageRetentionDays: stream.messageRetentionDays,
     channelPostPolicy: stream.channelPostPolicy,
+    canAddSubscribersGroup: stream.canAddSubscribersGroup,
+    canSubscribeGroup: stream.canSubscribeGroup,
     streamWeeklyTraffic: stream.streamWeeklyTraffic,
     desktopNotifications: desktopNotifications ?? false,
     emailNotifications: emailNotifications ?? false,
@@ -1171,6 +1177,9 @@ ChannelUpdateEvent channelUpdateEvent(
       assert(value is int?);
     case ChannelPropertyName.channelPostPolicy:
       assert(value is ChannelPostPolicy);
+    case ChannelPropertyName.canAddSubscribersGroup:
+    case ChannelPropertyName.canSubscribeGroup:
+      assert(value is GroupSettingValue);
     case ChannelPropertyName.streamWeeklyTraffic:
       assert(value is int?);
   }

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -198,6 +198,8 @@ int _lastUserGroupId = 100;
 
 UserGroup userGroup({
   int? id,
+  Iterable<int>? members,
+  Iterable<int>? directSubgroupIds,
   String? name,
   String? description,
   bool isSystemGroup = false,
@@ -205,6 +207,8 @@ UserGroup userGroup({
 }) {
   return UserGroup(
     id: id ??= _nextUserGroupId(),
+    members: Set.of(members ?? []),
+    directSubgroupIds: Set.of(directSubgroupIds ?? []),
     name: name ??= 'group-$id',
     description: description ?? 'A group named $name',
     isSystemGroup: isSystemGroup,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -216,6 +216,12 @@ UserGroup userGroup({
   );
 }
 
+final UserGroup nobodyGroup = userGroup(
+  isSystemGroup: true,
+  name: 'role:nobody', description: 'Nobody',
+  members: [], directSubgroupIds: [],
+);
+
 RealmEmojiItem realmEmojiItem({
   required String emojiCode,
   required String emojiName,

--- a/test/model/realm_test.dart
+++ b/test/model/realm_test.dart
@@ -6,6 +6,34 @@ import 'package:zulip/api/model/model.dart';
 import '../example_data.dart' as eg;
 
 void main() {
+  test('processTopicLikeServer', () {
+    final emptyTopicDisplayName = eg.defaultRealmEmptyTopicDisplayName;
+
+    TopicName process(TopicName topic, int zulipFeatureLevel) {
+      final account = eg.selfAccount.copyWith(zulipFeatureLevel: zulipFeatureLevel);
+      final store = eg.store(account: account, initialSnapshot: eg.initialSnapshot(
+        zulipFeatureLevel: zulipFeatureLevel,
+        realmEmptyTopicDisplayName: emptyTopicDisplayName));
+      return store.processTopicLikeServer(topic);
+    }
+
+    void doCheck(TopicName topic, TopicName expected, int zulipFeatureLevel) {
+      check(process(topic, zulipFeatureLevel)).equals(expected);
+    }
+
+    check(() => process(eg.t(''), 333)).throws<void>();
+    doCheck(eg.t('(no topic)'),          eg.t('(no topic)'),          333);
+    doCheck(eg.t(emptyTopicDisplayName), eg.t(emptyTopicDisplayName), 333);
+    doCheck(eg.t('other topic'),         eg.t('other topic'),         333);
+
+    doCheck(eg.t(''),                    eg.t(''),                    334);
+    doCheck(eg.t('(no topic)'),          eg.t('(no topic)'),          334);
+    doCheck(eg.t(emptyTopicDisplayName), eg.t(''),                    334);
+    doCheck(eg.t('other topic'),         eg.t('other topic'),         334);
+
+    doCheck(eg.t('(no topic)'),          eg.t(''),                    370);
+  });
+
   group('customProfileFields', () {
     test('update clobbers old list', () async {
       final store = eg.store(initialSnapshot: eg.initialSnapshot(
@@ -46,33 +74,5 @@ void main() {
       ]));
       check(store.customProfileFields.map((f) => f.id)).deepEquals([2, 0, 1]);
     });
-  });
-
-  test('processTopicLikeServer', () {
-    final emptyTopicDisplayName = eg.defaultRealmEmptyTopicDisplayName;
-
-    TopicName process(TopicName topic, int zulipFeatureLevel) {
-      final account = eg.selfAccount.copyWith(zulipFeatureLevel: zulipFeatureLevel);
-      final store = eg.store(account: account, initialSnapshot: eg.initialSnapshot(
-        zulipFeatureLevel: zulipFeatureLevel,
-        realmEmptyTopicDisplayName: emptyTopicDisplayName));
-      return store.processTopicLikeServer(topic);
-    }
-
-    void doCheck(TopicName topic, TopicName expected, int zulipFeatureLevel) {
-      check(process(topic, zulipFeatureLevel)).equals(expected);
-    }
-
-    check(() => process(eg.t(''), 333)).throws<void>();
-    doCheck(eg.t('(no topic)'),          eg.t('(no topic)'),          333);
-    doCheck(eg.t(emptyTopicDisplayName), eg.t(emptyTopicDisplayName), 333);
-    doCheck(eg.t('other topic'),         eg.t('other topic'),         333);
-
-    doCheck(eg.t(''),                    eg.t(''),                    334);
-    doCheck(eg.t('(no topic)'),          eg.t('(no topic)'),          334);
-    doCheck(eg.t(emptyTopicDisplayName), eg.t(''),                    334);
-    doCheck(eg.t('other topic'),         eg.t('other topic'),         334);
-
-    doCheck(eg.t('(no topic)'),          eg.t(''),                    370);
   });
 }

--- a/test/model/user_group_test.dart
+++ b/test/model/user_group_test.dart
@@ -2,6 +2,7 @@ import 'package:checks/checks.dart';
 import 'package:test_api/scaffolding.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
+import 'package:zulip/model/store.dart';
 import 'package:zulip/model/user_group.dart';
 
 import '../api/model/model_checks.dart';
@@ -90,6 +91,93 @@ void main() {
       'description': 'different description',
       'deactivated': false,
     }]);
+  });
+
+  group('membership', () {
+    // These tests exercise membership via selfInGroupSetting, because that's
+    // the main interface the app uses to consume group membership.
+
+    late PerAccountStore store;
+
+    void prepare(List<UserGroup> groups, {List<User>? users}) {
+      store = eg.store(initialSnapshot: eg.initialSnapshot(
+        realmUsers: users, realmUserGroups: groups));
+    }
+
+    bool isMember(UserGroup group) {
+      return store.selfInGroupSetting(GroupSettingValueNamed(group.id));
+    }
+
+    test('initial', () {
+      final groups = <UserGroup>[];
+      groups.add(eg.userGroup(members: [eg.selfUser.userId]));
+      groups.add(eg.userGroup(members: [eg.user().userId]));
+      groups.add(eg.userGroup(directSubgroupIds: [groups[0].id]));
+      groups.add(eg.userGroup(directSubgroupIds: [groups[2].id]));
+      groups.add(eg.userGroup(directSubgroupIds: [groups[1].id]));
+
+      prepare(groups);
+      check(groups.map(isMember)).deepEquals([
+        true,
+        false,
+        true,
+        true,
+        false,
+      ]);
+    });
+
+    test('UserGroupEvent', () async {
+      final groups = List.generate(4, (_) => eg.userGroup());
+      prepare(groups);
+      check(groups.map(isMember)).deepEquals([false, false, false, false]);
+
+      // Add a membership.
+      await store.handleEvent(UserGroupAddMembersEvent(id: 0,
+        groupId: groups[0].id, userIds: [eg.selfUser.userId]));
+      check(groups.map(isMember)).deepEquals([true, false, false, false]);
+
+      // Add a chain of transitive memberships.
+      await store.handleEvent(UserGroupAddSubgroupsEvent(id: 0,
+        groupId: groups[1].id, directSubgroupIds: [groups[0].id]));
+      check(groups.map(isMember)).deepEquals([true, true, false, false]);
+      await store.handleEvent(UserGroupAddSubgroupsEvent(id: 0,
+        groupId: groups[2].id, directSubgroupIds: [groups[1].id]));
+      check(groups.map(isMember)).deepEquals([true, true, true, false]);
+
+      // Cut the middle link of the chain.
+      await store.handleEvent(UserGroupRemoveSubgroupsEvent(id: 0,
+        groupId: groups[1].id, directSubgroupIds: [groups[0].id]));
+      check(groups.map(isMember)).deepEquals([true, false, false, false]);
+
+      // Restore the middle link; cut the bottom link.
+      await store.handleEvent(UserGroupAddSubgroupsEvent(id: 0,
+        groupId: groups[1].id, directSubgroupIds: [groups[0].id]));
+      check(groups.map(isMember)).deepEquals([true, true, true, false]);
+      await store.handleEvent(UserGroupRemoveMembersEvent(id: 0,
+        groupId: groups[0].id, userIds: [eg.selfUser.userId]));
+      check(groups.map(isMember)).deepEquals([false, false, false, false]);
+    });
+
+    test('RealmUserUpdateEvent', () async {
+      // This test uses the membership data structure directly, because
+      // selfInGroupSetting would only be affected if the self-user were
+      // deactivated, and in that case we wouldn't be getting an event.
+
+      final user = eg.user();
+      final group = eg.userGroup(members: [user.userId]);
+      prepare(users: [eg.selfUser, user], [group]);
+      check(store.getGroup(group.id)!.members).deepEquals([user.userId]);
+
+      // An update to a random irrelevant field has no effect.
+      await store.handleEvent(RealmUserUpdateEvent(id: 0,
+        userId: user.userId, fullName: 'New Name'));
+      check(store.getGroup(group.id)!.members).deepEquals([user.userId]);
+
+      // But deactivating the user removes them from groups.
+      await store.handleEvent(RealmUserUpdateEvent(id: 0,
+        userId: user.userId, isActive: false));
+      check(store.getGroup(group.id)!.members).isEmpty();
+    });
   });
 
   test('various fields make it through', () async {


### PR DESCRIPTION
Fixes #1687.
Fixes #814.

Stacked atop #1814.

This adds all the generic infrastructure needed for implementing any given group-based permission. The last commit (or pair of commits) then adds the permission "has content access (to a channel)" (which we'll want for #188), to demonstrate end-to-end how to add individual permissions using the new infrastructure.

