### PR TITLE
compose: Focus topic input first when opening compose box

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -590,6 +590,7 @@ class _ContentInput extends StatelessWidget {
               enabled: enabled,
               controller: controller.content,
               focusNode: controller.contentFocusNode,
+              onTap: controller.requestFocusIfUnfocused,
               contentInsertionConfiguration: ContentInsertionConfiguration(
                 onContentInserted: (content) => _handleContentInserted(context, content)),
               // Let the content show through the `contentPadding` so that


### PR DESCRIPTION
Fixes: #1448

### Before
In a channel feed, when there is no topic chosen yet, tapping the content input would choose "general chat" / "(no topic)" as the topic in the topic input and focus the content input. This would result in users accidentally sending messages to "general chat" / "(no topic)" while they were intending to send to a different topic.

https://github.com/user-attachments/assets/f648d1e7-f27b-4a54-8d25-3599e62077c5

### After
Now, when there is no topic chosen, tapping the content input would put focus on the topic input instead of the content input. This will hint to the user to choose the topic first, or skip the topic if they really want to.


https://github.com/user-attachments/assets/7e6d3e88-1919-4e9a-9990-4c9224751363

