### PR TITLE
Handle internal message moves causing message muting/unmuting

### DIFF
--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -100,12 +100,12 @@ mixin ChannelStore on UserStore {
   }
 
   /// Whether the given event will change the result of [isTopicVisibleInChannel]
-  /// for its stream and topic, compared to the current state.
-  UserTopicVisibilityEffect willChangeIfTopicVisibleInStream(UserTopicEvent event) {
-    final streamId = event.streamId;
+  /// for its channel and topic, compared to the current state.
+  UserTopicVisibilityEffect willChangeIfTopicVisibleInChannel(UserTopicEvent event) {
+    final channelId = event.streamId;
     final topic = event.topicName;
     return UserTopicVisibilityEffect._fromBeforeAfter(
-      _isTopicVisibleInChannel(topicVisibilityPolicy(streamId, topic)),
+      _isTopicVisibleInChannel(topicVisibilityPolicy(channelId, topic)),
       _isTopicVisibleInChannel(event.visibilityPolicy));
   }
 
@@ -137,13 +137,13 @@ mixin ChannelStore on UserStore {
   }
 
   /// Whether the given event will change the result of [isTopicVisible]
-  /// for its stream and topic, compared to the current state.
+  /// for its channel and topic, compared to the current state.
   UserTopicVisibilityEffect willChangeIfTopicVisible(UserTopicEvent event) {
-    final streamId = event.streamId;
+    final channelId = event.streamId;
     final topic = event.topicName;
     return UserTopicVisibilityEffect._fromBeforeAfter(
-      _isTopicVisible(streamId, topicVisibilityPolicy(streamId, topic)),
-      _isTopicVisible(streamId, event.visibilityPolicy));
+      _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic)),
+      _isTopicVisible(channelId, event.visibilityPolicy));
   }
 
   bool _isTopicVisible(int channelId, UserTopicVisibilityPolicy policy) {

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -101,7 +101,7 @@ mixin ChannelStore on UserStore {
 
   /// Whether the given event will change the result of [isTopicVisibleInChannel]
   /// for its channel and topic, compared to the current state.
-  UserTopicVisibilityEffect willChangeIfTopicVisibleInChannel(UserTopicEvent event) {
+  UserTopicVisibilityEffect willAffectIfTopicVisibleInChannel(UserTopicEvent event) {
     final channelId = event.streamId;
     final topic = event.topicName;
     return UserTopicVisibilityEffect._fromBeforeAfter(
@@ -138,7 +138,7 @@ mixin ChannelStore on UserStore {
 
   /// Whether the given event will change the result of [isTopicVisible]
   /// for its channel and topic, compared to the current state.
-  UserTopicVisibilityEffect willChangeIfTopicVisible(UserTopicEvent event) {
+  UserTopicVisibilityEffect willAffectIfTopicVisible(UserTopicEvent event) {
     final channelId = event.streamId;
     final topic = event.topicName;
     return UserTopicVisibilityEffect._fromBeforeAfter(

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -70,7 +70,7 @@ mixin ChannelStore on UserStore {
   /// and is mainly used in the implementation of other [ChannelStore] methods.
   ///
   /// For policies directly applicable in the UI, see
-  /// [isTopicVisibleInStream] and [isTopicVisible].
+  /// [isTopicVisibleInChannel] and [isTopicVisible].
   ///
   /// Topics are treated case-insensitively; see [TopicName.isSameAs].
   UserTopicVisibilityPolicy topicVisibilityPolicy(int streamId, TopicName topic);
@@ -85,31 +85,31 @@ mixin ChannelStore on UserStore {
   @visibleForTesting
   Map<int, Map<TopicName, UserTopicVisibilityPolicy>> get debugTopicVisibility;
 
-  /// Whether this topic should appear when already focusing on its stream.
+  /// Whether this topic should appear when already focusing on its channel.
   ///
   /// This is determined purely by the user's visibility policy for the topic.
   ///
   /// This function is appropriate for muting calculations in UI contexts that
-  /// are already specific to a stream: for example the stream's unread count,
-  /// or the message list in the stream's narrow.
+  /// are already specific to a channel: for example the channel's unread count,
+  /// or the message list in the channel's narrow.
   ///
-  /// For UI contexts that are not specific to a particular stream, see
+  /// For UI contexts that are not specific to a particular channel, see
   /// [isTopicVisible].
-  bool isTopicVisibleInStream(int streamId, TopicName topic) {
-    return _isTopicVisibleInStream(topicVisibilityPolicy(streamId, topic));
+  bool isTopicVisibleInChannel(int channelId, TopicName topic) {
+    return _isTopicVisibleInChannel(topicVisibilityPolicy(channelId, topic));
   }
 
-  /// Whether the given event will change the result of [isTopicVisibleInStream]
+  /// Whether the given event will change the result of [isTopicVisibleInChannel]
   /// for its stream and topic, compared to the current state.
   UserTopicVisibilityEffect willChangeIfTopicVisibleInStream(UserTopicEvent event) {
     final streamId = event.streamId;
     final topic = event.topicName;
     return UserTopicVisibilityEffect._fromBeforeAfter(
-      _isTopicVisibleInStream(topicVisibilityPolicy(streamId, topic)),
-      _isTopicVisibleInStream(event.visibilityPolicy));
+      _isTopicVisibleInChannel(topicVisibilityPolicy(streamId, topic)),
+      _isTopicVisibleInChannel(event.visibilityPolicy));
   }
 
-  static bool _isTopicVisibleInStream(UserTopicVisibilityPolicy policy) {
+  static bool _isTopicVisibleInChannel(UserTopicVisibilityPolicy policy) {
     switch (policy) {
       case UserTopicVisibilityPolicy.none:
         return true;
@@ -125,15 +125,15 @@ mixin ChannelStore on UserStore {
   }
 
   /// Whether this topic should appear when not specifically focusing
-  /// on this stream.
+  /// on this channel.
   ///
-  /// This takes into account the user's visibility policy for the stream
+  /// This takes into account the user's visibility policy for the channel
   /// overall, as well as their policy for this topic.
   ///
-  /// For UI contexts that are specific to a particular stream, see
-  /// [isTopicVisibleInStream].
-  bool isTopicVisible(int streamId, TopicName topic) {
-    return _isTopicVisible(streamId, topicVisibilityPolicy(streamId, topic));
+  /// For UI contexts that are specific to a particular channel, see
+  /// [isTopicVisibleInChannel].
+  bool isTopicVisible(int channelId, TopicName topic) {
+    return _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic));
   }
 
   /// Whether the given event will change the result of [isTopicVisible]
@@ -146,10 +146,10 @@ mixin ChannelStore on UserStore {
       _isTopicVisible(streamId, event.visibilityPolicy));
   }
 
-  bool _isTopicVisible(int streamId, UserTopicVisibilityPolicy policy) {
+  bool _isTopicVisible(int channelId, UserTopicVisibilityPolicy policy) {
     switch (policy) {
       case UserTopicVisibilityPolicy.none:
-        switch (subscriptions[streamId]?.isMuted) {
+        switch (subscriptions[channelId]?.isMuted) {
           case false: return true;
           case true:  return false;
           case null:  return false; // not subscribed; treat like muted
@@ -302,7 +302,7 @@ mixin ChannelStore on UserStore {
 }
 
 /// Whether and how a given [UserTopicEvent] will affect the results
-/// that [ChannelStore.isTopicVisible] or [ChannelStore.isTopicVisibleInStream]
+/// that [ChannelStore.isTopicVisible] or [ChannelStore.isTopicVisibleInChannel]
 /// would give for some messages.
 enum UserTopicVisibilityEffect {
   /// The event will have no effect on the visibility results.

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -785,7 +785,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   MutedUsersVisibilityEffect _mutedUsersEventCanAffectVisibility(MutedUsersEvent event) {
     switch(narrow) {
       case CombinedFeedNarrow():
-        return store.mightChangeShouldMuteDmConversation(event);
+        return store.willAffectShouldMuteDmConversation(event);
 
       case ChannelNarrow():
       case TopicNarrow():
@@ -793,13 +793,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         return MutedUsersVisibilityEffect.none;
 
       case MentionsNarrow():
-        return store.mightChangeShouldMuteDmConversation(event);
+        return store.willAffectShouldMuteDmConversation(event);
 
       case StarredMessagesNarrow():
         return MutedUsersVisibilityEffect.none;
 
       case KeywordSearchNarrow():
-        return store.mightChangeShouldMuteDmConversation(event);
+        return store.willAffectShouldMuteDmConversation(event);
     }
   }
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -677,8 +677,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   ///
   /// See also [_allMessagesVisible].
   // When updating this, check [_allMessagesVisible], [_willAffectVisibility],
-  // and [_mutedUsersEventWillAffectVisibility] to see whether they need to be
-  // updated too.
+  // [_mutedUsersEventWillAffectVisibility], and [messagesMoved] to see whether
+  // they need to be updated too.
   // Also check the unread-count methods in [Unreads] to make sure they count
   // exactly the unread messages for which this would return true.
   bool _messageVisible(MessageBase message) {
@@ -1237,11 +1237,20 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         return;
 
       case CombinedFeedNarrow():
+        final wasVisible = store.isTopicVisible(origStreamId, origTopic);
+        final isVisible = store.isTopicVisible(newStreamId, newTopic);
+        switch((wasVisible, isVisible)) {
+          case (false, false): return;
+          case (true,  true ): _messagesMovedInternally(messageIds);
+          case (false, true ): _messagesMovedIntoMessageList();
+          case (true,  false): _messagesMovedFromMessageList(messageIds);
+        }
+
       case MentionsNarrow():
       case StarredMessagesNarrow():
-        // The messages didn't enter or leave this narrow.
-        // TODO(#1255): … except they may have become muted or not.
-        //   We'll handle that at the same time as we handle muting itself changing.
+        // The messages didn't enter or leave this message list.
+        // (They may have been (un)muted, but we don't exclude channel messages
+        // in these narrows on the basis of muting. See _messageVisible.)
         // Recipient headers, and downstream of those, may change, though.
         _messagesMovedInternally(messageIds);
 
@@ -1250,21 +1259,20 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         // the topic alone, and topics change. Punt on trying to add/remove
         // messages, though, because we aren't equipped to evaluate the match
         // without asking the server.
+        // (Messages may have been (un)muted, but we don't exclude channel
+        // messages in this narrow on the basis of muting. See _messageVisible.)
         _messagesMovedInternally(messageIds);
 
       case ChannelNarrow(:final channelId):
-        switch ((origStreamId == channelId, newStreamId == channelId)) {
+        final wasInChannelAndVisible = origStreamId == channelId
+          && store.isTopicVisibleInChannel(origStreamId, origTopic);
+        final isInChannelAndVisible = newStreamId == channelId
+          && store.isTopicVisibleInChannel(newStreamId, newTopic);
+        switch ((wasInChannelAndVisible, isInChannelAndVisible)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
-          case (false, true ):
-            if (store.isTopicVisibleInChannel(newStreamId, newTopic)) {
-              _messagesMovedIntoMessageList();
-            }
-
-          case (true,  false):
-            if (store.isTopicVisibleInChannel(origStreamId, origTopic)) {
-              _messagesMovedFromMessageList(messageIds);
-            }
+          case (false, true ): _messagesMovedIntoMessageList();
+          case (true,  false): _messagesMovedFromMessageList(messageIds);
         }
 
       case TopicNarrow(:final channelId, :final topic):

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -765,11 +765,11 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   UserTopicVisibilityEffect _canAffectVisibility(UserTopicEvent event) {
     switch (narrow) {
       case CombinedFeedNarrow():
-        return store.willChangeIfTopicVisible(event);
+        return store.willAffectIfTopicVisible(event);
 
       case ChannelNarrow(:final channelId):
         if (event.streamId != channelId) return UserTopicVisibilityEffect.none;
-        return store.willChangeIfTopicVisibleInChannel(event);
+        return store.willAffectIfTopicVisibleInChannel(event);
 
       case TopicNarrow():
       case DmNarrow():

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1197,7 +1197,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     }
   }
 
-  void _messagesMovedIntoNarrow() {
+  void _messagesMovedIntoMessageList() {
     // If there are some messages we don't have in [MessageStore], and they
     // occur later than the messages we have here, then we just have to
     // re-fetch from scratch.  That's always valid, so just do that always.
@@ -1207,7 +1207,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     fetchInitial();
   }
 
-  void _messagesMovedFromNarrow(List<int> messageIds) {
+  void _messagesMovedFromMessageList(List<int> messageIds) {
     if (_removeMessagesById(messageIds)) {
       notifyListeners();
     }
@@ -1256,8 +1256,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         switch ((origStreamId == channelId, newStreamId == channelId)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
-          case (false, true ): _messagesMovedIntoNarrow();
-          case (true,  false): _messagesMovedFromNarrow(messageIds);
+          case (false, true ): _messagesMovedIntoMessageList();
+          case (true,  false): _messagesMovedFromMessageList(messageIds);
         }
 
       case TopicNarrow(:final channelId, :final topic):
@@ -1266,9 +1266,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         switch ((oldMatch, newMatch)) {
           case (false, false): return;
           case (true,  true ): return; // TODO(log) when no-op move
-          case (false, true ): _messagesMovedIntoNarrow();
+          case (false, true ): _messagesMovedIntoMessageList();
           case (true,  false):
-            _messagesMovedFromNarrow(messageIds);
+            _messagesMovedFromMessageList(messageIds);
             _handlePropagateMode(propagateMode, TopicNarrow(newStreamId, newTopic));
         }
     }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1256,8 +1256,15 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         switch ((origStreamId == channelId, newStreamId == channelId)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
-          case (false, true ): _messagesMovedIntoMessageList();
-          case (true,  false): _messagesMovedFromMessageList(messageIds);
+          case (false, true ):
+            if (store.isTopicVisibleInChannel(newStreamId, newTopic)) {
+              _messagesMovedIntoMessageList();
+            }
+
+          case (true,  false):
+            if (store.isTopicVisibleInChannel(origStreamId, origTopic)) {
+              _messagesMovedFromMessageList(messageIds);
+            }
         }
 
       case TopicNarrow(:final channelId, :final topic):

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -676,8 +676,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   /// see [RevealedMutedMessagesState] in lib/widgets/message_list.dart.
   ///
   /// See also [_allMessagesVisible].
-  // When updating this, check [_allMessagesVisible], [_canAffectVisibility],
-  // and [_mutedUsersEventCanAffectVisibility] to see whether they need to be
+  // When updating this, check [_allMessagesVisible], [_willAffectVisibility],
+  // and [_mutedUsersEventWillAffectVisibility] to see whether they need to be
   // updated too.
   // Also check the unread-count methods in [Unreads] to make sure they count
   // exactly the unread messages for which this would return true.
@@ -762,7 +762,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   /// Whether this event could affect the result that [_messageVisible]
   /// would ever have returned for any possible message in this message list.
-  UserTopicVisibilityEffect _canAffectVisibility(UserTopicEvent event) {
+  UserTopicVisibilityEffect _willAffectVisibility(UserTopicEvent event) {
     switch (narrow) {
       case CombinedFeedNarrow():
         return store.willAffectIfTopicVisible(event);
@@ -782,7 +782,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   /// Whether this event could affect the result that [_messageVisible]
   /// would ever have returned for any possible message in this message list.
-  MutedUsersVisibilityEffect _mutedUsersEventCanAffectVisibility(MutedUsersEvent event) {
+  MutedUsersVisibilityEffect _mutedUsersEventWillAffectVisibility(MutedUsersEvent event) {
     switch(narrow) {
       case CombinedFeedNarrow():
         return store.willAffectShouldMuteDmConversation(event);
@@ -1074,7 +1074,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   }
 
   void handleUserTopicEvent(UserTopicEvent event) {
-    switch (_canAffectVisibility(event)) {
+    switch (_willAffectVisibility(event)) {
       case UserTopicVisibilityEffect.none:
         return;
 
@@ -1106,7 +1106,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   }
 
   void handleMutedUsersEvent(MutedUsersEvent event) {
-    switch (_mutedUsersEventCanAffectVisibility(event)) {
+    switch (_mutedUsersEventWillAffectVisibility(event)) {
       case MutedUsersVisibilityEffect.none:
         return;
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -696,7 +696,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         assert(message is MessageBase<StreamConversation>
                && message.conversation.streamId == channelId);
         if (message is! MessageBase<StreamConversation>) return false;
-        return store.isTopicVisibleInStream(channelId, message.conversation.topic);
+        return store.isTopicVisibleInChannel(channelId, message.conversation.topic);
 
       case TopicNarrow():
         assert((narrow as TopicNarrow).containsMessage(message));

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -769,7 +769,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
       case ChannelNarrow(:final channelId):
         if (event.streamId != channelId) return UserTopicVisibilityEffect.none;
-        return store.willChangeIfTopicVisibleInStream(event);
+        return store.willChangeIfTopicVisibleInChannel(event);
 
       case TopicNarrow():
       case DmNarrow():

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1354,8 +1354,15 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         switch ((origStreamId == channelId, newStreamId == channelId)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
-          case (false, true ): _messagesMovedIntoMessageList();
-          case (true,  false): _messagesMovedFromMessageList(messageIds);
+          case (false, true ):
+            if (store.isTopicVisibleInChannel(newStreamId, newTopic)) {
+              _messagesMovedIntoMessageList();
+            }
+
+          case (true,  false):
+            if (store.isTopicVisibleInChannel(origStreamId, origTopic)) {
+              _messagesMovedFromMessageList(messageIds);
+            }
         }
 
       case TopicNarrow(:final channelId, :final topic):

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -732,8 +732,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   ///
   /// See also [_allMessagesVisible].
   // When updating this, check [_allMessagesVisible], [_willAffectVisibility],
-  // and [_mutedUsersEventWillAffectVisibility] to see whether they need to be
-  // updated too.
+  // [_mutedUsersEventWillAffectVisibility], and [messagesMoved] to see whether
+  // they need to be updated too.
   // Also check the unread-count methods in [Unreads] to make sure they count
   // exactly the unread messages for which this would return true.
   bool _messageVisible(MessageBase message) {
@@ -1335,11 +1335,20 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         return;
 
       case CombinedFeedNarrow():
+        final wasVisible = store.isTopicVisible(origStreamId, origTopic);
+        final isVisible = store.isTopicVisible(newStreamId, newTopic);
+        switch ((wasVisible, isVisible)) {
+          case (false, false): return;
+          case (true,  true ): _messagesMovedInternally(messageIds);
+          case (false, true ): _messagesMovedIntoMessageList();
+          case (true,  false): _messagesMovedFromMessageList(messageIds);
+        }
+
       case MentionsNarrow():
       case StarredMessagesNarrow():
-        // The messages didn't enter or leave this narrow.
-        // TODO(#1255): … except they may have become muted or not.
-        //   We'll handle that at the same time as we handle muting itself changing.
+        // The messages didn't enter or leave this message list.
+        // (They may have been (un)muted, but we don't exclude channel messages
+        // in these narrows on the basis of muting. See _messageVisible.)
         // Recipient headers, and downstream of those, may change, though.
         _messagesMovedInternally(messageIds);
 
@@ -1348,21 +1357,20 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         // the topic alone, and topics change. Punt on trying to add/remove
         // messages, though, because we aren't equipped to evaluate the match
         // without asking the server.
+        // (Messages may have been (un)muted, but we don't exclude channel
+        // messages in this narrow on the basis of muting. See _messageVisible.)
         _messagesMovedInternally(messageIds);
 
       case ChannelNarrow(:final channelId):
-        switch ((origStreamId == channelId, newStreamId == channelId)) {
+        final wasInChannelAndVisible = origStreamId == channelId
+          && store.isTopicVisibleInChannel(origStreamId, origTopic);
+        final isInChannelAndVisible = newStreamId == channelId
+          && store.isTopicVisibleInChannel(newStreamId, newTopic);
+        switch ((wasInChannelAndVisible, isInChannelAndVisible)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
-          case (false, true ):
-            if (store.isTopicVisibleInChannel(newStreamId, newTopic)) {
-              _messagesMovedIntoMessageList();
-            }
-
-          case (true,  false):
-            if (store.isTopicVisibleInChannel(origStreamId, origTopic)) {
-              _messagesMovedFromMessageList(messageIds);
-            }
+          case (false, true ): _messagesMovedIntoMessageList();
+          case (true,  false): _messagesMovedFromMessageList(messageIds);
         }
 
       case TopicNarrow(:final channelId, :final topic):

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1295,7 +1295,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     }
   }
 
-  void _messagesMovedIntoNarrow() {
+  void _messagesMovedIntoMessageList() {
     // If there are some messages we don't have in [MessageStore], and they
     // occur later than the messages we have here, then we just have to
     // re-fetch from scratch.  That's always valid, so just do that always.
@@ -1305,7 +1305,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     fetchInitial();
   }
 
-  void _messagesMovedFromNarrow(List<int> messageIds) {
+  void _messagesMovedFromMessageList(List<int> messageIds) {
     if (_removeMessagesById(messageIds)) {
       notifyListeners();
     }
@@ -1354,8 +1354,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         switch ((origStreamId == channelId, newStreamId == channelId)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
-          case (false, true ): _messagesMovedIntoNarrow();
-          case (true,  false): _messagesMovedFromNarrow(messageIds);
+          case (false, true ): _messagesMovedIntoMessageList();
+          case (true,  false): _messagesMovedFromMessageList(messageIds);
         }
 
       case TopicNarrow(:final channelId, :final topic):
@@ -1364,9 +1364,9 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         switch ((oldMatch, newMatch)) {
           case (false, false): return;
           case (true,  true ): return; // TODO(log) when no-op move
-          case (false, true ): _messagesMovedIntoNarrow();
+          case (false, true ): _messagesMovedIntoMessageList();
           case (true,  false):
-            _messagesMovedFromNarrow(messageIds);
+            _messagesMovedFromMessageList(messageIds);
             _handlePropagateMode(propagateMode, TopicNarrow(newStreamId, newTopic));
         }
     }

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -840,7 +840,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   MutedUsersVisibilityEffect _mutedUsersEventCanAffectVisibility(MutedUsersEvent event) {
     switch(narrow) {
       case CombinedFeedNarrow():
-        return store.mightChangeShouldMuteDmConversation(event);
+        return store.willAffectShouldMuteDmConversation(event);
 
       case ChannelNarrow():
       case TopicNarrow():
@@ -848,13 +848,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         return MutedUsersVisibilityEffect.none;
 
       case MentionsNarrow():
-        return store.mightChangeShouldMuteDmConversation(event);
+        return store.willAffectShouldMuteDmConversation(event);
 
       case StarredMessagesNarrow():
         return MutedUsersVisibilityEffect.none;
 
       case KeywordSearchNarrow():
-        return store.mightChangeShouldMuteDmConversation(event);
+        return store.willAffectShouldMuteDmConversation(event);
     }
   }
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -731,8 +731,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   /// see [RevealedMutedMessagesState] in lib/widgets/message_list.dart.
   ///
   /// See also [_allMessagesVisible].
-  // When updating this, check [_allMessagesVisible], [_canAffectVisibility],
-  // and [_mutedUsersEventCanAffectVisibility] to see whether they need to be
+  // When updating this, check [_allMessagesVisible], [_willAffectVisibility],
+  // and [_mutedUsersEventWillAffectVisibility] to see whether they need to be
   // updated too.
   // Also check the unread-count methods in [Unreads] to make sure they count
   // exactly the unread messages for which this would return true.
@@ -817,7 +817,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   /// Whether this event could affect the result that [_messageVisible]
   /// would ever have returned for any possible message in this message list.
-  UserTopicVisibilityEffect _canAffectVisibility(UserTopicEvent event) {
+  UserTopicVisibilityEffect _willAffectVisibility(UserTopicEvent event) {
     switch (narrow) {
       case CombinedFeedNarrow():
         return store.willAffectIfTopicVisible(event);
@@ -837,7 +837,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   /// Whether this event could affect the result that [_messageVisible]
   /// would ever have returned for any possible message in this message list.
-  MutedUsersVisibilityEffect _mutedUsersEventCanAffectVisibility(MutedUsersEvent event) {
+  MutedUsersVisibilityEffect _mutedUsersEventWillAffectVisibility(MutedUsersEvent event) {
     switch(narrow) {
       case CombinedFeedNarrow():
         return store.willAffectShouldMuteDmConversation(event);
@@ -1150,7 +1150,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   }
 
   void handleUserTopicEvent(UserTopicEvent event) {
-    switch (_canAffectVisibility(event)) {
+    switch (_willAffectVisibility(event)) {
       case UserTopicVisibilityEffect.none:
         return;
 
@@ -1182,7 +1182,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   }
 
   void handleMutedUsersEvent(MutedUsersEvent event) {
-    switch (_mutedUsersEventCanAffectVisibility(event)) {
+    switch (_mutedUsersEventWillAffectVisibility(event)) {
       case MutedUsersVisibilityEffect.none:
         return;
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -820,11 +820,11 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   UserTopicVisibilityEffect _canAffectVisibility(UserTopicEvent event) {
     switch (narrow) {
       case CombinedFeedNarrow():
-        return store.willChangeIfTopicVisible(event);
+        return store.willAffectIfTopicVisible(event);
 
       case ChannelNarrow(:final channelId):
         if (event.streamId != channelId) return UserTopicVisibilityEffect.none;
-        return store.willChangeIfTopicVisibleInChannel(event);
+        return store.willAffectIfTopicVisibleInChannel(event);
 
       case TopicNarrow():
       case DmNarrow():

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -824,7 +824,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
       case ChannelNarrow(:final channelId):
         if (event.streamId != channelId) return UserTopicVisibilityEffect.none;
-        return store.willChangeIfTopicVisibleInStream(event);
+        return store.willChangeIfTopicVisibleInChannel(event);
 
       case TopicNarrow():
       case DmNarrow():

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -751,7 +751,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         assert(message is MessageBase<StreamConversation>
                && message.conversation.streamId == channelId);
         if (message is! MessageBase<StreamConversation>) return false;
-        return store.isTopicVisibleInStream(channelId, message.conversation.topic);
+        return store.isTopicVisibleInChannel(channelId, message.conversation.topic);
 
       case TopicNarrow():
         assert((narrow as TopicNarrow).containsMessage(message));

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -193,7 +193,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
   }
 
   /// The "broad" unread count for this channel,
-  /// using [ChannelStore.isTopicVisibleInStream].
+  /// using [ChannelStore.isTopicVisibleInChannel].
   ///
   /// This includes topics that have no visibility policy of their own,
   /// even if the channel itself is muted.
@@ -206,7 +206,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
     if (topics == null) return 0;
     int c = 0;
     for (final entry in topics.entries) {
-      if (channelStore.isTopicVisibleInStream(channelId, entry.key)) {
+      if (channelStore.isTopicVisibleInChannel(channelId, entry.key)) {
         c = c + entry.value.length;
       }
     }

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -110,7 +110,7 @@ mixin UserStore on PerAccountStoreBase, RealmStore {
 
   /// Whether the given event might change the result of [shouldMuteDmConversation]
   /// for its list of muted users, compared to the current state.
-  MutedUsersVisibilityEffect mightChangeShouldMuteDmConversation(MutedUsersEvent event);
+  MutedUsersVisibilityEffect willAffectShouldMuteDmConversation(MutedUsersEvent event);
 
   /// The status of the user with the given ID.
   ///
@@ -150,8 +150,8 @@ mixin ProxyUserStore on UserStore {
     userStore.isUserMuted(userId, event: event);
 
   @override
-  MutedUsersVisibilityEffect mightChangeShouldMuteDmConversation(MutedUsersEvent event) =>
-    userStore.mightChangeShouldMuteDmConversation(event);
+  MutedUsersVisibilityEffect willAffectShouldMuteDmConversation(MutedUsersEvent event) =>
+    userStore.willAffectShouldMuteDmConversation(event);
 
   @override
   UserStatus getUserStatus(int userId) => userStore.getUserStatus(userId);
@@ -214,7 +214,7 @@ class UserStoreImpl extends HasRealmStore with UserStore {
   }
 
   @override
-  MutedUsersVisibilityEffect mightChangeShouldMuteDmConversation(MutedUsersEvent event) {
+  MutedUsersVisibilityEffect willAffectShouldMuteDmConversation(MutedUsersEvent event) {
     final sortedOld = _mutedUsers.toList()..sort();
     final sortedNew = event.mutedUsers.map((u) => u.id).toList()..sort();
     assert(isSortedWithoutDuplicates(sortedOld));

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -339,7 +339,7 @@ void main() {
       });
     });
 
-    group('willChangeIfTopicVisible/InChannel', () {
+    group('willAffectIfTopicVisible/InChannel', () {
       UserTopicEvent mkEvent(UserTopicVisibilityPolicy policy) =>
         eg.userTopicEvent(stream1.streamId, 'topic', policy);
 
@@ -360,12 +360,12 @@ void main() {
           UserTopicVisibilityEffect expectedInChannel,
           UserTopicVisibilityEffect expectedOverall) {
         final event = mkEvent(newPolicy);
-        check(store.willChangeIfTopicVisibleInChannel(event)).equals(expectedInChannel);
-        check(store.willChangeIfTopicVisible         (event)).equals(expectedOverall);
+        check(store.willAffectIfTopicVisibleInChannel(event)).equals(expectedInChannel);
+        check(store.willAffectIfTopicVisible         (event)).equals(expectedOverall);
 
         final event2 = mkEventDifferentlyCased(newPolicy);
-        check(store.willChangeIfTopicVisibleInChannel(event2)).equals(expectedInChannel);
-        check(store.willChangeIfTopicVisible         (event2)).equals(expectedOverall);
+        check(store.willAffectIfTopicVisibleInChannel(event2)).equals(expectedInChannel);
+        check(store.willAffectIfTopicVisible         (event2)).equals(expectedOverall);
       }
 
       test('channel not muted, policy none -> followed, no change', () async {
@@ -425,8 +425,8 @@ void main() {
               final oldVisible          = store.isTopicVisible(stream1.streamId, eg.t('topic'));
 
               final event = mkEvent(newPolicy);
-              final willChangeInChannel = store.willChangeIfTopicVisibleInChannel(event);
-              final willChange          = store.willChangeIfTopicVisible(event);
+              final willAffectInChannel = store.willAffectIfTopicVisibleInChannel(event);
+              final willAffect          = store.willAffectIfTopicVisible(event);
 
               await store.handleEvent(event);
               final newVisibleInChannel = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
@@ -437,9 +437,9 @@ void main() {
                 if (newVisible) return UserTopicVisibilityEffect.unmuted;
                 return UserTopicVisibilityEffect.muted;
               }
-              check(willChangeInChannel)
+              check(willAffectInChannel)
                 .equals(fromOldNew(oldVisibleInChannel, newVisibleInChannel));
-              check(willChange)
+              check(willAffect)
                 .equals(fromOldNew(oldVisible,         newVisible));
             });
           }

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -339,7 +339,7 @@ void main() {
       });
     });
 
-    group('willChangeIfTopicVisible/InStream', () {
+    group('willChangeIfTopicVisible/InChannel', () {
       UserTopicEvent mkEvent(UserTopicVisibilityPolicy policy) =>
         eg.userTopicEvent(stream1.streamId, 'topic', policy);
 
@@ -357,18 +357,18 @@ void main() {
 
       void checkChanges(PerAccountStore store,
           UserTopicVisibilityPolicy newPolicy,
-          UserTopicVisibilityEffect expectedInStream,
+          UserTopicVisibilityEffect expectedInChannel,
           UserTopicVisibilityEffect expectedOverall) {
         final event = mkEvent(newPolicy);
-        check(store.willChangeIfTopicVisibleInStream(event)).equals(expectedInStream);
-        check(store.willChangeIfTopicVisible        (event)).equals(expectedOverall);
+        check(store.willChangeIfTopicVisibleInChannel(event)).equals(expectedInChannel);
+        check(store.willChangeIfTopicVisible         (event)).equals(expectedOverall);
 
         final event2 = mkEventDifferentlyCased(newPolicy);
-        check(store.willChangeIfTopicVisibleInStream(event2)).equals(expectedInStream);
-        check(store.willChangeIfTopicVisible        (event2)).equals(expectedOverall);
+        check(store.willChangeIfTopicVisibleInChannel(event2)).equals(expectedInChannel);
+        check(store.willChangeIfTopicVisible         (event2)).equals(expectedOverall);
       }
 
-      test('stream not muted, policy none -> followed, no change', () async {
+      test('channel not muted, policy none -> followed, no change', () async {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
@@ -376,7 +376,7 @@ void main() {
           UserTopicVisibilityEffect.none, UserTopicVisibilityEffect.none);
       });
 
-      test('stream not muted, policy none -> muted, means muted', () async {
+      test('channel not muted, policy none -> muted, means muted', () async {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
@@ -384,7 +384,7 @@ void main() {
           UserTopicVisibilityEffect.muted, UserTopicVisibilityEffect.muted);
       });
 
-      test('stream muted, policy none -> followed, means none/unmuted', () async {
+      test('channel muted, policy none -> followed, means none/unmuted', () async {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
@@ -392,7 +392,7 @@ void main() {
           UserTopicVisibilityEffect.none, UserTopicVisibilityEffect.unmuted);
       });
 
-      test('stream muted, policy none -> muted, means muted/none', () async {
+      test('channel muted, policy none -> muted, means muted/none', () async {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
@@ -405,40 +405,40 @@ void main() {
         UserTopicVisibilityPolicy.none,
         UserTopicVisibilityPolicy.unmuted,
       ];
-      for (final streamMuted in [null, false, true]) {
+      for (final channelMuted in [null, false, true]) {
         for (final oldPolicy in policies) {
           for (final newPolicy in policies) {
-            final streamDesc = switch (streamMuted) {
-              false => "stream not muted",
-              true => "stream muted",
-              null => "stream unsubscribed",
+            final channelDesc = switch (channelMuted) {
+              false => "channel not muted",
+              true => "channel muted",
+              null => "channel unsubscribed",
             };
-            test('$streamDesc, topic ${oldPolicy.name} -> ${newPolicy.name}', () async {
+            test('$channelDesc, topic ${oldPolicy.name} -> ${newPolicy.name}', () async {
               final store = eg.store();
               await store.addStream(stream1);
-              if (streamMuted != null) {
+              if (channelMuted != null) {
                 await store.addSubscription(
-                  eg.subscription(stream1, isMuted: streamMuted));
+                  eg.subscription(stream1, isMuted: channelMuted));
               }
               await store.handleEvent(mkEvent(oldPolicy));
-              final oldVisibleInStream = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
-              final oldVisible         = store.isTopicVisible(stream1.streamId, eg.t('topic'));
+              final oldVisibleInChannel = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
+              final oldVisible          = store.isTopicVisible(stream1.streamId, eg.t('topic'));
 
               final event = mkEvent(newPolicy);
-              final willChangeInStream = store.willChangeIfTopicVisibleInStream(event);
-              final willChange         = store.willChangeIfTopicVisible(event);
+              final willChangeInChannel = store.willChangeIfTopicVisibleInChannel(event);
+              final willChange          = store.willChangeIfTopicVisible(event);
 
               await store.handleEvent(event);
-              final newVisibleInStream = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
-              final newVisible         = store.isTopicVisible(stream1.streamId, eg.t('topic'));
+              final newVisibleInChannel = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
+              final newVisible          = store.isTopicVisible(stream1.streamId, eg.t('topic'));
 
               UserTopicVisibilityEffect fromOldNew(bool oldVisible, bool newVisible) {
                 if (newVisible == oldVisible) return UserTopicVisibilityEffect.none;
                 if (newVisible) return UserTopicVisibilityEffect.unmuted;
                 return UserTopicVisibilityEffect.muted;
               }
-              check(willChangeInStream)
-                .equals(fromOldNew(oldVisibleInStream, newVisibleInStream));
+              check(willChangeInChannel)
+                .equals(fromOldNew(oldVisibleInChannel, newVisibleInChannel));
               check(willChange)
                 .equals(fromOldNew(oldVisible,         newVisible));
             });

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -275,28 +275,28 @@ void main() {
       });
     });
 
-    group('isTopicVisible/InStream', () {
-      test('with policy none, stream not muted', () async {
+    group('isTopicVisible/InChannel', () {
+      test('with policy none, channel not muted', () async {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('topic'))).isTrue();
       });
 
-      test('with policy none, stream muted', () async {
+      test('with policy none, channel muted', () async {
         final store = eg.store();
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('topic'))).isFalse();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('topic'))).isFalse();
       });
 
-      test('with policy none, stream unsubscribed', () async {
+      test('with policy none, channel unsubscribed', () async {
         final store = eg.store();
         await store.addStream(stream1);
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('topic'))).isFalse();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('topic'))).isFalse();
       });
 
       test('with policy muted', () async {
@@ -304,12 +304,12 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
         await store.setUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.muted);
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'))).isFalse();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('topic'))).isFalse();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'))).isFalse();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('topic'))).isFalse();
 
         // Case-insensitive
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('ToPiC'))).isFalse();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('ToPiC'))).isFalse();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('ToPiC'))).isFalse();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('ToPiC'))).isFalse();
       });
 
       test('with policy unmuted', () async {
@@ -317,12 +317,12 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
         await store.setUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.unmuted);
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('topic'))).isTrue();
 
         // Case-insensitive
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('tOpIc'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('tOpIc'))).isTrue();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('tOpIc'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('tOpIc'))).isTrue();
       });
 
       test('with policy followed', () async {
@@ -330,12 +330,12 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
         await store.setUserTopic(stream1, 'topic', UserTopicVisibilityPolicy.followed);
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('topic'))).isTrue();
 
         // Case-insensitive
-        check(store.isTopicVisibleInStream(stream1.streamId, eg.t('TOPIC'))).isTrue();
-        check(store.isTopicVisible        (stream1.streamId, eg.t('TOPIC'))).isTrue();
+        check(store.isTopicVisibleInChannel(stream1.streamId, eg.t('TOPIC'))).isTrue();
+        check(store.isTopicVisible         (stream1.streamId, eg.t('TOPIC'))).isTrue();
       });
     });
 
@@ -421,7 +421,7 @@ void main() {
                   eg.subscription(stream1, isMuted: streamMuted));
               }
               await store.handleEvent(mkEvent(oldPolicy));
-              final oldVisibleInStream = store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'));
+              final oldVisibleInStream = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
               final oldVisible         = store.isTopicVisible(stream1.streamId, eg.t('topic'));
 
               final event = mkEvent(newPolicy);
@@ -429,7 +429,7 @@ void main() {
               final willChange         = store.willChangeIfTopicVisible(event);
 
               await store.handleEvent(event);
-              final newVisibleInStream = store.isTopicVisibleInStream(stream1.streamId, eg.t('topic'));
+              final newVisibleInStream = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
               final newVisible         = store.isTopicVisible(stream1.streamId, eg.t('topic'));
 
               UserTopicVisibilityEffect fromOldNew(bool oldVisible, bool newVisible) {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -3304,7 +3304,7 @@ void checkInvariants(MessageListView model) {
           check(model.store.isTopicVisible(conversation.streamId, conversation.topic))
             .isTrue();
         case ChannelNarrow():
-          check(model.store.isTopicVisibleInStream(conversation.streamId, conversation.topic))
+          check(model.store.isTopicVisibleInChannel(conversation.streamId, conversation.topic))
             .isTrue();
         case TopicNarrow():
         case DmNarrow():

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -983,8 +983,8 @@ void main() {
   });
 
   group('UserTopicEvent', () {
-    // The ChannelStore.willChangeIfTopicVisible/InStream methods have their own
-    // thorough unit tests.  So these tests focus on the rest of the logic.
+    // The ChannelStore.willChangeIfTopicVisible/InChannel methods have their
+    // own thorough unit tests.  So these tests focus on the rest of the logic.
 
     final stream = eg.stream();
     const String topic = 'foo';

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1604,26 +1604,41 @@ void main() {
         checkNotified(count: 2);
       });
 
-      test('old channel -> channel: refetch', () => awaitFakeAsync((async) async {
-        await prepareNarrow(narrow, initialMessages);
+      group('old channel -> channel:', () {
+        test('new topic not muted - refetch', () => awaitFakeAsync((async) async {
+          await prepareNarrow(narrow, initialMessages);
 
-        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
-          foundOldest: false,
-          messages: initialMessages + movedMessages,
-        ).toJson());
-        await store.handleEvent(eg.updateMessageEventMoveTo(
-          origTopicStr: 'orig topic',
-          origStreamId: otherStream.streamId,
-          newMessages: movedMessages,
-        ));
-        check(model).fetched.isFalse();
-        checkHasMessages([]);
-        checkNotifiedOnce();
+          connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+            foundOldest: false,
+            messages: initialMessages + movedMessages,
+          ).toJson());
+          await store.handleEvent(eg.updateMessageEventMoveTo(
+            origTopicStr: 'orig topic',
+            origStreamId: otherStream.streamId,
+            newMessages: movedMessages));
+          check(model).fetched.isFalse();
+          checkHasMessages([]);
+          checkNotifiedOnce();
 
-        async.elapse(const Duration(seconds: 2));
-        checkHasMessages(initialMessages + movedMessages);
-        checkNotifiedOnce();
-      }));
+          async.elapse(const Duration(seconds: 2));
+          checkHasMessages(initialMessages + movedMessages);
+          checkNotifiedOnce();
+        }));
+
+        test('new topic muted - unaffected', () async {
+          await prepareNarrow(narrow, initialMessages);
+          await store.setUserTopic(stream, 'new', UserTopicVisibilityPolicy.muted);
+
+          final newTopicMovedMessages = List.generate(5, (i) =>
+            eg.streamMessage(stream: stream, topic: 'new'));
+          await store.handleEvent(eg.updateMessageEventMoveTo(
+            origTopicStr: 'orig topic',
+            origStreamId: otherStream.streamId,
+            newMessages: newTopicMovedMessages));
+          checkHasMessages(initialMessages);
+          checkNotNotified();
+        });
+      });
 
       test('channel -> new channel: remove moved messages', () async {
         await prepareNarrow(narrow, initialMessages + movedMessages);

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -37,6 +37,10 @@ const nearResult = eg.nearGetMessagesResult;
 const olderResult = eg.olderGetMessagesResult;
 const newerResult = eg.newerGetMessagesResult;
 
+/// The expected effect on a [MessageListView] when messages are moved
+/// within a narrow and muting may change their visibility.
+enum VisibilityEffect { unaffected, reprocessed, removed, refetched }
+
 void main() {
   // Arrange for errors caught within the Flutter framework to be printed
   // unconditionally, rather than throttled as they normally are in an app.
@@ -1554,33 +1558,133 @@ void main() {
       checkHasMessages(messages ?? []);
     }
 
-    group('in combined feed narrow', () {
-      const narrow = CombinedFeedNarrow();
-      final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
-      final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+    group('muting interactions on move', () {
+      /// Test that a message move (topic 'orig' → 'new' on [stream])
+      /// has the given [expected] effect on a [MessageListView] with
+      /// the given [narrow].
+      ///
+      /// The concrete muting state — [channelMuted], [origTopicPolicy],
+      /// [newTopicPolicy] — determines visibility differently depending
+      /// on the narrow type (see [MessageListView._messageVisible]), so
+      /// the same muting configuration can produce different effects in
+      /// different narrows.
+      void testMoveWithMuting({
+        required Narrow narrow,
+        required bool channelMuted,
+        required UserTopicVisibilityPolicy origTopicPolicy,
+        required UserTopicVisibilityPolicy newTopicPolicy,
+        required VisibilityEffect expected,
+      }) {
+        final channelDesc = channelMuted ? 'channel muted' : 'channel not muted';
+        final desc = '${narrow.runtimeType}, $channelDesc, '
+          '${origTopicPolicy.name} → ${newTopicPolicy.name}';
+        test(desc, () => awaitFakeAsync((async) async {
+          final flags = switch (narrow) {
+            MentionsNarrow()        => <MessageFlag>[.mentioned],
+            StarredMessagesNarrow() => <MessageFlag>[.starred],
+            _                       => <MessageFlag>[],
+          };
+          final notMovedMessages = List.generate(5, (i) =>
+            eg.streamMessage(stream: stream, topic: 'notMoved', flags: flags));
+          final movedMessages = List.generate(5, (i) =>
+            eg.streamMessage(stream: stream, topic: 'orig', flags: flags));
 
-      test('internal move between channels', () async {
-        await prepareNarrow(narrow, initialMessages);
+          await prepare(narrow: narrow,
+            starredMessages: narrow is StarredMessagesNarrow
+              ? (notMovedMessages + movedMessages).map((m) => m.id).toList()
+              : null);
+          await store.addStream(stream);
+          await store.addSubscription(
+            eg.subscription(stream, isMuted: channelMuted));
+          if (channelMuted) {
+            // Keep notMovedMessages visible despite channel muting.
+            await store.setUserTopic(stream, 'notMoved',
+              UserTopicVisibilityPolicy.unmuted);
+          }
+          if (origTopicPolicy != .none) {
+            await store.setUserTopic(stream, 'orig', origTopicPolicy);
+          }
+          if (newTopicPolicy != .none) {
+            await store.setUserTopic(stream, 'new', newTopicPolicy);
+          }
 
-        await store.handleEvent(eg.updateMessageEventMoveFrom(
-          origMessages: initialMessages,
-          newTopic: initialMessages[0].topic,
-          newStreamId: otherStream.streamId,
-        ));
-        checkHasMessages(initialMessages);
-        checkNotified(count: 2);
-      });
+          // The fetch includes all messages; _messageVisible filters by muting.
+          await prepareMessages(foundOldest: false,
+            messages: notMovedMessages + movedMessages);
 
-      test('internal move between topics', () async {
-        await prepareNarrow(narrow, initialMessages + movedMessages);
+          final postMoveMessages = <StreamMessage>[];
+          if (expected == .refetched) {
+            // The refetch returns messages at their post-move location.
+            postMoveMessages.addAll(movedMessages.map((m) => eg.streamMessage(
+              id: m.id, stream: stream, topic: 'new', flags: flags)));
+            connection.prepare(
+              delay: const Duration(seconds: 2),
+              json: newestResult(foundOldest: false,
+                messages: notMovedMessages + postMoveMessages).toJson());
+          }
 
-        await store.handleEvent(eg.updateMessageEventMoveFrom(
-          origMessages: movedMessages,
-          newTopicStr: 'new',
-        ));
-        checkHasMessages(initialMessages + movedMessages);
-        checkNotified(count: 2);
-      });
+          await store.handleEvent(eg.updateMessageEventMoveFrom(
+            origMessages: movedMessages, newTopicStr: 'new'));
+
+          switch (expected) {
+            case .unaffected:
+              checkHasMessages(notMovedMessages);
+              checkNotNotified();
+            case .reprocessed:
+              checkHasMessages(notMovedMessages + movedMessages);
+              checkNotified(count: 2);
+            case .removed:
+              checkHasMessages(notMovedMessages);
+              checkNotifiedOnce();
+            case .refetched:
+              check(model).fetched.isFalse();
+              checkHasMessages([]);
+              checkNotifiedOnce();
+              async.elapse(const Duration(seconds: 2));
+              checkHasMessages(notMovedMessages + postMoveMessages);
+              checkNotifiedOnce();
+          }
+        }));
+      }
+
+      final combinedFeed = const CombinedFeedNarrow();
+      final channel = ChannelNarrow(stream.streamId);
+      final mentions = const MentionsNarrow();
+      final starred = const StarredMessagesNarrow();
+
+      // Channel not muted: CombinedFeedNarrow and ChannelNarrow agree;
+      // MentionsNarrow and StarredMessagesNarrow always do internalMove
+      // because they don't exclude channel messages by muting.
+      for (final narrow in [combinedFeed, channel]) {
+        testMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .none,  newTopicPolicy: .none,  expected: .reprocessed);
+        testMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .removed);
+        testMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .refetched);
+        testMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .muted, newTopicPolicy: .muted, expected: .unaffected);
+      }
+      for (final narrow in [mentions, starred]) {
+        testMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .reprocessed);
+        testMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .reprocessed);
+      }
+
+      // Channel muted: CombinedFeedNarrow and ChannelNarrow diverge.
+      // With policy `none`, topics are invisible in CombinedFeedNarrow
+      // (because the channel is muted) but visible in ChannelNarrow
+      // (which doesn't consider channel muting).
+      testMoveWithMuting(narrow: combinedFeed, channelMuted: true,
+        origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .unaffected);
+      testMoveWithMuting(narrow: combinedFeed, channelMuted: true,
+        origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .unaffected);
+
+      testMoveWithMuting(narrow: channel, channelMuted: true,
+        origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .removed);
+      testMoveWithMuting(narrow: channel, channelMuted: true,
+        origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .refetched);
     });
 
     group('in channel narrow', () {
@@ -1588,17 +1692,6 @@ void main() {
       final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final otherChannelMovedMessages = List.generate(5, (i) => eg.streamMessage(stream: otherStream, topic: 'topic'));
-
-      test('channel -> channel: internal move', () async {
-        await prepareNarrow(narrow, initialMessages + movedMessages);
-
-        await store.handleEvent(eg.updateMessageEventMoveFrom(
-          origMessages: movedMessages,
-          newTopicStr: 'new',
-        ));
-        checkHasMessages(initialMessages + movedMessages);
-        checkNotified(count: 2);
-      });
 
       group('old channel -> channel:', () {
         test('new topic not muted - refetch', () => awaitFakeAsync((async) async {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:collection/collection.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
@@ -927,7 +926,7 @@ void main() {
   group('removeOutboxMessage', () {
     final stream = eg.stream();
 
-    Future<void> prepareFailedOutboxMessages(FakeAsync async, {
+    Future<void> prepareFailedOutboxMessages({
       required int count,
       required ZulipStream stream,
       String topic = 'some topic',
@@ -940,46 +939,43 @@ void main() {
       }
     }
 
-    test('in narrow', () => awaitFakeAsync((async) async {
+    test('in narrow', () async {
       await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
       await prepareMessages(foundOldest: true, messages:
         List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
-      await prepareFailedOutboxMessages(async,
-        count: 5, stream: stream);
+      await prepareFailedOutboxMessages(count: 5, stream: stream);
       check(model).outboxMessages.length.equals(5);
       checkNotified(count: 5);
 
       store.takeOutboxMessage(store.outboxMessages.keys.first);
       checkNotifiedOnce();
       check(model).outboxMessages.length.equals(4);
-    }));
+    });
 
-    test('not in narrow', () => awaitFakeAsync((async) async {
+    test('not in narrow', () async {
       await prepare(narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
       await prepareMessages(foundOldest: true, messages:
         List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
-      await prepareFailedOutboxMessages(async,
-        count: 5, stream: stream, topic: 'other topic');
+      await prepareFailedOutboxMessages(count: 5, stream: stream, topic: 'other topic');
       check(model).outboxMessages.isEmpty();
       checkNotNotified();
 
       store.takeOutboxMessage(store.outboxMessages.keys.first);
       check(model).outboxMessages.isEmpty();
       checkNotNotified();
-    }));
+    });
 
-    test('removed outbox message is the only message in narrow', () => awaitFakeAsync((async) async {
+    test('removed outbox message is the only message in narrow', () async {
       await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
       await prepareMessages(foundOldest: true, messages: []);
-      await prepareFailedOutboxMessages(async,
-        count: 1, stream: stream);
+      await prepareFailedOutboxMessages(count: 1, stream: stream);
       check(model).outboxMessages.single;
       checkNotified(count: 1);
 
       store.takeOutboxMessage(store.outboxMessages.keys.first);
       check(model).outboxMessages.isEmpty();
       checkNotifiedOnce();
-    }));
+    });
   });
 
   group('UserTopicEvent', () {
@@ -1192,7 +1188,7 @@ void main() {
         ..topic.equals(eg.t(topic));
     }));
 
-    test('unmute a topic before initial fetch completes -> do nothing', () => awaitFakeAsync((async) async {
+    test('unmute a topic before initial fetch completes -> do nothing', () async {
       await prepare(narrow: const CombinedFeedNarrow());
       await prepareMutes(true);
       final messages = [
@@ -1210,7 +1206,7 @@ void main() {
       await fetchFuture;
       checkNotifiedOnce();
       checkHasMessageIds([1]);
-    }));
+    });
   });
 
   group('MutedUsersEvent', () {
@@ -1335,7 +1331,7 @@ void main() {
       checkHasMessageIds([1, 2]);
     }));
 
-    test('unmute a user before initial fetch completes -> do nothing', () => awaitFakeAsync((async) async {
+    test('unmute a user before initial fetch completes -> do nothing', () async {
       await prepare(narrow: CombinedFeedNarrow(), users: users,
         mutedUserIds: [user1.userId]);
       final messages = <Message>[
@@ -1351,7 +1347,7 @@ void main() {
       await fetchFuture;
       checkNotifiedOnce();
       checkHasMessageIds([1, 2]);
-    }));
+    });
   });
 
   group('DeleteMessageEvent', () {
@@ -1563,7 +1559,7 @@ void main() {
       final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
 
-      test('internal move between channels', () => awaitFakeAsync((async) async {
+      test('internal move between channels', () async {
         await prepareNarrow(narrow, initialMessages);
 
         await store.handleEvent(eg.updateMessageEventMoveFrom(
@@ -1573,7 +1569,7 @@ void main() {
         ));
         checkHasMessages(initialMessages);
         checkNotified(count: 2);
-      }));
+      });
 
       test('internal move between topics', () async {
         await prepareNarrow(narrow, initialMessages + movedMessages);
@@ -1825,7 +1821,7 @@ void main() {
       });
 
       group('irrelevant moves', () {
-        test('(channel, old topic) -> (channel, unrelated topic)', () => awaitFakeAsync((async) async {
+        test('(channel, old topic) -> (channel, unrelated topic)', () async {
           await prepareNarrow(narrow, initialMessages);
 
           await store.handleEvent(eg.updateMessageEventMoveTo(
@@ -1835,9 +1831,9 @@ void main() {
           check(model).fetched.isTrue();
           checkHasMessages(initialMessages);
           checkNotNotified();
-        }));
+        });
 
-        test('(old channel, topic) - > (unrelated channel, topic)', () => awaitFakeAsync((async) async {
+        test('(old channel, topic) - > (unrelated channel, topic)', () async {
           await prepareNarrow(narrow, initialMessages);
 
           await store.handleEvent(eg.updateMessageEventMoveTo(
@@ -1847,7 +1843,7 @@ void main() {
           check(model).fetched.isTrue();
           checkHasMessages(initialMessages);
           checkNotNotified();
-        }));
+        });
       });
 
       void handleMoveEvent(PropagateMode propagateMode) => awaitFakeAsync((async) async {
@@ -2999,7 +2995,7 @@ void main() {
     final channelId = 1;
     final topic = 'some topic';
     void doTest({required Narrow narrow, required bool expected}) {
-      test('$narrow: ${expected ? 'yes' : 'no'}', () => awaitFakeAsync((async) async {
+      test('$narrow: ${expected ? 'yes' : 'no'}', () async {
         final sender = eg.user();
         final channel = eg.stream(streamId: channelId);
         final message1 = eg.streamMessage(
@@ -3033,7 +3029,7 @@ void main() {
           if (expected) (it) => it.isA<MessageListRecipientHeaderItem>(),
           (it) => it.isA<MessageListMessageItem>(),
         ]);
-      }));
+      });
     }
 
     doTest(narrow: CombinedFeedNarrow(),                expected: false);

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -983,7 +983,7 @@ void main() {
   });
 
   group('UserTopicEvent', () {
-    // The ChannelStore.willChangeIfTopicVisible/InChannel methods have their
+    // The ChannelStore.willAffectIfTopicVisible/InChannel methods have their
     // own thorough unit tests.  So these tests focus on the rest of the logic.
 
     final stream = eg.stream();

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -3618,7 +3618,7 @@ void checkInvariants(MessageListView model) {
           check(model.store.isTopicVisible(conversation.streamId, conversation.topic))
             .isTrue();
         case ChannelNarrow():
-          check(model.store.isTopicVisibleInStream(conversation.streamId, conversation.topic))
+          check(model.store.isTopicVisibleInChannel(conversation.streamId, conversation.topic))
             .isTrue();
         case TopicNarrow():
         case DmNarrow():

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1295,7 +1295,7 @@ void main() {
   });
 
   group('UserTopicEvent', () {
-    // The ChannelStore.willChangeIfTopicVisible/InChannel methods have their
+    // The ChannelStore.willAffectIfTopicVisible/InChannel methods have their
     // own thorough unit tests.  So these tests focus on the rest of the logic.
 
     final stream = eg.stream();

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1295,8 +1295,8 @@ void main() {
   });
 
   group('UserTopicEvent', () {
-    // The ChannelStore.willChangeIfTopicVisible/InStream methods have their own
-    // thorough unit tests.  So these tests focus on the rest of the logic.
+    // The ChannelStore.willChangeIfTopicVisible/InChannel methods have their
+    // own thorough unit tests.  So these tests focus on the rest of the logic.
 
     final stream = eg.stream();
     const String topic = 'foo';

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1916,26 +1916,41 @@ void main() {
         checkNotified(count: 2);
       });
 
-      test('old channel -> channel: refetch', () => awaitFakeAsync((async) async {
-        await prepareNarrow(narrow, initialMessages);
+      group('old channel -> channel:', () {
+        test('new topic not muted - refetch', () => awaitFakeAsync((async) async {
+          await prepareNarrow(narrow, initialMessages);
 
-        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
-          foundOldest: false,
-          messages: initialMessages + movedMessages,
-        ).toJson());
-        await store.handleEvent(eg.updateMessageEventMoveTo(
-          origTopicStr: 'orig topic',
-          origStreamId: otherStream.streamId,
-          newMessages: movedMessages,
-        ));
-        check(model).fetched.isFalse();
-        checkHasMessages([]);
-        checkNotifiedOnce();
+          connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+            foundOldest: false,
+            messages: initialMessages + movedMessages,
+          ).toJson());
+          await store.handleEvent(eg.updateMessageEventMoveTo(
+            origTopicStr: 'orig topic',
+            origStreamId: otherStream.streamId,
+            newMessages: movedMessages));
+          check(model).fetched.isFalse();
+          checkHasMessages([]);
+          checkNotifiedOnce();
 
-        async.elapse(const Duration(seconds: 2));
-        checkHasMessages(initialMessages + movedMessages);
-        checkNotifiedOnce();
-      }));
+          async.elapse(const Duration(seconds: 2));
+          checkHasMessages(initialMessages + movedMessages);
+          checkNotifiedOnce();
+        }));
+
+        test('new topic muted - unaffected', () async {
+          await prepareNarrow(narrow, initialMessages);
+          await store.setUserTopic(stream, 'new', UserTopicVisibilityPolicy.muted);
+
+          final newTopicMovedMessages = List.generate(5, (i) =>
+            eg.streamMessage(stream: stream, topic: 'new'));
+          await store.handleEvent(eg.updateMessageEventMoveTo(
+            origTopicStr: 'orig topic',
+            origStreamId: otherStream.streamId,
+            newMessages: newTopicMovedMessages));
+          checkHasMessages(initialMessages);
+          checkNotNotified();
+        });
+      });
 
       test('channel -> new channel: remove moved messages', () async {
         await prepareNarrow(narrow, initialMessages + movedMessages);

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -37,6 +37,10 @@ const nearResult = eg.nearGetMessagesResult;
 const olderResult = eg.olderGetMessagesResult;
 const newerResult = eg.newerGetMessagesResult;
 
+/// The expected effect on a [MessageListView] when messages are moved
+/// and the move may change whether they're muted.
+enum _VisibilityEffect { unaffected, reprocessed, removed, refetched }
+
 void main() {
   // Arrange for errors caught within the Flutter framework to be printed
   // unconditionally, rather than throttled as they normally are in an app.
@@ -1866,10 +1870,140 @@ void main() {
       checkHasMessages(messages ?? []);
     }
 
+    group('muting interactions on move', () {
+      /// Test that a message move (topic 'orig' → 'new' on [stream])
+      /// has the given [expected] effect on a [MessageListView] with
+      /// the given [narrow].
+      ///
+      /// The concrete muting state — [channelMuted], [origTopicPolicy],
+      /// [newTopicPolicy] — determines visibility differently depending
+      /// on the narrow type (see [MessageListView._messageVisible]), so
+      /// the same muting configuration can produce different effects in
+      /// different narrows.
+      void testCrossTopicMoveWithMuting({
+        required Narrow narrow,
+        required bool channelMuted,
+        required UserTopicVisibilityPolicy origTopicPolicy,
+        required UserTopicVisibilityPolicy newTopicPolicy,
+        required _VisibilityEffect expected,
+      }) {
+        final channelDesc = channelMuted ? 'channel muted' : 'channel not muted';
+        final desc = '${narrow.runtimeType}, $channelDesc, '
+          '${origTopicPolicy.name} → ${newTopicPolicy.name}';
+        test(desc, () => awaitFakeAsync((async) async {
+          final flags = switch (narrow) {
+            MentionsNarrow()        => <MessageFlag>[.mentioned],
+            StarredMessagesNarrow() => <MessageFlag>[.starred],
+            _                       => <MessageFlag>[],
+          };
+          final notMovedMessages = List.generate(5, (i) =>
+            eg.streamMessage(stream: stream, topic: 'notMoved', flags: flags));
+          final movedMessages = List.generate(5, (i) =>
+            eg.streamMessage(stream: stream, topic: 'orig', flags: flags));
+
+          await prepare(narrow: narrow,
+            starredMessages: narrow is StarredMessagesNarrow
+              ? (notMovedMessages + movedMessages).map((m) => m.id).toList()
+              : null);
+          await store.addStream(stream);
+          await store.addSubscription(
+            eg.subscription(stream, isMuted: channelMuted));
+          if (channelMuted) {
+            // Keep notMovedMessages visible despite channel muting.
+            await store.setUserTopic(stream, 'notMoved',
+              UserTopicVisibilityPolicy.unmuted);
+          }
+          if (origTopicPolicy != .none) {
+            await store.setUserTopic(stream, 'orig', origTopicPolicy);
+          }
+          if (newTopicPolicy != .none) {
+            await store.setUserTopic(stream, 'new', newTopicPolicy);
+          }
+
+          // The fetch includes all messages; _messageVisible filters by muting.
+          await prepareMessages(foundOldest: false,
+            messages: notMovedMessages + movedMessages);
+
+          final postMoveMessages = <StreamMessage>[];
+          if (expected == .refetched) {
+            // The refetch returns messages at their post-move location.
+            postMoveMessages.addAll(movedMessages.map((m) => eg.streamMessage(
+              id: m.id, stream: stream, topic: 'new', flags: flags)));
+            connection.prepare(
+              delay: const Duration(seconds: 2),
+              json: newestResult(foundOldest: false,
+                messages: notMovedMessages + postMoveMessages).toJson());
+          }
+
+          await store.handleEvent(eg.updateMessageEventMoveFrom(
+            origMessages: movedMessages, newTopicStr: 'new'));
+
+          switch (expected) {
+            case .unaffected:
+              checkHasMessages(notMovedMessages);
+              checkNotNotified();
+            case .reprocessed:
+              checkHasMessages(notMovedMessages + movedMessages);
+              checkNotified(count: 2);
+            case .removed:
+              checkHasMessages(notMovedMessages);
+              checkNotifiedOnce();
+            case .refetched:
+              check(model).fetched.isFalse();
+              checkHasMessages([]);
+              checkNotifiedOnce();
+              async.elapse(const Duration(seconds: 2));
+              checkHasMessages(notMovedMessages + postMoveMessages);
+              checkNotifiedOnce();
+          }
+        }));
+      }
+
+      final combinedFeed = const CombinedFeedNarrow();
+      final channel = ChannelNarrow(stream.streamId);
+      final mentions = const MentionsNarrow();
+      final starred = const StarredMessagesNarrow();
+
+      // Channel not muted: CombinedFeedNarrow and ChannelNarrow agree;
+      // MentionsNarrow and StarredMessagesNarrow always do "reprocessing"
+      // because they don't exclude channel messages by muting.
+      for (final narrow in [combinedFeed, channel]) {
+        testCrossTopicMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .none,  newTopicPolicy: .none,  expected: .reprocessed);
+        testCrossTopicMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .removed);
+        testCrossTopicMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .refetched);
+        testCrossTopicMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .muted, newTopicPolicy: .muted, expected: .unaffected);
+      }
+      for (final narrow in [mentions, starred]) {
+        testCrossTopicMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .reprocessed);
+        testCrossTopicMoveWithMuting(narrow: narrow, channelMuted: false,
+          origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .reprocessed);
+      }
+
+      // Channel muted: CombinedFeedNarrow and ChannelNarrow diverge.
+      // With policy `none`, topics are invisible in CombinedFeedNarrow
+      // (because the channel is muted) but visible in ChannelNarrow
+      // (which doesn't consider channel muting).
+      testCrossTopicMoveWithMuting(narrow: combinedFeed, channelMuted: true,
+        origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .unaffected);
+      testCrossTopicMoveWithMuting(narrow: combinedFeed, channelMuted: true,
+        origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .unaffected);
+
+      testCrossTopicMoveWithMuting(narrow: channel, channelMuted: true,
+        origTopicPolicy: .none,  newTopicPolicy: .muted, expected: .removed);
+      testCrossTopicMoveWithMuting(narrow: channel, channelMuted: true,
+        origTopicPolicy: .muted, newTopicPolicy: .none,  expected: .refetched);
+    });
+
     group('in combined feed narrow', () {
       const narrow = CombinedFeedNarrow();
       final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
+      final otherChannelMessages = List.generate(5, (i) => eg.streamMessage(stream: otherStream));
 
       test('internal move between channels', () async {
         await prepareNarrow(narrow, initialMessages);
@@ -1883,16 +2017,39 @@ void main() {
         checkNotified(count: 2);
       });
 
-      test('internal move between topics', () async {
+      test('channel -> muted channel: remove moved messages', () async {
         await prepareNarrow(narrow, initialMessages + movedMessages);
+        await store.updateSubscription(
+          otherStream.streamId, SubscriptionProperty.isMuted, true);
 
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: movedMessages,
-          newTopicStr: 'new',
-        ));
-        checkHasMessages(initialMessages + movedMessages);
-        checkNotified(count: 2);
+          newStreamId: otherStream.streamId));
+        checkHasMessages(initialMessages);
+        checkNotifiedOnce();
       });
+
+      test('muted channel -> channel: refetch', () => awaitFakeAsync((async) async {
+        await prepareNarrow(narrow, initialMessages);
+        await store.updateSubscription(
+          otherStream.streamId, SubscriptionProperty.isMuted, true);
+        await store.addMessages(otherChannelMessages);
+
+        connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+          foundOldest: false,
+          messages: initialMessages + otherChannelMessages,
+        ).toJson());
+        await store.handleEvent(eg.updateMessageEventMoveFrom(
+          origMessages: otherChannelMessages,
+          newStreamId: stream.streamId));
+        check(model).fetched.isFalse();
+        checkHasMessages([]);
+        checkNotifiedOnce();
+
+        async.elapse(const Duration(seconds: 2));
+        checkHasMessages(initialMessages + otherChannelMessages);
+        checkNotifiedOnce();
+      }));
     });
 
     group('in channel narrow', () {
@@ -1900,17 +2057,6 @@ void main() {
       final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final otherChannelMovedMessages = List.generate(5, (i) => eg.streamMessage(stream: otherStream, topic: 'topic'));
-
-      test('channel -> channel: internal move', () async {
-        await prepareNarrow(narrow, initialMessages + movedMessages);
-
-        await store.handleEvent(eg.updateMessageEventMoveFrom(
-          origMessages: movedMessages,
-          newTopicStr: 'new',
-        ));
-        checkHasMessages(initialMessages + movedMessages);
-        checkNotified(count: 2);
-      });
 
       group('old channel -> channel:', () {
         test('new topic not muted - refetch', () => awaitFakeAsync((async) async {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:collection/collection.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
@@ -1239,7 +1238,7 @@ void main() {
   group('removeOutboxMessage', () {
     final stream = eg.stream();
 
-    Future<void> prepareFailedOutboxMessages(FakeAsync async, {
+    Future<void> prepareFailedOutboxMessages({
       required int count,
       required ZulipStream stream,
       String topic = 'some topic',
@@ -1252,46 +1251,43 @@ void main() {
       }
     }
 
-    test('in narrow', () => awaitFakeAsync((async) async {
+    test('in narrow', () async {
       await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
       await prepareMessages(foundOldest: true, messages:
         List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
-      await prepareFailedOutboxMessages(async,
-        count: 5, stream: stream);
+      await prepareFailedOutboxMessages(count: 5, stream: stream);
       check(model).outboxMessages.length.equals(5);
       checkNotified(count: 5);
 
       store.takeOutboxMessage(store.outboxMessages.keys.first);
       checkNotifiedOnce();
       check(model).outboxMessages.length.equals(4);
-    }));
+    });
 
-    test('not in narrow', () => awaitFakeAsync((async) async {
+    test('not in narrow', () async {
       await prepare(narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
       await prepareMessages(foundOldest: true, messages:
         List.generate(30, (i) => eg.streamMessage(stream: stream, topic: 'topic')));
-      await prepareFailedOutboxMessages(async,
-        count: 5, stream: stream, topic: 'other topic');
+      await prepareFailedOutboxMessages(count: 5, stream: stream, topic: 'other topic');
       check(model).outboxMessages.isEmpty();
       checkNotNotified();
 
       store.takeOutboxMessage(store.outboxMessages.keys.first);
       check(model).outboxMessages.isEmpty();
       checkNotNotified();
-    }));
+    });
 
-    test('removed outbox message is the only message in narrow', () => awaitFakeAsync((async) async {
+    test('removed outbox message is the only message in narrow', () async {
       await prepare(narrow: ChannelNarrow(stream.streamId), stream: stream);
       await prepareMessages(foundOldest: true, messages: []);
-      await prepareFailedOutboxMessages(async,
-        count: 1, stream: stream);
+      await prepareFailedOutboxMessages(count: 1, stream: stream);
       check(model).outboxMessages.single;
       checkNotified(count: 1);
 
       store.takeOutboxMessage(store.outboxMessages.keys.first);
       check(model).outboxMessages.isEmpty();
       checkNotifiedOnce();
-    }));
+    });
   });
 
   group('UserTopicEvent', () {
@@ -1504,7 +1500,7 @@ void main() {
         ..topic.equals(eg.t(topic));
     }));
 
-    test('unmute a topic before initial fetch completes -> do nothing', () => awaitFakeAsync((async) async {
+    test('unmute a topic before initial fetch completes -> do nothing', () async {
       await prepare(narrow: const CombinedFeedNarrow());
       await prepareMutes(true);
       final messages = [
@@ -1522,7 +1518,7 @@ void main() {
       await fetchFuture;
       checkNotifiedOnce();
       checkHasMessageIds([1]);
-    }));
+    });
   });
 
   group('MutedUsersEvent', () {
@@ -1647,7 +1643,7 @@ void main() {
       checkHasMessageIds([1, 2]);
     }));
 
-    test('unmute a user before initial fetch completes -> do nothing', () => awaitFakeAsync((async) async {
+    test('unmute a user before initial fetch completes -> do nothing', () async {
       await prepare(narrow: CombinedFeedNarrow(), users: users,
         mutedUserIds: [user1.userId]);
       final messages = <Message>[
@@ -1663,7 +1659,7 @@ void main() {
       await fetchFuture;
       checkNotifiedOnce();
       checkHasMessageIds([1, 2]);
-    }));
+    });
   });
 
   group('DeleteMessageEvent', () {
@@ -1875,7 +1871,7 @@ void main() {
       final initialMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
       final movedMessages = List.generate(5, (i) => eg.streamMessage(stream: stream));
 
-      test('internal move between channels', () => awaitFakeAsync((async) async {
+      test('internal move between channels', () async {
         await prepareNarrow(narrow, initialMessages);
 
         await store.handleEvent(eg.updateMessageEventMoveFrom(
@@ -1885,7 +1881,7 @@ void main() {
         ));
         checkHasMessages(initialMessages);
         checkNotified(count: 2);
-      }));
+      });
 
       test('internal move between topics', () async {
         await prepareNarrow(narrow, initialMessages + movedMessages);
@@ -2137,7 +2133,7 @@ void main() {
       });
 
       group('irrelevant moves', () {
-        test('(channel, old topic) -> (channel, unrelated topic)', () => awaitFakeAsync((async) async {
+        test('(channel, old topic) -> (channel, unrelated topic)', () async {
           await prepareNarrow(narrow, initialMessages);
 
           await store.handleEvent(eg.updateMessageEventMoveTo(
@@ -2147,9 +2143,9 @@ void main() {
           check(model).fetched.isTrue();
           checkHasMessages(initialMessages);
           checkNotNotified();
-        }));
+        });
 
-        test('(old channel, topic) - > (unrelated channel, topic)', () => awaitFakeAsync((async) async {
+        test('(old channel, topic) - > (unrelated channel, topic)', () async {
           await prepareNarrow(narrow, initialMessages);
 
           await store.handleEvent(eg.updateMessageEventMoveTo(
@@ -2159,7 +2155,7 @@ void main() {
           check(model).fetched.isTrue();
           checkHasMessages(initialMessages);
           checkNotNotified();
-        }));
+        });
       });
 
       void handleMoveEvent(PropagateMode propagateMode) => awaitFakeAsync((async) async {
@@ -3311,7 +3307,7 @@ void main() {
     final channelId = 1;
     final topic = 'some topic';
     void doTest({required Narrow narrow, required bool expected}) {
-      test('$narrow: ${expected ? 'yes' : 'no'}', () => awaitFakeAsync((async) async {
+      test('$narrow: ${expected ? 'yes' : 'no'}', () async {
         final sender = eg.user();
         final channel = eg.stream(streamId: channelId);
         final message1 = eg.streamMessage(
@@ -3345,7 +3341,7 @@ void main() {
           if (expected) (it) => it.isA<MessageListRecipientHeaderItem>(),
           (it) => it.isA<MessageListMessageItem>(),
         ]);
-      }));
+      });
     }
 
     doTest(narrow: CombinedFeedNarrow(),                expected: false);

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -1687,7 +1687,7 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newStreamId: 20));
-        checkNotified(count: 2);
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) =>
           message.isA<StreamMessage>()
             ..editState.equals(MessageEditState.moved)
@@ -1700,7 +1700,7 @@ void main() {
           origMessages: origMessages,
           newStreamId: 20,
           newContent: 'new content'));
-        checkNotified(count: 2);
+        checkNotifiedOnce();
         check(store).messages[origMessages[0].id].editState.equals(MessageEditState.edited);
         check(store).messages[origMessages[1].id].editState.equals(MessageEditState.moved);
       });

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -1717,7 +1717,7 @@ void main() {
         await store.handleEvent(eg.updateMessageEventMoveFrom(
           origMessages: origMessages,
           newStreamId: 20));
-        checkNotified(count: 2);
+        checkNotifiedOnce();
         check(store).messages.values.every(((message) =>
           message.isA<StreamMessage>()
             ..editState.equals(MessageEditState.moved)
@@ -1730,7 +1730,7 @@ void main() {
           origMessages: origMessages,
           newStreamId: 20,
           newContent: 'new content'));
-        checkNotified(count: 2);
+        checkNotifiedOnce();
         check(store).messages[origMessages[0].id].editState.equals(MessageEditState.edited);
         check(store).messages[origMessages[1].id].editState.equals(MessageEditState.moved);
       });

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -393,6 +393,18 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     await handleEvent(SubscriptionRemoveEvent(id: 1, channelIds: channelIds));
   }
 
+  Future<void> updateSubscription(
+    int channelId,
+    SubscriptionProperty property,
+    Object? value,
+  ) async {
+    await handleEvent(SubscriptionUpdateEvent(
+      id: 1,
+      channelId: channelId,
+      property: property,
+      value: value));
+  }
+
   Future<void> addChannelFolder(ChannelFolder channelFolder) async {
     await handleEvent(ChannelFolderAddEvent(id: 1, channelFolder: channelFolder));
   }

--- a/test/model/user_test.dart
+++ b/test/model/user_test.dart
@@ -206,7 +206,7 @@ void main() {
       checkDmConversationMuted([], false);
     });
 
-    group('mightChangeShouldMuteDmConversation', () {
+    group('willAffectShouldMuteDmConversation', () {
       void doTest(
         String description,
         List<int> before,
@@ -219,7 +219,7 @@ void main() {
           await store.addUsers(before.map((id) => eg.user(userId: id)));
           await store.setMutedUsers(before);
           final event = eg.mutedUsersEvent(after);
-          check(store.mightChangeShouldMuteDmConversation(event)).equals(expected);
+          check(store.willAffectShouldMuteDmConversation(event)).equals(expected);
         });
       }
 


### PR DESCRIPTION
Fixes: #1476

In addition to addressing the main problem stated in #1476's description, which is about removing messages in some narrows after becoming muted by a message move, this PR also addresses a closely related problem: showing messages in the same narrows after becoming unmuted by a message move.