### PR TITLE
semantics: Fix content navigation order in message content when links present

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -295,13 +295,14 @@ class MessageContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final content = this.content;
-    return InheritedMessage(message: message,
-      child: DefaultTextStyle(
-        style: ContentTheme.of(context).textStylePlainParagraph,
-        child: switch (content) {
-          ZulipContent() => BlockContentList(nodes: content.nodes),
-          PollContent()  => PollWidget(messageId: message.id, poll: content.poll),
-        }));
+    return MergeSemantics(
+      child: InheritedMessage(message: message,
+        child: DefaultTextStyle(
+          style: ContentTheme.of(context).textStylePlainParagraph,
+          child: switch (content) {
+            ZulipContent() => BlockContentList(nodes: content.nodes),
+            PollContent()  => PollWidget(messageId: message.id, poll: content.poll),
+          })));
   }
 }
 
@@ -333,53 +334,55 @@ class BlockContentList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
-      ...nodes.map((node) {
-        return switch (node) {
-          LineBreakNode() =>
-            // This goes in a Column.  So to get the effect of a newline,
-            // just use an empty Text.
-            const Text(''),
-          ThematicBreakNode() => const ThematicBreak(),
-          ParagraphNode() => Paragraph(node: node),
-          HeadingNode() => Heading(node: node),
-          QuotationNode() => Quotation(node: node),
-          ListNode() => ListNodeWidget(node: node),
-          SpoilerNode() => Spoiler(node: node),
-          CodeBlockNode() => CodeBlock(node: node),
-          MathBlockNode() => MathBlock(node: node),
-          ImagePreviewNodeList() => MessageImagePreviewList(node: node),
-          ImagePreviewNode() => (){
-            assert(false,
-              "[ImagePreviewNode] not allowed in [BlockContentList]. "
-              "It should be wrapped in [ImagePreviewNodeList]."
-            );
-            return MessageImagePreview(node: node);
-          }(),
-          InlineVideoNode() => MessageInlineVideo(node: node),
-          EmbedVideoNode() => MessageEmbedVideo(node: node),
-          TableNode() => MessageTable(node: node),
-          TableRowNode() => () {
-            assert(false,
-              "[TableRowNode] not allowed in [BlockContentList]. "
-              "It should be wrapped in [TableNode]."
-            );
-            return const SizedBox.shrink();
-          }(),
-          TableCellNode() => () {
-            assert(false,
-              "[TableCellNode] not allowed in [BlockContentList]. "
-              "It should be wrapped in [TableRowNode]."
-            );
-            return const SizedBox.shrink();
-          }(),
-          WebsitePreviewNode() => WebsitePreview(node: node),
-          UnimplementedBlockContentNode() =>
-            Text.rich(_errorUnimplemented(node, context: context)),
-        };
-
-      }),
-    ]);
+    return Semantics(
+      explicitChildNodes: true,
+      child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+        ...nodes.map((node) {
+          return switch (node) {
+            LineBreakNode() =>
+              // This goes in a Column.  So to get the effect of a newline,
+              // just use an empty Text.
+              const Text(''),
+            ThematicBreakNode() => const ThematicBreak(),
+            ParagraphNode() => Paragraph(node: node),
+            HeadingNode() => Heading(node: node),
+            QuotationNode() => Quotation(node: node),
+            ListNode() => ListNodeWidget(node: node),
+            SpoilerNode() => Spoiler(node: node),
+            CodeBlockNode() => CodeBlock(node: node),
+            MathBlockNode() => MathBlock(node: node),
+            ImagePreviewNodeList() => MessageImagePreviewList(node: node),
+            ImagePreviewNode() => (){
+              assert(false,
+                "[ImagePreviewNode] not allowed in [BlockContentList]. "
+                "It should be wrapped in [ImagePreviewNodeList]."
+              );
+              return MessageImagePreview(node: node);
+            }(),
+            InlineVideoNode() => MessageInlineVideo(node: node),
+            EmbedVideoNode() => MessageEmbedVideo(node: node),
+            TableNode() => MessageTable(node: node),
+            TableRowNode() => () {
+              assert(false,
+                "[TableRowNode] not allowed in [BlockContentList]. "
+                "It should be wrapped in [TableNode]."
+              );
+              return const SizedBox.shrink();
+            }(),
+            TableCellNode() => () {
+              assert(false,
+                "[TableCellNode] not allowed in [BlockContentList]. "
+                "It should be wrapped in [TableRowNode]."
+              );
+              return const SizedBox.shrink();
+            }(),
+            WebsitePreviewNode() => WebsitePreview(node: node),
+            UnimplementedBlockContentNode() =>
+              Text.rich(_errorUnimplemented(node, context: context)),
+          };
+      
+        }),
+      ]));
   }
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -2205,53 +2205,54 @@ class MessageWithPossibleSender extends StatelessWidget {
         : () => showMessageActionSheet(context: context, message: message),
       child: Padding(
         padding: const EdgeInsets.only(top: 4),
-        child: Column(children: [
-          if (item.showSender)
-            SenderRow(message: message,
-              timestampStyle: MessageTimestampStyle.timeOnly),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: localizedTextBaseline(context),
-            children: [
-              const SizedBox(width: 16),
-              Expanded(child: showAsMuted
-                ? Align(
-                    alignment: AlignmentDirectional.topStart,
-                    child: ZulipWebUiKitButton(
-                      label: zulipLocalizations.revealButtonLabel,
-                      icon: ZulipIcons.eye,
-                      size: ZulipWebUiKitButtonSize.small,
-                      intent: ZulipWebUiKitButtonIntent.neutral,
-                      attention: ZulipWebUiKitButtonAttention.minimal,
-                      onPressed: () {
-                        MessageListPage.ancestorOf(context).revealMutedMessage(message.id);
-                      }))
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      content,
-                      if ((message.reactions?.total ?? 0) > 0)
-                        ReactionChipsList(messageId: message.id, reactions: message.reactions!),
-                      if (editMessageErrorStatus != null)
-                        _EditMessageStatusRow(messageId: message.id, status: editMessageErrorStatus)
-                      else if (editStateText != null)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 4),
-                          child: Text(editStateText,
-                            textAlign: TextAlign.end,
-                            style: TextStyle(
-                              color: designVariables.labelEdited,
-                              fontSize: 12,
-                              height: (12 / 12),
-                              letterSpacing: proportionalLetterSpacing(context,
-                                0.05, baseFontSize: 12))))
-                      else
-                        Padding(padding: const EdgeInsets.only(bottom: 4))
-                    ])),
-              SizedBox(width: 16,
-                child: star),
-            ]),
-        ])));
+        child: MergeSemantics(
+          child: Column(children: [
+            if (item.showSender)
+              SenderRow(message: message,
+                timestampStyle: MessageTimestampStyle.timeOnly),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: localizedTextBaseline(context),
+              children: [
+                const SizedBox(width: 16),
+                Expanded(child: showAsMuted
+                  ? Align(
+                      alignment: AlignmentDirectional.topStart,
+                      child: ZulipWebUiKitButton(
+                        label: zulipLocalizations.revealButtonLabel,
+                        icon: ZulipIcons.eye,
+                        size: ZulipWebUiKitButtonSize.small,
+                        intent: ZulipWebUiKitButtonIntent.neutral,
+                        attention: ZulipWebUiKitButtonAttention.minimal,
+                        onPressed: () {
+                          MessageListPage.ancestorOf(context).revealMutedMessage(message.id);
+                        }))
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        content,
+                        if ((message.reactions?.total ?? 0) > 0)
+                          ReactionChipsList(messageId: message.id, reactions: message.reactions!),
+                        if (editMessageErrorStatus != null)
+                          _EditMessageStatusRow(messageId: message.id, status: editMessageErrorStatus)
+                        else if (editStateText != null)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 4),
+                            child: Text(editStateText,
+                              textAlign: TextAlign.end,
+                              style: TextStyle(
+                                color: designVariables.labelEdited,
+                                fontSize: 12,
+                                height: (12 / 12),
+                                letterSpacing: proportionalLetterSpacing(context,
+                                  0.05, baseFontSize: 12))))
+                        else
+                          Padding(padding: const EdgeInsets.only(bottom: 4))
+                      ])),
+                SizedBox(width: 16,
+                  child: star),
+              ]),
+          ]))));
   }
 }
 


