### PR TITLE
msglist: Use directional positioning for unread marker in RTL

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1639,9 +1639,9 @@ class _UnreadMarker extends StatelessWidget {
     return Stack(
       children: [
         child,
-        Positioned(
+        PositionedDirectional(
           top: 0,
-          left: 0,
+          start: 0,
           bottom: 0,
           width: 4,
           child: AnimatedOpacity(
@@ -1653,7 +1653,7 @@ class _UnreadMarker extends StatelessWidget {
             child: DecoratedBox(
               decoration: BoxDecoration(
                 color: messageListTheme.unreadMarker,
-                border: Border(left: BorderSide(
+                border: BorderDirectional(start: BorderSide(
                   width: 1,
                   color: messageListTheme.unreadMarkerGap)))))),
       ]);


### PR DESCRIPTION
Fixes #1245

This PR corrects the unread-marker alignment in RTL layouts.

**Problem:** 
_UnreadMarker used LTR-specific properties (left: 0, Border(left: …)), causing the unread marker to always appear on the left, even for RTL languages like Arabic.

**Fix**
Therefore Replaced LTR-specific properties with directional equivalents:
PositionedDirectional(start: 0)
BorderDirectional(start: BorderSide(...))

This ensures the unread marker appears on the correct “start” side based on text direction.

Manually tested by setting:
locale: Locale('ar')

Verified correct behavior in both LTR and RTL layouts (screenshots included).

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/472926d4-a786-45a1-99d9-962d6a05e1d6" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/f778a083-bc14-44a6-94d4-f8ecdb252127" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/9948060a-ffbc-46e5-80c8-52a6e7c81445" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/5b40454b-8f79-4c57-9bde-082ddd1177d2" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>




