### PR TITLE
Update release instructions; make independent of legacy docs

### DIFF
--- a/docs/howto/alpha.md
+++ b/docs/howto/alpha.md
@@ -1,0 +1,48 @@
+# Joining the alpha channel
+
+If you're actively developing the app, you should join the [alpha
+channel](../release.md#terminology) so that when we make an alpha
+release you get it on your normal devices you use daily.  This means
+you'll see any regressions we have, so you can help find and fix them
+before they go out wider.
+
+* **Android**: A maintainer will add you to the list, and then give
+  you a link you'll use to confirm.
+
+  (Maintainer: see [Release > Testing > Internal testing >
+  Testers][play-internal-testers] in the Play Console.)
+
+* **iOS**: A maintainer will send you an invite to join App Store Connect.
+  Then after you join, there's a second step to join the list of users that
+  get alpha updates.
+
+  (Maintainer: that list is confusingly labeled in the UI as simply
+  ["App Store Connect Users"][] — don't be fooled.  Confirm the
+  person is on it; if not, see the plus-sign icon next to the
+  "Testers" heading, which lets you send an invite for that step.)
+
+[join-beta]: https://github.com/zulip/zulip-mobile#using-the-beta
+[play-internal-testers]: https://play.google.com/console/developers/8060868091387311598/app/4976350040864490411/tracks/internal-testing?tab=testers
+["App Store Connect Users"]: https://appstoreconnect.apple.com/apps/1203036395/testflight/groups/d246e92d-76a2-4b3e-8293-347a1a6e27ab
+
+
+## Joining the beta channel
+
+Historically we also used a [beta channel](../release.md#terminology).
+Our current practice is that the beta channel is nearly equivalent to
+the prod channel, though, so there's little effect to be had from
+joining the beta.
+
+Here are the instructions for joining the beta channel, mostly for the
+purpose of internal notes in case we decide to revive the use of it:
+
+* Android: install the app, then just
+  [join the testing program](https://play.google.com/apps/testing/com.zulipmobile/)
+  on Google Play.
+  * Or if you don't use Google Play, you can [download an
+    APK](https://github.com/zulip/zulip-flutter/releases/); the latest
+    release on GitHub (including "pre-releases") is the current beta.
+
+* iOS: install [TestFlight](https://developer.apple.com/testflight/testers/),
+  then open [this public invitation link](https://testflight.apple.com/join/ZuzqwXGf)
+  on your device.

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,14 +6,6 @@ iOS App Store, to the Google Play Store, and as APKs on the web.
 If you're reading this page for the first time, see the sections on
 [terminology](#terminology) and [setup](#setup) below.
 
-(Some additional information can be found in the [legacy app's release
-instructions][].  Incorporating those remaining pieces into this doc
-is an open TODO.
-
-The main release process, however, is all fully set forth below.)
-
-[legacy app's release instructions]: https://github.com/zulip/zulip-mobile/blob/main/docs/howto/release.md
-
 
 ## Prepare source tree
 
@@ -420,7 +412,7 @@ full complexity of either one, and for sanity's sake we use a common,
 simple terminology for the process we follow with both.
 
 * **Alpha**: A release only to active developers of the app.
-  See [instructions][join-alpha] for joining.
+  See [instructions](howto/alpha.md) for joining.
 
   * What this means on each platform:
     * Google Play: release to "Internal testing"
@@ -436,13 +428,12 @@ simple terminology for the process we follow with both.
     "Internal testing" and "Open testing".
     We don't use that feature.
 
-[join-alpha]: https://github.com/zulip/zulip-mobile/blob/main/docs/howto/alpha.md
 
-
-* **Beta**: A release to users who have volunteered to get new versions
-  early and give us feedback.  See
-  [instructions](https://github.com/zulip/zulip-mobile#using-the-beta) for
-  joining.
+* **Beta**: Historically, a release to users who have volunteered to
+  get new versions early and give us feedback.
+  More recently, we usually don't make use of this channel;
+  we send a release here just before sending the same release to prod.
+  See [discussion above](#release-to-production).
 
   * What this means on each platform:
     * Google Play: release to "Open testing"
@@ -450,12 +441,6 @@ simple terminology for the process we follow with both.
       "External Testers" group)
     * GitHub: a GitHub release with binaries and description,
       marked as pre-release
-
-  * We sometimes use this channel for wider testing of a release
-    before sending to production: historically about 2-4 days for a
-    typical new release.  More recently we tend to leave a release in
-    beta for at most 1 day before sending to prod; see discussion
-    above.
 
   * NB Google Play also calls this "Beta track" or "Open track", as
     well as "Open testing".


### PR DESCRIPTION
This resolves a TODO item which had been at the top of this doc since launch, and should simplify following the instructions for future releases.

Selected commit messages:

#### 10c0017fa docs/release: Finish updating release instructions to reflect main app

This documents the release process I've been doing since this app
launched as the main Zulip mobile app.



#### 1adc810ac docs/release: Incorporate terminology section on alpha/beta/prod

Adapted from the legacy app's version mostly by updating the
discussion of our beta practices.  Also putting this section at
the end, to avoid cluttering the way to the main instructions
that we use on each release.



#### 9ebff09ba docs/release: Add pointers at top to terminology and setup sections

Logically these sections come before the main instructions, as
they're needed before one can follow those.  It's convenient to keep
the main instructions handy right at the top, though, because we
consult them much more often.  So these links help make it
comfortable to maintain that inversion.



#### 3e55efb17 docs/release: Incorporate alpha/beta instructions; declare updates complete

This was the last piece of information where this doc relied on a
reference to the legacy app's documentation.
