### PR TITLE
deps: Revert Flutter to 3.39.0-1.0.pre-300

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -1323,5 +1323,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.11.0-233.0.dev <4.0.0"
-  flutter: ">=3.40.0-1.0.pre-124"
+  dart: ">=3.11.0-169.0.dev <4.0.0"
+  flutter: ">=3.39.0-1.0.pre-300"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.11.0-233.0.dev <4.0.0'
-  flutter: '>=3.40.0-1.0.pre-124'  # 86c12c1ed05985dcb16bb833145e198b889c6942
+  sdk: '>=3.11.0-169.0.dev <4.0.0'
+  flutter: '>=3.39.0-1.0.pre-300'  # 0e4cb8e86de0861c49875d04faa7b221c737e471
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
Fixes #2049.  Some recent changes in Flutter to support native assets seem to have a bug that doesn't work with package:sqlite3:
  https://github.com/flutter/flutter/issues/178602

This reverts commit 627bfd201, part of #2009.