### PR TITLE
action: Add dialog to markNarrowAsRead when outside of conversation view

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1017,19 +1017,23 @@
   "@errorMarkAsUnreadFailedTitle": {
     "description": "Error title when mark as unread action failed."
   },
-  "markAllAsReadConfirmationDialogTitle": "Mark messages as read?",
+  "markAllAsReadConfirmationDialogTitle": "{count, plural, =1{Mark {count}+ messages as read?} other{Mark {count}+ messages as read?}}",
   "@markAllAsReadConfirmationDialogTitle": {
-    "description": "Title of the confirmation dialog for marking all messages as read."
-  },
-  "markAllAsReadConfirmationDialogMessage": "{count, plural, =1{{count} message will be marked as read.} other{{count} messages will be marked as read.}}",
-  "@markAllAsReadConfirmationDialogMessage": {
-    "description": "Message in the confirmation dialog for marking all messages as read.",
+    "description": "Title of the confirmation dialog for marking all messages as read. The '+' means 'this many messages or more'.",
     "placeholders": {
       "count": {
         "type": "int",
-        "description": "Number of messages that will be marked as read"
+        "description": "Minimum number of messages that will be marked as read"
       }
     }
+  },
+  "markAllAsReadConfirmationDialogTitleNoCount": "Mark messages as read?",
+  "@markAllAsReadConfirmationDialogTitleNoCount": {
+    "description": "Title of the confirmation dialog for marking all messages as read."
+  },
+  "markAllAsReadConfirmationDialogMessage": "Messages in multiple conversations may be affected.",
+  "@markAllAsReadConfirmationDialogMessage": {
+    "description": "Message in the confirmation dialog for marking all messages as read."
   },
   "markAllAsReadConfirmationDialogConfirmButton": "Mark as read",
   "@markAllAsReadConfirmationDialogConfirmButton": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1505,17 +1505,23 @@ abstract class ZulipLocalizations {
   /// **'Mark as unread failed'**
   String get errorMarkAsUnreadFailedTitle;
 
+  /// Title of the confirmation dialog for marking all messages as read. The '+' means 'this many messages or more'.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Mark {count}+ messages as read?} other{Mark {count}+ messages as read?}}'**
+  String markAllAsReadConfirmationDialogTitle(int count);
+
   /// Title of the confirmation dialog for marking all messages as read.
   ///
   /// In en, this message translates to:
   /// **'Mark messages as read?'**
-  String get markAllAsReadConfirmationDialogTitle;
+  String get markAllAsReadConfirmationDialogTitleNoCount;
 
   /// Message in the confirmation dialog for marking all messages as read.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, =1{{count} message will be marked as read.} other{{count} messages will be marked as read.}}'**
-  String markAllAsReadConfirmationDialogMessage(int count);
+  /// **'Messages in multiple conversations may be affected.'**
+  String get markAllAsReadConfirmationDialogMessage;
 
   /// Label for the 'Mark as read' button on a confirmation dialog for marking all messages as read.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -878,18 +878,23 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'Als ungelesen markieren fehlgeschlagen';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -886,18 +886,23 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Échec du marquage comme non lu';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -865,18 +865,23 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
       'Contrassegno come non letti non riuscito';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -833,18 +833,23 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => '未読にできませんでした';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -869,18 +869,23 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Oznaczanie jako nieprzeczytane bez powodzenia';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -873,18 +873,23 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'Не удалось снять отметку прочтения';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -854,18 +854,23 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'Zlyhalo označenie správ za prečítané';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -882,18 +882,23 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
       'Označevanje kot neprebrano ni uspelo';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -870,18 +870,23 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
       'Не вдалося позначити як непрочитане';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -852,18 +852,23 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get errorMarkAsUnreadFailedTitle => 'Mark as unread failed';
 
   @override
-  String get markAllAsReadConfirmationDialogTitle => 'Mark messages as read?';
-
-  @override
-  String markAllAsReadConfirmationDialogMessage(int count) {
+  String markAllAsReadConfirmationDialogTitle(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages will be marked as read.',
-      one: '$count message will be marked as read.',
+      other: 'Mark $count+ messages as read?',
+      one: 'Mark $count+ messages as read?',
     );
     return '$_temp0';
   }
+
+  @override
+  String get markAllAsReadConfirmationDialogTitleNoCount =>
+      'Mark messages as read?';
+
+  @override
+  String get markAllAsReadConfirmationDialogMessage =>
+      'Messages in multiple conversations may be affected.';
 
   @override
   String get markAllAsReadConfirmationDialogConfirmButton => 'Mark as read';

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -47,9 +47,18 @@ abstract final class ZulipAction {
     };
     if (shouldShowConfirmationDialog) {
       final unreadCount = store.unreads.countInNarrow(narrow);
+      const minDisplayCount = 10;
+      const displayCountStepSize = 25;
+      final displayCount = switch (unreadCount) {
+        (< minDisplayCount)      => null,
+        (< displayCountStepSize) => unreadCount,
+        _ => unreadCount - (unreadCount % displayCountStepSize),
+      };
       final didConfirm = showSuggestedActionDialog(context: context,
-        title: zulipLocalizations.markAllAsReadConfirmationDialogTitle,
-        message: zulipLocalizations.markAllAsReadConfirmationDialogMessage(unreadCount),
+        title: displayCount == null
+          ? zulipLocalizations.markAllAsReadConfirmationDialogTitleNoCount
+          : zulipLocalizations.markAllAsReadConfirmationDialogTitle(displayCount),
+        message: zulipLocalizations.markAllAsReadConfirmationDialogMessage,
         actionButtonText: zulipLocalizations.markAllAsReadConfirmationDialogConfirmButton);
       if (await didConfirm.result != true) return;
       if (!context.mounted) return;

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -495,10 +495,9 @@ void main() {
         await tester.tap(findButtonForLabel('Mark channel as read'));
         await tester.pump();
         await tester.pump();
-        final unreadCount = store.unreads.countInChannelNarrow(someChannel.streamId);
         final (confirmButton, _) = checkSuggestedActionDialog(tester,
-          expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitle,
-          expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage(unreadCount),
+          expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitleNoCount,
+          expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage,
           expectedActionButtonText: zulipLocalizations.markAllAsReadConfirmationDialogConfirmButton);
         await tester.tap(find.byWidget(confirmButton));
         await tester.pumpAndSettle();
@@ -516,10 +515,9 @@ void main() {
         await tester.tap(findButtonForLabel('Mark channel as read'));
         await tester.pump();
         await tester.pump();
-        final unreadCount = store.unreads.countInChannelNarrow(someChannel.streamId);
         final (confirmButton, _) = checkSuggestedActionDialog(tester,
-          expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitle,
-          expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage(unreadCount),
+          expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitleNoCount,
+          expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage,
           expectedActionButtonText: zulipLocalizations.markAllAsReadConfirmationDialogConfirmButton);
         await tester.tap(find.byWidget(confirmButton));
         await tester.pumpAndSettle();

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -57,10 +57,11 @@ void main() {
 
     group('markNarrowAsRead', () {
       (Widget, Widget) checkConfirmDialog(WidgetTester tester, int unreadCount) {
+        // TODO write tests for the nuances of what message this dialog shows
         final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
         return checkSuggestedActionDialog(tester,
-          expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitle,
-          expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage(unreadCount),
+          expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitleNoCount,
+          expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage,
           expectDestructiveActionButton: false,
           expectedActionButtonText: zulipLocalizations.markAllAsReadConfirmationDialogConfirmButton);
       }

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1193,8 +1193,8 @@ void main() {
     (Widget, Widget) checkConfirmDialog(WidgetTester tester, int unreadCount) {
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       return checkSuggestedActionDialog(tester,
-        expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitle,
-        expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage(unreadCount),
+        expectedTitle: zulipLocalizations.markAllAsReadConfirmationDialogTitleNoCount,
+        expectedMessage: zulipLocalizations.markAllAsReadConfirmationDialogMessage,
         expectDestructiveActionButton: false,
         expectedActionButtonText: zulipLocalizations.markAllAsReadConfirmationDialogConfirmButton);
     }


### PR DESCRIPTION
Fixes: #1858

<details>
<summary> Still picture </summary>

| narrow | tap when long press |
| --- | --- |
|<img width="1080" height="2400" alt="Screenshot_1767458534" src="https://github.com/user-attachments/assets/7f80e8fc-6909-4c46-a16b-b1cf53d104ed" />|<img width="1080" height="2400" alt="Screenshot_1767458553" src="https://github.com/user-attachments/assets/ba90ae82-2004-4c85-b51f-763d97e210d3" />|




</details>

<details>
<summary> Screencasts </summary>

### combined feed narrow 
https://github.com/user-attachments/assets/b36a428f-ee31-444a-86ef-3cbec67d9530

### channel narrow 
https://github.com/user-attachments/assets/447733f6-6e52-44cc-bcfd-511b35f3e4c1

### mentions narrow 
https://github.com/user-attachments/assets/dfa78d7b-ae02-43fa-9ac9-940a2b254da4
</details>