### PR TITLE
Handle relative URLs in auth method display icons

### DIFF
--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -462,7 +462,12 @@ class _LoginPageState extends State<LoginPage> {
       if (externalAuthenticationMethods.isNotEmpty) ...[
         const OrDivider(),
         ...externalAuthenticationMethods.map((method) {
-          final icon = method.displayIcon;
+          final iconUrl = method.displayIcon;
+          final icon = (iconUrl != null)
+            ? (iconUrl.startsWith('http://') || iconUrl.startsWith('https://'))
+              ? iconUrl
+              : widget.serverSettings.realmUrl.resolve(iconUrl).toString()
+            : null;
           return OutlinedButton.icon(
             style: ButtonStyle(
               backgroundColor: WidgetStatePropertyAll(colorScheme.secondaryContainer),

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -408,6 +408,34 @@ void main() {
         debugNetworkImageHttpClientProvider = null;
       });
 
+      testWidgets('relative displayIcon URL is resolved correctly', (tester) async {
+        final method = ExternalAuthenticationMethod(
+          name: 'github',
+          displayName: 'GitHub',
+          displayIcon: '/static/images/authentication_backends/github-icon.png', // Relative URL
+          loginUrl: '/accounts/login/social/github',
+          signupUrl: '/accounts/register/social/github',
+        );
+        final serverSettings = eg.serverSettings(
+          externalAuthenticationMethods: [method]);
+        prepareBoringImageHttpClient(); // icon on social-auth button
+        await prepare(tester, serverSettings);
+        takeStartingRoutes();
+        check(pushedRoutes).isEmpty();
+        check(testBinding.globalStore.accounts).isEmpty();
+
+        // Verify the button exists
+        tester.widget(find.textContaining('GitHub'));
+
+        // Verify the Image.network widget receives the resolved absolute URL
+        final imageWidget = tester.widget<Image>(find.byType(Image));
+        final networkImage = imageWidget.image as NetworkImage;
+        final expectedResolvedUrl = eg.realmUrl.resolve(method.displayIcon!).toString();
+        check(networkImage.url).equals(expectedResolvedUrl);
+
+        debugNetworkImageHttpClientProvider = null;
+      });
+
       // TODO failures, such as: invalid loginUrl; URL can't be launched;
       //   WebAuthPayload.realm doesn't match the realm the UI is about
     });


### PR DESCRIPTION
## Summary
Implements support for relative URLs in `display_icon` field for external authentication methods, as requested in #1969.

## Changes
- Modified `lib/widgets/login.dart` to resolve relative URLs against `realmUrl` before passing to `Image.network()`
- Added unit test in `test/widgets/login_test.dart` to verify relative URL resolution works correctly

## Implementation Details
The fix checks if `displayIcon` starts with `http://` or `https://`. If not, it resolves the relative URL against `realmUrl` using `Uri.resolve()`, matching the pattern used for `loginUrl` resolution at line 359.

**Example:**
- Relative URL: `/static/images/google-icon.png`
- Resolved to: `https://chat.zulip.org/static/images/google-icon.png`

## Testing
- ✅ Unit test added and passing: Verifies relative URLs are correctly resolved to absolute URLs
- ✅ Backward compatibility: Absolute URLs still work as before (verified by existing test)
- ⚠️ Manual testing: I wasn't able to set up a test Zulip server to manually verify this. The unit test covers the logic, but would appreciate help from maintainers or other contributors to verify the manual testing requirement mentioned in the issue.

## Related
Fixes #1969