### PR TITLE
content: Render large emoji in emoji-only paragraphs

### DIFF
--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -358,6 +358,29 @@ void main() {
 
   testContentSmoke(ContentExample.quotation);
 
+  group('emoji-only rendering', () {
+    testWidgets('Unicode emoji in span are rendered at double size', (tester) async {
+      final example = ContentExample.emojiUnicode;
+      await prepareContent(tester, messageContent(example.html));
+      final style = mergedStyleOf(tester, example.expectedText!);
+      check(style?.fontSize).equals(kBaseFontSize * 2);
+    });
+
+    testWidgets('plain-text emoji (text node) are not affected', (tester) async {
+      final example = ContentExample.emojiUnicodeLiteral;
+      await prepareContent(tester, messageContent(example.html));
+      final style = mergedStyleOf(tester, example.expectedText!);
+      check(style?.fontSize).equals(kBaseFontSize);
+    });
+
+    testWidgets('multi-paragraph message does not show large emojis', (tester) async {
+      const html = '<p>Text</p><p>🚀</p>';
+      await prepareContent(tester, messageContent(html));
+      final style = mergedStyleOf(tester, '🚀');
+      check(style?.fontSize).equals(kBaseFontSize);
+    });
+  });
+
   group('MessageImagePreview, MessageImagePreviewList', () {
     Future<void> prepare(WidgetTester tester, String html) async {
       await prepareContent(tester,


### PR DESCRIPTION
content: Render large emoji in emoji-only paragraphs

## Summary
This PR updates the message rendering to display paragraphs containing only emojis (Unicode or custom image emojis) at a larger size. This brings the mobile app's presentation into parity with the web app.

To support this, `MessageImageEmoji` has been updated to derive its size from the ambient text style rather than a fixed pixel value, ensuring custom emojis scale proportionally with the font size.

## Screenshots

| Before | After |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/9c548dca-0e6e-43ad-bee6-badea7b0a957) | ![After](https://github.com/user-attachments/assets/35e38d0d-9364-43de-9bed-d13a4a7b594e) |

## Changes
* **Detection**: Added logic to identify paragraphs that consist solely of emojis and whitespace.
* **Styling**: Applied a 2× font scaling to `DefaultTextStyle` for these paragraphs.
* **Components**: Refactored `MessageImageEmoji` to respect the ambient `fontSize`, enabling it to grow when the parent paragraph's font size increases.

## References
* **Web Implementation:** [zulip/zulip#36681](https://github.com/zulip/zulip/pull/36681)
* **Design Discussion:** [#design > emoji-only message presentation](https://chat.zulip.org/#narrow/channel/101-design/topic/emoji-only.20message.20presentation/with/2305093)
* **Feature Request:** zulip/zulip#15390

## Fixed Issues
Fixes: #1995