### PR TITLE
Ignore upcoming experimental_member_use warning

### DIFF
--- a/lib/model/database.dart
+++ b/lib/model/database.dart
@@ -1,5 +1,10 @@
 import 'package:drift/drift.dart';
 import 'package:drift/internal/versioned_schema.dart';
+// `package:drift/remote.dart` says:
+//   The public apis of this libraries are stable. The present [experimental]
+//   annotation refers to the underlying protocol implementation.
+// We use it only for the public API, and only of DriftRemoteException.
+// ignore: experimental_member_use  // see explanation above
 import 'package:drift/remote.dart';
 import 'package:sqlite3/common.dart';
 


### PR DESCRIPTION
In an upcoming Dart SDK change
(https://dart-review.googlesource.com/c/sdk/+/450970), I intend to add logic to the analyzer for generating a warning if an API marked @experimental is used. This will allow experimental analyzer features to be developed without creating a risk of breaking changes downstream.

To avoid this change producing a failure in the customer_testing bot (https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20customer_testing), the `zulip-flutter` customer test needs to first be modified in order to ignore the upcoming warning.