### PR TITLE
Fix (issue#1974)  iOS keyboard glitch when switching between topic and content inputs

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -606,6 +606,10 @@ class _ContentInput extends StatelessWidget {
               minLines: 2,
               maxLines: null,
               textCapitalization: TextCapitalization.sentences,
+              // Disable scribble to maintain keyboard continuity on iOS
+              // when switching between topic and content inputs.
+              // See: https://github.com/zulip/zulip-flutter/issues/1974
+              scribbleEnabled: false,
               decoration: InputDecoration(
                 // This padding ensures that the user can always scroll long
                 // content entirely out of the top or bottom shadow if desired.
@@ -867,7 +871,11 @@ class _TopicInputState extends State<_TopicInput> {
           focusNode: widget.controller.topicFocusNode,
           textInputAction: TextInputAction.next,
           style: topicTextStyle,
-          decoration: decoration)));
+          decoration: decoration,
+          // Disable scribble to maintain keyboard continuity on iOS
+          // when switching between topic and content inputs.
+          // See: https://github.com/zulip/zulip-flutter/issues/1974
+          scribbleEnabled: false)));
   }
 }
 


### PR DESCRIPTION
Disable scribbleEnabled on both topic and content TextFields to prevent the keyboard from briefly sliding out and back in when switching focus between the two inputs on iOS.

This is a workaround for an upstream Flutter bug in the iOS keyboard lifecycle management. The trade-off is that Apple Pencil Scribble handwriting input is disabled for these fields, which is acceptable since most users compose with the keyboard.

Fixes: #1974