### PR TITLE
autocomplete: Use directional alignment for autocomplete results

### DIFF
--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -132,7 +132,7 @@ class _AutocompleteFieldState<QueryT extends AutocompleteQuery, ResultT extends 
       //   AutocompleteView.
       optionsViewBuilder: (context, _, _) {
         return Align(
-          alignment: Alignment.bottomLeft,
+          alignment: AlignmentDirectional.bottomStart,
           child: Material(
             elevation: 4.0,
             child: ConstrainedBox(


### PR DESCRIPTION
Use AlignmentDirectional.bottomStart instead of Alignment.bottomLeft for the autocomplete dropdown positioning. This ensures the dropdown alignment respects text direction in RTL layouts.

The autocomplete dropdown spans the full available width, so Align has no extra space to reposition it—making bottomStart vs bottomLeft visually identical despite the directional correctness fix.

Fixes the issue described here:
https://github.com/zulip/zulip-flutter/pull/1991#issuecomment-3726847283

Before
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/450cad83-add7-4000-89de-f7029a1f6fc0" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/66c94c80-a934-438e-ac54-a23b012d4bc7" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>

After
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/450cad83-add7-4000-89de-f7029a1f6fc0" alt="LTR" width="300"/>
      <p align="center"><strong>LTR</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/8bf1f115-8b3a-4aff-9350-4e136def6314" alt="RTL" width="300"/>
      <p align="center"><strong>RTL</strong></p>
    </td>
  </tr>
</table>