### PR TITLE
home: Add icons label on main navigation bar.

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1231,6 +1231,18 @@
   "@wildcardMentionTopicDescription": {
     "description": "Description for \"@topic\" wildcard-mention autocomplete options when writing a channel message."
   },
+  "navBarFeedLabel": "Combined Feed",
+  "@navBarFeedLabel": {
+    "description": "Label for the Feed button on the bottom navigation bar."
+  },
+  "navBarDmLabel": "DMs",
+  "@navBarDmLabel": {
+    "description": "Label for the Direct Messages button on the bottom navigation bar."
+  },
+  "navBarMenuLabel": "Menu",
+  "@navBarMenuLabel": {
+    "description": "Label for the Menu button on the bottom navigation bar."
+  },
   "messageIsEditedLabel": "EDITED",
   "@messageIsEditedLabel": {
     "description": "Label for an edited message. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)"

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1791,6 +1791,24 @@ abstract class ZulipLocalizations {
   /// **'Notify topic'**
   String get wildcardMentionTopicDescription;
 
+  /// Label for the Feed button on the bottom navigation bar.
+  ///
+  /// In en, this message translates to:
+  /// **'Combined Feed'**
+  String get navBarFeedLabel;
+
+  /// Label for the Direct Messages button on the bottom navigation bar.
+  ///
+  /// In en, this message translates to:
+  /// **'DMs'**
+  String get navBarDmLabel;
+
+  /// Label for the Menu button on the bottom navigation bar.
+  ///
+  /// In en, this message translates to:
+  /// **'Menu'**
+  String get navBarMenuLabel;
+
   /// Label for an edited message. (Use ALL CAPS for cased alphabets: Latin, Greek, Cyrillic, etc.)
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1028,6 +1028,15 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'إخطار الموضوع';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'EDITED';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -1051,6 +1051,15 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Thema benachrichtigen';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'BEARBEITET';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1028,6 +1028,15 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'EDITED';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -1042,6 +1042,15 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'EDITED';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -1043,6 +1043,15 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notifica argomento';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'MODIFICATO';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1007,6 +1007,15 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'トピック参加者に通知';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => '編集済み';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -1028,6 +1028,15 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'EDITED';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -1043,6 +1043,15 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Powiadom w wątku';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'ZMIENIONO';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -1055,6 +1055,15 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Оповестить тему';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'ИЗМЕНЕНО';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -1030,6 +1030,15 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'UPRAVENÉ';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -1065,6 +1065,15 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Obvesti udeležence teme';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'UREJENO';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -1044,6 +1044,15 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Повідомити канал';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'РЕДАГОВАНО';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -1028,6 +1028,15 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get navBarFeedLabel => 'Combined Feed';
+
+  @override
+  String get navBarDmLabel => 'DMs';
+
+  @override
+  String get navBarMenuLabel => 'Menu';
+
+  @override
   String get messageIsEditedLabel => 'EDITED';
 
   @override

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -86,6 +86,8 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+
     const pageBodies = [
       (_HomePageTab.inbox,          InboxPageBody()),
       (_HomePageTab.channels,       SubscriptionListPageBody()),
@@ -93,28 +95,34 @@ class _HomePageState extends State<HomePage> {
       (_HomePageTab.directMessages, RecentDmConversationsPageBody()),
     ];
 
-    _NavigationBarButton button(_HomePageTab tab, IconData icon) {
+    _NavigationBarButton button(_HomePageTab tab, IconData icon, String label) {
       return _NavigationBarButton(icon: icon,
         selected: _tab.value == tab,
         onPressed: () {
           _tab.value = tab;
-        });
+        },
+        label: label);
     }
 
     // TODO(a11y): add tooltips for these buttons
     final navigationBarButtons = [
-      button(_HomePageTab.inbox,          ZulipIcons.inbox),
+      button(_HomePageTab.inbox,          ZulipIcons.inbox,
+        zulipLocalizations.inboxPageTitle),
       _NavigationBarButton(         icon: ZulipIcons.message_feed,
         selected: false,
         onPressed: () => Navigator.push(context,
           MessageListPage.buildRoute(context: context,
-            narrow: const CombinedFeedNarrow()))),
-      button(_HomePageTab.channels,       ZulipIcons.hash_italic),
+            narrow: const CombinedFeedNarrow())), 
+        label: zulipLocalizations.navBarFeedLabel),
+      button(_HomePageTab.channels,       ZulipIcons.hash_italic,
+        zulipLocalizations.channelsPageTitle),
       // TODO(#1094): Users
-      button(_HomePageTab.directMessages, ZulipIcons.two_person),
+      button(_HomePageTab.directMessages, ZulipIcons.two_person,
+        zulipLocalizations.navBarDmLabel),
       _NavigationBarButton(         icon: ZulipIcons.menu,
         selected: false,
-        onPressed: () => _showMainMenu(context, tabNotifier: _tab)),
+        onPressed: () => _showMainMenu(context, tabNotifier: _tab),
+        label: zulipLocalizations.navBarMenuLabel),
     ];
 
     final designVariables = DesignVariables.of(context);
