### PR TITLE
button: Replace GestureDetector with Listener for `AnimatedScaleOnTap`

### DIFF
--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -289,7 +289,7 @@ class _NavigationBarButton extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
     final color = selected ? designVariables.iconSelected : designVariables.icon;
 
-    Widget result = AnimatedScaleOnTap(
+    Widget result = AnimatedScaleOnPress(
       scaleEnd: 0.875,
       duration: const Duration(milliseconds: 100),
       child: Material(
@@ -410,7 +410,7 @@ class _MainMenu extends StatelessWidget {
               child: Column(children: menuItems)))),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16),
-            child: AnimatedScaleOnTap(
+            child: AnimatedScaleOnPress(
               scaleEnd: 0.95,
               duration: Duration(milliseconds: 100),
               child: BottomSheetDismissButton(
@@ -565,7 +565,7 @@ abstract class MenuButton extends StatelessWidget {
 
     final trailing = buildTrailing(context);
 
-    return AnimatedScaleOnTap(
+    return AnimatedScaleOnPress(
       duration: const Duration(milliseconds: 100),
       scaleEnd: 0.95,
       child: TextButton(


### PR DESCRIPTION
Fixes #1953.

The Scale down and Scale up as well as Ink Splash animation occurs after a finite delay of [100ms](https://main-api.flutter.dev/flutter/gestures/kPressTimeout-constant.html). Mainly due to `GestureDetector` used inside `AnimatedScaleOnTap`. 

This can be fixed by using `Listener` hence replacing the `GestureDetector` inside `AnimatedScaleOnTap`.

Discussion: [#mobile > issue in responsiveness of home bottom navbar icons](https://chat.zulip.org/#narrow/channel/48-mobile/topic/issue.20in.20responsiveness.20of.20home.20bottom.20navbar.20icons/with/2287111)
Design: [Figma Design](https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=2961-53767&t=mRzTcUA3JoTDsUTj-4)

<details>
<summary>Comparison Through Video of Fix-up</summary>

### Before

https://github.com/user-attachments/assets/cc3c66a5-00cc-450c-88dc-6a6b9bb80d57

### After

https://github.com/user-attachments/assets/00fd4d59-564f-4041-9c19-03168a67de79


</details>


