### PR TITLE
content: Use directional layout for message media

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -741,11 +741,11 @@ class MessageMediaContainer extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: UnconstrainedBox(
-        alignment: Alignment.centerLeft,
+        alignment: AlignmentDirectional.centerStart,
         child: Padding(
           // TODO clean up this padding by imitating web less precisely;
           //   in particular, avoid adding loose whitespace at end of message.
-          padding: const EdgeInsets.only(right: 5, bottom: 5),
+          padding: const EdgeInsetsDirectional.only(end: 5, bottom: 5),
           child: ColoredBox(
             color: ContentTheme.of(context).colorMessageMediaContainerBackground,
             child: Padding(


### PR DESCRIPTION
This fixes the layout of images and video thumbnails in the message list for RTL languages.

Previously, these media containers were hardcoded to align to the Left side with padding on the Right, even in RTL mode. Now, they correctly flip to the Right side (the "start" of the message) with padding on the correct side.

This addresses the second RTL issue identified by @gnprice in [this comment](https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3573671163).

**Before**
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/52e4c391-e86f-40b3-b961-732edd3904df" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/ccfbdd69-844f-4d4f-b27d-a2726b3af11e" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

**After**
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/e44fee79-023d-447c-8295-d69b6871b187" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/06c8f177-9f3f-4dae-9fad-c5cbe1723752" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>


Since the Difference is very minute, this might help.

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/490e63ca-d839-48dd-8d58-ea7368c28c4f" alt="LTR" width="300"/>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/8c17e39a-9f29-4271-87ce-8ce40df95bd2" alt="RTL" width="300"/>
    </td>
  </tr>
</table>