### PR TITLE
emoji: Use directional alignment for Unicode emoji on iOS

### DIFF
--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -161,7 +161,7 @@ class UnicodeEmojiWidget extends StatelessWidget {
         //   accomplished with help from a [StrutStyle]; see below).
         // - There seems to be approximately no space on its left.
         final boxSize = textScaler.scale(size);
-        return Stack(alignment: Alignment.centerLeft, clipBehavior: Clip.none, children: [
+        return Stack(alignment: Alignment.center, clipBehavior: Clip.none, children: [
           SizedBox(height: boxSize, width: boxSize),
           PositionedDirectional(start: 0, child: Text(
             textScaler: textScaler,


### PR DESCRIPTION
On iOS and macOS, use AlignmentDirectional.centerStart instead of Alignment.centerLeft for the Stack containing Unicode emoji.

This addresses a issue identified by @gnprice in  [this comment](https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3726847283).

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/b78d44f0-70a6-4474-90f6-c2061e1f24ed" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/2710572d-14fa-469f-bf02-2722912c0c95" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/f7e92d26-296c-434f-98fc-3b2ddc877b00" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/c03bc763-8e6a-4623-9d99-951dc9a8c583" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>