### PR DESCRIPTION
Fixes #1963.

Displaying Semantic widget tree by wrapping the required widget with [SemanticDebugger](https://api.flutter.dev/flutter/widgets/SemanticsDebugger-class.html#:~:text=description-,SemanticsDebugger,-class) .

Possible Cause: Flutter Automatically rearranging the semantics nodes in wrong order?

<details>
<summary>Changes Displayed using SemanticsDebugger widget(Updated)</summary>

<br>

**### Clearly the Semantic Widget Tree is cleaned and is in proper order after incorporating the changes.**
<br>

| Before(Turned Off Debugger) | Before(Turned On Debugger) | After(Turned On Debugger) |
|---|---|---|
| ![1000053632](https://github.com/user-attachments/assets/ef76c36b-da9e-4460-b68c-522a4b5a9367) | ![1000053634](https://github.com/user-attachments/assets/df6ff5d3-8013-404d-8c7e-7efd29d0f3c0) | ![Screenshot_20251102_174128](https://github.com/user-attachments/assets/0f91dce5-7161-4156-b94a-f4290ab0aa15) |



</details>

Changes Done And their respective significance: 

1. Added 'Semantic' Widget over the Columns of message content to make sure the flutter does not reorder them as per its wish and provide them as isolated semantics in same order as they are placed in widget tree.

2. Added 'MergeSemantics' Widget over the `InheritedMessage` to merge semantic nodes in the same order as they were given i.e after isolating them they were passed in the same order as that of the widget tree.

3. Added 'MergeSemantics' in `MessageWithPossibleSender` to make sure when the user click the message box, i.e. click even the avatar of message receipt it should read the message of the user, not just the user name and the time it was sent at(Before the changes implemented in this PR it used to do that!).  This implementation was taken from WhatsApp where a similar behavior was observed that even clicking the avatar of the message receipt activated the whole message to be talked aloud instead of just the receipt name and time it was sent at.