### PR TITLE
tools/bump-version: Update for current version numbers; refactor; handle mismatch

### DIFF
--- a/tools/bump-version
+++ b/tools/bump-version
@@ -12,7 +12,7 @@ EOF
 
 shift && usage;
 
-major_version=0
+major_version=30
 minor_version=0
 pub_version_regexp="${major_version}\.${minor_version}\.(\d+)\+\1"
 

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eu
 
 usage () {
     cat <<EOF >&2
@@ -12,13 +12,23 @@ EOF
 
 shift && usage;
 
+major_version=0
+minor_version=0
+pub_version_regexp="${major_version}\.${minor_version}\.(\d+)\+\1"
+
 date="$(date --iso)"
 
 old_version_int="$(perl -lne '
-print $1 if (/^version: 0\.0\.(\d+)\+\1$/);
+print $1 if (/^version: '"${pub_version_regexp}"'$/);
 ' pubspec.yaml)"
+if [ -z "${old_version_int}" ]; then
+    echo >&2 "error: failed to parse current version in pubspec.yaml"
+    exit 1
+fi
+
 version_int=$(( old_version_int + 1 ))
-version_name="0.0.${version_int}"
+version_name="${major_version}.${minor_version}.${version_int}"
+pub_version="${version_name}+${version_int}"
 tag_name=v"${version_name}"
 
 had_uncommitted=
@@ -27,8 +37,8 @@ if ! git diff-index --quiet HEAD; then
 fi
 
 perl -i -0pe '
-s<^version: \K0\.0\.(\d+)\+\1$>
- <0.0.'"${version_int}"'+'"${version_int}"'>m;
+s<^version: \K'"${pub_version_regexp}"'$>
+ <'"${pub_version}"'>m;
 ' pubspec.yaml
 
 perl -i -0pe '


### PR DESCRIPTION
Tested this script manually, and with this change it's back to working for me.


## Commit messages

#### 913621b2e tools/bump-version: Better centralize version format; handle mismatch

This is NFC except in its handling of errors.

I haven't been using this script since the app launched (and have
instead done its work manually), because it assumes the version
numbers are 0.0.N+N.  After this commit, it's a small local change to
make the script handle the new 30.0.N+N version numbers, and the
script will also fail cleanly if we ever change the format again.



#### d8840782c tools/bump-version: Update for current version numbers

In principle it wouldn't be hard to generalize this logic further,
reading out the current major and minor version numbers rather than
expecting them to have certain values.

But it's not obvious what direction we'd want such generalization
to go in -- that depends on what our version-numbering practices
would be after they change.  On current plans, the versions will be
30.0.N+N indefinitely, so it's inherently uncertain what pattern we
might choose (and therefore how the version should get bumped by
this script) after we change those plans, if we someday do.
So just leave the generalization to be done if and when we need it.
