### PR TITLE
msglist: Rename (unknown channel) and (unknown user)

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -632,7 +632,7 @@
   "@composeBoxSendTooltip":  {
     "description": "Tooltip for send button in compose box."
   },
-  "unknownChannelName": "(unknown channel)",
+  "unknownChannelName": "Unknown channel",
   "@unknownChannelName": {
     "description": "Replacement name for channel when it cannot be found in the store."
   },
@@ -661,7 +661,7 @@
       "messageId": {"type": "int", "example": "1234"}
     }
   },
-  "unknownUserName": "(unknown user)",
+  "unknownUserName": "unknown user",
   "@unknownUserName": {
     "description": "Name placeholder to use for a user when we don't know their name."
   },

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1008,7 +1008,7 @@ abstract class ZulipLocalizations {
   /// Replacement name for channel when it cannot be found in the store.
   ///
   /// In en, this message translates to:
-  /// **'(unknown channel)'**
+  /// **'Unknown channel'**
   String get unknownChannelName;
 
   /// Hint text for topic input widget in compose box.
@@ -1038,7 +1038,7 @@ abstract class ZulipLocalizations {
   /// Name placeholder to use for a user when we don't know their name.
   ///
   /// In en, this message translates to:
-  /// **'(unknown user)'**
+  /// **'unknown user'**
   String get unknownUserName;
 
   /// Message list page title for a DM group that only includes yourself.

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -545,7 +545,7 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -566,7 +566,7 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -529,7 +529,7 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get composeBoxSendTooltip => 'Send';
 
   @override
-  String get unknownChannelName => '(unknown channel)';
+  String get unknownChannelName => 'Unknown channel';
 
   @override
   String get composeBoxTopicHintText => 'Topic';
@@ -550,7 +550,7 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   }
 
   @override
-  String get unknownUserName => '(unknown user)';
+  String get unknownUserName => 'unknown user';
 
   @override
   String get dmsWithYourselfPageTitle => 'DMs with yourself';

--- a/test/model/user_test.dart
+++ b/test/model/user_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     test('on an unknown user', () {
       final store = eg.store();
-      check(store.userDisplayName(eg.user().userId)).equals('(unknown user)');
+      check(store.userDisplayName(eg.user().userId)).equals('unknown user');
     });
   });
 
@@ -54,7 +54,7 @@ void main() {
       check(store.senderDisplayName(message)).equals('Some User');
       // ... even though `store.userDisplayName` (with no message available
       // for fallback) only has a generic fallback name.
-      check(store.userDisplayName(message.senderId)).equals('(unknown user)');
+      check(store.userDisplayName(message.senderId)).equals('unknown user');
     });
   });
 

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -630,7 +630,7 @@ void main() {
       final message = eg.streamMessage(stream: stream);
       await checkNotifications(async, messageFcmMessage(message, streamName: null),
         expectedIsGroupConversation: true,
-        expectedTitle: '#(unknown channel) > ${message.topic}',
+        expectedTitle: '#Unknown channel > ${message.topic}',
         expectedTagComponent: 'stream:${message.streamId}:${message.topic}');
     })));
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -268,7 +268,7 @@ void main() {
         child: TopicListPage(streamId: streamId)));
       await tester.pump();
 
-      final titleText = store.streams[streamId]?.name ?? '(unknown channel)';
+      final titleText = store.streams[streamId]?.name ?? 'Unknown channel';
       await tester.longPress(find.descendant(
         of: find.byType(ZulipAppBar),
         matching: find.text(titleText)));
