### PR TITLE
emoji: increase size for emoji-only messages (#1995)

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -99,6 +99,17 @@ class ZulipContent extends ContentNode implements ZulipMessageContent {
 
   final List<BlockContentNode> nodes;
 
+  /// Whether this content consists of a single paragraph containing only emoji.
+  ///
+  /// When true, the emoji should be displayed at a larger size.
+  bool get isEmojiOnly {
+    if (nodes.length != 1) return false;
+    final node = nodes.single;
+    if (node is! ParagraphNode) return false;
+    if (node.nodes.isEmpty) return false;
+    return node.nodes.every((n) => n is EmojiNode);
+  }
+
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
     return nodes.map((node) => node.toDiagnosticsNode()).toList();


### PR DESCRIPTION
Messages containing only emoji characters are now displayed at a larger size for better readability and visual impact.

Resolves #1995

https://github.com/user-attachments/assets/2d62e326-d9ed-4ba1-bd8e-4ef48d27a267

