### PR TITLE
compose: Enable 'Quote message' in all views.

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1919,10 +1919,11 @@ class _EditMessageBannerTrailing extends StatelessWidget {
 /// Takes the full screen width, covering the horizontal insets with its surface.
 /// Also covers the bottom inset with its surface.
 class ComposeBox extends StatefulWidget {
-  ComposeBox({super.key, required this.narrow})
+  ComposeBox({super.key, required this.narrow, this.initialQuoteText})
     : assert(ComposeBox.hasComposeBox(narrow));
 
   final Narrow narrow;
+  final String? initialQuoteText;
 
   static bool hasComposeBox(Narrow narrow) {
     switch (narrow) {
@@ -2122,6 +2123,18 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     });
   }
 
+  void _handleInitQuoteText(String quoteText) {
+    final controller = this.controller;
+
+    // Use insertPadded to insert the text, which handles spacing if there was already content
+    // (though here we expect it to be empty usually).
+    controller.content.insertPadded(quoteText);
+
+    if (!controller.contentFocusNode.hasFocus) {
+      controller.contentFocusNode.requestFocus();
+    }
+  }
+
   @override
   void onNewStore() {
     final newStore = PerAccountStoreWidget.of(context);
@@ -2129,6 +2142,9 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     final controller = _controller;
     if (controller == null) {
       _setNewController(newStore);
+      if (widget.initialQuoteText != null) {
+        _handleInitQuoteText(widget.initialQuoteText!);
+      }
       return;
     }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -180,6 +180,7 @@ class MessageListPage extends StatefulWidget {
     super.key,
     required this.initNarrow,
     this.initAnchorMessageId,
+    this.initialQuoteText,
   });
 
   static AccountRoute<void> buildRoute({
@@ -188,6 +189,7 @@ class MessageListPage extends StatefulWidget {
     GlobalKey<MessageListPageState>? key,
     required Narrow narrow,
     int? initAnchorMessageId,
+    String? initialQuoteText,
   }) {
     return MaterialAccountWidgetRoute(
       accountId: accountId,
@@ -195,7 +197,8 @@ class MessageListPage extends StatefulWidget {
       page: MessageListPage(
         key: key,
         initNarrow: narrow,
-        initAnchorMessageId: initAnchorMessageId));
+        initAnchorMessageId: initAnchorMessageId,
+        initialQuoteText: initialQuoteText));
   }
 
   /// The "revealed" state of a message from a muted sender,
@@ -243,6 +246,7 @@ class MessageListPage extends StatefulWidget {
 
   final Narrow initNarrow;
   final int? initAnchorMessageId; // TODO(#1564) highlight target upon load
+  final String? initialQuoteText;
 
   @override
   State<MessageListPage> createState() => _MessageListPageState();
@@ -376,7 +380,7 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
                   markReadOnScroll: markReadOnScroll,
                 ))),
             if (ComposeBox.hasComposeBox(narrow))
-              ComposeBox(key: _composeBoxKey, narrow: narrow)
+              ComposeBox(key: _composeBoxKey, narrow: narrow, initialQuoteText: widget.initialQuoteText)
           ]);
         }));
 


### PR DESCRIPTION
Previously, the 'Quote message' option was only available in views that already had a compose box (like Channel or DM narrows).

This commit enables the button in all views (e.g., Combined Feed). When triggered from a view without a compose box, it now:
1. Calculates the correct destination narrow.
2. Fetches the raw Markdown content of the message.
3. Navigates to the conversation view, passing the quoted text to pre-fill the compose box.

Fixes #2008

Screenshots:
Before
<img width="596" height="1280" alt="image" src="https://github.com/user-attachments/assets/151d5c23-347d-4774-8ccb-e8f45ab7cbe0" />
After
<img width="596" height="1280" alt="image" src="https://github.com/user-attachments/assets/cc88e66e-51e3-4bca-b764-502c96953006" />
