### PR TITLE
compose: Show a Refresh/Subscribe banner when unsubscribed and can't send

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -482,6 +482,18 @@
   "@errorBannerCannotPostInChannelLabel": {
     "description": "Error-banner text replacing the compose box when you do not have permission to send a message to the channel."
   },
+  "composeBoxBannerLabelUnsubscribedWhenCannotSend": "New messages will not appear automatically.",
+  "@composeBoxBannerLabelUnsubscribedWhenCannotSend": {
+    "description": "Label text for a compose-box banner when you are viewing an unsubscribed channel in which you do not have permission to send messages."
+  },
+  "composeBoxBannerButtonRefresh": "Refresh",
+  "@composeBoxBannerButtonRefresh": {
+    "description": "Label text for the 'Refresh' button in the compose-box banner when you are viewing an unsubscribed channel."
+  },
+  "composeBoxBannerButtonSubscribe": "Subscribe",
+  "@composeBoxBannerButtonSubscribe": {
+    "description": "Label text for the 'Subscribe' button in the compose-box banner when you are viewing an unsubscribed channel."
+  },
   "composeBoxBannerLabelEditMessage": "Edit message",
   "@composeBoxBannerLabelEditMessage": {
     "description": "Label text for the compose-box banner when you are editing a message."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -781,6 +781,24 @@ abstract class ZulipLocalizations {
   /// **'You do not have permission to post in this channel.'**
   String get errorBannerCannotPostInChannelLabel;
 
+  /// Label text for a compose-box banner when you are viewing an unsubscribed channel in which you do not have permission to send messages.
+  ///
+  /// In en, this message translates to:
+  /// **'New messages will not appear automatically.'**
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend;
+
+  /// Label text for the 'Refresh' button in the compose-box banner when you are viewing an unsubscribed channel.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh'**
+  String get composeBoxBannerButtonRefresh;
+
+  /// Label text for the 'Subscribe' button in the compose-box banner when you are viewing an unsubscribed channel.
+  ///
+  /// In en, this message translates to:
+  /// **'Subscribe'**
+  String get composeBoxBannerButtonSubscribe;
+
   /// Label text for the compose-box banner when you are editing a message.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -410,6 +410,16 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
       'You do not have permission to post in this channel.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Edit message';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -426,6 +426,16 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'Du hast keine Berechtigung in diesen Kanal zu schreiben.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Nachricht bearbeiten';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -410,6 +410,16 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
       'You do not have permission to post in this channel.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Edit message';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -424,6 +424,16 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Vous n\'avez pas l\'autorisation de poster sur ce canal.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Editer le message';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -420,6 +420,16 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
       'Non hai l\'autorizzazione per postare su questo canale.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Modifica messaggio';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -400,6 +400,16 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get errorBannerCannotPostInChannelLabel => 'このチャンネルに投稿する権限がありません。';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'メッセージを編集';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -410,6 +410,16 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
       'You do not have permission to post in this channel.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Edit message';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -421,6 +421,16 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Nie masz uprawnień do dodawania wpisów w tym kanale.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Zmień wiadomość';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -424,6 +424,16 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'У вас нет права писать в этом канале.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Редактирование сообщения';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -410,6 +410,16 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'You do not have permission to post in this channel.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Edit message';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -430,6 +430,16 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
       'Nimate dovoljenja za objavljanje v tem kanalu.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Uredi sporočilo';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -423,6 +423,16 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
       'Ви не маєте дозволу на публікацію в цьому каналі.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Редагування повідомлення';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -410,6 +410,16 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
       'You do not have permission to post in this channel.';
 
   @override
+  String get composeBoxBannerLabelUnsubscribedWhenCannotSend =>
+      'New messages will not appear automatically.';
+
+  @override
+  String get composeBoxBannerButtonRefresh => 'Refresh';
+
+  @override
+  String get composeBoxBannerButtonSubscribe => 'Subscribe';
+
+  @override
   String get composeBoxBannerLabelEditMessage => 'Edit message';
 
   @override

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -622,9 +622,10 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   Narrow get narrow => _narrow;
   Narrow _narrow;
 
-  /// Set [narrow] to [newNarrow], reset, [notifyListeners], and [fetchInitial].
-  void renarrowAndFetch(Narrow newNarrow) {
+  /// Set [narrow] and [anchor], reset, [notifyListeners], and [fetchInitial].
+  void renarrowAndFetch(Narrow newNarrow, Anchor anchor) {
     _narrow = newNarrow;
+    _anchor = anchor;
     _reset();
     notifyListeners();
     fetchInitial();
@@ -1185,7 +1186,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     switch (propagateMode) {
       case PropagateMode.changeAll:
       case PropagateMode.changeLater:
-        renarrowAndFetch(newNarrow);
+        // TODO(#1009) anchor to some visible message, if any
+        renarrowAndFetch(newNarrow, anchor);
       case PropagateMode.changeOne:
     }
   }

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -486,27 +486,7 @@ class SubscribeButton extends ActionSheetMenuItemButton {
 
   @override
   void onPressed() async {
-    final store = PerAccountStoreWidget.of(pageContext);
-    final channel = store.streams[channelId];
-    if (channel == null || channel is Subscription) return; // TODO could give feedback
-
-    try {
-      await subscribeToChannel(store.connection, subscriptions: [channel.name]);
-    } catch (e) {
-      if (!pageContext.mounted) return;
-
-      String? errorMessage;
-      switch (e) {
-        case ZulipApiException():
-          errorMessage = e.message;
-          // TODO(#741) specific messages for common errors, like network errors
-          //   (support with reusable code)
-        default:
-      }
-
-      final title = ZulipLocalizations.of(pageContext).subscribeFailedTitle;
-      showErrorDialog(context: pageContext, title: title, message: errorMessage);
-    }
+    await ZulipAction.subscribeToChannel(pageContext, channelId: channelId);
   }
 }
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -7,6 +7,7 @@ import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/model/narrow.dart';
 import '../api/route/messages.dart';
+import '../api/route/channels.dart' as channels_api;
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/binding.dart';
 import '../model/narrow.dart';
@@ -238,6 +239,32 @@ abstract final class ZulipAction {
     }
 
     return fetchedMessage?.content;
+  }
+
+  static Future<void> subscribeToChannel(BuildContext context, {
+    required int channelId,
+  }) async {
+    final store = PerAccountStoreWidget.of(context);
+    final channel = store.streams[channelId];
+    if (channel == null || channel is Subscription) return; // TODO could give feedback
+
+    try {
+      await channels_api.subscribeToChannel(store.connection, subscriptions: [channel.name]);
+    } catch (e) {
+      if (!context.mounted) return;
+
+      String? errorMessage;
+      switch (e) {
+        case ZulipApiException():
+          errorMessage = e.message;
+          // TODO(#741) specific messages for common errors, like network errors
+          //   (support with reusable code)
+        default:
+      }
+
+      final title = ZulipLocalizations.of(context).subscribeFailedTitle;
+      showErrorDialog(context: context, title: title, message: errorMessage);
+    }
   }
 }
 

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -41,6 +41,18 @@ class ZulipWebUiKitButton extends StatelessWidget {
         });
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.neutral):
+      case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.warning):
+        throw UnimplementedError();
+      case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.warning):
+        return WidgetStateColor.fromMap({
+          WidgetState.pressed: designVariables.btnBgAttMediumIntWarningActive,
+          ~WidgetState.pressed: designVariables.btnBgAttMediumIntWarningNormal,
+        });
+      case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.warning):
+        return WidgetStateColor.fromMap({
+          WidgetState.pressed: designVariables.btnBgAttHighIntWarningActive,
+          ~WidgetState.pressed: designVariables.btnBgAttHighIntWarningNormal,
+        });
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.info):
         throw UnimplementedError();
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.info):
@@ -63,6 +75,12 @@ class ZulipWebUiKitButton extends StatelessWidget {
         return designVariables.neutralButtonLabel.withFadedAlpha(0.85);
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.neutral):
+      case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.warning):
+        throw UnimplementedError();
+      case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.warning):
+        return designVariables.btnLabelAttMediumIntWarning;
+      case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.warning):
+        return designVariables.btnLabelAttHighIntWarning;
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.info):
         throw UnimplementedError();
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.info):
@@ -195,7 +213,7 @@ enum ZulipWebUiKitButtonAttention {
 
 enum ZulipWebUiKitButtonIntent {
   neutral,
-  // warning,
+  warning,
   // danger,
   info,
   // success,

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1727,9 +1727,9 @@ class EditMessageComposeBoxController extends ComposeBoxController {
 abstract class _Banner extends StatelessWidget {
   const _Banner();
 
+  _BannerIntent get intent;
+
   String getLabel(ZulipLocalizations zulipLocalizations);
-  Color getLabelColor(DesignVariables designVariables);
-  Color getBackgroundColor(DesignVariables designVariables);
 
   /// A trailing element, with vertical but not horizontal outer padding
   /// for spacing/positioning.
@@ -1757,16 +1757,23 @@ abstract class _Banner extends StatelessWidget {
   Widget build(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
+
+    final (labelColor, backgroundColor) = switch (intent) {
+      _BannerIntent.info =>
+        (designVariables.bannerTextIntInfo, designVariables.bannerBgIntInfo),
+      _BannerIntent.danger =>
+        (designVariables.btnLabelAttMediumIntDanger, designVariables.bannerBgIntDanger),
+    };
+
     final labelTextStyle = TextStyle(
       fontSize: 17,
       height: 22 / 17,
-      color: getLabelColor(designVariables),
+      color: labelColor,
     ).merge(weightVariableTextStyle(context, wght: 600));
 
     final trailing = buildTrailing(PageRoot.contextOf(context));
     return DecoratedBox(
-      decoration: BoxDecoration(
-        color: getBackgroundColor(designVariables)),
+      decoration: BoxDecoration(color: backgroundColor),
       child: SafeArea(
         minimum: EdgeInsetsDirectional.only(start: 8, end: padEnd ? 8 : 0)
           // (SafeArea.minimum doesn't take an EdgeInsetsDirectional)
@@ -1790,6 +1797,11 @@ abstract class _Banner extends StatelessWidget {
   }
 }
 
+enum _BannerIntent {
+  info,
+  danger,
+}
+
 class _ErrorBanner extends _Banner {
   const _ErrorBanner({
     required String Function(ZulipLocalizations) getLabel,
@@ -1801,12 +1813,7 @@ class _ErrorBanner extends _Banner {
   final String Function(ZulipLocalizations) _getLabel;
 
   @override
-  Color getLabelColor(DesignVariables designVariables) =>
-    designVariables.btnLabelAttMediumIntDanger;
-
-  @override
-  Color getBackgroundColor(DesignVariables designVariables) =>
-    designVariables.bannerBgIntDanger;
+  _BannerIntent get intent => _BannerIntent.danger;
 
   @override
   Widget? buildTrailing(pageContext) {
@@ -1828,12 +1835,7 @@ class _EditMessageBanner extends _Banner {
     zulipLocalizations.composeBoxBannerLabelEditMessage;
 
   @override
-  Color getLabelColor(DesignVariables designVariables) =>
-    designVariables.bannerTextIntInfo;
-
-  @override
-  Color getBackgroundColor(DesignVariables designVariables) =>
-    designVariables.bannerBgIntInfo;
+  _BannerIntent get intent => _BannerIntent.info;
 
   void _handleTapSave (BuildContext pageContext) async {
     final store = PerAccountStoreWidget.of(pageContext);

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -2129,7 +2129,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
   }
 
   /// A [_Banner] that replaces the compose box's text inputs.
-  Widget? _errorBannerComposingNotAllowed(BuildContext context) {
+  Widget? _bannerComposingNotAllowed(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
     switch (widget.narrow) {
@@ -2139,7 +2139,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
         if (channel == null || !store.selfCanSendMessage(inChannel: channel,
             byDate: DateTime.now())) {
           return _Banner(
-            intent: _BannerIntent.danger,
+            intent: _BannerIntent.info,
             label: zulipLocalizations.errorBannerCannotPostInChannelLabel);
         }
 
@@ -2148,7 +2148,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
           !(store.getUser(id)?.isActive ?? true));
         if (hasDeactivatedUser) {
           return _Banner(
-            intent: _BannerIntent.danger,
+            intent: _BannerIntent.info,
             label: zulipLocalizations.errorBannerDeactivatedDmLabel);
         }
 
@@ -2165,10 +2165,10 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
   Widget build(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    final errorBanner = _errorBannerComposingNotAllowed(context);
-    if (errorBanner != null) {
+    final bannerComposingNotAllowed = _bannerComposingNotAllowed(context);
+    if (bannerComposingNotAllowed != null) {
       return ComposeBoxInheritedWidget.fromComposeBoxState(this,
-        child: _ComposeBoxContainer(body: null, banner: errorBanner));
+        child: _ComposeBoxContainer(body: null, banner: bannerComposingNotAllowed));
     }
 
     final Widget? body;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -24,6 +24,7 @@ import 'color.dart';
 import 'dialog.dart';
 import 'icons.dart';
 import 'inset_shadow.dart';
+import 'message_list.dart';
 import 'page.dart';
 import 'store.dart';
 import 'text.dart';
@@ -1768,6 +1769,8 @@ class _Banner extends StatelessWidget {
     final (labelColor, backgroundColor) = switch (intent) {
       _BannerIntent.info =>
         (designVariables.bannerTextIntInfo, designVariables.bannerBgIntInfo),
+      _BannerIntent.warning =>
+        (designVariables.btnLabelAttMediumIntWarning, designVariables.bannerBgIntWarning),
       _BannerIntent.danger =>
         (designVariables.btnLabelAttMediumIntDanger, designVariables.bannerBgIntDanger),
     };
@@ -1805,7 +1808,42 @@ class _Banner extends StatelessWidget {
 
 enum _BannerIntent {
   info,
+  warning,
   danger,
+}
+
+class _UnsubscribedChannelBannerTrailing extends StatelessWidget {
+  const _UnsubscribedChannelBannerTrailing({required this.channelId});
+
+  final int channelId;
+
+  @override
+  Widget build(BuildContext context) {
+    // (A BuildContext that's expected to remain mounted until the whole page
+    // disappears, which may be long after the banner disappears.)
+    final pageContext = PageRoot.contextOf(context);
+
+    final zulipLocalizations = ZulipLocalizations.of(pageContext);
+    return Row(mainAxisSize: MainAxisSize.min, spacing: 8, children: [
+      ZulipWebUiKitButton(
+        label: zulipLocalizations.composeBoxBannerButtonRefresh,
+        intent: ZulipWebUiKitButtonIntent.warning,
+        onPressed: () {
+          // TODO better to refetch around some visible message if any
+          MessageListPage.ancestorOf(pageContext).refresh(AnchorCode.newest);
+        }),
+      ZulipWebUiKitButton(
+        label: zulipLocalizations.composeBoxBannerButtonSubscribe,
+        intent: ZulipWebUiKitButtonIntent.warning,
+        attention: ZulipWebUiKitButtonAttention.high,
+        onPressed: () async {
+          await ZulipAction.subscribeToChannel(pageContext, channelId: channelId);
+          if (!pageContext.mounted) return;
+          // TODO better to refetch around some visible message if any
+          MessageListPage.ancestorOf(pageContext).refresh(AnchorCode.newest);
+        }),
+    ]);
+  }
 }
 
 class _EditMessageBannerTrailing extends StatelessWidget {
@@ -2138,9 +2176,14 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
         final channel = store.streams[streamId];
         if (channel == null || !store.selfCanSendMessage(inChannel: channel,
             byDate: DateTime.now())) {
-          return _Banner(
-            intent: _BannerIntent.info,
-            label: zulipLocalizations.errorBannerCannotPostInChannelLabel);
+          return (channel == null || channel is Subscription)
+            ? _Banner(
+                intent: _BannerIntent.info,
+                label: zulipLocalizations.errorBannerCannotPostInChannelLabel)
+            : _Banner(
+                intent: _BannerIntent.warning,
+                label: zulipLocalizations.composeBoxBannerLabelUnsubscribedWhenCannotSend,
+                trailing: _UnsubscribedChannelBannerTrailing(channelId: streamId));
         }
 
       case DmNarrow(:final otherRecipientIds):

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1724,14 +1724,20 @@ class EditMessageComposeBoxController extends ComposeBoxController {
 /// A banner to display over or instead of interactive compose-box content.
 ///
 /// Must have a [PageRoot] ancestor.
-abstract class _Banner extends StatelessWidget {
-  const _Banner();
+class _Banner extends StatelessWidget {
+  const _Banner({
+    required this.intent,
+    required this.label,
+    this.trailing,
+    this.padEnd = true, // ignore: unused_element_parameter
+  });
 
-  _BannerIntent get intent;
+  final _BannerIntent intent;
+  final String label;
 
-  String getLabel(ZulipLocalizations zulipLocalizations);
-
-  /// A trailing element, with vertical but not horizontal outer padding
+  /// An optional trailing element.
+  ///
+  /// It should include vertical but not horizontal outer padding
   /// for spacing/positioning.
   ///
   /// An interactive element's touchable area should have height at least 44px,
@@ -1739,23 +1745,24 @@ abstract class _Banner extends StatelessWidget {
   /// what gets painted:
   ///   https://github.com/zulip/zulip-flutter/pull/1432#discussion_r2023907300
   ///
-  /// To control the element's distance from the end edge, override [padEnd].
-  ///
-  /// The passed [BuildContext] will be the result of [PageRoot.contextOf],
-  /// so it's expected to remain mounted until the whole page disappears,
-  /// which may be long after the banner disappears.
-  Widget? buildTrailing(BuildContext pageContext);
+  /// To control the element's distance from the end edge, use [padEnd].
+  // An "x" button could go here.
+  // 24px square with 8px touchable padding in all directions?
+  // and `padEnd: false`; see Figma:
+  //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=4031-17029&m=dev
+  final Widget? trailing;
 
   /// Whether to apply `end: 8` in [SafeArea.minimum].
   ///
-  /// Subclasses can use `false` when the [buildTrailing] element
+  /// Pass `false` when the [trailing] element
   /// is meant to abut the edge of the screen
   /// in the common case that there are no horizontal device insets.
-  bool get padEnd => true;
+  ///
+  /// Defaults to `true`.
+  final bool padEnd;
 
   @override
   Widget build(BuildContext context) {
-    final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
 
     final (labelColor, backgroundColor) = switch (intent) {
@@ -1771,7 +1778,6 @@ abstract class _Banner extends StatelessWidget {
       color: labelColor,
     ).merge(weightVariableTextStyle(context, wght: 600));
 
-    final trailing = buildTrailing(PageRoot.contextOf(context));
     return DecoratedBox(
       decoration: BoxDecoration(color: backgroundColor),
       child: SafeArea(
@@ -1788,10 +1794,10 @@ abstract class _Banner extends StatelessWidget {
                   child: Text(
                     style: labelTextStyle,
                     textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
-                    getLabel(zulipLocalizations)))),
+                    label))),
               if (trailing != null) ...[
                 const SizedBox(width: 8),
-                trailing,
+                trailing!,
               ],
             ]))));
   }
@@ -1802,40 +1808,10 @@ enum _BannerIntent {
   danger,
 }
 
-class _ErrorBanner extends _Banner {
-  const _ErrorBanner({
-    required String Function(ZulipLocalizations) getLabel,
-  }) : _getLabel = getLabel;
-
-  @override
-  String getLabel(ZulipLocalizations zulipLocalizations) =>
-    _getLabel(zulipLocalizations);
-  final String Function(ZulipLocalizations) _getLabel;
-
-  @override
-  _BannerIntent get intent => _BannerIntent.danger;
-
-  @override
-  Widget? buildTrailing(pageContext) {
-    // An "x" button can go here.
-    // 24px square with 8px touchable padding in all directions?
-    // and `bool get padEnd => false`; see Figma:
-    //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=4031-17029&m=dev
-    return null;
-  }
-}
-
-class _EditMessageBanner extends _Banner {
-  const _EditMessageBanner({required this.composeBoxState});
+class _EditMessageBannerTrailing extends StatelessWidget {
+  const _EditMessageBannerTrailing({required this.composeBoxState});
 
   final ComposeBoxState composeBoxState;
-
-  @override
-  String getLabel(ZulipLocalizations zulipLocalizations) =>
-    zulipLocalizations.composeBoxBannerLabelEditMessage;
-
-  @override
-  _BannerIntent get intent => _BannerIntent.info;
 
   void _handleTapSave (BuildContext pageContext) async {
     final store = PerAccountStoreWidget.of(pageContext);
@@ -1884,7 +1860,11 @@ class _EditMessageBanner extends _Banner {
   }
 
   @override
-  Widget buildTrailing(pageContext) {
+  Widget build(BuildContext context) {
+    // (A BuildContext that's expected to remain mounted until the whole page
+    // disappears, which may be long after the banner disappears.)
+    final pageContext = PageRoot.contextOf(context);
+
     final zulipLocalizations = ZulipLocalizations.of(pageContext);
     return Row(mainAxisSize: MainAxisSize.min, spacing: 8, children: [
       ZulipWebUiKitButton(label: zulipLocalizations.composeBoxBannerButtonCancel,
@@ -2148,25 +2128,28 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     super.dispose();
   }
 
-  /// An [_ErrorBanner] that replaces the compose box's text inputs.
+  /// A [_Banner] that replaces the compose box's text inputs.
   Widget? _errorBannerComposingNotAllowed(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
     switch (widget.narrow) {
       case ChannelNarrow(:final streamId):
       case TopicNarrow(:final streamId):
         final channel = store.streams[streamId];
         if (channel == null || !store.selfCanSendMessage(inChannel: channel,
             byDate: DateTime.now())) {
-          return _ErrorBanner(getLabel: (zulipLocalizations) =>
-            zulipLocalizations.errorBannerCannotPostInChannelLabel);
+          return _Banner(
+            intent: _BannerIntent.danger,
+            label: zulipLocalizations.errorBannerCannotPostInChannelLabel);
         }
 
       case DmNarrow(:final otherRecipientIds):
         final hasDeactivatedUser = otherRecipientIds.any((id) =>
           !(store.getUser(id)?.isActive ?? true));
         if (hasDeactivatedUser) {
-          return _ErrorBanner(getLabel: (zulipLocalizations) =>
-            zulipLocalizations.errorBannerDeactivatedDmLabel);
+          return _Banner(
+            intent: _BannerIntent.danger,
+            label: zulipLocalizations.errorBannerDeactivatedDmLabel);
         }
 
       case CombinedFeedNarrow():
@@ -2180,6 +2163,8 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+
     final errorBanner = _errorBannerComposingNotAllowed(context);
     if (errorBanner != null) {
       return ComposeBoxInheritedWidget.fromComposeBoxState(this,
@@ -2202,7 +2187,10 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
       }
       case EditMessageComposeBoxController(): {
         body = _EditMessageComposeBoxBody(controller: controller, narrow: narrow);
-        banner = _EditMessageBanner(composeBoxState: this);
+        banner = _Banner(
+          intent: _BannerIntent.info,
+          label: zulipLocalizations.composeBoxBannerLabelEditMessage,
+          trailing: _EditMessageBannerTrailing(composeBoxState: this));
       }
     }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -639,7 +639,8 @@ class MessageListAppBarTitle extends StatelessWidget {
       case KeywordSearchNarrow():
         assert(!willCenterTitle);
         return _SearchBar(onSubmitted: (narrow) {
-          MessageListPage.ancestorOf(context).model!.renarrowAndFetch(narrow);
+          MessageListPage.ancestorOf(context).model!
+            .renarrowAndFetch(narrow, AnchorCode.newest);
         });
     }
   }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -137,6 +137,16 @@ abstract class MessageListPageState extends State<MessageListPage> {
   /// The narrow for this page's message list.
   Narrow get narrow;
 
+  /// Resets the [MessageListView] model, triggering an initial fetch
+  /// at [anchor].
+  ///
+  /// Useful when updates won't arrive through the event system,
+  /// as when showing an unsubscribed channel.
+  /// (New-message events aren't sent for unsubscribed channels.)
+  ///
+  /// Does nothing if [MessageList] has not mounted yet.
+  void refresh(Anchor anchor);
+
   /// The [ComposeBoxState] for this [MessageListPage]'s compose box,
   /// if this [MessageListPage] offers a compose box and it has mounted,
   /// else null.
@@ -266,6 +276,9 @@ class MessageListPage extends StatefulWidget {
 class _MessageListPageState extends State<MessageListPage> implements MessageListPageState {
   @override
   late Narrow narrow;
+
+  @override
+  void refresh(Anchor anchor) => model?.renarrowAndFetch(narrow, anchor);
 
   @override
   ComposeBoxState? get composeBoxState => _composeBoxKey.currentState;

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -138,6 +138,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     background: const Color(0xffffffff),
     bannerBgIntDanger: const Color(0xfff2e4e4),
     bannerBgIntInfo: const Color(0xffddecf6),
+    bannerBgIntWarning: const Color(0xfffaf5dc),
     bannerTextIntInfo: const Color(0xff06037c),
     bgBotBar: const Color(0xfff6f6f6),
     bgContextMenu: const Color(0xfff2f2f2),
@@ -150,13 +151,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     borderMenuButtonSelected: Colors.black.withValues(alpha: 0.2),
     btnBgAttHighIntInfoActive: const Color(0xff1e41d3),
     btnBgAttHighIntInfoNormal: const Color(0xff3c6bff),
+    btnBgAttHighIntWarningActive: const Color(0xffeba002),
+    btnBgAttHighIntWarningNormal: const Color(0xfffebe3d),
     btnBgAttMediumIntInfoActive: const Color(0xff3c6bff).withValues(alpha: 0.22),
     btnBgAttMediumIntInfoNormal: const Color(0xff3c6bff).withValues(alpha: 0.12),
+    btnBgAttMediumIntWarningActive: const Color(0xffeba001).withValues(alpha: 0.28),
+    btnBgAttMediumIntWarningNormal: const Color(0xffeba002).withValues(alpha: 0.18),
     btnLabelAttHigh: const Color(0xffffffff),
+    btnLabelAttHighIntWarning: const Color(0xff000000).withValues(alpha: 0.88),
     btnLabelAttLowIntDanger: const Color(0xffc0070a),
     btnLabelAttLowIntInfo: const Color(0xff2347c6),
     btnLabelAttMediumIntDanger: const Color(0xffac0508),
     btnLabelAttMediumIntInfo: const Color(0xff1027a6),
+    btnLabelAttMediumIntWarning: const Color(0xff764607),
     btnShadowAttMed: const Color(0xff000000).withValues(alpha: 0.20),
     composeBoxBg: const Color(0xffffffff),
     contextMenuCancelText: const Color(0xff222222),
@@ -229,6 +236,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     background: const Color(0xff000000),
     bannerBgIntDanger: const Color(0xff461616),
     bannerBgIntInfo: const Color(0xff00253d),
+    bannerBgIntWarning: const Color(0xff332b00),
     bannerTextIntInfo: const Color(0xffcbdbfd),
     bgBotBar: const Color(0xff222222),
     bgContextMenu: const Color(0xff262626),
@@ -241,13 +249,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     borderMenuButtonSelected: Colors.white.withValues(alpha: 0.1),
     btnBgAttHighIntInfoActive: const Color(0xff1e41d3),
     btnBgAttHighIntInfoNormal: const Color(0xff1e41d3),
+    btnBgAttHighIntWarningActive: const Color(0xffdb920d),
+    btnBgAttHighIntWarningNormal: const Color(0xffdb920d),
     btnBgAttMediumIntInfoActive: const Color(0xff97b6fe).withValues(alpha: 0.12),
     btnBgAttMediumIntInfoNormal: const Color(0xff97b6fe).withValues(alpha: 0.12),
+    btnBgAttMediumIntWarningActive: const Color(0xffdb920d).withValues(alpha: 0.12),
+    btnBgAttMediumIntWarningNormal: const Color(0xffdb920d).withValues(alpha: 0.12),
     btnLabelAttHigh: const Color(0xffffffff).withValues(alpha: 0.85),
+    btnLabelAttHighIntWarning: const Color(0xff000000).withValues(alpha: 0.90),
     btnLabelAttLowIntDanger: const Color(0xffff8b7c),
     btnLabelAttLowIntInfo: const Color(0xff84a8fd),
     btnLabelAttMediumIntDanger: const Color(0xffff8b7c),
     btnLabelAttMediumIntInfo: const Color(0xff97b6fe),
+    btnLabelAttMediumIntWarning: const Color(0xfff8b325),
     btnShadowAttMed: const Color(0xffffffff).withValues(alpha: 0.21),
     composeBoxBg: const Color(0xff0f0f0f),
     contextMenuCancelText: const Color(0xffffffff).withValues(alpha: 0.75),
@@ -329,6 +343,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.background,
     required this.bannerBgIntDanger,
     required this.bannerBgIntInfo,
+    required this.bannerBgIntWarning,
     required this.bannerTextIntInfo,
     required this.bgBotBar,
     required this.bgContextMenu,
@@ -341,13 +356,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.borderMenuButtonSelected,
     required this.btnBgAttHighIntInfoActive,
     required this.btnBgAttHighIntInfoNormal,
+    required this.btnBgAttHighIntWarningActive,
+    required this.btnBgAttHighIntWarningNormal,
     required this.btnBgAttMediumIntInfoActive,
     required this.btnBgAttMediumIntInfoNormal,
+    required this.btnBgAttMediumIntWarningActive,
+    required this.btnBgAttMediumIntWarningNormal,
     required this.btnLabelAttHigh,
+    required this.btnLabelAttHighIntWarning,
     required this.btnLabelAttLowIntDanger,
     required this.btnLabelAttLowIntInfo,
     required this.btnLabelAttMediumIntDanger,
     required this.btnLabelAttMediumIntInfo,
+    required this.btnLabelAttMediumIntWarning,
     required this.btnShadowAttMed,
     required this.composeBoxBg,
     required this.contextMenuCancelText,
@@ -420,6 +441,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color background;
   final Color bannerBgIntDanger;
   final Color bannerBgIntInfo;
+  final Color bannerBgIntWarning;
   final Color bannerTextIntInfo;
   final Color bgBotBar;
   final Color bgContextMenu;
@@ -432,13 +454,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color borderMenuButtonSelected;
   final Color btnBgAttHighIntInfoActive;
   final Color btnBgAttHighIntInfoNormal;
+  final Color btnBgAttHighIntWarningActive;
+  final Color btnBgAttHighIntWarningNormal;
   final Color btnBgAttMediumIntInfoActive;
   final Color btnBgAttMediumIntInfoNormal;
+  final Color btnBgAttMediumIntWarningActive;
+  final Color btnBgAttMediumIntWarningNormal;
   final Color btnLabelAttHigh;
+  final Color btnLabelAttHighIntWarning;
   final Color btnLabelAttLowIntDanger;
   final Color btnLabelAttLowIntInfo;
   final Color btnLabelAttMediumIntDanger;
   final Color btnLabelAttMediumIntInfo;
+  final Color btnLabelAttMediumIntWarning;
   final Color btnShadowAttMed;
   final Color composeBoxBg;
   final Color contextMenuCancelText;
@@ -506,6 +534,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? background,
     Color? bannerBgIntDanger,
     Color? bannerBgIntInfo,
+    Color? bannerBgIntWarning,
     Color? bannerTextIntInfo,
     Color? bgBotBar,
     Color? bgContextMenu,
@@ -518,13 +547,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? borderMenuButtonSelected,
     Color? btnBgAttHighIntInfoActive,
     Color? btnBgAttHighIntInfoNormal,
+    Color? btnBgAttHighIntWarningActive,
+    Color? btnBgAttHighIntWarningNormal,
     Color? btnBgAttMediumIntInfoActive,
     Color? btnBgAttMediumIntInfoNormal,
+    Color? btnBgAttMediumIntWarningActive,
+    Color? btnBgAttMediumIntWarningNormal,
     Color? btnLabelAttHigh,
+    Color? btnLabelAttHighIntWarning,
     Color? btnLabelAttLowIntDanger,
     Color? btnLabelAttLowIntInfo,
     Color? btnLabelAttMediumIntDanger,
     Color? btnLabelAttMediumIntInfo,
+    Color? btnLabelAttMediumIntWarning,
     Color? btnShadowAttMed,
     Color? composeBoxBg,
     Color? contextMenuCancelText,
@@ -587,6 +622,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       background: background ?? this.background,
       bannerBgIntDanger: bannerBgIntDanger ?? this.bannerBgIntDanger,
       bannerBgIntInfo: bannerBgIntInfo ?? this.bannerBgIntInfo,
+      bannerBgIntWarning: bannerBgIntWarning ?? this.bannerBgIntWarning,
       bannerTextIntInfo: bannerTextIntInfo ?? this.bannerTextIntInfo,
       bgBotBar: bgBotBar ?? this.bgBotBar,
       bgContextMenu: bgContextMenu ?? this.bgContextMenu,
@@ -599,13 +635,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       borderMenuButtonSelected: borderMenuButtonSelected ?? this.borderMenuButtonSelected,
       btnBgAttHighIntInfoActive: btnBgAttHighIntInfoActive ?? this.btnBgAttHighIntInfoActive,
       btnBgAttHighIntInfoNormal: btnBgAttHighIntInfoNormal ?? this.btnBgAttHighIntInfoNormal,
+      btnBgAttHighIntWarningActive: btnBgAttHighIntWarningActive ?? this.btnBgAttHighIntWarningActive,
+      btnBgAttHighIntWarningNormal: btnBgAttHighIntWarningNormal ?? this.btnBgAttHighIntWarningNormal,
       btnBgAttMediumIntInfoActive: btnBgAttMediumIntInfoActive ?? this.btnBgAttMediumIntInfoActive,
       btnBgAttMediumIntInfoNormal: btnBgAttMediumIntInfoNormal ?? this.btnBgAttMediumIntInfoNormal,
+      btnBgAttMediumIntWarningActive: btnBgAttMediumIntWarningActive ?? this.btnBgAttMediumIntWarningActive,
+      btnBgAttMediumIntWarningNormal: btnBgAttMediumIntWarningNormal ?? this.btnBgAttMediumIntWarningNormal,
       btnLabelAttHigh: btnLabelAttHigh ?? this.btnLabelAttHigh,
+      btnLabelAttHighIntWarning: btnLabelAttHighIntWarning ?? this.btnLabelAttHighIntWarning,
       btnLabelAttLowIntDanger: btnLabelAttLowIntDanger ?? this.btnLabelAttLowIntDanger,
       btnLabelAttLowIntInfo: btnLabelAttLowIntInfo ?? this.btnLabelAttLowIntInfo,
       btnLabelAttMediumIntDanger: btnLabelAttMediumIntDanger ?? this.btnLabelAttMediumIntDanger,
       btnLabelAttMediumIntInfo: btnLabelAttMediumIntInfo ?? this.btnLabelAttMediumIntInfo,
+      btnLabelAttMediumIntWarning: btnLabelAttMediumIntWarning ?? this.btnLabelAttMediumIntWarning,
       btnShadowAttMed: btnShadowAttMed ?? this.btnShadowAttMed,
       composeBoxBg: composeBoxBg ?? this.composeBoxBg,
       contextMenuCancelText: contextMenuCancelText ?? this.contextMenuCancelText,
@@ -675,6 +717,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       background: Color.lerp(background, other.background, t)!,
       bannerBgIntDanger: Color.lerp(bannerBgIntDanger, other.bannerBgIntDanger, t)!,
       bannerBgIntInfo: Color.lerp(bannerBgIntInfo, other.bannerBgIntInfo, t)!,
+      bannerBgIntWarning: Color.lerp(bannerBgIntWarning, other.bannerBgIntWarning, t)!,
       bannerTextIntInfo: Color.lerp(bannerTextIntInfo, other.bannerTextIntInfo, t)!,
       bgBotBar: Color.lerp(bgBotBar, other.bgBotBar, t)!,
       bgContextMenu: Color.lerp(bgContextMenu, other.bgContextMenu, t)!,
@@ -687,13 +730,19 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       borderMenuButtonSelected: Color.lerp(borderMenuButtonSelected, other.borderMenuButtonSelected, t)!,
       btnBgAttHighIntInfoActive: Color.lerp(btnBgAttHighIntInfoActive, other.btnBgAttHighIntInfoActive, t)!,
       btnBgAttHighIntInfoNormal: Color.lerp(btnBgAttHighIntInfoNormal, other.btnBgAttHighIntInfoNormal, t)!,
+      btnBgAttHighIntWarningActive: Color.lerp(btnBgAttHighIntWarningActive, other.btnBgAttHighIntWarningActive, t)!,
+      btnBgAttHighIntWarningNormal: Color.lerp(btnBgAttHighIntWarningNormal, other.btnBgAttHighIntWarningNormal, t)!,
       btnBgAttMediumIntInfoActive: Color.lerp(btnBgAttMediumIntInfoActive, other.btnBgAttMediumIntInfoActive, t)!,
       btnBgAttMediumIntInfoNormal: Color.lerp(btnBgAttMediumIntInfoNormal, other.btnBgAttMediumIntInfoNormal, t)!,
+      btnBgAttMediumIntWarningActive: Color.lerp(btnBgAttMediumIntWarningActive, other.btnBgAttMediumIntWarningActive, t)!,
+      btnBgAttMediumIntWarningNormal: Color.lerp(btnBgAttMediumIntWarningNormal, other.btnBgAttMediumIntWarningNormal, t)!,
       btnLabelAttHigh: Color.lerp(btnLabelAttHigh, other.btnLabelAttHigh, t)!,
+      btnLabelAttHighIntWarning: Color.lerp(btnLabelAttHighIntWarning, other.btnLabelAttHighIntWarning, t)!,
       btnLabelAttLowIntDanger: Color.lerp(btnLabelAttLowIntDanger, other.btnLabelAttLowIntDanger, t)!,
       btnLabelAttLowIntInfo: Color.lerp(btnLabelAttLowIntInfo, other.btnLabelAttLowIntInfo, t)!,
       btnLabelAttMediumIntDanger: Color.lerp(btnLabelAttMediumIntDanger, other.btnLabelAttMediumIntDanger, t)!,
       btnLabelAttMediumIntInfo: Color.lerp(btnLabelAttMediumIntInfo, other.btnLabelAttMediumIntInfo, t)!,
+      btnLabelAttMediumIntWarning: Color.lerp(btnLabelAttMediumIntWarning, other.btnLabelAttMediumIntWarning, t)!,
       btnShadowAttMed: Color.lerp(btnShadowAttMed, other.btnShadowAttMed, t)!,
       composeBoxBg: Color.lerp(composeBoxBg, other.composeBoxBg, t)!,
       contextMenuCancelText: Color.lerp(contextMenuCancelText, other.contextMenuCancelText, t)!,

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -449,23 +449,28 @@ void main() {
       final generationBefore = model.generation;
 
       final newNarrow = ChannelNarrow(channel.streamId);
+      final newAnchor = NumericAnchor(messages[3].id);
 
       final result = eg.getMessagesResult(
-        anchor: model.anchor, foundOldest: false, messages: messages);
+        anchor: newAnchor,
+        foundOldest: false, foundNewest: false,
+        messages: messages.sublist(3, 5));
       connection.prepare(json: result.toJson(), delay: Duration(seconds: 1));
-      model.renarrowAndFetch(newNarrow);
+      model.renarrowAndFetch(newNarrow, newAnchor);
       checkNotifiedOnce();
       check(model)
         ..generation.equals(generationBefore + 1)
         ..fetched.isFalse()
         ..narrow.equals(newNarrow)
+        ..anchor.equals(newAnchor)
         ..messages.isEmpty();
 
       async.elapse(Duration(seconds: 1));
       check(model)
         ..fetched.isTrue()
         ..narrow.equals(newNarrow)
-        ..messages.length.equals(100);
+        ..anchor.equals(newAnchor)
+        ..messages.length.equals(2);
     }));
   });
 
@@ -3403,6 +3408,7 @@ extension MessageListMessageItemChecks on Subject<MessageListMessageItem> {
 extension MessageListViewChecks on Subject<MessageListView> {
   Subject<PerAccountStore> get store => has((x) => x.store, 'store');
   Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
+  Subject<Anchor> get anchor => has((x) => x.anchor, 'anchor');
   Subject<int> get generation => has((x) => x.generation, 'generation');
   Subject<List<Message>> get messages => has((x) => x.messages, 'messages');
   Subject<List<OutboxMessage>> get outboxMessages => has((x) => x.outboxMessages, 'outboxMessages');

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -427,6 +427,48 @@ void main() {
     });
   });
 
+  group('renarrowAndFetch', () {
+    test('smoke', () => awaitFakeAsync((async) async {
+      final channel = eg.stream();
+
+      const narrow = CombinedFeedNarrow();
+      await prepare(narrow: narrow, stream: channel);
+      final messages = List.generate(100,
+        (i) => eg.streamMessage(id: 1000 + i, stream: channel));
+      await prepareMessages(foundOldest: false, messages: messages);
+
+      // …do something unrelated…
+      connection.prepare(json: olderResult(
+        anchor: 1000, foundOldest: false,
+        messages: List.generate(100,
+          (i) => eg.streamMessage(id: 900 + i, stream: channel)),
+      ).toJson());
+      await model.fetchOlder();
+      checkNotified(count: 2);
+
+      final generationBefore = model.generation;
+
+      final newNarrow = ChannelNarrow(channel.streamId);
+
+      final result = eg.getMessagesResult(
+        anchor: model.anchor, foundOldest: false, messages: messages);
+      connection.prepare(json: result.toJson(), delay: Duration(seconds: 1));
+      model.renarrowAndFetch(newNarrow);
+      checkNotifiedOnce();
+      check(model)
+        ..generation.equals(generationBefore + 1)
+        ..fetched.isFalse()
+        ..narrow.equals(newNarrow)
+        ..messages.isEmpty();
+
+      async.elapse(Duration(seconds: 1));
+      check(model)
+        ..fetched.isTrue()
+        ..narrow.equals(newNarrow)
+        ..messages.length.equals(100);
+    }));
+  });
+
   group('fetching more', () {
     test('fetchOlder smoke', () async {
       const narrow = CombinedFeedNarrow();
@@ -3361,6 +3403,7 @@ extension MessageListMessageItemChecks on Subject<MessageListMessageItem> {
 extension MessageListViewChecks on Subject<MessageListView> {
   Subject<PerAccountStore> get store => has((x) => x.store, 'store');
   Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
+  Subject<int> get generation => has((x) => x.generation, 'generation');
   Subject<List<Message>> get messages => has((x) => x.messages, 'messages');
   Subject<List<OutboxMessage>> get outboxMessages => has((x) => x.outboxMessages, 'outboxMessages');
   Subject<int> get middleMessage => has((x) => x.middleMessage, 'middleMessage');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -58,11 +58,14 @@ void main() {
     required Narrow narrow,
     User? selfUser,
     List<User> otherUsers = const [],
-    List<ZulipStream> streams = const [],
+    List<ZulipStream>? streams,
+    List<Subscription> subscriptions = const [],
     List<Message>? messages,
     bool? mandatoryTopics,
     int? zulipFeatureLevel,
   }) async {
+    streams ??= subscriptions;
+
     if (narrow case ChannelNarrow(:var streamId) || TopicNarrow(: var streamId)) {
       final channel = streams.firstWhereOrNull((s) => s.streamId == streamId);
       assert(channel != null,
@@ -82,6 +85,7 @@ void main() {
     await testBinding.globalStore.add(selfAccount, eg.initialSnapshot(
       realmUsers: [selfUser, ...otherUsers],
       streams: streams,
+      subscriptions: subscriptions,
       zulipFeatureLevel: zulipFeatureLevel,
       realmMandatoryTopics: mandatoryTopics,
       realmAllowMessageEditing: true,
@@ -1417,8 +1421,8 @@ void main() {
           await prepareComposeBox(tester,
             narrow: narrow,
             selfUser: eg.user(role: UserRole.administrator),
-            streams: [eg.stream(streamId: 1,
-              channelPostPolicy: ChannelPostPolicy.moderators)]);
+            subscriptions: [eg.subscription(eg.stream(streamId: 1,
+              channelPostPolicy: ChannelPostPolicy.moderators))]);
           checkComposeBox(isShown: true);
         });
 
@@ -1426,8 +1430,8 @@ void main() {
           await prepareComposeBox(tester,
             narrow: narrow,
             selfUser: eg.user(role: UserRole.moderator),
-            streams: [eg.stream(streamId: 1,
-              channelPostPolicy: ChannelPostPolicy.administrators)]);
+            subscriptions: [eg.subscription(eg.stream(streamId: 1,
+              channelPostPolicy: ChannelPostPolicy.administrators))]);
           checkComposeBox(isShown: false);
         });
       }
@@ -1437,8 +1441,8 @@ void main() {
         await prepareComposeBox(tester,
           narrow: const ChannelNarrow(1),
           selfUser: selfUser,
-          streams: [eg.stream(streamId: 1,
-            channelPostPolicy: ChannelPostPolicy.administrators)]);
+          subscriptions: [eg.subscription(eg.stream(streamId: 1,
+            channelPostPolicy: ChannelPostPolicy.administrators))]);
         checkComposeBox(isShown: true);
 
         await store.handleEvent(RealmUserUpdateEvent(id: 1,
@@ -1452,8 +1456,8 @@ void main() {
         await prepareComposeBox(tester,
           narrow: const ChannelNarrow(1),
           selfUser: selfUser,
-          streams: [eg.stream(streamId: 1,
-            channelPostPolicy: ChannelPostPolicy.moderators)]);
+          subscriptions: [eg.subscription(eg.stream(streamId: 1,
+            channelPostPolicy: ChannelPostPolicy.moderators))]);
         checkComposeBox(isShown: false);
 
         await store.handleEvent(RealmUserUpdateEvent(id: 1,
@@ -1470,7 +1474,7 @@ void main() {
         await prepareComposeBox(tester,
           narrow: const ChannelNarrow(1),
           selfUser: selfUser,
-          streams: [channel]);
+          subscriptions: [eg.subscription(channel)]);
         checkComposeBox(isShown: true);
 
         await store.handleEvent(eg.channelUpdateEvent(channel,
@@ -1488,7 +1492,7 @@ void main() {
         await prepareComposeBox(tester,
           narrow: const ChannelNarrow(1),
           selfUser: selfUser,
-          streams: [channel]);
+          subscriptions: [eg.subscription(channel)]);
         checkComposeBox(isShown: false);
 
         await store.handleEvent(eg.channelUpdateEvent(channel,

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1411,30 +1411,53 @@ void main() {
       void checkComposeBox({required bool isShown}) => checkComposeBoxIsShown(isShown,
         bannerLabel: zulipLocalizations.errorBannerCannotPostInChannelLabel);
 
-      final narrowTestCases = [
-        ('channel', const ChannelNarrow(1)),
-        ('topic',   eg.topicNarrow(1, 'topic')),
-      ];
+      const channelNarrow = ChannelNarrow(1);
+      final topicNarrow = eg.topicNarrow(1, 'topic');
 
-      for (final (String narrowType, Narrow narrow) in narrowTestCases) {
-        testWidgets('compose box is shown in $narrowType narrow', (tester) async {
+      void doTestComposeBoxShown({
+        required Narrow narrow,
+        required ChannelPostPolicy channelPostPolicy,
+        required UserRole selfUserRole,
+        required bool expected,
+      }) {
+        final description = [
+          narrow.toString(),
+          'channelPostPolicy: ${channelPostPolicy.name}',
+          'self-user role: ${selfUserRole.name}',
+        ].join(', ');
+        testWidgets(description, (tester) async {
           await prepareComposeBox(tester,
             narrow: narrow,
-            selfUser: eg.user(role: UserRole.administrator),
+            selfUser: eg.user(role: selfUserRole),
             subscriptions: [eg.subscription(eg.stream(streamId: 1,
-              channelPostPolicy: ChannelPostPolicy.moderators))]);
-          checkComposeBox(isShown: true);
-        });
-
-        testWidgets('error banner is shown in $narrowType narrow', (tester) async {
-          await prepareComposeBox(tester,
-            narrow: narrow,
-            selfUser: eg.user(role: UserRole.moderator),
-            subscriptions: [eg.subscription(eg.stream(streamId: 1,
-              channelPostPolicy: ChannelPostPolicy.administrators))]);
-          checkComposeBox(isShown: false);
+              channelPostPolicy: channelPostPolicy))]);
+          checkComposeBox(isShown: expected);
         });
       }
+
+      doTestComposeBoxShown(
+        narrow: channelNarrow,
+        channelPostPolicy: ChannelPostPolicy.moderators,
+        selfUserRole: UserRole.administrator,
+        expected: true);
+
+      doTestComposeBoxShown(
+        narrow: topicNarrow,
+        channelPostPolicy: ChannelPostPolicy.moderators,
+        selfUserRole: UserRole.administrator,
+        expected: true);
+
+      doTestComposeBoxShown(
+        narrow: channelNarrow,
+        channelPostPolicy: ChannelPostPolicy.administrators,
+        selfUserRole: UserRole.moderator,
+        expected: false);
+
+      doTestComposeBoxShown(
+        narrow: topicNarrow,
+        channelPostPolicy: ChannelPostPolicy.administrators,
+        selfUserRole: UserRole.moderator,
+        expected: false);
 
       testWidgets('user loses privilege -> compose box is replaced with the banner', (tester) async {
         final selfUser = eg.user(role: UserRole.administrator);

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -34,6 +34,7 @@ import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
+import '../model/message_list_test.dart';
 import '../model/store_checks.dart';
 import '../model/test_store.dart';
 import '../model/typing_status_test.dart';
@@ -1416,48 +1417,145 @@ void main() {
 
       void doTestComposeBoxShown({
         required Narrow narrow,
+        required bool isChannelSubscribed,
         required ChannelPostPolicy channelPostPolicy,
         required UserRole selfUserRole,
         required bool expected,
       }) {
         final description = [
           narrow.toString(),
+          'channel subscribed? $isChannelSubscribed',
           'channelPostPolicy: ${channelPostPolicy.name}',
           'self-user role: ${selfUserRole.name}',
         ].join(', ');
         testWidgets(description, (tester) async {
+          final channel = eg.stream(streamId: 1,
+            channelPostPolicy: channelPostPolicy);
           await prepareComposeBox(tester,
             narrow: narrow,
             selfUser: eg.user(role: selfUserRole),
-            subscriptions: [eg.subscription(eg.stream(streamId: 1,
-              channelPostPolicy: channelPostPolicy))]);
-          checkComposeBox(isShown: expected);
+            streams: [channel],
+            subscriptions: isChannelSubscribed ? [eg.subscription(channel)] : []);
+          checkComposeBoxIsShown(expected,
+            bannerLabel: isChannelSubscribed
+              ? zulipLocalizations.errorBannerCannotPostInChannelLabel
+              : zulipLocalizations.composeBoxBannerLabelUnsubscribedWhenCannotSend);
         });
       }
 
       doTestComposeBoxShown(
         narrow: channelNarrow,
-        channelPostPolicy: ChannelPostPolicy.moderators,
-        selfUserRole: UserRole.administrator,
-        expected: true);
-
-      doTestComposeBoxShown(
-        narrow: topicNarrow,
+        isChannelSubscribed: true,
         channelPostPolicy: ChannelPostPolicy.moderators,
         selfUserRole: UserRole.administrator,
         expected: true);
 
       doTestComposeBoxShown(
         narrow: channelNarrow,
+        isChannelSubscribed: false,
+        channelPostPolicy: ChannelPostPolicy.moderators,
+        selfUserRole: UserRole.administrator,
+        expected: true);
+
+      doTestComposeBoxShown(
+        narrow: topicNarrow,
+        isChannelSubscribed: true,
+        channelPostPolicy: ChannelPostPolicy.moderators,
+        selfUserRole: UserRole.administrator,
+        expected: true);
+
+      doTestComposeBoxShown(
+        narrow: topicNarrow,
+        isChannelSubscribed: false,
+        channelPostPolicy: ChannelPostPolicy.moderators,
+        selfUserRole: UserRole.administrator,
+        expected: true);
+
+      doTestComposeBoxShown(
+        narrow: channelNarrow,
+        isChannelSubscribed: true,
+        channelPostPolicy: ChannelPostPolicy.administrators,
+        selfUserRole: UserRole.moderator,
+        expected: false);
+
+      doTestComposeBoxShown(
+        narrow: channelNarrow,
+        isChannelSubscribed: false,
         channelPostPolicy: ChannelPostPolicy.administrators,
         selfUserRole: UserRole.moderator,
         expected: false);
 
       doTestComposeBoxShown(
         narrow: topicNarrow,
+        isChannelSubscribed: true,
         channelPostPolicy: ChannelPostPolicy.administrators,
         selfUserRole: UserRole.moderator,
         expected: false);
+
+      doTestComposeBoxShown(
+        narrow: topicNarrow,
+        isChannelSubscribed: false,
+        channelPostPolicy: ChannelPostPolicy.administrators,
+        selfUserRole: UserRole.moderator,
+        expected: false);
+
+      void doTestRefreshSubscribeButtons({required Narrow narrow}) {
+        testWidgets('Refresh/Subscribe buttons when cannot send and channel unsubscribed, $narrow', (tester) async {
+          final channel = eg.stream(streamId: 1,
+            channelPostPolicy: ChannelPostPolicy.administrators);
+          final messages = List.generate(100, (i) => eg.streamMessage(id: 1000 + i,
+            stream: channel, topic: topicNarrow.topic.apiName));
+
+          await prepareComposeBox(tester,
+            narrow: ChannelNarrow(channel.streamId),
+            selfUser: eg.user(role: UserRole.member),
+            streams: [channel],
+            subscriptions: [],
+            messages: messages);
+          checkComposeBoxIsShown(false,
+            bannerLabel: zulipLocalizations.composeBoxBannerLabelUnsubscribedWhenCannotSend);
+          check(store.debugMessageListViews).single
+            ..fetched.isTrue()..messages.length.equals(100);
+
+          connection.prepare(json:
+            eg.newestGetMessagesResult(foundOldest: true, messages: messages).toJson(),
+            delay: Duration(seconds: 1));
+          await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Refresh'));
+          await tester.pump();
+          check(store.debugMessageListViews).single
+            ..fetched.isFalse()..messages.length.equals(0);
+          await tester.pump(Duration(seconds: 1));
+          check(store.debugMessageListViews).single
+            ..fetched.isTrue()..messages.length.equals(100);
+
+          connection.takeRequests();
+
+          // prepare subscribe request, then refresh (get-messages) request
+          connection
+            ..prepare(json: {}, delay: Duration(milliseconds: 500))
+            ..prepare(json:
+                eg.newestGetMessagesResult(foundOldest: true, messages: messages).toJson(),
+                delay: Duration(seconds: 1));
+          await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Subscribe'));
+          await tester.pump();
+          await tester.pump(Duration.zero);
+          check(connection.lastRequest).isA<http.Request>()
+            ..method.equals('POST')
+            ..url.path.equals('/api/v1/users/me/subscriptions')
+            ..bodyFields.deepEquals({
+              'subscriptions': jsonEncode([{'name': channel.name}]),
+            });
+          await tester.pump(Duration(milliseconds: 500));
+          check(store.debugMessageListViews).single
+            ..fetched.isFalse()..messages.length.equals(0);
+          await tester.pump(Duration(seconds: 1));
+          check(store.debugMessageListViews).single
+            ..fetched.isTrue()..messages.length.equals(100);
+        });
+      }
+
+      doTestRefreshSubscribeButtons(narrow: channelNarrow);
+      doTestRefreshSubscribeButtons(narrow: topicNarrow);
 
       testWidgets('user loses privilege -> compose box is replaced with the banner', (tester) async {
         final selfUser = eg.user(role: UserRole.administrator);


### PR DESCRIPTION
This fixes part of the "second buggy behavior" that I described
in #1789: specifically, it fixes that behavior when the self-user
doesn't have permission to send messages in the channel.

Later, for the case where there *is* permission to send messages, we
should use a different banner label, like "Replies to your messages
will not appear automatically." I think it's smoothest not to touch
that case until we've fixed the "first" and "third" parts of #1798,
because those are bugs in the send-message experience.

Fixes-partly: #1798