### PR TITLE
action_sheet: Use directional border radius for reaction buttons

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -1233,7 +1233,8 @@ class ReactionButtons extends StatelessWidget {
       onTap: () => _handleTapReaction(emoji: emoji, isSelfVoted: isSelfVoted),
       splashFactory: NoSplash.splashFactory,
       borderRadius: isFirst
-        ? const BorderRadius.only(topLeft: Radius.circular(7))
+        ? const BorderRadiusDirectional.only(topStart: Radius.circular(7))
+            .resolve(Directionality.of(context))
         : null,
       overlayColor: WidgetStateColor.resolveWith((states) =>
         states.any((e) => e == WidgetState.pressed)
@@ -1253,6 +1254,7 @@ class ReactionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textDirection = Directionality.of(context);
     final store = PerAccountStoreWidget.of(pageContext);
     final popularEmojiCandidates = store.popularEmojiCandidates();
     assert(popularEmojiCandidates.every(
@@ -1289,7 +1291,8 @@ class ReactionButtons extends StatelessWidget {
         InkWell(
           onTap: _handleTapMore,
           splashFactory: NoSplash.splashFactory,
-          borderRadius: const BorderRadius.only(topRight: Radius.circular(7)),
+          borderRadius: const BorderRadiusDirectional.only(
+            topEnd: Radius.circular(7)).resolve(textDirection),
           overlayColor: WidgetStateColor.resolveWith((states) =>
             states.any((e) => e == WidgetState.pressed)
               ? designVariables.contextMenuItemBg.withFadedAlpha(0.20)


### PR DESCRIPTION
This fixes the border radius of the reaction buttons in the message action sheet for RTL languages.

Previously, the "First" button (e.g., thumbs up) and the "More" button (...) had hardcoded rounded corners. In RTL mode, these corners remained on the physical side, which resulted in the *inner* corners being rounded instead of the *outer* ones.

We now use `BorderRadiusDirectional` resolved against the text direction to ensure the outer edges are always the ones rounded.

This addresses the third RTL issue identified by @gnprice in [this comment](https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3573671163).

**Before**

<table>
  <thead>
    <tr>
      <th>Component</th>
      <th align="center">LTR (English)</th>
      <th align="center">RTL (Arabic)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center"><strong>First Button<br>(Thumbs Up)</strong></td>
      <td>
        <img src="https://github.com/user-attachments/assets/69d59c56-4f80-445e-8800-b32e29415ce1" alt="Before LTR Thumbs" width="300"/>
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/5155204e-f662-4e51-aca9-8454cb43b921" alt="Before RTL Thumbs" width="300"/>
      </td>
    </tr>
    <tr>
      <td align="center"><strong>Last Button<br>(More ...)</strong></td>
      <td>
        <img src="https://github.com/user-attachments/assets/76e82fd1-82e8-4288-ad7e-625128ada7f5" alt="Before LTR More" width="300"/>
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/eb2a791c-52dc-461e-810e-0417d7a072e8" alt="Before RTL More" width="300"/>
      </td>
    </tr>
  </tbody>
</table>

**After**

<table>
  <thead>
    <tr>
      <th>Component</th>
      <th align="center">LTR (English)</th>
      <th align="center">RTL (Arabic)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center"><strong>First Button<br>(Thumbs Up)</strong></td>
      <td>
        <img src="https://github.com/user-attachments/assets/69d59c56-4f80-445e-8800-b32e29415ce1" alt="After LTR Thumbs" width="300"/>
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/517dc94e-fe52-48f1-86ff-9fba9414478a" alt="After RTL Thumbs" width="300"/>
      </td>
    </tr>
    <tr>
      <td align="center"><strong>Last Button<br>(More ...)</strong></td>
      <td>
        <img src="https://github.com/user-attachments/assets/76e82fd1-82e8-4288-ad7e-625128ada7f5" alt="After LTR More" width="300"/>
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/3fdd97ed-8f86-43bb-83ad-722943c0f42e" alt="After RTL More" width="300"/>
      </td>
    </tr>
  </tbody>
</table>