### PR TITLE
accessibility: Add Semantics to loading indicators so screen readers announce loading

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -255,7 +255,13 @@ class BottomSheetEmptyContentPlaceholder extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
 
     final child = loading
-      ? CircularProgressIndicator()
+      ? Semantics(
+      textDirection: Directionality.of(context),
+      focusable: true,
+      liveRegion: true,
+      label: 'Loading…',
+      child: CircularProgressIndicator(),
+    )
       : Text(
           textAlign: TextAlign.center,
           style: TextStyle(
@@ -627,6 +633,8 @@ class ChannelFeedButton extends ActionSheetMenuItemButton {
       MessageListPage.buildRoute(context: pageContext, narrow: ChannelNarrow(channelId)));
   }
 }
+
+
 
 class CopyChannelLinkButton extends ActionSheetMenuItemButton {
   const CopyChannelLinkButton({

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -246,7 +246,12 @@ class _LoadingPlaceholderPageState extends State<_LoadingPlaceholderPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const CircularProgressIndicator(),
+            Semantics(
+              label: 'Loading…',
+              textDirection: Directionality.of(context),
+              liveRegion: true,
+              child:const CircularProgressIndicator(),
+            ),
             Visibility(
               visible: showTryAnotherAccount,
               maintainSize: true,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1029,7 +1029,20 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
   Widget build(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    if (!model.fetched) return const Center(child: CircularProgressIndicator());
+    if (!model.fetched) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          child: Semantics(
+            label: 'Loading more messages',
+            textDirection: Directionality.of(context),
+            liveRegion: true,
+            child: const CircularProgressIndicator(),
+          ),
+        ),
+      );
+    }
+
 
     if (model.items.isEmpty && model.haveNewest && model.haveOldest) {
       final String header;
@@ -1283,10 +1296,18 @@ class _MessageListLoadingMore extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 16.0),
-        child: CircularProgressIndicator())); // TODO perhaps a different indicator
+        padding: const EdgeInsets.symmetric(vertical: 16.0),
+        child: Semantics(
+          textDirection: Directionality.of(context),
+          label: 'Loading more messages',
+          liveRegion: true,
+          child: const CircularProgressIndicator(),
+        ),
+      ),
+    );
+    // TODO perhaps a different indicator
   }
 }
 

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -166,8 +166,20 @@ class _TopicListState extends State<_TopicList> with PerAccountStoreAwareStateMi
   @override
   Widget build(BuildContext context) {
     if (lastFetchedTopics == null) {
-      return const Center(child: CircularProgressIndicator());
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          child: Semantics(
+            textDirection: Directionality.of(context),
+            label: 'Loading…',       // plain string (not localized)
+            liveRegion: true,
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      );
+
     }
+
 
     // TODO(design) handle the rare case when `lastFetchedTopics` is empty
 

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -397,116 +397,164 @@ void main () {
     }
 
     testWidgets('smoke', (tester) async {
-      addTearDown(testBinding.reset);
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
-      await prepare(tester);
-      await tester.pump(loadPerAccountDuration);
-      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+      final SemanticsHandle semanticsHandle = tester.ensureSemantics();
+      try {
+        addTearDown(testBinding.reset);
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+        await prepare(tester);
+
+        // While loading, the loading page should be shown and have the semantics label.
+        checkOnLoadingPage();
+        expect(find.bySemanticsLabel('Loading…'), findsOneWidget);
+
+        await tester.pump(loadPerAccountDuration);
+        checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+      } finally {
+        semanticsHandle.dispose();
+      }
     });
+
 
     testWidgets('"Try another account" button appears after timeout', (tester) async {
-      addTearDown(testBinding.reset);
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
-      await prepare(tester);
-      checkOnLoadingPage();
-      check(find.text('Try another account').hitTestable()).findsNothing();
+      final SemanticsHandle semanticsHandle = tester.ensureSemantics();
+      try {
+        addTearDown(testBinding.reset);
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+        await prepare(tester);
+        checkOnLoadingPage();
+        // No try-another button immediately.
+        check(find.text('Try another account').hitTestable()).findsNothing();
 
-      await tester.pump(kTryAnotherAccountWaitPeriod);
-      checkOnLoadingPage();
-      check(find.text('Try another account').hitTestable()).findsOne();
+        // The loading semantics should already be present.
+        expect(find.bySemanticsLabel('Loading…'), findsOneWidget);
 
-      await tester.pump(loadPerAccountDuration);
-      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+        await tester.pump(kTryAnotherAccountWaitPeriod);
+        checkOnLoadingPage();
+        check(find.text('Try another account').hitTestable()).findsOne();
+
+        await tester.pump(loadPerAccountDuration);
+        checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+      } finally {
+        semanticsHandle.dispose();
+      }
     });
+
 
     testWidgets('while loading, go back from ChooseAccountPage', (tester) async {
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
-      await prepare(tester);
-      await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapTryAnotherAccount(tester);
+      final SemanticsHandle semanticsHandle = tester.ensureSemantics();
+      try {
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+        await prepare(tester);
+        await tester.pump(kTryAnotherAccountWaitPeriod);
+        await tapTryAnotherAccount(tester);
 
-      lastPoppedRoute = null;
-      await tester.tap(find.byType(BackButton));
-      await tester.pump();
-      check(lastPoppedRoute).isA<MaterialWidgetRoute>().page.isA<ChooseAccountPage>();
-      await tester.pump(
-        (lastPoppedRoute as TransitionRoute).reverseTransitionDuration
-        // TODO not sure why a 1ms fudge is needed; investigate.
-        + Duration(milliseconds: 1));
-      checkOnLoadingPage();
+        lastPoppedRoute = null;
+        await tester.tap(find.byType(BackButton));
+        await tester.pump();
+        check(lastPoppedRoute).isA<MaterialWidgetRoute>().page.isA<ChooseAccountPage>();
+        await tester.pump(
+            (lastPoppedRoute as TransitionRoute).reverseTransitionDuration
+                // TODO not sure why a 1ms fudge is needed; investigate.
+                + Duration(milliseconds: 1));
+        checkOnLoadingPage();
 
-      await tester.pump(loadPerAccountDuration);
-      checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+        // Semantics check: loading label present
+        expect(find.bySemanticsLabel('Loading…'), findsOneWidget);
+
+        await tester.pump(loadPerAccountDuration);
+        checkOnHomePage(tester, expectedAccount: eg.selfAccount);
+      } finally {
+        semanticsHandle.dispose();
+      }
     });
+
 
     testWidgets('while loading, choose a different account', (tester) async {
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
-      await prepare(tester);
-      await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapTryAnotherAccount(tester);
+      final SemanticsHandle semanticsHandle = tester.ensureSemantics();
+      try {
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+        await prepare(tester);
+        await tester.pump(kTryAnotherAccountWaitPeriod);
+        await tapTryAnotherAccount(tester);
 
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration * 2;
-      await chooseAccountWithEmail(tester, eg.otherAccount.email);
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration * 2;
+        await chooseAccountWithEmail(tester, eg.otherAccount.email);
 
-      await tester.pump(loadPerAccountDuration);
-      // The second loadPerAccount is still pending.
-      checkOnLoadingPage();
+        // While the second account is still loading, we should be on a loading page.
+        await tester.pump(loadPerAccountDuration);
+        checkOnLoadingPage();
+        expect(find.bySemanticsLabel('Loading…'), findsOneWidget);
 
-      await tester.pump(loadPerAccountDuration);
-      // The second loadPerAccount finished.
-      checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+        await tester.pump(loadPerAccountDuration);
+        // The second load finished.
+        checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+      } finally {
+        semanticsHandle.dispose();
+      }
     });
+
 
     testWidgets('while loading, choosing an account disallows going back', (tester) async {
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
-      await prepare(tester);
-      await tester.pump(kTryAnotherAccountWaitPeriod);
-      await tapTryAnotherAccount(tester);
+      final SemanticsHandle semanticsHandle = tester.ensureSemantics();
+      try {
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+        await prepare(tester);
+        await tester.pump(kTryAnotherAccountWaitPeriod);
+        await tapTryAnotherAccount(tester);
 
-      // While still loading, choose a different account.
-      await chooseAccountWithEmail(tester, eg.otherAccount.email);
+        // While still loading, choose a different account.
+        await chooseAccountWithEmail(tester, eg.otherAccount.email);
 
-      // User cannot go back because the navigator stack
-      // was cleared after choosing an account.
-      check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
-        .isNotNull().isFirst.isTrue();
+        // User cannot go back because the navigator stack was cleared after choosing an account.
+        check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
+            .isNotNull().isFirst.isTrue();
 
-      await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
-      checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+        // Semantics check: ensure loading label present and first route is our account route.
+        expect(find.bySemanticsLabel('Loading…'), findsOneWidget);
+
+        await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
+        checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+      } finally {
+        semanticsHandle.dispose();
+      }
     });
 
-    testWidgets('while loading, go to nested levels of ChooseAccountPage', (tester) async {
-      testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
-      final thirdAccount = eg.account(user: eg.thirdUser);
-      await testBinding.globalStore.add(thirdAccount, eg.initialSnapshot(
-        realmUsers: [eg.thirdUser]));
-      await prepare(tester);
 
-      await tester.pump(kTryAnotherAccountWaitPeriod);
-      // While still loading the first account, choose a different account.
-      await tapTryAnotherAccount(tester);
-      await chooseAccountWithEmail(tester, eg.otherAccount.email);
-      // User cannot go back because the navigator stack
-      // was cleared after choosing an account.
-      check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
-        .isA<MaterialAccountWidgetRoute>()
+    testWidgets('while loading, go to nested levels of ChooseAccountPage', (tester) async {
+      final SemanticsHandle semanticsHandle = tester.ensureSemantics();
+      try {
+        testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
+        final thirdAccount = eg.account(user: eg.thirdUser);
+        await testBinding.globalStore.add(thirdAccount, eg.initialSnapshot(
+            realmUsers: [eg.thirdUser]));
+        await prepare(tester);
+
+        await tester.pump(kTryAnotherAccountWaitPeriod);
+        await tapTryAnotherAccount(tester);
+        await chooseAccountWithEmail(tester, eg.otherAccount.email);
+        check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
+            .isA<MaterialAccountWidgetRoute>()
           ..isFirst.isTrue()
           ..accountId.equals(eg.otherAccount.id);
 
-      await tester.pump(kTryAnotherAccountWaitPeriod);
-      // While still loading the second account, choose a different account.
-      await tapTryAnotherAccount(tester);
-      await chooseAccountWithEmail(tester, thirdAccount.email);
-      // User cannot go back because the navigator stack
-      // was cleared after choosing an account.
-      check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
-        .isA<MaterialAccountWidgetRoute>()
+        // Semantics check: loading label present
+        expect(find.bySemanticsLabel('Loading…'), findsOneWidget);
+
+        await tester.pump(kTryAnotherAccountWaitPeriod);
+        await tapTryAnotherAccount(tester);
+        await chooseAccountWithEmail(tester, thirdAccount.email);
+        check(getRouteOf(tester, find.byType(CircularProgressIndicator)))
+            .isA<MaterialAccountWidgetRoute>()
           ..isFirst.isTrue()
           ..accountId.equals(thirdAccount.id);
 
-      await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
-      checkOnHomePage(tester, expectedAccount: thirdAccount);
+        await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
+        checkOnHomePage(tester, expectedAccount: thirdAccount);
+      } finally {
+        semanticsHandle.dispose();
+      }
     });
+
 
     testWidgets('after finishing loading, go back from ChooseAccountPage', (tester) async {
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;


### PR DESCRIPTION
Fixes: #1962

This PR improves accessibility by adding `Semantics` widgets around loading
indicators so screen readers (TalkBack / VoiceOver) announce that the app is
loading content.

### What’s changed
- Wrapped `CircularProgressIndicator` (and similar loading states) in:
    `Semantics(label: 'Loading…', liveRegion: true)`
- Updated loading indicators in:
    - message_list.dart
    - topic_list.dart
    - home.dart / action_sheet.dart (where applicable)
- Kept changes minimal and within existing widgets, as requested.

### Why
Screen readers were not able to focus on or announce the loading state,
making the app inaccessible while fetching messages or topics.

### Testing
- Verified on Android emulator with TalkBack:
  When loading appears, TalkBack reads: "**Loading…**".
- Confirmed that no visual changes occurred.


### Screenshot (TalkBack focus on loading indicator)

This shows the loading indicator now exposes an accessible label via `Semantics()`.

![Loading indicator with TalkBack focus](https://github.com/user-attachments/assets/1a39b1ae-a751-4e19-8322-1e9e79955ebb)



Let me know if you prefer a localized label or a different semantics approach!
