### PR TITLE
lightbox: Use ZulipIcons.copy for copy-link button

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -16,6 +16,7 @@ import 'message_list.dart';
 import 'page.dart';
 import 'store.dart';
 import 'user.dart';
+import 'icons.dart';
 
 /// Identifies which [LightboxHero]s should match up with each other
 /// to produce a hero animation.
@@ -104,7 +105,7 @@ class _CopyLinkButton extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     return IconButton(
       tooltip: zulipLocalizations.lightboxCopyLinkTooltip,
-      icon: const Icon(Icons.copy),
+      icon: const Icon(ZulipIcons.copy),
       onPressed: () async {
         PlatformActions.copyWithPopup(context: context,
           successContent: Text(zulipLocalizations.successLinkCopied),


### PR DESCRIPTION
Fixed #2014 
Before
![b3b94a41-edc1-4865-a40b-e94dcacaecab](https://github.com/user-attachments/assets/db9344dd-ea7f-4771-9bd5-c564e3446d7a)

After
![4e81ac5c-eec2-4c8a-ab50-035f298a8ac3](https://github.com/user-attachments/assets/a6d75329-e221-44f2-b668-929e0f21f3a0)
