### PR TITLE
deps: Upgrade Flutter to 3.40.0-1.0.pre-487

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -1323,5 +1323,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.11.0-169.0.dev <4.0.0"
-  flutter: ">=3.39.0-1.0.pre-300"
+  dart: ">=3.11.0-296.2.beta <4.0.0"
+  flutter: ">=3.40.0-1.0.pre-487"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.11.0-169.0.dev <4.0.0'
-  flutter: '>=3.39.0-1.0.pre-300'  # 0e4cb8e86de0861c49875d04faa7b221c737e471
+  sdk: '>=3.11.0-296.2.beta <4.0.0'
+  flutter: '>=3.40.0-1.0.pre-487'  # 8cb340cd7a9b0127f8c2a4dda0523b22c3f6a54e
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
And update Flutter's supporting libraries to match.

---

We had worked around an upstream bug which caused the iOS App Store validation to fail (#2049), by reverting to an older Flutter SDK version in #2050. We can now upgrade to latest SDK because a fix for that bug has been merged upstream, specifically this commit: https://github.com/flutter/flutter/commit/941130b9f128cadf7e69d670fdd01c18349847da.