### PR TITLE
check: Fix error condition in parsing Flutter version from pubspec

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -242,7 +242,7 @@ run_flutter_version() {
              print "$1 $2" if (
                  /^  sdk: .*\n  flutter: '\''>=(\S+)'\''\s*# ([0-9a-f]{40})$/m)'
     ) ) || return
-    if [ -z "${#parsed[@]}" ]; then
+    if (( ! "${#parsed[@]}" )); then
         echo >&2 "error: Flutter version spec not recognized in pubspec.yaml"
         return 1
     fi


### PR DESCRIPTION
This is intended to check if the pattern failed to match, by checking whether the array `parsed` has zero elements.  To do this, it looks at the length of the array... but then it was checking if that length, as a string, is empty.  Oops.  Instead, check if the length, as a number, is zero.