### PR TITLE
content: Change `UserMention` to render user mentions dynamically

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1078,6 +1078,7 @@ class UserMentionNode extends InlineContainerNode {
     super.debugHtmlNode,
     required super.nodes,
     required this.userId,
+    required this.isSilent,
   });
 
   /// The ID of the user being mentioned.
@@ -1086,18 +1087,19 @@ class UserMentionNode extends InlineContainerNode {
   /// or when the user ID is unavailable in the HTML (e.g., legacy mentions).
   final int? userId;
 
+  final bool isSilent; // TODO(#647)
+
   // For the legacy design, we don't need this information in code; instead,
   // the inner text already shows how to communicate it to the user
-  // (e.g., silent mentions' text lacks a leading "@"),
   // and we show that text in the same style for all types of @-mention.
   // We'll need these for implementing the post-2023 Zulip design, though.
   //   final UserMentionType mentionType; // TODO(#646)
-  //   final bool isSilent; // TODO(#647)
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(IntProperty('userId', userId));
+    properties.add(FlagProperty('isSilent', value: isSilent, ifTrue: "is silent"));
   }
 }
 
@@ -1309,8 +1311,10 @@ class _ZulipInlineContentParser {
     }
 
     if (i >= classes.length) return null;
+    bool isSilent = false;
     if (classes[i] == 'silent') {
-      // A silent @-mention.  We ignore this flag; see [UserMentionNode].
+      // A silent @-mention.
+      isSilent = true;
       i++;
     }
 
@@ -1341,7 +1345,11 @@ class _ZulipInlineContentParser {
     //   either a debug-mode check, or perhaps we can make expectations much
     //   tighter on a UserMentionNode's contents overall.
     final nodes = parseInlineContentList(element.nodes);
-    return UserMentionNode(nodes: nodes, userId: userId, debugHtmlNode: debugHtmlNode);
+    return UserMentionNode(
+      nodes: nodes,
+      userId: userId,
+      isSilent: isSilent,
+      debugHtmlNode: debugHtmlNode);
   }
 
   /// The links found so far in the current block inline container.

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1194,7 +1194,15 @@ class UserMention extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
     final contentTheme = ContentTheme.of(context);
