### PR TITLE
compose: Improve placeholder for self-DMs

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -597,7 +597,7 @@
   "@composeBoxGroupDmContentHint": {
     "description": "Hint text for content input when sending a message to a group."
   },
-  "composeBoxSelfDmContentHint": "Jot down something",
+  "composeBoxSelfDmContentHint": "Write yourself a note",
   "@composeBoxSelfDmContentHint": {
     "description": "Hint text for content input when sending a message to yourself."
   },

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -952,7 +952,7 @@ abstract class ZulipLocalizations {
   /// Hint text for content input when sending a message to yourself.
   ///
   /// In en, this message translates to:
-  /// **'Jot down something'**
+  /// **'Write yourself a note'**
   String get composeBoxSelfDmContentHint;
 
   /// Hint text for content input when sending a message to a channel.

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -501,7 +501,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get composeBoxGroupDmContentHint => 'Message group';
 
   @override
-  String get composeBoxSelfDmContentHint => 'Jot down something';
+  String get composeBoxSelfDmContentHint => 'Write yourself a note';
 
   @override
   String composeBoxChannelContentHint(String destination) {

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -501,7 +501,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get composeBoxGroupDmContentHint => 'Message group';
 
   @override
-  String get composeBoxSelfDmContentHint => 'Jot down something';
+  String get composeBoxSelfDmContentHint => 'Write yourself a note';
 
   @override
   String composeBoxChannelContentHint(String destination) {

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -515,7 +515,7 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get composeBoxGroupDmContentHint => 'Message group';
 
   @override
-  String get composeBoxSelfDmContentHint => 'Jot down something';
+  String get composeBoxSelfDmContentHint => 'Write yourself a note';
 
   @override
   String composeBoxChannelContentHint(String destination) {

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -501,7 +501,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get composeBoxGroupDmContentHint => 'Message group';
 
   @override
-  String get composeBoxSelfDmContentHint => 'Jot down something';
+  String get composeBoxSelfDmContentHint => 'Write yourself a note';
 
   @override
   String composeBoxChannelContentHint(String destination) {

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -501,7 +501,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get composeBoxGroupDmContentHint => 'Message group';
 
   @override
-  String get composeBoxSelfDmContentHint => 'Jot down something';
+  String get composeBoxSelfDmContentHint => 'Write yourself a note';
 
   @override
   String composeBoxChannelContentHint(String destination) {

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -501,7 +501,7 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get composeBoxGroupDmContentHint => 'Message group';
 
   @override
-  String get composeBoxSelfDmContentHint => 'Jot down something';
+  String get composeBoxSelfDmContentHint => 'Write yourself a note';
 
   @override
   String composeBoxChannelContentHint(String destination) {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -686,7 +686,7 @@ void main() {
       await prepare(tester, narrow: DmNarrow.withUser(
         eg.selfUser.userId, selfUserId: eg.selfUser.userId));
       checkComposeBoxHintTexts(tester,
-        contentHintText: 'Jot down something');
+        contentHintText: 'Write yourself a note');
     });
 
     testWidgets('to 1:1 DmNarrow', (tester) async {


### PR DESCRIPTION
Prompted by a chat thread:
  https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/placeholder.20for.20messages.20to.20yourself/near/2264458

/cc @alya 