### PR TITLE
test: Use pumpAndSettle to await overscroll animation

### DIFF
--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -613,7 +613,7 @@ void main() {
 
         // Scroll to the very bottom of the list with a large offset.
         await tester.drag(scrollViewFinder, Offset(0, -500));
-        await tester.pump();
+        await tester.pumpAndSettle();  // let overscroll finish
         // The top edge of the list entries is out of view;
         // the bottom is padded by 8px, the minimum padding, from the bottom
         // edge of the scroll view.
@@ -637,7 +637,7 @@ void main() {
 
         // Scroll to the very bottom of the list with a large offset.
         await tester.drag(scrollViewFinder, Offset(0, -500));
-        await tester.pump();
+        await tester.pumpAndSettle();  // let overscroll finish
         // The top edge of the list entries is out of view;
         // the bottom edge is padded by 10px from the bottom edge of the scroll
         // view, because the view bottom padding is larger than the minimum 8px.


### PR DESCRIPTION
 I'm currently working on a PR to port the new Android 12 overscroll effect. During this process, I encountered a test that was failing when it should have passed.

The root cause of the failure is that the test asserts a widget's absolute position immediately after a scroll gesture, without waiting for the overscroll physics animation to complete. A single pump() is insufficient for the animation to settle.
The solution is to replace the `pump()` call with `pumpAndSettle()`. This ensures that all animations are finished before the test makes its assertions, making the test reliable.

For more technical context on this new overscroll animation, please refer to the PR at:
https://github.com/flutter/flutter/pull/173849