### PR TITLE
message: Give access to ChannelStore in outbox-handling logic

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -913,7 +913,7 @@ class DmOutboxMessage extends OutboxMessage<DmConversation> {
 }
 
 /// Manages the outbox messages portion of [MessageStore].
-mixin _OutboxMessageStore on HasRealmStore {
+mixin _OutboxMessageStore on HasChannelStore {
   late final UnmodifiableMapView<int, OutboxMessage> outboxMessages =
     UnmodifiableMapView(_outboxMessages);
   final Map<int, OutboxMessage> _outboxMessages = {};


### PR DESCRIPTION
We'll use this for #1798 to check whether we're sending a message to an unsubscribed channel.