### PR TITLE
push_device: Move registering push token off of UpdateMachine; fix ad-hoc Future used for tests

### DIFF
--- a/lib/model/push_device.dart
+++ b/lib/model/push_device.dart
@@ -5,7 +5,12 @@ import 'store.dart';
 /// and tracking the server's responses on the status of push devices.
 // TODO(#1764) do that tracking of responses
 class PushDeviceManager extends PerAccountStoreBase {
-  PushDeviceManager({required super.core});
+  PushDeviceManager({required super.core}) {
+    if (!debugAutoRegisterToken) {
+      return;
+    }
+    registerToken();
+  }
 
   bool _disposed = false;
 
@@ -27,9 +32,6 @@ class PushDeviceManager extends PerAccountStoreBase {
   // TODO(#322) save acked token, to dedupe updating it on the server
   // TODO(#323) track the addFcmToken/etc request, warn if not succeeding
   Future<void> registerToken() async {
-    if (!debugEnableRegisterToken) {
-      return;
-    }
     NotificationService.instance.token.addListener(_registerToken);
     await _registerToken();
   }
@@ -40,22 +42,22 @@ class PushDeviceManager extends PerAccountStoreBase {
     await NotificationService.instance.registerToken(connection);
   }
 
-  /// In debug mode, controls whether [registerToken] should
-  /// have its normal effect.
+  /// In debug mode, controls whether [registerToken] should be called
+  /// immediately in the constructor.
   ///
   /// Outside of debug mode, this is always true and the setter has no effect.
-  static bool get debugEnableRegisterToken {
+  static bool get debugAutoRegisterToken {
     bool result = true;
     assert(() {
-      result = _debugEnableRegisterToken;
+      result = _debugAutoRegisterToken;
       return true;
     }());
     return result;
   }
-  static bool _debugEnableRegisterToken = true;
-  static set debugEnableRegisterToken(bool value) {
+  static bool _debugAutoRegisterToken = true;
+  static set debugAutoRegisterToken(bool value) {
     assert(() {
-      _debugEnableRegisterToken = value;
+      _debugAutoRegisterToken = value;
       return true;
     }());
   }

--- a/lib/model/push_device.dart
+++ b/lib/model/push_device.dart
@@ -1,0 +1,62 @@
+import '../notifications/receive.dart';
+import 'store.dart';
+
+/// Manages telling the server this device's push token,
+/// and tracking the server's responses on the status of push devices.
+// TODO(#1764) do that tracking of responses
+class PushDeviceManager extends PerAccountStoreBase {
+  PushDeviceManager({required super.core});
+
+  bool _disposed = false;
+
+  /// Cleans up resources and tells the instance not to make new API requests.
+  ///
+  /// After this is called, the instance is not in a usable state
+  /// and should be abandoned.
+  void dispose() {
+    assert(!_disposed);
+    NotificationService.instance.token.removeListener(_registerToken);
+    _disposed = true;
+  }
+
+  /// Send this client's notification token to the server, now and if it changes.
+  ///
+  /// TODO The returned future isn't especially meaningful (it may or may not
+  ///   mean we actually sent the token).  Make it just `void` once we fix the
+  ///   one test that relies on the future.
+  // TODO(#322) save acked token, to dedupe updating it on the server
+  // TODO(#323) track the addFcmToken/etc request, warn if not succeeding
+  Future<void> registerToken() async {
+    if (!debugEnableRegisterToken) {
+      return;
+    }
+    NotificationService.instance.token.addListener(_registerToken);
+    await _registerToken();
+  }
+
+  Future<void> _registerToken() async {
+    // TODO it would be nice to register the token before even registerQueue:
+    //   https://github.com/zulip/zulip-flutter/pull/325#discussion_r1365982807
+    await NotificationService.instance.registerToken(connection);
+  }
+
+  /// In debug mode, controls whether [registerToken] should
+  /// have its normal effect.
+  ///
+  /// Outside of debug mode, this is always true and the setter has no effect.
+  static bool get debugEnableRegisterToken {
+    bool result = true;
+    assert(() {
+      result = _debugEnableRegisterToken;
+      return true;
+    }());
+    return result;
+  }
+  static bool _debugEnableRegisterToken = true;
+  static set debugEnableRegisterToken(bool value) {
+    assert(() {
+      _debugEnableRegisterToken = value;
+      return true;
+    }());
+  }
+}

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1123,7 +1123,6 @@ class UpdateMachine {
       //   serverEmojiDataUrl are already unsupported at time of writing.)
       unawaited(updateMachine.fetchEmojiData(initialSnapshot.serverEmojiDataUrl!));
     }
-    unawaited(store.pushDevices.registerToken());
     store.presence.start();
     return updateMachine;
   }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1522,9 +1522,7 @@ class UpdateMachine {
   }
 
   Future<void> _registerNotificationToken() async {
-    final token = NotificationService.instance.token.value;
-    if (token == null) return;
-    await NotificationService.registerToken(store.connection, token: token);
+    await NotificationService.instance.registerToken(store.connection);
   }
 
   /// Cleans up resources and tells the instance not to make new API requests.

--- a/lib/notifications/receive.dart
+++ b/lib/notifications/receive.dart
@@ -147,7 +147,10 @@ class NotificationService {
     token.value = value;
   }
 
-  static Future<void> registerToken(ApiConnection connection, {required String token}) async {
+  Future<void> registerToken(ApiConnection connection) async {
+    final token = this.token.value;
+    if (token == null) return;
+
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         await addFcmToken(connection, token: token);

--- a/test/model/actions_test.dart
+++ b/test/model/actions_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 import 'package:zulip/model/actions.dart';
+import 'package:zulip/model/push_device.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/notifications/receive.dart';
 
@@ -147,6 +148,8 @@ void main() {
     }));
 
     test('notifications are removed after logout', () => awaitFakeAsync((async) async {
+      PushDeviceManager.debugAutoRegisterToken = false;
+      addTearDown(() => PushDeviceManager.debugAutoRegisterToken = true);
       await prepare();
       testBinding.firebaseMessagingInitialToken = '123';
       addTearDown(NotificationService.debugReset);

--- a/test/model/actions_test.dart
+++ b/test/model/actions_test.dart
@@ -180,6 +180,7 @@ void main() {
 
     test('fallback to current token if acked is missing', () => awaitFakeAsync((async) async {
       await prepare(ackedPushToken: null);
+      addTearDown(NotificationService.debugReset);
       NotificationService.instance.token = ValueNotifier('asdf');
 
       final newConnection = separateConnection()
@@ -193,6 +194,7 @@ void main() {
 
     test('no error if acked token and current token both missing', () => awaitFakeAsync((async) async {
       await prepare(ackedPushToken: null);
+      addTearDown(NotificationService.debugReset);
       NotificationService.instance.token = ValueNotifier(null);
 
       final newConnection = separateConnection();

--- a/test/model/actions_test.dart
+++ b/test/model/actions_test.dart
@@ -148,8 +148,8 @@ void main() {
     }));
 
     test('notifications are removed after logout', () => awaitFakeAsync((async) async {
-      PushDeviceManager.debugAutoRegisterToken = false;
-      addTearDown(() => PushDeviceManager.debugAutoRegisterToken = true);
+      PushDeviceManager.debugAutoPause = true;
+      addTearDown(() => PushDeviceManager.debugAutoPause = false);
       await prepare();
       testBinding.firebaseMessagingInitialToken = '123';
       addTearDown(NotificationService.debugReset);

--- a/test/model/push_device_test.dart
+++ b/test/model/push_device_test.dart
@@ -16,10 +16,14 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   group('registerToken', () {
+    // TODO test registerToken gets called on constructing an instance
+
     late PushDeviceManager model;
     late FakeApiConnection connection;
 
     void prepareStore() {
+      PushDeviceManager.debugAutoRegisterToken = false;
+      addTearDown(() => PushDeviceManager.debugAutoRegisterToken = true);
       final store = eg.store();
       model = store.pushDevices;
       connection = store.connection as FakeApiConnection;

--- a/test/model/push_device_test.dart
+++ b/test/model/push_device_test.dart
@@ -1,0 +1,128 @@
+import 'package:checks/checks.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/scaffolding.dart';
+import 'package:zulip/model/push_device.dart';
+import 'package:zulip/notifications/receive.dart';
+
+import '../api/fake_api.dart';
+import '../example_data.dart' as eg;
+import '../fake_async.dart';
+import 'binding.dart';
+import 'store_test.dart';
+import '../stdlib_checks.dart';
+
+void main() {
+  TestZulipBinding.ensureInitialized();
+
+  group('registerToken', () {
+    late PushDeviceManager model;
+    late FakeApiConnection connection;
+
+    void prepareStore() {
+      final store = eg.store();
+      model = store.pushDevices;
+      connection = store.connection as FakeApiConnection;
+    }
+
+    void checkLastRequestApns({required String token, required String appid}) {
+      check(connection.takeRequests()).single.isA<http.Request>()
+        ..method.equals('POST')
+        ..url.path.equals('/api/v1/users/me/apns_device_token')
+        ..bodyFields.deepEquals({'token': token, 'appid': appid});
+    }
+
+    void checkLastRequestFcm({required String token}) {
+      check(connection.takeRequests()).single.isA<http.Request>()
+        ..method.equals('POST')
+        ..url.path.equals('/api/v1/users/me/android_gcm_reg_id')
+        ..bodyFields.deepEquals({'token': token});
+    }
+
+    testAndroidIos('token already known', () => awaitFakeAsync((async) async {
+      // This tests the case where [NotificationService.start] has already
+      // learned the token before the store is created.
+      // (This is probably the common case.)
+      addTearDown(testBinding.reset);
+      testBinding.firebaseMessagingInitialToken = '012abc';
+      testBinding.packageInfoResult = eg.packageInfo(packageName: 'com.zulip.flutter');
+      addTearDown(NotificationService.debugReset);
+      await NotificationService.instance.start();
+
+      // On store startup, send the token.
+      prepareStore();
+      connection.prepare(json: {});
+      await model.registerToken();
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        checkLastRequestFcm(token: '012abc');
+      } else {
+        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
+      }
+
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        // If the token changes, send it again.
+        testBinding.firebaseMessaging.setToken('456def');
+        connection.prepare(json: {});
+        async.flushMicrotasks();
+        checkLastRequestFcm(token: '456def');
+      }
+    }));
+
+    testAndroidIos('token initially unknown', () => awaitFakeAsync((async) async {
+      // This tests the case where the store is created while our
+      // request for the token is still pending.
+      addTearDown(testBinding.reset);
+      testBinding.firebaseMessagingInitialToken = '012abc';
+      testBinding.packageInfoResult = eg.packageInfo(packageName: 'com.zulip.flutter');
+      addTearDown(NotificationService.debugReset);
+      final startFuture = NotificationService.instance.start();
+
+      // TODO this test is a bit brittle in its interaction with asynchrony;
+      //   to fix, probably extend TestZulipBinding to control when getToken finishes.
+      //
+      // The aim here is to first wait for `model.registerToken`
+      // to complete whatever it's going to do; then check no request was made;
+      // and only after that wait for `NotificationService.start` to finish,
+      // including its `getToken` call.
+
+      // On store startup, send nothing (because we have nothing to send).
+      prepareStore();
+      await model.registerToken();
+      check(connection.lastRequest).isNull();
+
+      // When the token later appears, send it.
+      connection.prepare(json: {});
+      await startFuture;
+      async.flushMicrotasks();
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        checkLastRequestFcm(token: '012abc');
+      } else {
+        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
+      }
+
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        // If the token subsequently changes, send it again.
+        testBinding.firebaseMessaging.setToken('456def');
+        connection.prepare(json: {});
+        async.flushMicrotasks();
+        checkLastRequestFcm(token: '456def');
+      }
+    }));
+
+    test('on iOS, use provided app ID from packageInfo', () => awaitFakeAsync((async) async {
+      final origTargetPlatform = debugDefaultTargetPlatformOverride;
+      addTearDown(() => debugDefaultTargetPlatformOverride = origTargetPlatform);
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(testBinding.reset);
+      testBinding.firebaseMessagingInitialToken = '012abc';
+      testBinding.packageInfoResult = eg.packageInfo(packageName: 'com.example.test');
+      addTearDown(NotificationService.debugReset);
+      await NotificationService.instance.start();
+
+      prepareStore();
+      connection.prepare(json: {});
+      await model.registerToken();
+      checkLastRequestApns(token: '012abc', appid: 'com.example.test');
+    }));
+  });
+}

--- a/test/model/push_device_test.dart
+++ b/test/model/push_device_test.dart
@@ -15,15 +15,13 @@ import '../stdlib_checks.dart';
 void main() {
   TestZulipBinding.ensureInitialized();
 
-  group('registerToken', () {
-    // TODO test registerToken gets called on constructing an instance
-
+  group('register token', () {
     late PushDeviceManager model;
     late FakeApiConnection connection;
 
     void prepareStore() {
-      PushDeviceManager.debugAutoRegisterToken = false;
-      addTearDown(() => PushDeviceManager.debugAutoRegisterToken = true);
+      PushDeviceManager.debugAutoPause = true;
+      addTearDown(() => PushDeviceManager.debugAutoPause = false);
       final store = eg.store();
       model = store.pushDevices;
       connection = store.connection as FakeApiConnection;
@@ -56,7 +54,7 @@ void main() {
       // On store startup, send the token.
       prepareStore();
       connection.prepare(json: {});
-      await model.registerToken();
+      await model.debugUnpauseRegisterToken();
       if (defaultTargetPlatform == TargetPlatform.android) {
         checkLastRequestFcm(token: '012abc');
       } else {
@@ -84,14 +82,14 @@ void main() {
       // TODO this test is a bit brittle in its interaction with asynchrony;
       //   to fix, probably extend TestZulipBinding to control when getToken finishes.
       //
-      // The aim here is to first wait for `model.registerToken`
+      // The aim here is to first wait for `model.debugUnpauseRegisterToken`
       // to complete whatever it's going to do; then check no request was made;
       // and only after that wait for `NotificationService.start` to finish,
       // including its `getToken` call.
 
       // On store startup, send nothing (because we have nothing to send).
       prepareStore();
-      await model.registerToken();
+      await model.debugUnpauseRegisterToken();
       check(connection.lastRequest).isNull();
 
       // When the token later appears, send it.
@@ -125,7 +123,7 @@ void main() {
 
       prepareStore();
       connection.prepare(json: {});
-      await model.registerToken();
+      await model.debugUnpauseRegisterToken();
       checkLastRequestApns(token: '012abc', appid: 'com.example.test');
     }));
   });

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -17,6 +17,7 @@ import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/log.dart';
 import 'package:zulip/model/actions.dart';
 import 'package:zulip/model/presence.dart';
+import 'package:zulip/model/push_device.dart';
 import 'package:zulip/model/server_support.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/notifications/receive.dart';
@@ -483,8 +484,8 @@ void main() {
         as FakeApiConnection);
       UpdateMachine.debugEnableFetchEmojiData = false;
       addTearDown(() => UpdateMachine.debugEnableFetchEmojiData = true);
-      UpdateMachine.debugEnableRegisterNotificationToken = false;
-      addTearDown(() => UpdateMachine.debugEnableRegisterNotificationToken = true);
+      PushDeviceManager.debugEnableRegisterToken = false;
+      addTearDown(() => PushDeviceManager.debugEnableRegisterToken = true);
     }
 
     void checkLastRequest() {
@@ -571,7 +572,7 @@ void main() {
     }));
 
     // TODO test UpdateMachine.load starts polling loop
-    // TODO test UpdateMachine.load calls registerNotificationToken
+    // TODO test UpdateMachine.load calls [PushDeviceManager.registerToken]
   });
 
   group('UpdateMachine.fetchEmojiData', () {
@@ -1157,116 +1158,6 @@ void main() {
       async.flushTimers();
       // Reload never succeeds and there are no unhandled errors.
       check(globalStore.perAccountSync(eg.selfAccount.id)).isNull();
-    }));
-  });
-
-  group('UpdateMachine.registerNotificationToken', () {
-    late UpdateMachine updateMachine;
-    late FakeApiConnection connection;
-
-    void prepareStore() {
-      updateMachine = eg.updateMachine();
-      connection = updateMachine.store.connection as FakeApiConnection;
-    }
-
-    void checkLastRequestApns({required String token, required String appid}) {
-      check(connection.takeRequests()).single.isA<http.Request>()
-        ..method.equals('POST')
-        ..url.path.equals('/api/v1/users/me/apns_device_token')
-        ..bodyFields.deepEquals({'token': token, 'appid': appid});
-    }
-
-    void checkLastRequestFcm({required String token}) {
-      check(connection.takeRequests()).single.isA<http.Request>()
-        ..method.equals('POST')
-        ..url.path.equals('/api/v1/users/me/android_gcm_reg_id')
-        ..bodyFields.deepEquals({'token': token});
-    }
-
-    testAndroidIos('token already known', () => awaitFakeAsync((async) async {
-      // This tests the case where [NotificationService.start] has already
-      // learned the token before the store is created.
-      // (This is probably the common case.)
-      addTearDown(testBinding.reset);
-      testBinding.firebaseMessagingInitialToken = '012abc';
-      testBinding.packageInfoResult = eg.packageInfo(packageName: 'com.zulip.flutter');
-      addTearDown(NotificationService.debugReset);
-      await NotificationService.instance.start();
-
-      // On store startup, send the token.
-      prepareStore();
-      connection.prepare(json: {});
-      await updateMachine.registerNotificationToken();
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        checkLastRequestFcm(token: '012abc');
-      } else {
-        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
-      }
-
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        // If the token changes, send it again.
-        testBinding.firebaseMessaging.setToken('456def');
-        connection.prepare(json: {});
-        async.flushMicrotasks();
-        checkLastRequestFcm(token: '456def');
-      }
-    }));
-
-    testAndroidIos('token initially unknown', () => awaitFakeAsync((async) async {
-      // This tests the case where the store is created while our
-      // request for the token is still pending.
-      addTearDown(testBinding.reset);
-      testBinding.firebaseMessagingInitialToken = '012abc';
-      testBinding.packageInfoResult = eg.packageInfo(packageName: 'com.zulip.flutter');
-      addTearDown(NotificationService.debugReset);
-      final startFuture = NotificationService.instance.start();
-
-      // TODO this test is a bit brittle in its interaction with asynchrony;
-      //   to fix, probably extend TestZulipBinding to control when getToken finishes.
-      //
-      // The aim here is to first wait for `store.registerNotificationToken`
-      // to complete whatever it's going to do; then check no request was made;
-      // and only after that wait for `NotificationService.start` to finish,
-      // including its `getToken` call.
-
-      // On store startup, send nothing (because we have nothing to send).
-      prepareStore();
-      await updateMachine.registerNotificationToken();
-      check(connection.lastRequest).isNull();
-
-      // When the token later appears, send it.
-      connection.prepare(json: {});
-      await startFuture;
-      async.flushMicrotasks();
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        checkLastRequestFcm(token: '012abc');
-      } else {
-        checkLastRequestApns(token: '012abc', appid: 'com.zulip.flutter');
-      }
-
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        // If the token subsequently changes, send it again.
-        testBinding.firebaseMessaging.setToken('456def');
-        connection.prepare(json: {});
-        async.flushMicrotasks();
-        checkLastRequestFcm(token: '456def');
-      }
-    }));
-
-    test('on iOS, use provided app ID from packageInfo', () => awaitFakeAsync((async) async {
-      final origTargetPlatform = debugDefaultTargetPlatformOverride;
-      addTearDown(() => debugDefaultTargetPlatformOverride = origTargetPlatform);
-      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      addTearDown(testBinding.reset);
-      testBinding.firebaseMessagingInitialToken = '012abc';
-      testBinding.packageInfoResult = eg.packageInfo(packageName: 'com.example.test');
-      addTearDown(NotificationService.debugReset);
-      await NotificationService.instance.start();
-
-      prepareStore();
-      connection.prepare(json: {});
-      await updateMachine.registerNotificationToken();
-      checkLastRequestApns(token: '012abc', appid: 'com.example.test');
     }));
   });
 

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -10,6 +10,7 @@ import 'package:zulip/host/notifications.dart';
 import 'package:zulip/model/database.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
+import 'package:zulip/model/push_device.dart';
 import 'package:zulip/notifications/open.dart';
 import 'package:zulip/notifications/receive.dart';
 import 'package:zulip/widgets/app.dart';
@@ -80,6 +81,8 @@ void main() {
     testBinding.firebaseMessagingInitialToken = '012abc';
     addTearDown(NotificationService.debugReset);
     NotificationService.debugBackgroundIsolateIsLive = false;
+    PushDeviceManager.debugAutoRegisterToken = false;
+    addTearDown(() => PushDeviceManager.debugAutoRegisterToken = true);
     await NotificationService.instance.start();
   }
 

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -81,8 +81,8 @@ void main() {
     testBinding.firebaseMessagingInitialToken = '012abc';
     addTearDown(NotificationService.debugReset);
     NotificationService.debugBackgroundIsolateIsLive = false;
-    PushDeviceManager.debugAutoRegisterToken = false;
-    addTearDown(() => PushDeviceManager.debugAutoRegisterToken = true);
+    PushDeviceManager.debugAutoPause = true;
+    addTearDown(() => PushDeviceManager.debugAutoPause = false);
     await NotificationService.instance.start();
   }
 

--- a/test/notifications/receive_test.dart
+++ b/test/notifications/receive_test.dart
@@ -20,8 +20,7 @@ void main() {
   // are tested end-to-end in `display_test.dart`, by posting FCM messages
   // to the respective streams and checking that the right logic then runs.
 
-  // The token logic is tested end-to-end in `test/model/store_test.dart` in the
-  // `UpdateMachine.registerNotificationToken` tests.
+  // The token logic is tested end-to-end in `test/model/push_device_test.dart`.
 
   group('permissions', () {
     testWidgets('request permission', (tester) async {


### PR DESCRIPTION
This refactor helps prepare for #1764, the new E2EE notifications.

As a bonus, it also cleans up what had been a messy area of UpdateMachine.
