### PR TITLE
message list: Add (you) indicator for self user in DM conversations

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -665,9 +665,13 @@
   "@unknownUserName": {
     "description": "Name placeholder to use for a user when we don't know their name."
   },
+  "youLabel": "(you)",
+  "@youLabel": {
+    "description": "Label shown after the current user's display name in direct messages."
+  },
   "dmsWithYourselfPageTitle": "DMs with yourself",
   "@dmsWithYourselfPageTitle": {
-    "description": "Message list page title for a DM group that only includes yourself."
+    "description": "Label shown after the self-user's name on the 'Direct messages' page"
   },
   "messageListGroupYouAndOthers": "You and {others}",
   "@messageListGroupYouAndOthers": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1041,7 +1041,13 @@ abstract class ZulipLocalizations {
   /// **'(unknown user)'**
   String get unknownUserName;
 
-  /// Message list page title for a DM group that only includes yourself.
+  /// Label shown after the current user's display name in direct messages.
+  ///
+  /// In en, this message translates to:
+  /// **'(you)'**
+  String get youLabel;
+
+  /// Label shown after the self-user's name on the 'Direct messages' page
   ///
   /// In en, this message translates to:
   /// **'DMs with yourself'**

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -572,6 +572,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get unknownUserName => '(Nutzer:in unbekannt)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DNs mit dir selbst';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -569,6 +569,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -566,6 +566,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get unknownUserName => '(utente sconosciuto)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'MD con te stesso';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -541,6 +541,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get unknownUserName => '（不明なユーザー）';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => '自分とのDM';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -566,6 +566,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get unknownUserName => '(nieznany użytkownik)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DM do siebie';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -567,6 +567,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get unknownUserName => '(неизвестный пользователь)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'ЛС с собой';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -578,6 +578,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get unknownUserName => '(neznan uporabnik)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'Neposredna sporočila s samim seboj';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -567,6 +567,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get unknownUserName => '(невідомий користувач)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'Особисті повідомлення із собою';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -553,6 +553,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get unknownUserName => '(unknown user)';
 
   @override
+  String get youLabel => '(you)';
+
+  @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';
 
   @override


### PR DESCRIPTION
Fixes #1320.
### What this PR changes
This PR adds a localized "(you)" marker after the current user's own
display name in the DM conversation list. This helps distinguish the
self-user from other participants in self-DMs and group DMs.

### Screenshots

**Before:**
<img width="1080" height="2400" alt="Screenshot_20251206_011218" src="https://github.com/user-attachments/assets/b5d12a53-31ff-4ae4-a442-470eae6ce69a" />

**After:**
<img width="1080" height="2400" alt="Screenshot_20251206_004856" src="https://github.com/user-attachments/assets/02902390-5e6d-4b50-bb9d-f7229bee0b20" />

Adding "(you)" improves clarity and matches common UX patterns.