### PR TITLE
emoji: Ensure consistent row height for plain text emoji theme.

### DIFF
--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -578,20 +578,22 @@ class EmojiPickerListEntry extends StatelessWidget {
           : Colors.transparent),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Row(spacing: 4, children: [
-          if (glyph != null)
-            Padding(
-              padding: const EdgeInsets.all(10),
-              child: glyph),
-          Flexible(child: Text(label,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              fontSize: 17,
-              height: 18 / 17,
-              color: designVariables.textMessage)))
-        ]),
-      ));
+        child: ConstrainedBox(
+          // Ensure the row meets the minimum touch target height.
+          constraints: const BoxConstraints(minHeight: 44),
+          child: Row(spacing: 4, children: [
+            if (glyph != null)
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: glyph),
+            Flexible(child: Text(label,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 17,
+                height: 18 / 17,
+                color: designVariables.textMessage)))
+          ]))));
   }
 }
 


### PR DESCRIPTION
Fixes #1587

Fix vertical layout shift in plain-text emoji picker by enforcing 44px minimum row height to match icon-based rows.

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/72ef2e4a-ba77-4f82-822e-092b3da623df" alt="Google" width="300"/>
      <p align="center"><strong>Default</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/693f56d1-73cc-4032-94d7-113ce3211eb8" alt="Plain Text" width="300"/>
      <p align="center"><strong>Plain Text</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/72ef2e4a-ba77-4f82-822e-092b3da623df" alt="LTR" width="300"/>
      <p align="center"><strong>Default</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/44621f24-0713-415f-9e21-dd225dd5304f" alt="RTL" width="300"/>
      <p align="center"><strong>Plain Text</strong></p>
    </td>
  </tr>
</table>
