### PR TITLE
page: Split empty-page placeholder messages into `header` and `message`

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -80,8 +80,8 @@
   "@allChannelsPageTitle": {
     "description": "Title for the 'All channels' page."
   },
-  "allChannelsEmptyPlaceholder": "There are no channels you can view in this organization.",
-  "@allChannelsEmptyPlaceholder": {
+  "allChannelsEmptyPlaceholderHeader": "There are no channels you can view in this organization.",
+  "@allChannelsEmptyPlaceholderHeader": {
     "description": "Centered text on the 'All channels' page saying that there is no content to show."
   },
   "profileButtonSendDirectMessage": "Send direct message",
@@ -1090,9 +1090,13 @@
   "@inboxPageTitle": {
     "description": "Title for the page with unreads."
   },
-  "inboxEmptyPlaceholder": "There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.",
-  "@inboxEmptyPlaceholder": {
+  "inboxEmptyPlaceholderHeader": "There are no unread messages in your inbox.",
+  "@inboxEmptyPlaceholderHeader": {
     "description": "Centered text on the 'Inbox' page saying that there is no content to show."
+  },
+  "inboxEmptyPlaceholderMessage": "Use the buttons below to view the combined feed or list of channels.",
+  "@inboxEmptyPlaceholderMessage": {
+    "description": "Additional centered text on the 'Inbox' page saying that there is no content to show."
   },
   "recentDmConversationsPageTitle": "Direct messages",
   "@recentDmConversationsPageTitle": {
@@ -1102,9 +1106,13 @@
   "@recentDmConversationsSectionHeader": {
     "description": "Heading for direct messages section on the 'Inbox' message view."
   },
-  "recentDmConversationsEmptyPlaceholder": "You have no direct messages yet! Why not start the conversation?",
-  "@recentDmConversationsEmptyPlaceholder": {
+  "recentDmConversationsEmptyPlaceholderHeader": "You have no direct messages yet!",
+  "@recentDmConversationsEmptyPlaceholderHeader": {
     "description": "Centered text on the 'Direct messages' page saying that there is no content to show."
+  },
+  "recentDmConversationsEmptyPlaceholderMessage": "Why not start a conversation?",
+  "@recentDmConversationsEmptyPlaceholderMessage": {
+    "description": "Additional centered text on the 'Direct messages' page saying that there is no content to show."
   },
   "combinedFeedPageTitle": "Combined feed",
   "@combinedFeedPageTitle": {
@@ -1122,12 +1130,12 @@
   "@channelsPageTitle": {
     "description": "Title for the page with a list of subscribed channels."
   },
-  "channelsEmptyPlaceholder": "You’re not subscribed to any channels yet.",
-  "@channelsEmptyPlaceholder": {
+  "channelsEmptyPlaceholderHeader": "You’re not subscribed to any channels yet.",
+  "@channelsEmptyPlaceholderHeader": {
     "description": "Centered text on the 'Channels' page saying that there is no content to show."
   },
-  "channelsEmptyPlaceholderWithAllChannelsLink": "You’re not subscribed to any channels yet. Try going to <z-link>{allChannelsPageTitle}</z-link> and joining some of them.",
-  "@channelsEmptyPlaceholderWithAllChannelsLink": {
+  "channelsEmptyPlaceholderMessage": "Try going to <z-link>{allChannelsPageTitle}</z-link> and joining some of them.",
+  "@channelsEmptyPlaceholderMessage": {
     "description": "Centered text on the 'Channels' page saying that there is no content to show, with a link to 'All channels'.",
     "placeholders": {
       "allChannelsPageTitle": {"type": "String", "example": "All channels"}

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -263,7 +263,7 @@ abstract class ZulipLocalizations {
   ///
   /// In en, this message translates to:
   /// **'There are no channels you can view in this organization.'**
-  String get allChannelsEmptyPlaceholder;
+  String get allChannelsEmptyPlaceholderHeader;
 
   /// Label for button in profile screen to navigate to DMs with the shown user.
   ///
@@ -1620,8 +1620,14 @@ abstract class ZulipLocalizations {
   /// Centered text on the 'Inbox' page saying that there is no content to show.
   ///
   /// In en, this message translates to:
-  /// **'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.'**
-  String get inboxEmptyPlaceholder;
+  /// **'There are no unread messages in your inbox.'**
+  String get inboxEmptyPlaceholderHeader;
+
+  /// Additional centered text on the 'Inbox' page saying that there is no content to show.
+  ///
+  /// In en, this message translates to:
+  /// **'Use the buttons below to view the combined feed or list of channels.'**
+  String get inboxEmptyPlaceholderMessage;
 
   /// Title for the page with a list of DM conversations.
   ///
@@ -1638,8 +1644,14 @@ abstract class ZulipLocalizations {
   /// Centered text on the 'Direct messages' page saying that there is no content to show.
   ///
   /// In en, this message translates to:
-  /// **'You have no direct messages yet! Why not start the conversation?'**
-  String get recentDmConversationsEmptyPlaceholder;
+  /// **'You have no direct messages yet!'**
+  String get recentDmConversationsEmptyPlaceholderHeader;
+
+  /// Additional centered text on the 'Direct messages' page saying that there is no content to show.
+  ///
+  /// In en, this message translates to:
+  /// **'Why not start a conversation?'**
+  String get recentDmConversationsEmptyPlaceholderMessage;
 
   /// Page title for the 'Combined feed' message view.
   ///
@@ -1669,15 +1681,13 @@ abstract class ZulipLocalizations {
   ///
   /// In en, this message translates to:
   /// **'You’re not subscribed to any channels yet.'**
-  String get channelsEmptyPlaceholder;
+  String get channelsEmptyPlaceholderHeader;
 
   /// Centered text on the 'Channels' page saying that there is no content to show, with a link to 'All channels'.
   ///
   /// In en, this message translates to:
-  /// **'You’re not subscribed to any channels yet. Try going to <z-link>{allChannelsPageTitle}</z-link> and joining some of them.'**
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  );
+  /// **'Try going to <z-link>{allChannelsPageTitle}</z-link> and joining some of them.'**
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle);
 
   /// Title for the page about sharing content received from other apps.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -74,8 +74,8 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get allChannelsPageTitle => 'Alle Kanäle';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
-      'Es gibt in dieser Organisation keine Kanäle die du ansehen kannst.';
+  String get allChannelsEmptyPlaceholderHeader =>
+      'There are no channels you can view in this organization.';
 
   @override
   String get profileButtonSendDirectMessage => 'Direktnachricht senden';
@@ -936,8 +936,12 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get inboxPageTitle => 'Eingang';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'Es sind keine ungelesenen Nachrichten in deinem Eingang. Verwende die Buttons unten, um den kombinierten Feed oder die Kanalliste anzusehen.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direktnachrichten';
@@ -946,8 +950,12 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direktnachrichten';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'Du hast noch keine Direktnachrichten! Warum nicht die Unterhaltung beginnen?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Kombinierter Feed';
@@ -962,13 +970,12 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get channelsPageTitle => 'Kanäle';
 
   @override
-  String get channelsEmptyPlaceholder => 'Du hast noch keine Kanäle abonniert.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'Du hast noch keine Kanäle abonniert. Probiere zu <z-link>$allChannelsPageTitle</z-link> zu gehen und ein paar von ihnen beizutreten.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -75,7 +75,7 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -927,8 +927,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get inboxPageTitle => 'Boîte de réception';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'Aucun message non lu dans votre boîte de réception. Utilisez les boutons ci-dessous pour voir le fil groupé ou la liste des chaînes.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Messages directs';
@@ -937,8 +941,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Messages directs';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'Vous n\'avez aucun message direct pour l\'instant ! Et si vous lanciez une conversation ?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Fil groupé';
@@ -953,14 +961,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get channelsPageTitle => 'Chaînes';
 
   @override
-  String get channelsEmptyPlaceholder =>
-      'Vous n\'êtes abonné à aucune chaîne pour l\'instant.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'Vous n\'êtes abonné à aucune chaîne pour l\'instant. Allez sur <z-link>$allChannelsPageTitle</z-link> pour vous abonner.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -75,7 +75,7 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get allChannelsPageTitle => 'Titolo per la pagina \"Tutti i canali\".';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -930,8 +930,12 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'Non ci sono messaggi non letti nella posta in arrivo. Usare i pulsanti sotto per visualizzare il feed combinato o l\'elenco dei canali.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Messaggi diretti';
@@ -940,8 +944,12 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Messaggi diretti';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'Non ci sono ancora messaggi diretti! Perché non iniziare la conversazione?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Feed combinato';
@@ -956,14 +964,12 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get channelsPageTitle => 'Canali';
 
   @override
-  String get channelsEmptyPlaceholder =>
-      'Non sei ancora iscritto ad alcun canale.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -73,7 +73,7 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -891,8 +891,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get inboxPageTitle => '受信箱';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      '未読メッセージはありません。下のボタンから、統合フィードまたはチャンネル一覧を表示できます。';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'ダイレクトメッセージ';
@@ -901,8 +905,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'ダイレクトメッセージ';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'まだダイレクトメッセージはありません！会話を始めてみませんか？';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => '統合フィード';
@@ -917,13 +925,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get channelsPageTitle => 'チャンネル';
 
   @override
-  String get channelsEmptyPlaceholder => 'まだ参加しているチャンネルはありません。';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -74,8 +74,8 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get allChannelsPageTitle => 'Wszystkie kanały';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
-      'Brak kanałów, które możesz przeglądać w tej organizacji.';
+  String get allChannelsEmptyPlaceholderHeader =>
+      'There are no channels you can view in this organization.';
 
   @override
   String get profileButtonSendDirectMessage => 'Wyślij wiadomość bezpośrednią';
@@ -927,8 +927,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get inboxPageTitle => 'Odebrane';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'Obecnie brak nowych wiadomości. Skorzystaj z przycisków u dołu ekranu aby przejść do widoku mieszanego lub listy kanałów.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Wiadomości bezpośrednie';
@@ -937,8 +941,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Wiadomości bezpośrednie';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'Brak wiadomości w archiwum! Może warto rozpocząć dyskusję?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Mieszany widok';
@@ -953,13 +961,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get channelsPageTitle => 'Kanały';
 
   @override
-  String get channelsEmptyPlaceholder => 'Nie śledzisz żadnego z kanałów.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'Nie śledzisz żadnego z kanałów. Sprawdź dostępne <z-link>$allChannelsPageTitle</z-link> i dołącz do części z nich.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -74,8 +74,8 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get allChannelsPageTitle => 'Все каналы';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
-      'В этой организации нет доступных вам для просмотра каналов.';
+  String get allChannelsEmptyPlaceholderHeader =>
+      'There are no channels you can view in this organization.';
 
   @override
   String get profileButtonSendDirectMessage => 'Отправить личное сообщение';
@@ -936,8 +936,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get inboxPageTitle => 'Входящие';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'Нет непрочитанных входящих сообщений. Используйте кнопки ниже для просмотра объединенной ленты или списка каналов.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Личные сообщения';
@@ -946,8 +950,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Личные сообщения';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'У вас пока нет личных сообщений! Почему бы не начать беседу?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Объединенная лента';
@@ -962,14 +970,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get channelsPageTitle => 'Каналы';
 
   @override
-  String get channelsEmptyPlaceholder =>
-      'Вы ещё не подписаны ни на один канал.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'Вы ещё не подписаны ни на один канал. Можете посмотреть <z-link>$allChannelsPageTitle</z-link> и подписаться на какие-то из них.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -913,8 +913,12 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Priama správa';
@@ -923,8 +927,12 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Zlúčený kanál';
@@ -939,14 +947,12 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get channelsPageTitle => 'Kanály';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -73,8 +73,8 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get allChannelsPageTitle => 'Vsi kanali';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
-      'V tej organizaciji ni kanalov, ki bi si jih lahko ogledali.';
+  String get allChannelsEmptyPlaceholderHeader =>
+      'There are no channels you can view in this organization.';
 
   @override
   String get profileButtonSendDirectMessage => 'Pošlji neposredno sporočilo';
@@ -947,8 +947,12 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get inboxPageTitle => 'Nabiralnik';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'V vašem nabiralniku ni neprebranih sporočil. Uporabite spodnje gumbe za ogled združenega prikaza ali seznama kanalov.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Neposredna sporočila';
@@ -957,8 +961,12 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Neposredna sporočila';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'Zaenkrat še nimate neposrednih sporočil! Zakaj ne bi začeli pogovora?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Združen prikaz';
@@ -973,13 +981,12 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get channelsPageTitle => 'Kanali';
 
   @override
-  String get channelsEmptyPlaceholder => 'Niste še naročeni na noben kanal.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'Naročeni še niste na noben kanal. Poskusite odpreti <z-link>$allChannelsPageTitle</z-link> in se pridružiti kateremu od njih.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -74,8 +74,8 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get allChannelsPageTitle => 'Усі канали';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
-      'У цій організації немає каналів, які ви можете переглянути.';
+  String get allChannelsEmptyPlaceholderHeader =>
+      'There are no channels you can view in this organization.';
 
   @override
   String get profileButtonSendDirectMessage =>
@@ -928,8 +928,12 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get inboxPageTitle => 'Вхідні';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'Немає непрочитаних вхідних повідомлень. Використовуйте кнопки знизу для перегляду обʼєднаної стрічки або списку каналів.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Особисті повідомлення';
@@ -938,8 +942,12 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Особисті повідомлення';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'У вас поки що немає особистих повідомлень! Чому б не розпочати бесіду?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Об\'єднана стрічка';
@@ -954,13 +962,12 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get channelsPageTitle => 'Канали';
 
   @override
-  String get channelsEmptyPlaceholder => 'Ви ще не підписані на жодний канал.';
+  String get channelsEmptyPlaceholderHeader =>
+      'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'Ви ще не підписані на жодний канал. Спробуйте перейти за посиланням <z-link>$allChannelsPageTitle</z-link> та приєднатися до деяких із них.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -74,7 +74,7 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get allChannelsPageTitle => 'All channels';
 
   @override
-  String get allChannelsEmptyPlaceholder =>
+  String get allChannelsEmptyPlaceholderHeader =>
       'There are no channels you can view in this organization.';
 
   @override
@@ -911,8 +911,12 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get inboxPageTitle => 'Inbox';
 
   @override
-  String get inboxEmptyPlaceholder =>
-      'There are no unread messages in your inbox. Use the buttons below to view the combined feed or list of channels.';
+  String get inboxEmptyPlaceholderHeader =>
+      'There are no unread messages in your inbox.';
+
+  @override
+  String get inboxEmptyPlaceholderMessage =>
+      'Use the buttons below to view the combined feed or list of channels.';
 
   @override
   String get recentDmConversationsPageTitle => 'Direct messages';
@@ -921,8 +925,12 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
-  String get recentDmConversationsEmptyPlaceholder =>
-      'You have no direct messages yet! Why not start the conversation?';
+  String get recentDmConversationsEmptyPlaceholderHeader =>
+      'You have no direct messages yet!';
+
+  @override
+  String get recentDmConversationsEmptyPlaceholderMessage =>
+      'Why not start a conversation?';
 
   @override
   String get combinedFeedPageTitle => 'Combined feed';
@@ -937,14 +945,12 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get channelsPageTitle => 'Channels';
 
   @override
-  String get channelsEmptyPlaceholder =>
+  String get channelsEmptyPlaceholderHeader =>
       'You’re not subscribed to any channels yet.';
 
   @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return 'You’re not subscribed to any channels yet. Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
+  String channelsEmptyPlaceholderMessage(String allChannelsPageTitle) {
+    return 'Try going to <z-link>$allChannelsPageTitle</z-link> and joining some of them.';
   }
 
   @override
@@ -1231,9 +1237,6 @@ class ZulipLocalizationsZhHansCn extends ZulipLocalizationsZh {
 
   @override
   String get allChannelsPageTitle => '所有频道';
-
-  @override
-  String get allChannelsEmptyPlaceholder => '在该组织里你没有可以查看的频道。';
 
   @override
   String get profileButtonSendDirectMessage => '发送私信';
@@ -2025,16 +2028,10 @@ class ZulipLocalizationsZhHansCn extends ZulipLocalizationsZh {
   String get inboxPageTitle => '收件箱';
 
   @override
-  String get inboxEmptyPlaceholder => '您的收件箱中没有未读消息。您可以通过底部导航栏访问综合消息或者频道列表。';
-
-  @override
   String get recentDmConversationsPageTitle => '私信';
 
   @override
   String get recentDmConversationsSectionHeader => '私信';
-
-  @override
-  String get recentDmConversationsEmptyPlaceholder => '您还没有任何私信消息！何不开启一个新对话？';
 
   @override
   String get combinedFeedPageTitle => '综合消息';
@@ -2047,16 +2044,6 @@ class ZulipLocalizationsZhHansCn extends ZulipLocalizationsZh {
 
   @override
   String get channelsPageTitle => '频道';
-
-  @override
-  String get channelsEmptyPlaceholder => '您还没有订阅任何频道。';
-
-  @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return '你还没订阅任何频道。可以访问 <z-link>$allChannelsPageTitle</z-link>然后加入。';
-  }
 
   @override
   String get sharePageTitle => '分享';
@@ -2337,9 +2324,6 @@ class ZulipLocalizationsZhHantTw extends ZulipLocalizationsZh {
 
   @override
   String get allChannelsPageTitle => '所有頻道';
-
-  @override
-  String get allChannelsEmptyPlaceholder => '在此組織中沒有您可以查看的頻道。';
 
   @override
   String get profileButtonSendDirectMessage => '發送私訊';
@@ -3150,16 +3134,10 @@ class ZulipLocalizationsZhHantTw extends ZulipLocalizationsZh {
   String get inboxPageTitle => '收件匣';
 
   @override
-  String get inboxEmptyPlaceholder => '您的收件匣中沒有未讀訊息。請使用下方按鈕查看整合訊息流或頻道清單。';
-
-  @override
   String get recentDmConversationsPageTitle => '私人訊息';
 
   @override
   String get recentDmConversationsSectionHeader => '私人訊息';
-
-  @override
-  String get recentDmConversationsEmptyPlaceholder => '您尚未有任何私人訊息！不如開始一段對話吧？';
 
   @override
   String get combinedFeedPageTitle => '綜合饋給';
@@ -3172,16 +3150,6 @@ class ZulipLocalizationsZhHantTw extends ZulipLocalizationsZh {
 
   @override
   String get channelsPageTitle => '頻道';
-
-  @override
-  String get channelsEmptyPlaceholder => '您尚未訂閱任何頻道。';
-
-  @override
-  String channelsEmptyPlaceholderWithAllChannelsLink(
-    String allChannelsPageTitle,
-  ) {
-    return '您尚未訂閱任何頻道。請前往 <z-link>$allChannelsPageTitle</z-link> 並加入一些頻道。';
-  }
 
   @override
   String get sharePageTitle => '分享';

--- a/lib/widgets/all_channels.dart
+++ b/lib/widgets/all_channels.dart
@@ -56,7 +56,7 @@ class AllChannelsPageBody extends StatelessWidget {
 
     if (channels.isEmpty) {
       return PageBodyEmptyContentPlaceholder(
-        message: zulipLocalizations.allChannelsEmptyPlaceholder);
+        header: zulipLocalizations.allChannelsEmptyPlaceholderHeader);
     }
 
     final items = channels.values.toList();

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -165,7 +165,8 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
     if (sections.isEmpty) {
       return PageBodyEmptyContentPlaceholder(
         // TODO(#315) add e.g. "You might be interested in recent conversations."
-        message: zulipLocalizations.inboxEmptyPlaceholder);
+        header: zulipLocalizations.inboxEmptyPlaceholderHeader,
+        message: zulipLocalizations.inboxEmptyPlaceholderMessage);
     }
 
     return SafeArea( // horizontal insets

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1032,14 +1032,14 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     if (!model.fetched) return const Center(child: CircularProgressIndicator());
 
     if (model.items.isEmpty && model.haveNewest && model.haveOldest) {
-      final String message;
+      final String header;
       if (widget.narrow is KeywordSearchNarrow) {
-        message = zulipLocalizations.emptyMessageListSearch;
+        header = zulipLocalizations.emptyMessageListSearch;
       } else {
-        message = zulipLocalizations.emptyMessageList;
+        header = zulipLocalizations.emptyMessageList;
       }
 
-      return PageBodyEmptyContentPlaceholder(message: message);
+      return PageBodyEmptyContentPlaceholder(header: header);
     }
 
     // Pad the left and right insets, for small devices in landscape.

--- a/lib/widgets/page.dart
+++ b/lib/widgets/page.dart
@@ -216,6 +216,8 @@ class LoadingPlaceholderPage extends StatelessWidget {
 ///
 /// Suitable for the inbox, the message-list page, etc.
 ///
+/// Specify a header and optionally a message.
+///
 /// This handles the horizontal device insets
 /// and the bottom inset when needed (in a message list with no compose box).
 /// The top inset is handled externally by the app bar.
@@ -228,16 +230,46 @@ class LoadingPlaceholderPage extends StatelessWidget {
 class PageBodyEmptyContentPlaceholder extends StatelessWidget {
   const PageBodyEmptyContentPlaceholder({
     super.key,
+    this.header,
+    this.headerWithLinkMarkup,
+    this.onTapHeaderLink,
     this.message,
     this.messageWithLinkMarkup,
-    this.onTapLink,
+    this.onTapMessageLink,
   }) : assert(
-         (message != null)
-         ^ (messageWithLinkMarkup != null && onTapLink != null));
+         (header != null)
+         ^ (headerWithLinkMarkup != null && onTapHeaderLink != null));
 
+  final String? header;
+  final String? headerWithLinkMarkup;
+  final VoidCallback? onTapHeaderLink;
   final String? message;
   final String? messageWithLinkMarkup;
-  final VoidCallback? onTapLink;
+  final VoidCallback? onTapMessageLink;
+
+  TextStyle _headerStyle(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    return TextStyle(
+      color: designVariables.labelSearchPrompt,
+      fontSize: 22,
+      height: 1.30,
+    ).merge(weightVariableTextStyle(context, wght: 600));
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    if (header != null) {
+      return Text(
+        textAlign: TextAlign.center,
+        style: _headerStyle(context),
+        header!);
+    }
+    return TextWithLink(
+      onTap: onTapHeaderLink!,
+      textAlign: TextAlign.center,
+      style: _headerStyle(context),
+      markup: headerWithLinkMarkup!);
+  }
 
   TextStyle _messageStyle(BuildContext context) {
     final designVariables = DesignVariables.of(context);
@@ -258,25 +290,33 @@ class PageBodyEmptyContentPlaceholder extends StatelessWidget {
     }
     if (messageWithLinkMarkup != null) {
       return TextWithLink(
-        onTap: onTapLink!,
+        onTap: onTapMessageLink!,
         textAlign: TextAlign.center,
         style: _messageStyle(context),
         markup: messageWithLinkMarkup!);
     }
-    assert(false);
     return null;
   }
 
   @override
   Widget build(BuildContext context) {
+    final header = _buildHeader(context);
+    final message = _buildMessage(context);
+
     return SafeArea(
       minimum: EdgeInsets.fromLTRB(24, 0, 24, 16),
       child: Padding(
         padding: EdgeInsets.only(top: 48),
         child: Align(
           alignment: Alignment.topCenter,
-          // TODO leading and trailing elements, like in Figma (given as SVGs):
-          //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=5957-167736&m=dev
-          child: _buildMessage(context))));
+          child: Column(
+            spacing: 16,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // TODO leading and trailing elements, like in Figma (given as SVGs):
+              //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=5957-167736&m=dev
+              header,
+              ?message,
+            ]))));
   }
 }

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -107,7 +107,8 @@ class _RecentDmConversationsPageBodyState extends State<RecentDmConversationsPag
       children: [
         if (sorted.isEmpty)
           PageBodyEmptyContentPlaceholder(
-            message: zulipLocalizations.recentDmConversationsEmptyPlaceholder)
+            header: zulipLocalizations.recentDmConversationsEmptyPlaceholderHeader,
+            message: zulipLocalizations.recentDmConversationsEmptyPlaceholderMessage)
         else
           SafeArea(
             // Don't pad the bottom here; we want the list content to do that.

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -137,14 +137,15 @@ class _SubscriptionListPageBodyState extends State<SubscriptionListPageBody> wit
     if (pinned.isEmpty && unpinned.isEmpty) {
       if (includeAllChannelsButton) {
         return PageBodyEmptyContentPlaceholder(
+          header: zulipLocalizations.channelsEmptyPlaceholderHeader,
           messageWithLinkMarkup:
-            zulipLocalizations.channelsEmptyPlaceholderWithAllChannelsLink(
+            zulipLocalizations.channelsEmptyPlaceholderMessage(
               zulipLocalizations.allChannelsPageTitle),
-          onTapLink: () => Navigator.push(context,
+          onTapMessageLink: () => Navigator.push(context,
             AllChannelsPage.buildRoute(context: context)));
       } else {
         return PageBodyEmptyContentPlaceholder(
-          message: zulipLocalizations.channelsEmptyPlaceholder);
+          header: zulipLocalizations.channelsEmptyPlaceholderHeader);
       }
     }
 

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -73,8 +73,8 @@ void main() {
   group('RecentDmConversationsPage', () {
     testWidgets('appearance when empty', (tester) async {
       await setupPage(tester, users: [], dmMessages: []);
-      check(find.text('You have no direct messages yet! Why not start the conversation?'))
-        .findsOne();
+      check(find.text('You have no direct messages yet!')).findsOne();
+      check(find.text('Why not start a conversation?')).findsOne();
     });
 
     testWidgets('page builds; conversations appear in order', (tester) async {

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -63,9 +63,8 @@ void main() {
     check(getItemCount()).equals(0);
     check(isPinnedHeaderInTree()).isFalse();
     check(isUnpinnedHeaderInTree()).isFalse();
-    check(find.text(
-      'You’re not subscribed to any channels yet. Try going to All channels and joining some of them.'
-    )).findsOne();
+    check(find.text('You’re not subscribed to any channels yet.')).findsOne();
+    check(find.text('Try going to All channels and joining some of them.')).findsOne();
   });
 
   testWidgets('basic subscriptions', (tester) async {


### PR DESCRIPTION
Following a new Figma frame that specifies larger text for the first part:
  https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=11194-18392&m=dev

cc @alya @terpimost

👉 When there's just one thing to say (like "There are no messages here."), do we want that text to be big or small? I've chosen big, here, but that might not actually be intended in the Figma? Figma screenshot:

<img width="982" height="702" alt="image" src="https://github.com/user-attachments/assets/872f9861-d4c4-4fde-b443-98d51576eac9" />

-----

(This comes from rebasing/developing part of #1640.)

Note changed "the" to "a" on the "Direct messages" page.

| Before | After |
| --- | --- |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/22b43c2e-9188-4822-9830-fa1903ff1884" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/876aefa4-47dd-457a-bca1-b0ae25565e1a" /> |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/4f8f8d91-a1b2-423a-8b6b-e53059a6c5d1" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/775338e2-e899-4fb0-96d9-7af5735c069a" /> |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/da1b16e5-0018-46fb-9080-42815337514d" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/2cd49a8f-62ac-4aee-a14b-4afd367cbe23" /> |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/072a11c8-566e-4181-a4c6-8896a7f608bc" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/3eca88f5-b220-4053-9217-3f453f6e1d7c" /> |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/d18f7f67-75dd-41ca-8b1b-9ead1d428323" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/c2f5f00f-45ce-498f-8be7-e3c777eb9dfd" /> |
| <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/596948e2-8905-4575-b05e-20334e01fd98" /> | <img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/02a27c1a-6020-4dfa-8e50-82a485d99e20" /> |