### PR TITLE
theme: Fix bgMessageRegular to match Figma specification

### DIFF
--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -246,7 +246,7 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.2),
     bgMenuButtonSelected: Colors.black.withValues(alpha: 0.25),
-    bgMessageRegular: const HSLColor.fromAHSL(1, 0, 0, 0.11).toColor(),
+    bgMessageRegular: const Color(0xff1d1d1d),
     bgTopBar: const Color(0xff242424),
     borderBar: const Color(0xffffffff).withValues(alpha: 0.1),
     borderMenuButtonSelected: Colors.white.withValues(alpha: 0.1),


### PR DESCRIPTION
theme: Fix bgMessageRegular to match Figma specification

The dark mode `bgMessageRegular` color was defined as 
`HSLColor.fromAHSL(1, 0, 0, 0.11)`, intended to match the 
[Figma design specification](https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=6262-90970&t=m9JTZk7mwN1Se9Sx-0) 
of `#1D1D1D`. However, the implementation was slightly darker 
than the design.

The HSL lightness value of 0.11 corresponds to RGB 28 (0.11 × 255),
while the target hex value 0x1D corresponds to RGB 29. This 
one-value difference is subtle but visible when comparing code 
blocks side by side as seen on the image 

This pr updates the color to `const Color(0xff1d1d1d)` to precisely 
match the Figma design, ensuring visual consistency with the 
design system.

| Before | After |
| :--- | :--- |
| <img width="500" alt="before" src="https://github.com/user-attachments/assets/45587d86-67e7-4b31-91cb-87f8c9fcb054" /> | <img width="500" alt="after" src="https://github.com/user-attachments/assets/0c27cb8a-b15e-4f1e-bf82-45876b47cb2f" /> |

Fixes #1685.