### PR TITLE
msglist: Use directional positioning for ScrollToBottomButton

### DIFF
--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1054,9 +1054,9 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
             child: Stack(
               children: <Widget>[
                 _buildListView(context),
-                Positioned(
+                PositionedDirectional(
                   bottom: 0,
-                  right: 0,
+                  end: 0,
                   // TODO(#311) SafeArea shouldn't be needed if we have a
                   //   bottom nav; that will pad the bottom inset. Remove it,
                   //   and the mention of bottom-inset handling in


### PR DESCRIPTION
Previously, the `ScrollToBottomButton` was stuck on the right even in RTL layouts. This fixes it to work correctly in both RTL and LTR.

This addresses a issue identified by @gnprice in [this comment](https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3706174056).

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/f2c5de3d-5999-4e8b-ba67-1e953f8d6313" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/0bf8dbcd-5f29-48f2-b9ca-b09183a74c82" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/8911408d-a96e-41ac-a51f-2f819fe9609c" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/c74002cd-5c63-41ea-9d6e-df2b36b16f81" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>