### PR TITLE
submessage: Remove invalid @override on factory constructors

### DIFF
--- a/lib/api/model/submessage.dart
+++ b/lib/api/model/submessage.dart
@@ -263,7 +263,6 @@ class PollNewOptionEventSubmessage extends PollEventSubmessage {
 
   PollNewOptionEventSubmessage({required this.option, required this.idx});
 
-  @override
   factory PollNewOptionEventSubmessage.fromJson(Map<String, Object?> json) =>
     _$PollNewOptionEventSubmessageFromJson(json);
 
@@ -284,7 +283,6 @@ class PollQuestionEventSubmessage extends PollEventSubmessage {
 
   PollQuestionEventSubmessage({required this.question});
 
-  @override
   factory PollQuestionEventSubmessage.fromJson(Map<String, Object?> json) =>
     _$PollQuestionEventSubmessageFromJson(json);
 
@@ -310,7 +308,6 @@ class PollVoteEventSubmessage extends PollEventSubmessage {
 
   PollVoteEventSubmessage({required this.key, required this.op});
 
-  @override
   factory PollVoteEventSubmessage.fromJson(Map<String, Object?> json) {
     final result = _$PollVoteEventSubmessageFromJson(json);
     // Crunchy-shell validation


### PR DESCRIPTION
When building with newer Dart/Flutter versions (e.g., Dart 3.12.0 / Flutter 3.41.0), the analyzer reports errors for `@override` annotations on factory constructors, as they are static members and cannot technically override anything.

This PR removes the invalid `@override` annotations from:
- `PollNewOptionEventSubmessage.fromJson`
- `PollQuestionEventSubmessage.fromJson`
- `PollVoteEventSubmessage.fromJson`

Fixes: #2082