@@ -345,7 +345,7 @@ void main() {
           check(store.streams[someChannel.streamId]).isNull();
           await showFromTopicListAppBar(tester);
           check(findInHeader(find.byType(Icon))).findsNothing();
-          check(findInHeader(find.textContaining('(unknown channel)'))).findsOne();
+          check(findInHeader(find.textContaining('Unknown channel'))).findsOne();
         });
       });
 

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -239,7 +239,7 @@ void main() {
             runSmokeTest('same reaction, different users, with one unknown user', [
               Reaction.fromJson({ ...u1, 'user_id': user1.userId}),
               Reaction.fromJson({ ...u1, 'user_id': user2.userId}),
-              // unknown user; shouldn't crash (name should show as "(unknown user)")
+              // unknown user; shouldn't crash (name should show as "unknown user")
               Reaction.fromJson({ ...u1, 'user_id': eg.user().userId}),
             ], users: users, realmEmoji: realmEmoji);
 
@@ -385,7 +385,7 @@ void main() {
   // - Tapping a chip does the right thing
   // - When an image emoji fails to load, falls back to :text_emoji:
   // - Label text correctly chooses names or number
-  // - When a user isn't found, says "(unknown user)"
+  // - When a user isn't found, says "unknown user"
   // - More about layout? (not just that it's error-free)
   // - Non-animated image emoji is selected when intended
 

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -504,7 +504,7 @@ void main() {
         narrow: DmNarrow.withUser(eg.user().userId, selfUserId: selfUserId), messages: [], users: [eg.selfUser]);
       check(findPlaceholder).findsOne();
       check(findTextInPlaceholder('this user')).findsOne();
-      check(findTextInPlaceholder('(unknown user)')).findsNothing();
+      check(findTextInPlaceholder('unknown user')).findsNothing();
 
       // No need to encourage starting a conversation...right?
       check(findTextInPlaceholder('yet.')).findsNothing();
@@ -1143,7 +1143,7 @@ void main() {
         narrow: narrow, users: [], messages: [streamMessage]);
       await checkTyping(tester,
         eg.typingEvent(narrow, TypingOp.start, 1000),
-        expected: '(unknown user) is typing…',
+        expected: 'unknown user is typing…',
       );
       // Wait for the pending timers to end.
       await tester.pump(const Duration(seconds: 15));
@@ -1795,7 +1795,7 @@ void main() {
         tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
           zulipLocalizations.unknownUserName)));
         tester.widget(find.text(zulipLocalizations.messageListGroupYouAndOthers(
-          "${zulipLocalizations.unknownUserName}, ${eg.thirdUser.fullName}")));
+          "${eg.thirdUser.fullName}, ${zulipLocalizations.unknownUserName}")));
       });
 
       testWidgets('show "Muted user" label for muted users', (tester) async {

--- a/test/widgets/poll_test.dart
+++ b/test/widgets/poll_test.dart
@@ -115,7 +115,7 @@ void main() {
   testWidgets('show unknown voter', (tester) async {
     await preparePollWidget(tester, pollWidgetData,
       users: [eg.selfUser], voterIdxPairs: [(eg.thirdUser, 1)]);
-    check(findInPoll(find.text('((unknown user))'))).findsOne();
+    check(findInPoll(find.text('(unknown user)'))).findsOne();
   });
 
   testWidgets('poll title missing', (tester) async {

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -348,7 +348,7 @@ void main() {
         customProfileFields: [eg.customProfileField(0, CustomProfileFieldType.user)],
       );
 
-      final textFinder = find.text('(unknown user)');
+      final textFinder = find.text('unknown user');
       check(textFinder.evaluate()).length.equals(1);
     });
 

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -309,7 +309,7 @@ void main() {
           );
 
           checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
-          checkTitle(tester, '(unknown user)');
+          checkTitle(tester, 'unknown user');
         });
 
         testWidgets('short name takes one line', (tester) async {
@@ -424,7 +424,7 @@ void main() {
           );
 
           checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
-          checkTitle(tester, '${user0.fullName}, (unknown user)');
+          checkTitle(tester, '${user0.fullName}, unknown user');
         });
 
         testWidgets('few names takes one line', (tester) async {

--- a/test/widgets/topic_list_test.dart
+++ b/test/widgets/topic_list_test.dart
@@ -75,7 +75,7 @@ void main() {
         child: TopicListPage(streamId: channel.streamId)));
       await tester.pump();
       await tester.pump(Duration.zero);
-      check(find.widgetWithText(ZulipAppBar, '(unknown channel)')).findsOne();
+      check(find.widgetWithText(ZulipAppBar, 'Unknown channel')).findsOne();
     });
 
     testWidgets('navigate to channel feed', (tester) async {


### PR DESCRIPTION
Fixes #2035.

After investigation of several mainstream app and their UI like IPhone's Phone UI(caller id display), Truecaller(for hidden and private numbers) and Whatsapp(For showing Unknown caller's name), they uses plain fallback label like “Unknown …” (no parentheses).