### PR TITLE
msglist: Fetch more messages despite previous muted batch

### DIFF
--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -593,7 +593,7 @@ bool _sameDay(DateTime date1, DateTime date2) {
 ///  * Add listeners with [addListener].
 ///  * Fetch messages with [fetchInitial].  When the fetch completes, this object
 ///    will notify its listeners (as it will any other time the data changes.)
-///  * Fetch more messages as needed with [fetchOlder].
+///  * Fetch more messages as needed with [fetchOlder] and [fetchNewer].
 ///  * On reassemble, call [reassemble].
 ///  * When the object will no longer be used, call [dispose] to free
 ///    resources on the [PerAccountStore].

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -977,7 +977,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       numBefore: kMessageListFetchBatchSize,
       numAfter: 0,
       processResult: (result) {
-        _oldestFetchedMessageId = result.messages.firstOrNull?.id ?? _oldestFetchedMessageId;
+        if (result.messages.isNotEmpty) {
+          _oldestFetchedMessageId = result.messages.first.id;
+        }
         store.reconcileMessages(result.messages);
         store.recentSenders.handleMessages(result.messages); // TODO(#824)
 
@@ -1008,7 +1010,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       numBefore: 0,
       numAfter: kMessageListFetchBatchSize,
       processResult: (result) {
-        _newestFetchedMessageId = result.messages.lastOrNull?.id ?? _newestFetchedMessageId;
+        if (result.messages.isNotEmpty) {
+          _newestFetchedMessageId = result.messages.last.id;
+        }
         store.reconcileMessages(result.messages);
         store.recentSenders.handleMessages(result.messages); // TODO(#824)
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -141,6 +141,32 @@ mixin _MessageSequence {
   /// The corresponding item index is [middleItem].
   int middleMessage = 0;
 
+  /// The ID of the oldest message fetched so far in this narrow.
+  ///
+  /// This is used as the anchor for fetching the next batch of older messages
+  /// and will be `null` if no messages of this narrow have been fetched yet.
+  ///
+  /// A message with this ID might not appear in [messages]:
+  /// - The message may be in a muted conversation.
+  /// - The message may have been moved or deleted after it was fetched.
+  ///
+  /// See also [newestFetchedMessageId].
+  int? get oldestFetchedMessageId => _oldestFetchedMessageId;
+  int? _oldestFetchedMessageId;
+
+  /// The ID of the newest message fetched so far in this narrow.
+  ///
+  /// This is used as the anchor for fetching the next batch of newer messages
+  /// and will be `null` if no messages of this narrow have been fetched yet.
+  ///
+  /// A message with this ID might not appear in [messages]:
+  /// - The message may be in a muted conversation.
+  /// - The message may have been moved or deleted after it was fetched.
+  ///
+  /// See also [oldestFetchedMessageId].
+  int? get newestFetchedMessageId => _newestFetchedMessageId;
+  int? _newestFetchedMessageId;
+
   /// Whether [messages] and [items] represent the results of a fetch.
   ///
   /// This allows the UI to distinguish "still working on fetching messages"
@@ -432,6 +458,8 @@ mixin _MessageSequence {
     generation += 1;
     messages.clear();
     middleMessage = 0;
+    _oldestFetchedMessageId = null;
+    _newestFetchedMessageId = null;
     outboxMessages.clear();
     _haveOldest = false;
     _haveNewest = false;
@@ -841,6 +869,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   Future<void> fetchInitial() async {
     assert(!fetched && !haveOldest && !haveNewest && !busyFetchingMore);
     assert(messages.isEmpty && contents.isEmpty);
+    assert(oldestFetchedMessageId == null && newestFetchedMessageId == null);
 
     if (narrow case KeywordSearchNarrow(keyword: '')) {
       // The server would reject an empty keyword search; skip the request.
@@ -855,6 +884,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     _setStatus(FetchingStatus.fetchInitial, was: FetchingStatus.unstarted);
     // TODO schedule all this in another isolate
     final generation = this.generation;
+    // TODO(#2085): handle request failure
     final result = await getMessages(store.connection,
       narrow: narrow.apiEncode(),
       anchor: anchor,
@@ -863,6 +893,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       allowEmptyTopicName: true,
     );
     if (this.generation > generation) return;
+
+    _oldestFetchedMessageId = result.messages.firstOrNull?.id;
+    _newestFetchedMessageId = result.messages.lastOrNull?.id;
 
     _adjustNarrowForTopicPermalink(result.messages.firstOrNull);
 
@@ -938,12 +971,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     if (haveOldest) return;
     if (busyFetchingMore) return;
     assert(fetched);
-    assert(messages.isNotEmpty);
+    assert(oldestFetchedMessageId != null);
     await _fetchMore(
-      anchor: NumericAnchor(messages[0].id),
+      anchor: NumericAnchor(oldestFetchedMessageId!),
       numBefore: kMessageListFetchBatchSize,
       numAfter: 0,
       processResult: (result) {
+        _oldestFetchedMessageId = result.messages.firstOrNull?.id ?? _oldestFetchedMessageId;
         store.reconcileMessages(result.messages);
         store.recentSenders.handleMessages(result.messages); // TODO(#824)
 
@@ -968,12 +1002,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     if (haveNewest) return;
     if (busyFetchingMore) return;
     assert(fetched);
-    assert(messages.isNotEmpty);
+    assert(newestFetchedMessageId != null);
     await _fetchMore(
-      anchor: NumericAnchor(messages.last.id),
+      anchor: NumericAnchor(newestFetchedMessageId!),
       numBefore: 0,
       numAfter: kMessageListFetchBatchSize,
       processResult: (result) {
+        _newestFetchedMessageId = result.messages.lastOrNull?.id ?? _newestFetchedMessageId;
         store.reconcileMessages(result.messages);
         store.recentSenders.handleMessages(result.messages); // TODO(#824)
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -620,7 +620,7 @@ bool _sameDay(DateTime date1, DateTime date2) {
 ///  * Add listeners with [addListener].
 ///  * Fetch messages with [fetchInitial].  When the fetch completes, this object
 ///    will notify its listeners (as it will any other time the data changes.)
-///  * Fetch more messages as needed with [fetchOlder].
+///  * Fetch more messages as needed with [fetchOlder] and [fetchNewer].
 ///  * On reassemble, call [reassemble].
 ///  * When the object will no longer be used, call [dispose] to free
 ///    resources on the [PerAccountStore].

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -923,6 +923,28 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       // This method was called because that just changed.
     });
 
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!model.fetched || !scrollController.hasClients) {
+        return;
+      }
+
+      // If fetchInitial or fetchOlder/fetchNewer
+      // haven't filled model.messages with any visible (i.e. unmuted) messages,
+      // or anyway not enough to fill the screen, fetch again.
+      // If we're in a long run of muted messages, this has the effect of
+      // fetching in a loop until we've either fetched the narrow's whole history
+      // or we've filled the screen with visible messages,
+      // without needing user scroll input between iterations.
+      //
+      // The right time for the "if-needed" check is
+      // after the current model change has been laid out
+      // and the scroll metrics have been updated,
+      // so that when we receive and lay out a screenful of messages,
+      // we don't fetch again unnecessarily.
+      // That's why we do it in a post-frame callback.
+      _fetchMoreIfNeeded(scrollController.position);
+    });
+
     if (!_prevFetched && model.fetched && model.messages.isEmpty) {
       // If the fetch came up empty, there's nothing to read,
       // so opening the keyboard won't be bothersome and could be helpful.

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -895,7 +895,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     model.fetchInitial();
   }
 
-  bool _prevFetched = false;
+  bool _hasAutofocused = false;
 
   void _modelChanged() {
     // When you're scrolling quickly, our mark-as-read requests include the
@@ -945,14 +945,14 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       _fetchMoreIfNeeded(scrollController.position);
     });
 
-    if (!_prevFetched && model.fetched && model.messages.isEmpty) {
-      // If the fetch came up empty, there's nothing to read,
-      // so opening the keyboard won't be bothersome and could be helpful.
+    if (model.messages.isEmpty && model.haveNewest && model.haveOldest && !_hasAutofocused) {
+      // If there are no messages to show in the whole history,
+      // opening the keyboard won't be bothersome and could be helpful.
       // It's definitely helpful if we got here from the new-DM page.
       MessageListPage.ancestorOf(context)
         .composeBoxState?.controller.requestFocusIfUnfocused();
+      _hasAutofocused = true;
     }
-    _prevFetched = model.fetched;
   }
 
   /// Find the range of message IDs on screen, as a (first, last) tuple,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -894,7 +894,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     model.fetchInitial();
   }
 
-  bool _prevFetched = false;
+  bool _autofocusDecided = false;
 
   void _modelChanged() {
     // When you're scrolling quickly, our mark-as-read requests include the
@@ -944,14 +944,17 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       _fetchMoreIfNeeded(scrollController.position);
     });
 
-    if (!_prevFetched && model.fetched && model.messages.isEmpty) {
-      // If the fetch came up empty, there's nothing to read,
-      // so opening the keyboard won't be bothersome and could be helpful.
-      // It's definitely helpful if we got here from the new-DM page.
-      MessageListPage.ancestorOf(context)
-        .composeBoxState?.controller.requestFocusIfUnfocused();
+    if (!_autofocusDecided && model.fetched
+        && (model.messages.isNotEmpty || (model.haveOldest && model.haveNewest))) {
+      _autofocusDecided = true;
+      if (model.messages.isEmpty) {
+        // If there are no messages to show in the whole history,
+        // opening the keyboard won't be bothersome and could be helpful.
+        // It's definitely helpful if we got here from the new-DM page.
+        MessageListPage.ancestorOf(context)
+          .composeBoxState?.controller.requestFocusIfUnfocused();
+      }
     }
-    _prevFetched = model.fetched;
   }
 
   /// Find the range of message IDs on screen, as a (first, last) tuple,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -922,6 +922,28 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
       // This method was called because that just changed.
     });
 
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!model.fetched || !scrollController.hasClients) {
+        return;
+      }
+
+      // If fetchInitial or fetchOlder/fetchNewer
+      // haven't filled model.messages with any visible (i.e. unmuted) messages,
+      // or anyway not enough to fill the screen, fetch again.
+      // If we're in a long run of muted messages, this has the effect of
+      // fetching in a loop until we've either fetched the narrow's whole history
+      // or we've filled the screen with visible messages,
+      // without needing user scroll input between iterations.
+      //
+      // The right time for the "if-needed" check is
+      // after the current model change has been laid out
+      // and the scroll metrics have been updated,
+      // so that when we receive and lay out a screenful of messages,
+      // we don't fetch again unnecessarily.
+      // That's why we do it in a post-frame callback.
+      _fetchMoreIfNeeded(scrollController.position);
+    });
+
     if (!_prevFetched && model.fetched && model.messages.isEmpty) {
       // If the fetch came up empty, there's nothing to read,
       // so opening the keyboard won't be bothersome and could be helpful.

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -729,6 +729,206 @@ void main() {
     });
   });
 