@@ -124,17 +132,19 @@ class _HomePageState extends State<HomePage> {
       body: Stack(
         children: [
           for (final (tab, body) in pageBodies)
-            // TODO(#535): Decide if we find it helpful to use something like
-            //   [SemanticsProperties.namesRoute] to structure this UI better
-            //   for screen-reader software.
-            Offstage(offstage: tab != _tab.value, child: body),
+            Offstage(
+              offstage: tab != _tab.value,
+              child: Semantics(
+                namesRoute: true,
+                child: body))
         ]),
       bottomNavigationBar: DecoratedBox(
         decoration: BoxDecoration(
           border: Border(top: BorderSide(color: designVariables.borderBar)),
           color: designVariables.bgBotBar),
         child: SafeArea(
-          child: SizedBox(height: 48,
+          child: SizedBox(
+            height: 62,
             child: Center(
               child: ConstrainedBox(
                 // TODO(design): determine a suitable max width for bottom nav bar
@@ -231,11 +241,13 @@ class _NavigationBarButton extends StatelessWidget {
     required this.icon,
     required this.selected,
     required this.onPressed,
+    required this.label,
   });
 
   final IconData icon;
   final bool selected;
   final void Function() onPressed;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
@@ -247,19 +259,36 @@ class _NavigationBarButton extends StatelessWidget {
                                      : designVariables.icon,
     });
 
+    final textColor = selected ? designVariables.iconSelected : designVariables.icon;
+
     return AnimatedScaleOnTap(
       scaleEnd: 0.875,
       duration: const Duration(milliseconds: 100),
-      child: IconButton(
-        icon: Icon(icon, size: 24),
-        onPressed: onPressed,
-        style: IconButton.styleFrom(
-          // TODO(#417): Disable splash effects for all buttons globally.
-          splashFactory: NoSplash.splashFactory,
-          highlightColor: designVariables.navigationButtonBg,
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(4))),
-        ).copyWith(foregroundColor: iconColor)));
+      child: Column(
+        children: [
+          SizedBox(
+            height: 34,
+            child: IconButton(
+              icon: Icon(icon, size: 24),
+              onPressed: onPressed,
+              style: IconButton.styleFrom(
+                // TODO(#417): Disable splash effects for all buttons globally.
+                splashFactory: NoSplash.splashFactory,
+                highlightColor: designVariables.navigationButtonBg,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(4))),
+              ).copyWith(foregroundColor: iconColor)),
+          ),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: textColor,
+              height: 1.0,),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis)
+        ]));
   }
 }
 


### PR DESCRIPTION
### This PR introduces several improvements to the `HomePage` bottom navigation bar, focusing on UI enhancements for clarity, new functionality, and accessibility.

**Key Changes:**

| Dark Theme | Light Theme |
|---------|---------|
| ![1000051472](https://github.com/user-attachments/assets/dd6848fa-b72f-4f34-8c3f-b8837f6e4aa9) | ![1000051473](https://github.com/user-attachments/assets/19e987d9-67c6-4e94-a0be-5e8759f20093) |






1.  **Localizations:**
    *   Introduced corresponding localization keys (`navBarFeedLabel`, `navBarDmLabel`, `navBarMenuLabel`) in `app_en.arb`. The generated `l10n` files reflecting these additions are included.

2.  **Updated `_NavigationBarButton` Styling and Layout:**
    *   **Label Font Size:** The font size for navigation bar button labels (`_NavigationBarButton`) has been increased to `12px`. This change addresses design [feedback](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Flutter.20feedback.20-.20Icons.20in.20app/with/2223128:~:text=I%20think%20we,shouldn%27t%20be%20abbreviated.) from Vlad and Alya, aiming for better readability.
    *   **Multi-line Labels:** Labels are now configured to wrap up to two lines (`maxLines: 2`) with `TextOverflow.ellipsis`. This ensures that longer localized strings can be displayed without truncation, allowing the text to naturally occupy one or two lines as needed.
    *   **Fixed Navigation Bar Height (62px):**
        *   The overall height of the bottom navigation bar is maintained at a fixed `62px` (defined by the `SizedBox` in `HomePage`).
        *   **Reasoning for Fixed Height:** While consideration was given to a fully dynamic navigation bar height that adjusts based on label content across languages, this approach was not pursued. Implementing such dynamic height adjustments introduces significant layout complexity and potential for UI jitter (where the bar changes size abruptly), which can negatively impact user experience. The current fixed height of `62px` is designed to comfortably accommodate the icon (within its `34px` `SizedBox`) and up to two lines of `12px` text. The content within each button (icon and text) is currently top-aligned.

3.  **Accessibility Improvements (`SemanticsProperties.namesRoute`):**
    *   Integrated `Semantics(namesRoute: true)` for each of the page bodies (`InboxPageBody`, `SubscriptionListPageBody`, `RecentDmConversationsPageBody`) within the `HomePage`'s `Stack`.
    *   This addresses `TODO(#535)` and enhances accessibility by allowing screen readers to announce transitions between these views (Inbox, Channels, DMs) as distinct route changes, using the `AppBar` title as the route name.

4.  **Code Formatting:**
    *   Minor code formatting adjustments, such as for the `Text()` widget in `_NavigationBarButton`, have been applied for consistency with the codebase.
    *   Updating the Label Text Color Dynamically similar to that used in iconColor using Design Variables.
   
5.  **Self Admitted Technical Dept:**
    *   Language Consistency for all language for the added labels will be fixed after receiving feedback from the Moderators about the Implementation of the solution.

These changes collectively improve the functionality, visual presentation, and accessibility of the home page navigation.
