### PR TITLE
Autocomplete: reopen @-mention suggestions when backspacing inside formatted mentions

### DIFF
--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -129,10 +129,10 @@ void main() {
     doTest('email support@ with details of the issue^', null);
     doTest('email support@^ with details of the issue', null);
 
-    doTest('Ask @**Chris Bobbe**^', null); doTest('Ask @_**Chris Bobbe**^', null);
-    doTest('Ask @**Chris Bobbe^**', null); doTest('Ask @_**Chris Bobbe^**', null);
-    doTest('Ask @**Chris^ Bobbe**', null); doTest('Ask @_**Chris^ Bobbe**', null);
-    doTest('Ask @**^Chris Bobbe**', null); doTest('Ask @_**^Chris Bobbe**', null);
+    doTest('Ask ~@**Chris Bobbe**^', mention('Chris Bobbe'));doTest('Ask ~@_**Chris Bobbe**^', silentMention('Chris Bobbe'));
+    doTest('Ask ~@**Chris Bobbe^**', mention('Chris Bobbe'));doTest('Ask ~@_**Chris Bobbe^**', silentMention('Chris Bobbe'));
+    doTest('Ask ~@**Chris^ Bobbe**', mention('Chris'));      doTest('Ask ~@_**Chris^ Bobbe**', silentMention('Chris'));
+    doTest('Ask ~@**^Chris Bobbe**', mention(''));           doTest('Ask ~@_**^Chris Bobbe**', silentMention(''));
 
     doTest('`@chris^', null); doTest('`@_chris^', null);
 

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -161,6 +161,9 @@ void main() {
       check(find.text(user.fullName)).findsExactly(expected ? 1 : 0);
       check(findAvatarImage(user.userId)).findsExactly(expected ? 1 : 0);
     }
+    void checkAutocompleteHidden() {
+      check(find.byType(Autocomplete)).findsNothing();
+    }
 
     testWidgets('user options appear, disappear, and change correctly', (tester) async {
       final user1 = eg.user(userId: 1, fullName: 'User One', avatarUrl: 'user1.png');
@@ -185,9 +188,8 @@ void main() {
       await tester.pump();
       check(tester.widget<TextField>(composeInputFinder).controller!.text)
         .contains(userMention(user3, users: store));
-      checkUserShown(user1, expected: false);
-      checkUserShown(user2, expected: false);
-      checkUserShown(user3, expected: false);
+      checkAutocompleteHidden();
+
 
       // Then a new autocomplete intent brings up options again
       // TODO(#226): Remove this extra edit when this bug is fixed.
@@ -200,9 +202,8 @@ void main() {
       // TODO(#226): Remove one of these edits when this bug is fixed.
       await tester.enterText(composeInputFinder, '');
       await tester.enterText(composeInputFinder, ' ');
-      checkUserShown(user1, expected: false);
-      checkUserShown(user2, expected: false);
-      checkUserShown(user3, expected: false);
+      checkAutocompleteHidden();
+
 
       debugNetworkImageHttpClientProvider = null;
     });
@@ -279,15 +280,10 @@ void main() {
 
       // Finishing autocomplete updates compose box; causes options to disappear
       await tester.tap(find.text(WildcardMentionOption.channel.canonicalString));
-      await tester.pump();
+      await tester.pumpAndSettle();
       check(tester.widget<TextField>(composeInputFinder).controller!.text)
         .contains(wildcardMention(WildcardMentionOption.channel, store: store));
-      checkWildcardShown(WildcardMentionOption.channel, expected: false);
-      checkWildcardShown(WildcardMentionOption.topic, expected: false);
-      checkWildcardShown(WildcardMentionOption.all, expected: false);
-      checkWildcardShown(WildcardMentionOption.everyone, expected: false);
-      checkWildcardShown(WildcardMentionOption.stream, expected: false);
-
+      checkAutocompleteHidden();
       debugNetworkImageHttpClientProvider = null;
     });
 


### PR DESCRIPTION
This PR updates the @-mention autocomplete behavior to match the web app.

When a user backspaces inside a formatted mention (e.g. `@**Chris Bobbe**`),
the autocomplete is now reopened by stripping the formatting and re-evaluating
the mention query, instead of suppressing autocomplete entirely.

As part of this change:
- Mention autocomplete logic was updated to normalize formatted mentions
  before matching.
- Model tests were updated to reflect the new behavior when backspacing
  inside formatted mentions.
- Widget tests were updated to assert the correct lifecycle of the
  autocomplete UI, which is now unmounted when no valid intent exists
  instead of remaining visible with empty results.
- Async widget tests were fully settled after choosing an option to avoid
  pending timers at teardown.

Screenshots attached show the behavior before and after this change.

Before: Backspacing inside a formatted mention does not reopen autocomplete.
![WhatsApp Image 2025-12-14 at 18 44 11_3d0d395c](https://github.com/user-attachments/assets/30682341-221c-4a30-bb7b-977955a7e232)

After: Autocomplete reopens correctly, matching web behavior.
<img width="1080" height="2400" alt="Screenshot_20251214_183837" src="https://github.com/user-attachments/assets/2e2a4b84-8e3a-46dd-8691-57cec55c11fa" />

Fixes #1967