+  group('oldestFetchedMessageId, newestFetchedMessageId', () {
+    final mutedUser = eg.user();
+
+    Message channelMessage({required int id}) =>
+      eg.streamMessage(id: id, sender: eg.selfUser);
+
+    List<Message> channelMessages({required int fromId, required int count}) =>
+      List.generate(count, (i) => channelMessage(id: fromId + i));
+
+    List<Message> mutedDmMessages({required int fromId, required int count}) =>
+      List.generate(count, (i) =>
+        eg.dmMessage(id: fromId + i, from: eg.selfUser, to: [mutedUser]));
+
+    group('fetchInitial', () {
+      test('visible messages', () async {
+        await prepare();
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+        connection.prepare(json: newestResult(
+          foundOldest: true,
+          messages: channelMessages(fromId: 100, count: 100),
+        ).toJson());
+        await model.fetchInitial();
+
+        checkNotifiedOnce();
+        check(model)
+          ..messages.length.equals(100)
+          ..messages.first.id.equals(100)..messages.last.id.equals(199)
+          ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(199);
+      });
+
+      test('invisible messages', () async {
+        await prepare(users: [mutedUser], mutedUserIds: [mutedUser.userId]);
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+        connection.prepare(json: newestResult(
+          foundOldest: true,
+          messages: mutedDmMessages(fromId: 100, count: 100),
+        ).toJson());
+        await model.fetchInitial();
+
+        checkNotifiedOnce();
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(199);
+      });
+
+      test('no messages found', () async {
+        await prepare();
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+        connection.prepare(json: newestResult(
+          foundOldest: true,
+          messages: [],
+        ).toJson());
+        await model.fetchInitial();
+
+        checkNotifiedOnce();
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+      });
+    });
+
+    group('fetching more', () {
+      test('visible messages', () async {
+        await prepare(anchor: AnchorCode.firstUnread);
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+        await prepareMessages(
+          foundOldest: false, foundNewest: false,
+          anchorMessageId: 250,
+          messages: channelMessages(fromId: 200, count: 100));
+        check(model)
+          ..messages.length.equals(100)
+          ..messages.first.id.equals(200)..messages.last.id.equals(299)
+          ..oldestFetchedMessageId.equals(200)..newestFetchedMessageId.equals(299);
+
+        connection.prepare(json: olderResult(
+          anchor: 200, foundOldest: true,
+          messages: channelMessages(fromId: 100, count: 100),
+        ).toJson());
+        await model.fetchOlder();
+        checkNotified(count: 2);
+        check(model)
+          ..messages.length.equals(200)
+          ..messages.first.id.equals(100)..messages.last.id.equals(299)
+          ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(299);
+
+        connection.prepare(json: newerResult(
+          anchor: 299, foundNewest: true,
+          messages: channelMessages(fromId: 300, count: 100),
+        ).toJson());
+        await model.fetchNewer();
+        checkNotified(count: 2);
+        check(model)
+          ..messages.length.equals(300)
+          ..messages.first.id.equals(100)..messages.last.id.equals(399)
+          ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(399);
+      });
+
+      test('invisible messages', () async {
+        await prepare(anchor: AnchorCode.firstUnread,
+          users: [mutedUser], mutedUserIds: [mutedUser.userId]);
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+        await prepareMessages(
+          foundOldest: false, foundNewest: false,
+          anchorMessageId: 250,
+          messages: [
+            ...mutedDmMessages(fromId: 200, count: 40),
+            ...channelMessages(fromId: 240, count: 20),
+            ...mutedDmMessages(fromId: 260, count: 40),
+          ]);
+        check(model)
+          ..messages.length.equals(20)
+          ..messages.first.id.equals(240)..messages.last.id.equals(259)
+          ..oldestFetchedMessageId.equals(200)..newestFetchedMessageId.equals(299);
+
+        connection.prepare(json: olderResult(
+          anchor: 200, foundOldest: true,
+          messages: mutedDmMessages(fromId: 100, count: 100),
+        ).toJson());
+        await model.fetchOlder();
+        checkNotified(count: 2);
+        check(connection.lastRequest).isA<http.Request>()
+          .url.queryParameters['anchor'].equals('200');
+        check(model)
+          ..messages.length.equals(20)
+          ..messages.first.id.equals(240)..messages.last.id.equals(259)
+          ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(299);
+
+        connection.prepare(json: newerResult(
+          anchor: 299, foundNewest: true,
+          messages: mutedDmMessages(fromId: 300, count: 100),
+        ).toJson());
+        await model.fetchNewer();
+        checkNotified(count: 2);
+        check(connection.lastRequest).isA<http.Request>()
+          .url.queryParameters['anchor'].equals('299');
+        check(model)
+          ..messages.length.equals(20)
+          ..messages.first.id.equals(240)..messages.last.id.equals(259)
+          ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(399);
+      });
+
+      test('no messages found', () async {
+        await prepare(anchor: AnchorCode.firstUnread);
+        check(model)
+          ..messages.isEmpty()
+          ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+        await prepareMessages(
+          foundOldest: false, foundNewest: false,
+          anchorMessageId: 250,
+          messages: channelMessages(fromId: 200, count: 100));
+        check(model)
+          ..messages.length.equals(100)
+          ..messages.first.id.equals(200)..messages.last.id.equals(299)
+          ..oldestFetchedMessageId.equals(200)..newestFetchedMessageId.equals(299);
+
+        // This can happen if after the initial fetch,
+        // all the older messages got deleted/moved out of the narrow.
+        connection.prepare(json: olderResult(
+          anchor: 200, foundOldest: true,
+          messages: [],
+        ).toJson());
+        await model.fetchOlder();
+        checkNotified(count: 2);
+        check(model)
+          ..messages.length.equals(100)
+          ..messages.first.id.equals(200)..messages.last.id.equals(299)
+          ..oldestFetchedMessageId.equals(200)..newestFetchedMessageId.equals(299);
+
+        // This can happen if after the initial fetch,
+        // all the newer messages got deleted/moved out of the narrow.
+        connection.prepare(json: newerResult(
+          anchor: 299, foundNewest: true,
+          messages: [],
+        ).toJson());
+        await model.fetchNewer();
+        checkNotified(count: 2);
+        check(model)
+          ..messages.length.equals(100)
+          ..messages.first.id.equals(200)..messages.last.id.equals(299)
+          ..oldestFetchedMessageId.equals(200)..newestFetchedMessageId.equals(299);
+      });
+    });
+  });
+
   // TODO(#1569): test jumpToEnd
 
   group('MessageEvent', () {
@@ -3382,6 +3582,8 @@ void checkInvariants(MessageListView model) {
     check(model)
       ..messages.isEmpty()
       ..outboxMessages.isEmpty()
+      ..oldestFetchedMessageId.isNull()
+      ..newestFetchedMessageId.isNull()
       ..haveOldest.isFalse()
       ..haveNewest.isFalse()
       ..busyFetchingMore.isFalse();
@@ -3570,6 +3772,8 @@ extension MessageListViewChecks on Subject<MessageListView> {
   Subject<List<MessageListItem>> get items => has((x) => x.items, 'items');
   Subject<int> get middleItem => has((x) => x.middleItem, 'middleItem');
   Subject<bool> get fetched => has((x) => x.fetched, 'fetched');
+  Subject<int?> get oldestFetchedMessageId => has((x) => x.oldestFetchedMessageId, 'oldestFetchedMessageId');
+  Subject<int?> get newestFetchedMessageId => has((x) => x.newestFetchedMessageId, 'newestFetchedMessageId');
   Subject<bool> get haveOldest => has((x) => x.haveOldest, 'haveOldest');
   Subject<bool> get haveNewest => has((x) => x.haveNewest, 'haveNewest');
   Subject<bool> get busyFetchingMore => has((x) => x.busyFetchingMore, 'busyFetchingMore');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -65,11 +65,14 @@ void main() {
     List<User> otherUsers = const [],
     List<ZulipStream>? streams,
     List<Subscription> subscriptions = const [],
+    List<UserTopicItem>? userTopics,
     List<Message>? messages,
+    bool foundOldest = true,
     bool? mandatoryTopics,
     RealmTopicsPolicy? realmTopicsPolicy,
     int? zulipFeatureLevel,
     int? maxTopicLength,
+    bool skipPumpAndSettle = false,
   }) async {
     streams ??= subscriptions;
 
@@ -93,6 +96,7 @@ void main() {
       realmUsers: [selfUser, ...otherUsers],
       streams: streams,
       subscriptions: subscriptions,
+      userTopics: userTopics,
       zulipFeatureLevel: zulipFeatureLevel,
       realmTopicsPolicy: realmTopicsPolicy,
       realmMandatoryTopics: mandatoryTopics,
@@ -106,15 +110,20 @@ void main() {
     connection = store.connection as FakeApiConnection;
 
     connection.prepare(json:
-      eg.newestGetMessagesResult(foundOldest: true, messages: messages).toJson());
+      eg.newestGetMessagesResult(foundOldest: foundOldest, messages: messages).toJson());
     if (narrow is ChannelNarrow && messages.isEmpty) {
       // The topic input will autofocus, triggering a getChannelTopics request.
       connection.prepare(json: GetChannelTopicsResult(topics: []).toJson());
     }
     await tester.pumpWidget(TestZulipApp(accountId: selfAccount.id,
       child: MessageListPage(initNarrow: narrow)));
-    await tester.pumpAndSettle();
-    connection.takeRequests();
+    if (skipPumpAndSettle) {
+      await tester.pump(); // global store loaded
+      await tester.pump(); // per-account store loaded
+    } else {
+      await tester.pumpAndSettle();
+      connection.takeRequests();
+    }
 
     state = tester.state<ComposeBoxState>(find.byType(ComposeBox));
     controller = state.controller;
@@ -195,6 +204,86 @@ void main() {
       check(controller).isA<StreamComposeBoxController>()
         ..topicFocusNode.hasFocus.isFalse()
         ..contentFocusNode.hasFocus.isTrue();
+    });
+
+    testWidgets('ChannelNarrow, non-empty fetch, all muted, more unmuted history', (tester) async {
+      final channel = eg.stream();
+      await prepareComposeBox(tester,
+        narrow: ChannelNarrow(channel.streamId),
+        subscriptions: [eg.subscription(channel)],
+        userTopics: [eg.userTopicItem(channel, 'topic', .muted)],
+        messages: [eg.streamMessage(id: 100, stream: channel, topic: 'topic')],
+        foundOldest: false,
+        skipPumpAndSettle: true);
+
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(
+          anchor: 100, foundOldest: true,
+          messages: [eg.streamMessage(id: 99, stream: channel, topic: 'another')],
+        ).toJson());
+      await tester.pump(Duration.zero); // initial message fetch request
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
+
+      await tester.pump(Duration(milliseconds: 1)); // older message fetch request
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
+    });
+
+    testWidgets('ChannelNarrow, non-empty fetch, all muted, remaining history muted', (tester) async {
+      final channel = eg.stream();
+      await prepareComposeBox(tester,
+        narrow: ChannelNarrow(channel.streamId),
+        subscriptions: [eg.subscription(channel)],
+        userTopics: [eg.userTopicItem(channel, 'topic', .muted)],
+        messages: [eg.streamMessage(id: 100, stream: channel, topic: 'topic')],
+        foundOldest: false,
+        skipPumpAndSettle: true);
+
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(
+          anchor: 100, foundOldest: true,
+          messages: [eg.streamMessage(id: 99, stream: channel, topic: 'topic')],
+        ).toJson());
+      await tester.pump(Duration.zero); // initial message fetch request
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
+
+      // The topic input will autofocus, triggering a getChannelTopics request.
+      connection.prepare(json: GetChannelTopicsResult(topics: []).toJson());
+      await tester.pump(Duration(milliseconds: 1)); // older message fetch request
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isTrue()
+        ..contentFocusNode.hasFocus.isFalse();
+    });
+
+    testWidgets('ChannelNarrow, non-empty fetch, then messages deleted', (tester) async {
+      final channel = eg.stream();
+      final message = eg.streamMessage(stream: channel);
+      await prepareComposeBox(tester,
+        narrow: ChannelNarrow(channel.streamId),
+        subscriptions: [eg.subscription(channel)],
+        messages: [message]);
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
+
+      await store.handleEvent(eg.deleteMessageEvent([message]));
+      await tester.pump();
+      check(controller).isA<StreamComposeBoxController>()
+        ..topicFocusNode.hasFocus.isFalse()
+        ..contentFocusNode.hasFocus.isFalse();
     });
 
     testWidgets('TopicNarrow, non-empty fetch', (tester) async {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -908,6 +908,105 @@ void main() {
     });
   });
 
+  group('muted messages', () {
+    final mutedUser = eg.user();
+    const messageContent = '<p>first line</p>\n<p>second line</p>';
+
+    Message channelMessage({required int id}) =>
+      eg.streamMessage(id: id, sender: eg.selfUser, content: messageContent);
+
+    List<Message> channelMessages({required int fromId, required int count}) =>
+      List.generate(count, (i) => channelMessage(id: fromId + i));
+
+    List<Message> mutedDmMessages({required int fromId, required int count}) =>
+      List.generate(count, (i) =>
+        eg.dmMessage(id: fromId + i, from: eg.selfUser, to: [mutedUser], content: messageContent));
+
+    testWidgets('multiple fetch-older requests are made until there are enough messages', (tester) async {
+      await setupMessageListPage(tester, foundOldest: false,
+        mutedUserIds: [mutedUser.userId],
+        messages: [
+          channelMessage(id: 1000),
+          ...mutedDmMessages(fromId: 1001, count: 99),
+        ],
+        skipPumpAndSettle: true);
+
+      await tester.pump(); // global store loaded
+      await tester.pump(); // per-account store loaded
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(anchor: 1000, foundOldest: false,
+          messages: [
+            ...channelMessages(fromId: 900, count: 2),
+            ...mutedDmMessages(fromId: 902, count: 98),
+          ]).toJson());
+      await tester.pump(Duration.zero); // initial message fetch request
+      // (one item for the message and one for the recipient header)
+      check(messageListItemCount(tester)).equals(2);
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(anchor: 900, foundOldest: false,
+          messages: [
+            ...channelMessages(fromId: 800, count: 98),
+            ...mutedDmMessages(fromId: 898, count: 2),
+          ]).toJson());
+      await tester.pump(Duration(milliseconds: 1));
+      // The two newly-fetched messages don't trigger a scroll-metrics
+      // notification to fetch more messages, but the model listener will
+      // trigger fetching more messages.
+      check(messageListItemCount(tester)).equals(2 + 2);
+
+      // Although there are more messages in the history (`foundOldest: false`
+      // in the last reponse), another request is not made as there are
+      // enough messages for now.
+      await tester.pump(Duration(milliseconds: 1));
+      check(messageListItemCount(tester)).equals(2 + 2 + 98);
+    });
+
+    testWidgets('mid-history, fetch-initial and fetch-older with too few messages -> fetch-newer request gets made', (tester) async {
+      // Test for a potential regression: https://github.com/zulip/zulip-flutter/pull/1989#discussion_r2677697050
+
+      await setupMessageListPage(tester,
+        mutedUserIds: [mutedUser.userId],
+        fetchResult: eg.nearGetMessagesResult(
+          anchor: 1000, foundOldest: false, foundNewest: false,
+          messages: [
+            ...mutedDmMessages(fromId: 900, count: 100),
+            channelMessage(id: 1000),
+            ...mutedDmMessages(fromId: 1001, count: 99),
+          ]),
+        skipPumpAndSettle: true);
+
+      await tester.pump(); // global store loaded
+      await tester.pump(); // per-account store loaded
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(anchor: 900, foundOldest: true,
+          messages: [
+            ...channelMessages(fromId: 800, count: 2),
+            ...mutedDmMessages(fromId: 802, count: 98),
+          ]).toJson());
+      await tester.pump(Duration.zero); // initial message fetch request
+      // (one item for the message and one for the recipient header)
+      check(messageListItemCount(tester)).equals(2);
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.newerGetMessagesResult(anchor: 1100, foundNewest: true,
+          messages: [
+            ...channelMessages(fromId: 1100, count: 2),
+            ...mutedDmMessages(fromId: 1102, count: 98),
+          ]).toJson());
+      await tester.pump(Duration(milliseconds: 1)); // older message fetch request
+      // The two newly-fetched (older) messages don't trigger a scroll-metrics
+      // notification to fetch newer messages, but the model listener will
+      // trigger fetching newer messages.
+      check(messageListItemCount(tester)).equals(2 + 2);
+
+      await tester.pump(Duration(milliseconds: 1)); // newer message fetch request
+      check(messageListItemCount(tester)).equals(2 + 2 + 2);
+    });
+  });
+
   group('scroll position', () {
     // The scrolling behavior is tested in more detail in the tests of
     // [MessageListScrollView], in scrolling_test.dart .
@@ -1648,7 +1747,12 @@ void main() {
         ..decoration.isNotNull().hintText.equals('Message #${channel.name} > $topic')
         ..controller.isNotNull().text.equals('Some text');
 
-      prepareGetMessageResponse([message]);
+      prepareGetMessageResponse(
+        // `foundOldest: true` just to avoid having to prepare a fetch-older
+        // response; the message list would otherwise refetch when it notices
+        // it doesn't have a screenful of messages.
+        foundOldest: true,
+        [message]);
       await handleMessageMoveEvent([message], 'new topic', newChannelId: otherChannel.streamId);
       await tester.pump(const Duration(seconds: 1));
       check(tester.widget<TextField>(channelContentInputFinder))
@@ -1710,7 +1814,12 @@ void main() {
       await setupMessageListPage(tester,
         narrow: narrow, messages: [message], subscriptions: [subscription]);
 
-      prepareGetMessageResponse([message]);
+      prepareGetMessageResponse(
+        // `foundOldest: true` just to avoid having to prepare a fetch-older
+        // response; the message list would otherwise refetch when it notices
+        // it doesn't have a screenful of messages.
+        foundOldest: true,
+        [message]);
       await handleMessageMoveEvent([message], 'new topic');
       await tester.pump(const Duration(seconds: 1));
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -135,8 +135,14 @@ void main() {
     return findScrollView(tester).controller;
   }
 
+  int? messageListItemCount(WidgetTester tester) =>
+    findScrollView(tester).semanticChildCount;
+
   final contentInputFinder = find.byWidgetPredicate(
     (widget) => widget is TextField && widget.controller is ComposeContentController);
+
+  final findPlaceholder = find.byType(PageBodyEmptyContentPlaceholder);
+  final findLoadingIndicator = find.byType(CircularProgressIndicator);
 
   group('MessageListPage', () {
     testWidgets('ancestorOf finds page state from message', (tester) async {
@@ -406,8 +412,6 @@ void main() {
   });
 
   group('no-messages placeholder', () {
-    final findPlaceholder = find.byType(PageBodyEmptyContentPlaceholder);
-
     Finder findTextInPlaceholder(String text) =>
       find.descendant(of: findPlaceholder, matching: find.textContaining(text));
 
@@ -819,13 +823,10 @@ void main() {
     //   in particular test it happens even when near top as well as bottom
     //   (because may have haveOldest true but haveNewest false)
 
-    int? itemCount(WidgetTester tester) =>
-      findScrollView(tester).semanticChildCount;
-
     testWidgets('basic', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
         messages: List.generate(300, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
-      check(itemCount(tester)).equals(301);
+      check(messageListItemCount(tester)).equals(301);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -838,14 +839,14 @@ void main() {
       await tester.pump(Duration.zero); // Allow a frame for the response to arrive.
 
       // Now we have more messages.
-      check(itemCount(tester)).equals(401);
+      check(messageListItemCount(tester)).equals(401);
     });
 
     testWidgets('no double-fetch glitch', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
         messages: List.generate(300, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
       connection.takeRequests();
-      check(itemCount(tester)).equals(301);
+      check(messageListItemCount(tester)).equals(301);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -869,7 +870,7 @@ void main() {
 
       // Allow a delayed frame for the response to arrive.
       await tester.pump(Duration(milliseconds: 1));
-      check(itemCount(tester)).equals(401);
+      check(messageListItemCount(tester)).equals(401);
       await tester.pumpAndSettle();
       // Check there is no additional request made to cause double-fetch glitch.
       check(connection.takeRequests()).isEmpty();
@@ -883,7 +884,7 @@ void main() {
         ...List.generate(100, (i) => eg.streamMessage(id: 1302 + i)),
       ]);
       final lastRequest = connection.lastRequest;
-      check(itemCount(tester)).equals(402);
+      check(messageListItemCount(tester)).equals(402);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -1075,8 +1076,6 @@ void main() {
   // TODO test markers at start of list (`_buildStartCap`)
 
   group('markers at end of list', () {
-    final findLoadingIndicator = find.byType(CircularProgressIndicator);
-
     testWidgets('spacer when have newest', (tester) async {
       final messages = List.generate(10,
         (i) => eg.streamMessage(content: '<p>message $i</p>'));

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -925,6 +925,108 @@ void main() {
     });
   });
 
+  group('muted messages', () {
+    final mutedUser = eg.user();
+    // Two-line content; with ~100 messages, this keeps us
+    // from reaching `kFetchMessagesBufferPixels` and triggering
+    // another message fetch.
+    const messageContent = '<p>first line</p>\n<p>second line</p>';
+
+    Message channelMessage({required int id}) =>
+      eg.streamMessage(id: id, sender: eg.selfUser, content: messageContent);
+
+    List<Message> channelMessages({required int fromId, required int count}) =>
+      List.generate(count, (i) => channelMessage(id: fromId + i));
+
+    List<Message> mutedDmMessages({required int fromId, required int count}) =>
+      List.generate(count, (i) =>
+        eg.dmMessage(id: fromId + i, from: eg.selfUser, to: [mutedUser], content: messageContent));
+
+    testWidgets('multiple fetch-older requests are made until there are enough messages', (tester) async {
+      await setupMessageListPage(tester, foundOldest: false,
+        mutedUserIds: [mutedUser.userId],
+        messages: [
+          channelMessage(id: 1000),
+          ...mutedDmMessages(fromId: 1001, count: 99),
+        ],
+        skipPumpAndSettle: true);
+
+      await tester.pump(); // global store loaded
+      await tester.pump(); // per-account store loaded
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(anchor: 1000, foundOldest: false,
+          messages: [
+            ...channelMessages(fromId: 900, count: 2),
+            ...mutedDmMessages(fromId: 902, count: 98),
+          ]).toJson());
+      await tester.pump(Duration.zero); // initial message fetch request
+      // (one item for the message and one for the recipient header)
+      check(messageListItemCount(tester)).equals(2);
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(anchor: 900, foundOldest: false,
+          messages: [
+            ...channelMessages(fromId: 800, count: 98),
+            ...mutedDmMessages(fromId: 898, count: 2),
+          ]).toJson());
+      await tester.pump(Duration(milliseconds: 1));
+      // The two newly-fetched messages don't trigger a scroll-metrics
+      // notification to fetch more messages, but the model listener will
+      // trigger fetching more messages.
+      check(messageListItemCount(tester)).equals(2 + 2);
+
+      // Although there are more messages in the history (`foundOldest: false`
+      // in the last response), another request is not made as there are
+      // enough messages for now.
+      await tester.pump(Duration(milliseconds: 1));
+      check(messageListItemCount(tester)).equals(2 + 2 + 98);
+    });
+
+    testWidgets('mid-history, fetch-initial and fetch-older with too few messages -> fetch-newer request gets made', (tester) async {
+      // Test for a potential regression: https://github.com/zulip/zulip-flutter/pull/1989#discussion_r2677697050
+
+      await setupMessageListPage(tester,
+        mutedUserIds: [mutedUser.userId],
+        fetchResult: eg.nearGetMessagesResult(
+          anchor: 1000, foundOldest: false, foundNewest: false,
+          messages: [
+            ...mutedDmMessages(fromId: 900, count: 100),
+            channelMessage(id: 1000),
+            ...mutedDmMessages(fromId: 1001, count: 99),
+          ]),
+        skipPumpAndSettle: true);
+
+      await tester.pump(); // global store loaded
+      await tester.pump(); // per-account store loaded
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.olderGetMessagesResult(anchor: 900, foundOldest: true,
+          messages: [
+            ...channelMessages(fromId: 800, count: 2),
+            ...mutedDmMessages(fromId: 802, count: 98),
+          ]).toJson());
+      await tester.pump(Duration.zero); // initial message fetch request
+      // (one item for the message and one for the recipient header)
+      check(messageListItemCount(tester)).equals(2);
+
+      connection.prepare(delay: Duration(milliseconds: 1),
+        json: eg.newerGetMessagesResult(anchor: 1099, foundNewest: true,
+          messages: [
+            ...channelMessages(fromId: 1100, count: 2),
+            ...mutedDmMessages(fromId: 1102, count: 98),
+          ]).toJson());
+      await tester.pump(Duration(milliseconds: 1)); // older message fetch request
+      // The two newly-fetched (older) messages don't trigger a scroll-metrics
+      // notification to fetch newer messages, but the model listener will
+      // trigger fetching newer messages.
+      check(messageListItemCount(tester)).equals(2 + 2);
+
+      await tester.pump(Duration(milliseconds: 1)); // newer message fetch request
+      check(messageListItemCount(tester)).equals(2 + 2 + 2);
+    });
+  });
+
   group('scroll position', () {
     // The scrolling behavior is tested in more detail in the tests of
     // [MessageListScrollView], in scrolling_test.dart .
@@ -1665,7 +1767,12 @@ void main() {
         ..decoration.isNotNull().hintText.equals('Message #${channel.name} > $topic')
         ..controller.isNotNull().text.equals('Some text');
 
-      prepareGetMessageResponse([message]);
+      prepareGetMessageResponse(
+        // `foundOldest: true` just to avoid having to prepare a fetch-older
+        // response; the message list would otherwise refetch when it notices
+        // it doesn't have a screenful of messages.
+        foundOldest: true,
+        [message]);
       await handleMessageMoveEvent([message], 'new topic', newChannelId: otherChannel.streamId);
       await tester.pump(const Duration(seconds: 1));
       check(tester.widget<TextField>(channelContentInputFinder))
@@ -1727,7 +1834,12 @@ void main() {
       await setupMessageListPage(tester,
         narrow: narrow, messages: [message], subscriptions: [subscription]);
 
-      prepareGetMessageResponse([message]);
+      prepareGetMessageResponse(
+        // `foundOldest: true` just to avoid having to prepare a fetch-older
+        // response; the message list would otherwise refetch when it notices
+        // it doesn't have a screenful of messages.
+        foundOldest: true,
+        [message]);
       await handleMessageMoveEvent([message], 'new topic');
       await tester.pump(const Duration(seconds: 1));
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -136,8 +136,14 @@ void main() {
     return findScrollView(tester).controller;
   }
 
+  int? messageListItemCount(WidgetTester tester) =>
+    findScrollView(tester).semanticChildCount;
+
   final contentInputFinder = find.byWidgetPredicate(
     (widget) => widget is TextField && widget.controller is ComposeContentController);
+
+  final findPlaceholder = find.byType(PageBodyEmptyContentPlaceholder);
+  final findLoadingIndicator = find.byType(CircularProgressIndicator);
 
   group('MessageListPage', () {
     testWidgets('ancestorOf finds page state from message', (tester) async {
@@ -423,8 +429,6 @@ void main() {
   });
 
   group('no-messages placeholder', () {
-    final findPlaceholder = find.byType(PageBodyEmptyContentPlaceholder);
-
     Finder findTextInPlaceholder(String text) =>
       find.descendant(of: findPlaceholder, matching: find.textContaining(text));
 
@@ -836,13 +840,10 @@ void main() {
     //   in particular test it happens even when near top as well as bottom
     //   (because may have haveOldest true but haveNewest false)
 
-    int? itemCount(WidgetTester tester) =>
-      findScrollView(tester).semanticChildCount;
-
     testWidgets('basic', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
         messages: List.generate(300, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
-      check(itemCount(tester)).equals(301);
+      check(messageListItemCount(tester)).equals(301);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -855,14 +856,14 @@ void main() {
       await tester.pump(Duration.zero); // Allow a frame for the response to arrive.
 
       // Now we have more messages.
-      check(itemCount(tester)).equals(401);
+      check(messageListItemCount(tester)).equals(401);
     });
 
     testWidgets('no double-fetch glitch', (tester) async {
       await setupMessageListPage(tester, foundOldest: false,
         messages: List.generate(300, (i) => eg.streamMessage(id: 950 + i, sender: eg.selfUser)));
       connection.takeRequests();
-      check(itemCount(tester)).equals(301);
+      check(messageListItemCount(tester)).equals(301);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -886,7 +887,7 @@ void main() {
 
       // Allow a delayed frame for the response to arrive.
       await tester.pump(Duration(milliseconds: 1));
-      check(itemCount(tester)).equals(401);
+      check(messageListItemCount(tester)).equals(401);
       await tester.pumpAndSettle();
       // Check there is no additional request made to cause double-fetch glitch.
       check(connection.takeRequests()).isEmpty();
@@ -900,7 +901,7 @@ void main() {
         ...List.generate(100, (i) => eg.streamMessage(id: 1302 + i)),
       ]);
       final lastRequest = connection.lastRequest;
-      check(itemCount(tester)).equals(402);
+      check(messageListItemCount(tester)).equals(402);
 
       // Fling-scroll upward...
       await tester.fling(find.byType(MessageListPage), const Offset(0, 300), 8000);
@@ -1092,8 +1093,6 @@ void main() {
   // TODO test markers at start of list (`_buildStartCap`)
 
   group('markers at end of list', () {
-    final findLoadingIndicator = find.byType(CircularProgressIndicator);
-
     testWidgets('spacer when have newest', (tester) async {
       final messages = List.generate(10,
         (i) => eg.streamMessage(content: '<p>message $i</p>'));


### PR DESCRIPTION
Fixes: #1256

<details>
<summary>Screen recordings</summary>

### First batch - Empty

#### Before
https://github.com/user-attachments/assets/9d631020-262e-4fed-94b5-9c40485d3787

#### After
https://github.com/user-attachments/assets/de47ac15-3c15-48f1-a271-91d0604ab1ff

### First batch - Less than a screenful

#### Before
https://github.com/user-attachments/assets/6db2189f-5486-497c-bc0b-4642a12dafb1

#### After
https://github.com/user-attachments/assets/30582988-4deb-466a-81e1-b4add904c2a1

</details>