+    var nodes = node.nodes;
+    if (node.userId case final userId?) {
+      final user = store.getUser(userId);
+      if (user case User(:final fullName)) {
+        nodes = [TextNode(node.isSilent ? fullName : '@$fullName')];
+      }
+    }
     return Container(
       decoration: BoxDecoration(
         // TODO(#646) different for wildcard mentions
@@ -1213,7 +1221,7 @@ class UserMention extends StatelessWidget {
         //   distinguish font color between direct and wildcard mentions
         style: ambientTextStyle,
 
-        nodes: node.nodes));
+        nodes: nodes));
   }
 
 // This is a more literal translation of Zulip web's CSS.

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -111,105 +111,105 @@ class ContentExample {
     "@**Greg Price**",
     expectedText: '@Greg Price',
     '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('@Greg Price')], userId: 2187));
+    const UserMentionNode(nodes: [TextNode('@Greg Price')], userId: 2187, isSilent: false));
 
   static final userMentionSilent = ContentExample.inline(
     'silent user @-mention',
     "@_**Greg Price**",
     expectedText: 'Greg Price',
     '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187));
+    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187, isSilent: true));
 
   static final userMentionSilentClassOrderReversed = ContentExample.inline(
     'silent user @-mention, class order reversed',
     "@_**Greg Price**", // (hypothetical server variation)
     expectedText: 'Greg Price',
     '<p><span class="silent user-mention" data-user-id="2187">Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187));
+    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187, isSilent: true));
 
   static final groupMentionPlain = ContentExample.inline(
     'plain group @-mention',
     "@*test-empty*",
     expectedText: '@test-empty',
     '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('@test-empty')], userId: null));
+    const UserMentionNode(nodes: [TextNode('@test-empty')], userId: null, isSilent: false));
 
   static final groupMentionSilent = ContentExample.inline(
     'silent group @-mention',
     "@_*test-empty*",
     expectedText: 'test-empty',
     '<p><span class="user-group-mention silent" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null));
+    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null, isSilent: true));
 
   static final groupMentionSilentClassOrderReversed = ContentExample.inline(
     'silent group @-mention, class order reversed',
     "@_*test-empty*", // (hypothetical server variation)
     expectedText: 'test-empty',
     '<p><span class="silent user-group-mention" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null));
+    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null, isSilent: true));
 
   static final channelWildcardMentionPlain = ContentExample.inline(
     'plain channel wildcard @-mention',
     "@**all**",
     expectedText: '@all',
     '<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span></p>',
-    const UserMentionNode(nodes: [TextNode('@all')], userId: null));
+    const UserMentionNode(nodes: [TextNode('@all')], userId: null, isSilent: false));
 
   static final channelWildcardMentionSilent = ContentExample.inline(
     'silent channel wildcard @-mention',
     "@_**everyone**",
     expectedText: 'everyone',
     '<p><span class="user-mention channel-wildcard-mention silent" data-user-id="*">everyone</span></p>',
-    const UserMentionNode(nodes: [TextNode('everyone')], userId: null));
+    const UserMentionNode(nodes: [TextNode('everyone')], userId: null, isSilent: true));
 
   static final channelWildcardMentionSilentClassOrderReversed = ContentExample.inline(
     'silent channel wildcard @-mention, class order reversed',
     "@_**channel**", // (hypothetical server variation)
     expectedText: 'channel',
     '<p><span class="silent user-mention channel-wildcard-mention" data-user-id="*">channel</span></p>',
-    const UserMentionNode(nodes: [TextNode('channel')], userId: null));
+    const UserMentionNode(nodes: [TextNode('channel')], userId: null, isSilent: true));
 
   static final legacyChannelWildcardMentionPlain = ContentExample.inline(
     'legacy plain channel wildcard @-mention',
     "@**channel**",
     expectedText: '@channel',
     '<p><span class="user-mention" data-user-id="*">@channel</span></p>',
-    const UserMentionNode(nodes: [TextNode('@channel')], userId: null));
+    const UserMentionNode(nodes: [TextNode('@channel')], userId: null, isSilent: false));
 
   static final legacyChannelWildcardMentionSilent = ContentExample.inline(
     'legacy silent channel wildcard @-mention',
     "@_**stream**",
     expectedText: 'stream',
     '<p><span class="user-mention silent" data-user-id="*">stream</span></p>',
-    const UserMentionNode(nodes: [TextNode('stream')], userId: null));
+    const UserMentionNode(nodes: [TextNode('stream')], userId: null, isSilent: true));
 
   static final legacyChannelWildcardMentionSilentClassOrderReversed = ContentExample.inline(
     'legacy silent channel wildcard @-mention, class order reversed',
     "@_**all**", // (hypothetical server variation)
     expectedText: 'all',
     '<p><span class="silent user-mention" data-user-id="*">all</span></p>',
-    const UserMentionNode(nodes: [TextNode('all')], userId: null));
+    const UserMentionNode(nodes: [TextNode('all')], userId: null, isSilent: true));
 
   static final topicMentionPlain = ContentExample.inline(
     'plain @-topic',
     "@**topic**",
     expectedText: '@topic',
     '<p><span class="topic-mention">@topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('@topic')], userId: null));
+    const UserMentionNode(nodes: [TextNode('@topic')], userId: null, isSilent: false));
 
   static final topicMentionSilent = ContentExample.inline(
     'silent @-topic',
     "@_**topic**",
     expectedText: 'topic',
     '<p><span class="topic-mention silent">topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('topic')], userId: null));
+    const UserMentionNode(nodes: [TextNode('topic')], userId: null, isSilent: true));
 
   static final topicMentionSilentClassOrderReversed = ContentExample.inline(
     'silent @-topic, class order reversed',
     "@_**topic**", // (hypothetical server variation)
     expectedText: 'topic',
     '<p><span class="silent topic-mention">topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('topic')], userId: null));
+    const UserMentionNode(nodes: [TextNode('topic')], userId: null, isSilent: true));
 
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -111,105 +111,105 @@ class ContentExample {
     "@**Greg Price**",
     expectedText: '@Greg Price',
     '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('@Greg Price')]));
+    const UserMentionNode(nodes: [TextNode('@Greg Price')], userId: 2187));
 
   static final userMentionSilent = ContentExample.inline(
     'silent user @-mention',
     "@_**Greg Price**",
     expectedText: 'Greg Price',
     '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('Greg Price')]));
+    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187));
 
   static final userMentionSilentClassOrderReversed = ContentExample.inline(
     'silent user @-mention, class order reversed',
     "@_**Greg Price**", // (hypothetical server variation)
     expectedText: 'Greg Price',
     '<p><span class="silent user-mention" data-user-id="2187">Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('Greg Price')]));
+    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187));
 
   static final groupMentionPlain = ContentExample.inline(
     'plain group @-mention',
     "@*test-empty*",
     expectedText: '@test-empty',
     '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('@test-empty')]));
+    const UserMentionNode(nodes: [TextNode('@test-empty')], userId: null));
 
   static final groupMentionSilent = ContentExample.inline(
     'silent group @-mention',
     "@_*test-empty*",
     expectedText: 'test-empty',
     '<p><span class="user-group-mention silent" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')]));
