### PR TITLE
action_sheet: Prefix channel name with "#" in a confirmation dialog title

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -140,7 +140,7 @@
   "@unsubscribeConfirmationDialogTitle": {
     "description": "Title for a confirmation dialog for unsubscribing from a channel.",
     "placeholders": {
-      "channelName": {"type": "String", "example": "mobile"}
+      "channelName": {"type": "String", "example": "#mobile"}
     }
   },
   "unsubscribeConfirmationDialogMessageCannotResubscribe": "Once you leave this channel, you will not be able to rejoin.",

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -647,7 +647,7 @@ class UnsubscribeButton extends ActionSheetMenuItemButton {
       final zulipLocalizations = ZulipLocalizations.of(pageContext);
 
       final dialog = showSuggestedActionDialog(context: pageContext,
-        title: zulipLocalizations.unsubscribeConfirmationDialogTitle(subscription.name),
+        title: zulipLocalizations.unsubscribeConfirmationDialogTitle('#${subscription.name}'),
         message: zulipLocalizations.unsubscribeConfirmationDialogMessageCannotResubscribe,
         destructiveActionButton: true,
         actionButtonText: zulipLocalizations.unsubscribeConfirmationDialogConfirmButton);

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -599,7 +599,7 @@ void main() {
         await tester.pump();
 
         final (unsubscribeButton, cancelButton) = checkSuggestedActionDialog(tester,
-          expectedTitle: 'Unsubscribe from ${channel.name}?',
+          expectedTitle: 'Unsubscribe from #${channel.name}?',
           expectedMessage: 'Once you leave this channel, you will not be able to rejoin.',
           expectDestructiveActionButton: true,
           expectedActionButtonText: 'Unsubscribe');


### PR DESCRIPTION
See Alya's feedback on #1890:

https://github.com/zulip/zulip-flutter/pull/1890#issuecomment-3358327567
> In general, our pattern is to always show a privacy marker or (if
> not convenient) a `#` before a channel name. It can be a separate
> PR, but can we add that to these confirmation dialogs?

Doing this in code, rather than in the translators' source string, because we don't want it to vary by language.