### PR TITLE
content: Use directional layout for block quotations

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -468,12 +468,12 @@ class Quotation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 10),
+      padding: const EdgeInsetsDirectional.only(start: 10),
       child: Container(
-        padding: const EdgeInsets.only(left: 5),
+        padding: const EdgeInsetsDirectional.only(start: 5),
         decoration: BoxDecoration(
-          border: Border(
-            left: BorderSide(
+          border: BorderDirectional(
+            start: BorderSide(
               width: 5,
               // Web has the same color in light and dark mode.
               color: const HSLColor.fromAHSL(1, 0, 0, 0.87).toColor()))),


### PR DESCRIPTION
This fixes the layout of block quotes (`> quote`) in RTL languages.

Previously, the vertical bar was stuck on the Left side even in RTL mode. Now, it correctly flips to the Right side (the "start" of the text).

This addresses one of the RTL issues identified by @gnprice in [this comment](https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3573671163).

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/c8f2be40-6ef7-4609-9198-4f71fdc4612a" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/30d5ca1e-82e2-4e8c-af48-e1237485f195" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/d6dbd168-af49-4085-a483-fbd71bc7b05d" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/74611645-bbf1-4fc8-ae65-8dc58d931433" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>