+    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null));
 
   static final groupMentionSilentClassOrderReversed = ContentExample.inline(
     'silent group @-mention, class order reversed',
     "@_*test-empty*", // (hypothetical server variation)
     expectedText: 'test-empty',
     '<p><span class="silent user-group-mention" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')]));
+    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null));
 
   static final channelWildcardMentionPlain = ContentExample.inline(
     'plain channel wildcard @-mention',
     "@**all**",
     expectedText: '@all',
     '<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span></p>',
-    const UserMentionNode(nodes: [TextNode('@all')]));
+    const UserMentionNode(nodes: [TextNode('@all')], userId: null));
 
   static final channelWildcardMentionSilent = ContentExample.inline(
     'silent channel wildcard @-mention',
     "@_**everyone**",
     expectedText: 'everyone',
     '<p><span class="user-mention channel-wildcard-mention silent" data-user-id="*">everyone</span></p>',
-    const UserMentionNode(nodes: [TextNode('everyone')]));
+    const UserMentionNode(nodes: [TextNode('everyone')], userId: null));
 
   static final channelWildcardMentionSilentClassOrderReversed = ContentExample.inline(
     'silent channel wildcard @-mention, class order reversed',
     "@_**channel**", // (hypothetical server variation)
     expectedText: 'channel',
     '<p><span class="silent user-mention channel-wildcard-mention" data-user-id="*">channel</span></p>',
-    const UserMentionNode(nodes: [TextNode('channel')]));
+    const UserMentionNode(nodes: [TextNode('channel')], userId: null));
 
   static final legacyChannelWildcardMentionPlain = ContentExample.inline(
     'legacy plain channel wildcard @-mention',
     "@**channel**",
     expectedText: '@channel',
     '<p><span class="user-mention" data-user-id="*">@channel</span></p>',
-    const UserMentionNode(nodes: [TextNode('@channel')]));
+    const UserMentionNode(nodes: [TextNode('@channel')], userId: null));
 
   static final legacyChannelWildcardMentionSilent = ContentExample.inline(
     'legacy silent channel wildcard @-mention',
     "@_**stream**",
     expectedText: 'stream',
     '<p><span class="user-mention silent" data-user-id="*">stream</span></p>',
-    const UserMentionNode(nodes: [TextNode('stream')]));
+    const UserMentionNode(nodes: [TextNode('stream')], userId: null));
 
   static final legacyChannelWildcardMentionSilentClassOrderReversed = ContentExample.inline(
     'legacy silent channel wildcard @-mention, class order reversed',
     "@_**all**", // (hypothetical server variation)
     expectedText: 'all',
     '<p><span class="silent user-mention" data-user-id="*">all</span></p>',
-    const UserMentionNode(nodes: [TextNode('all')]));
+    const UserMentionNode(nodes: [TextNode('all')], userId: null));
 
   static final topicMentionPlain = ContentExample.inline(
     'plain @-topic',
     "@**topic**",
     expectedText: '@topic',
     '<p><span class="topic-mention">@topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('@topic')]));
+    const UserMentionNode(nodes: [TextNode('@topic')], userId: null));
 
   static final topicMentionSilent = ContentExample.inline(
     'silent @-topic',
     "@_**topic**",
     expectedText: 'topic',
     '<p><span class="topic-mention silent">topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('topic')]));
+    const UserMentionNode(nodes: [TextNode('topic')], userId: null));
 
   static final topicMentionSilentClassOrderReversed = ContentExample.inline(
     'silent @-topic, class order reversed',
     "@_**topic**", // (hypothetical server variation)
     expectedText: 'topic',
     '<p><span class="silent topic-mention">topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('topic')]));
+    const UserMentionNode(nodes: [TextNode('topic')], userId: null));
 
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -981,19 +981,32 @@ void main() {
   });
 
   group('UserMention', () {
-    testContentSmoke(ContentExample.userMentionPlain);
-    testContentSmoke(ContentExample.userMentionSilent);
-    testContentSmoke(ContentExample.groupMentionPlain);
-    testContentSmoke(ContentExample.groupMentionSilent);
-    testContentSmoke(ContentExample.channelWildcardMentionPlain);
-    testContentSmoke(ContentExample.channelWildcardMentionSilent);
-    testContentSmoke(ContentExample.channelWildcardMentionSilentClassOrderReversed);
-    testContentSmoke(ContentExample.legacyChannelWildcardMentionPlain);
-    testContentSmoke(ContentExample.legacyChannelWildcardMentionSilent);
-    testContentSmoke(ContentExample.legacyChannelWildcardMentionSilentClassOrderReversed);
-    testContentSmoke(ContentExample.topicMentionPlain);
-    testContentSmoke(ContentExample.topicMentionSilent);
-    testContentSmoke(ContentExample.topicMentionSilentClassOrderReversed);
+    testContentSmoke(ContentExample.userMentionPlain,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.userMentionSilent,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.groupMentionPlain,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.groupMentionSilent,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.channelWildcardMentionPlain,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.channelWildcardMentionSilent,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.channelWildcardMentionSilentClassOrderReversed,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.legacyChannelWildcardMentionPlain,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.legacyChannelWildcardMentionSilent,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.legacyChannelWildcardMentionSilentClassOrderReversed,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.topicMentionPlain,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.topicMentionSilent,
+      wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.topicMentionSilentClassOrderReversed,
+      wrapWithPerAccountStoreWidget: true);
 
     UserMention? findUserMentionInSpan(InlineSpan rootSpan) {
       UserMention? result;
@@ -1015,6 +1028,7 @@ void main() {
     testWidgets('maintains font-size ratio with surrounding text', (tester) async {
       await checkFontSizeRatio(tester,
         targetHtml: '<span class="user-mention" data-user-id="13313">@Chris Bobbe</span>',
+        wrapWithPerAccountStoreWidget: true,
         targetFontSizeFinder: (rootSpan) {
           final widget = findUserMentionInSpan(rootSpan);
           final style = textStyleFromWidget(tester, widget!, '@Chris Bobbe');
@@ -1027,6 +1041,7 @@ void main() {
       // @_**Greg Price**
       content: plainContent(
         '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>'),
+      wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
           tester.widget(find.byType(UserMention)), 'Greg Price');
@@ -1041,6 +1056,7 @@ void main() {
       // # @_**Chris Bobbe**
       content: plainContent(
         '<h1><span class="user-mention silent" data-user-id="13313">Chris Bobbe</span></h1>'),
+      wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
           tester.widget(find.byType(UserMention)), 'Chris Bobbe');
@@ -1049,6 +1065,52 @@ void main() {
     // TODO(#647):
     //  testFontWeight('non-silent self-user mention in bold context',
     //    expectedWght: 800, // [etc.]
+
+    group('dynamic name resolution', () {
+      Future<void> prepare({
+        required WidgetTester tester,
+        required String html,
+        List<User>? users,
+      }) async {
+        final initialSnapshot = eg.initialSnapshot(realmUsers: users);
+        await prepareContent(tester,
+          wrapWithPerAccountStoreWidget: true,
+          initialSnapshot: initialSnapshot,
+          plainContent(html));
+      }
+
+      testWidgets('resolves current user name from store', (tester) async {
+        await prepare(
+          tester: tester,
+          html: '<p><span class="user-mention" data-user-id="123">@Old Name</span></p>',
+          users: [eg.selfUser, eg.user(userId: 123, fullName: 'New Name')]);
+        check(find.text('@New Name')).findsOne();
+        check(find.text('@Old Name')).findsNothing();
+      });
+
+      testWidgets('falls back to original text when user not found', (tester) async {
+        await prepare(
+          tester: tester,
+          html: '<p><span class="user-mention" data-user-id="999">@Unknown User</span></p>');
+        check(find.text('@Unknown User')).findsOne();
+      });
+
+      testWidgets('falls back to original text when userId is null', (tester) async {
+        await prepare(
+          tester: tester,
+          html: '<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span></p>');
+        check(find.text('@all')).findsOne();
+      });
+
+      testWidgets('handles silent mentions correctly', (tester) async {
+        await prepare(
+          tester: tester,
+          html: '<p><span class="user-mention silent" data-user-id="123">Old Name</span></p>',
+          users: [eg.selfUser, eg.user(userId: 123, fullName: 'New Name')]);
+        check(find.text('New Name')).findsOne();
+        check(find.text('@New Name')).findsNothing();
+      });
+    });
   });
 
   Future<void> tapText(WidgetTester tester, Finder textFinder) async {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -171,9 +171,10 @@ void main() {
   /// check that the content has actually rendered.  For examples where there's
   /// no suitable value for [ContentExample.expectedText], use [prepareContent]
   /// and write an appropriate content-has-rendered check directly.
-  void testContentSmoke(ContentExample example) {
+  void testContentSmoke(ContentExample example, {bool wrapWithPerAccountStoreWidget = false}) {
     testWidgets('smoke: ${example.description}', (tester) async {
-      await prepareContent(tester, plainContent(example.html));
+      await prepareContent(tester, plainContent(example.html),
+        wrapWithPerAccountStoreWidget: wrapWithPerAccountStoreWidget);
       assert(example.expectedText != null,
         'testContentExample requires expectedText');
       tester.widget(find.text(example.expectedText!));
@@ -192,6 +193,7 @@ void main() {
     required Widget content,
     required double expectedWght,
     required TextStyle Function(WidgetTester tester) styleFinder,
+    bool wrapWithPerAccountStoreWidget = false,
   }) {
     for (final platformRequestsBold in [false, true]) {
       testWidgets(
@@ -199,7 +201,8 @@ void main() {
         (tester) async {
           tester.platformDispatcher.accessibilityFeaturesTestValue =
             FakeAccessibilityFeatures(boldText: platformRequestsBold);
-          await prepareContent(tester, content);
+          await prepareContent(tester, content,
+            wrapWithPerAccountStoreWidget: wrapWithPerAccountStoreWidget);
           final style = styleFinder(tester);
           double effectiveExpectedWght = expectedWght;
           if (platformRequestsBold) {


### PR DESCRIPTION
Fixes zulip#1258

| Before | After |
|--------|-------|
|<img width="1080" height="2400" alt="Screenshot_20260117-131618 Zulip" src="https://github.com/user-attachments/assets/00ac5942-5324-4cc4-bc1b-fbbd608a32bb" />| <img width="1080" height="2400" alt="Screenshot_20260117-132059 Zulip" src="https://github.com/user-attachments/assets/331bcd99-a294-40a9-823f-8a71e87f03ec" />|
|<img width="1080" height="2400" alt="Screenshot_20260117-131627 Zulip" src="https://github.com/user-attachments/assets/aabb6e7e-0a9c-4b18-aecb-284c937a8a3b" />|<img width="1080" height="2400" alt="Screenshot_20260117-132050 Zulip" src="https://github.com/user-attachments/assets/1cffcb5e-8c0a-4183-9f8b-70f25ee836d9" />|
| User mention shows old name "Old Name" | User mention shows current name "New Name" from store |

### Changes:

#### Model:
Added userId, isSilent and updated parser.

#### Widget:
Modified widget to fetch username from store and handle isSilent flag.

#### Tests:
Updated parser tests and added new widget tests.

### Doubts:

1. Running flutter analyze gives error on code from main branch as mentioned in zulip#2082

UPDATE: Removing the error causing annotations fixes the CI testing issue. However, since this code change is not related to issue zulip#1258, please advise on how I should proceed.

2. Old widget tests for UserMention don't pass store. So I've added defensive check for store in UserMention widget even though store will probably never be null in production. Should I keep the code as it is or should I change all old tests for UserMention?