### PR TITLE
msglist: Fix recipient header date alignment for RTL layouts.

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1975,7 +1975,7 @@ class RecipientHeaderDate extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(10, 0, 16, 0),
+      padding: const EdgeInsetsDirectional.fromSTEB(10, 0, 16, 0),
       child: DateText(
         fontSize: 16,
         // In Figma this has a line-height of 19, but using 18


### PR DESCRIPTION
Fix recipient header date label alignment in RTL.

Use EdgeInsetsDirectional.fromSTEB for date label padding so alignment is correct in both LTR and RTL layouts.

This addresses a issue identified by @gnprice in [this comment](https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3644514203).

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/06ece5b2-16f9-456b-b591-5568d430f159" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/e8a43faf-fbaa-4769-bdae-f8f137451d2a" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/931ec05c-b6ea-4812-966b-df714ba97bc6" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/86ed3c44-9cf4-4672-9056-5b8e38f21fb7" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>