### PR TITLE
tools/bump-version: Ensure using GNU coreutils

### DIFF
--- a/tools/bump-version
+++ b/tools/bump-version
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
+this_dir=${BASH_SOURCE[0]%/*}
+
+# shellcheck source=tools/lib/ensure-coreutils.sh
+. "${this_dir}"/lib/ensure-coreutils.sh
+
 usage () {
     cat <<EOF >&2
 usage: bump-version


### PR DESCRIPTION
We rely on this for `date --iso`.