### PR TITLE
fix: replace Icons.copy with ZulipIcons.copy in lightbox   #2014

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -11,6 +11,7 @@ import '../model/binding.dart';
 import 'actions.dart';
 import 'content.dart';
 import 'dialog.dart';
+import 'icons.dart';
 import 'image.dart';
 import 'message_list.dart';
 import 'page.dart';
@@ -104,7 +105,7 @@ class _CopyLinkButton extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     return IconButton(
       tooltip: zulipLocalizations.lightboxCopyLinkTooltip,
-      icon: const Icon(Icons.copy),
+      icon: const Icon(ZulipIcons.copy),
       onPressed: () async {
         PlatformActions.copyWithPopup(context: context,
           successContent: Text(zulipLocalizations.successLinkCopied),


### PR DESCRIPTION


This PR updates the "Copy link" action in the lightbox to use ZulipIcons.copy instead of the generic Icons.copy. This ensures consistency with Zulip’s design system and improves the visual alignment with other app actions.

Issue

Fixes #2014

Changes

Replaced Icons.copy with ZulipIcons.copy in the lightbox action menu.

No functional changes; purely a UI/icon update.

Screenshots

Before
![WhatsApp Image 2025-12-11 at 12 09 38 PM](https://github.com/user-attachments/assets/d9780312-dd99-443a-a66a-2540ce51f777)


After
<img width="429" height="899" alt="After" src="https://github.com/user-attachments/assets/9a7735c6-fc82-4922-a14b-3fc876498a56" />

Testing

1 Open any image → lightbox.

2 Tap the 3-dot menu → Copy button.

3 Confirm that the new Zulip icon appears instead of the generic one.