### PR TITLE
Remove unknown from UserTopicVisibilityPolicy

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1051,7 +1051,8 @@ class UserTopicEvent extends Event {
   final int streamId;
   final TopicName topicName;
   final int lastUpdated;
-  final UserTopicVisibilityPolicy visibilityPolicy;
+  @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+  final UserTopicVisibilityPolicy? visibilityPolicy;
 
   UserTopicEvent({
     required super.id,

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -679,9 +679,10 @@ UserTopicEvent _$UserTopicEventFromJson(Map<String, dynamic> json) =>
       streamId: (json['stream_id'] as num).toInt(),
       topicName: TopicName.fromJson(json['topic_name'] as String),
       lastUpdated: (json['last_updated'] as num).toInt(),
-      visibilityPolicy: $enumDecode(
+      visibilityPolicy: $enumDecodeNullable(
         _$UserTopicVisibilityPolicyEnumMap,
         json['visibility_policy'],
+        unknownValue: JsonKey.nullForUndefinedEnumValue,
       ),
     );
 
@@ -700,7 +701,6 @@ const _$UserTopicVisibilityPolicyEnumMap = {
   UserTopicVisibilityPolicy.muted: 1,
   UserTopicVisibilityPolicy.unmuted: 2,
   UserTopicVisibilityPolicy.followed: 3,
-  UserTopicVisibilityPolicy.unknown: null,
 };
 
 MutedUsersEvent _$MutedUsersEventFromJson(Map<String, dynamic> json) =>

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -370,8 +370,8 @@ class UserTopicItem {
   final int streamId;
   final TopicName topicName;
   final int lastUpdated;
-  @JsonKey(unknownEnumValue: UserTopicVisibilityPolicy.unknown)
-  final UserTopicVisibilityPolicy visibilityPolicy;
+  @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+  final UserTopicVisibilityPolicy? visibilityPolicy;
 
   UserTopicItem({
     required this.streamId,

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -328,10 +328,10 @@ UserTopicItem _$UserTopicItemFromJson(Map<String, dynamic> json) =>
       streamId: (json['stream_id'] as num).toInt(),
       topicName: TopicName.fromJson(json['topic_name'] as String),
       lastUpdated: (json['last_updated'] as num).toInt(),
-      visibilityPolicy: $enumDecode(
+      visibilityPolicy: $enumDecodeNullable(
         _$UserTopicVisibilityPolicyEnumMap,
         json['visibility_policy'],
-        unknownValue: UserTopicVisibilityPolicy.unknown,
+        unknownValue: JsonKey.nullForUndefinedEnumValue,
       ),
     );
 
@@ -348,7 +348,6 @@ const _$UserTopicVisibilityPolicyEnumMap = {
   UserTopicVisibilityPolicy.muted: 1,
   UserTopicVisibilityPolicy.unmuted: 2,
   UserTopicVisibilityPolicy.followed: 3,
-  UserTopicVisibilityPolicy.unknown: null,
 };
 
 UnreadMessagesSnapshot _$UnreadMessagesSnapshotFromJson(

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -899,8 +899,8 @@ enum UserTopicVisibilityPolicy {
   none(apiValue: 0),
   muted(apiValue: 1),
   unmuted(apiValue: 2), // TODO(server-7) newly added
-  followed(apiValue: 3), // TODO(server-8) newly added
-  unknown(apiValue: null); // TODO(#1074) remove this
+  followed(apiValue: 3); // TODO(server-8) newly added
+   //Removed unknown (#1074)
 
   const UserTopicVisibilityPolicy({required this.apiValue});
 

--- a/lib/api/route/channels.dart
+++ b/lib/api/route/channels.dart
@@ -119,7 +119,6 @@ Future<void> updateUserTopic(ApiConnection connection, {
   required TopicName topic,
   required UserTopicVisibilityPolicy visibilityPolicy,
 }) {
-  assert(visibilityPolicy != UserTopicVisibilityPolicy.unknown);
   assert(connection.zulipFeatureLevel! >= 170);
   return connection.post('updateUserTopic', (_) {}, 'user_topics', {
     'stream_id': streamId,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -725,10 +725,6 @@ void showTopicActionSheet(BuildContext context, {
         if (supportsFollowingTopics) {
           visibilityOptions.add(UserTopicVisibilityPolicy.none);
         }
-      case UserTopicVisibilityPolicy.unknown:
-        // TODO(#1074): This should be unreachable as we keep `unknown` out of
-        //   our data structures.
-        assert(false);
     }
   } else {
     // Channel is muted.
@@ -750,10 +746,6 @@ void showTopicActionSheet(BuildContext context, {
           if (supportsFollowingTopics) {
             visibilityOptions.add(UserTopicVisibilityPolicy.none);
           }
-        case UserTopicVisibilityPolicy.unknown:
-          // TODO(#1074): This should be unreachable as we keep `unknown` out of
-          //   our data structures.
-          assert(false);
       }
     }
   }
@@ -824,11 +816,6 @@ class UserTopicUpdateButton extends ActionSheetMenuItemButton {
         return ZulipIcons.unmute;
       case UserTopicVisibilityPolicy.followed:
         return ZulipIcons.follow;
-      case UserTopicVisibilityPolicy.unknown:
-        // TODO(#1074): This should be unreachable as we keep `unknown` out of
-        //   our data structures.
-        assert(false);
-        return ZulipIcons.inherit;
     }
   }
 
@@ -855,11 +842,6 @@ class UserTopicUpdateButton extends ActionSheetMenuItemButton {
         assert(false);
         return '';
 
-      case (_, UserTopicVisibilityPolicy.unknown):
-        // This case is unreachable (or should be) because we keep `unknown` out
-        // of our data structures. We plan to remove the `unknown` case in #1074.
-        assert(false);
-        return '';
     }
   }
 
@@ -885,11 +867,6 @@ class UserTopicUpdateButton extends ActionSheetMenuItemButton {
         assert(false);
         return '';
 
-      case (_, UserTopicVisibilityPolicy.unknown):
-        // This case is unreachable (or should be) because we keep `unknown` out
-        // of our data structures. We plan to remove the `unknown` case in #1074.
-        assert(false);
-        return '';
     }
   }
 

--- a/lib/widgets/icons.dart
+++ b/lib/widgets/icons.dart
@@ -226,10 +226,5 @@ IconData? iconDataForTopicVisibilityPolicy(UserTopicVisibilityPolicy policy) {
       return ZulipIcons.follow;
     case UserTopicVisibilityPolicy.none:
       return null;
-    case UserTopicVisibilityPolicy.unknown:
-      // This case is unreachable (or should be) because we keep `unknown` out
-      // of our data structures. We plan to remove the `unknown` case in #1074.
-      assert(false);
-      return null;
   }
 }

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -247,9 +247,6 @@ class _TopicItem extends StatelessWidget {
       case UserTopicVisibilityPolicy.unmuted:
       case UserTopicVisibilityPolicy.followed:
         opacity = 1;
-      case UserTopicVisibilityPolicy.unknown:
-        assert(false);
-        opacity = 1;
     }
 
     final visibilityIcon = iconDataForTopicVisibilityPolicy(visibilityPolicy);

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -88,5 +88,12 @@ extension HeartbeatEventChecks on Subject<HeartbeatEvent> {
   // No properties not covered by Event.
 }
 
+extension UserTopicEventChecks on Subject<UserTopicEvent> {
+  Subject<int> get streamId => has((e) => e.streamId, 'streamId');
+  Subject<TopicName> get topicName => has((e) => e.topicName, 'topicName');
+  Subject<int> get lastUpdated => has((e) => e.lastUpdated, 'lastUpdated');
+  Subject<UserTopicVisibilityPolicy?> get visibilityPolicy => has((e) => e.visibilityPolicy, 'visibilityPolicy');
+}
+
 // Add more extensions here for more event types as needed.
 // Keep them in the same order as the event types' own definitions.

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -331,4 +331,39 @@ void main() {
       })).recipientIds.isNotNull().deepEquals([1, 2, 4, 8, 10]);
     });
   });
+  group('user_topic: visibility_policy null handling', () {
+    final baseJson = {
+      'id': 1,
+      'type': 'user_topic',
+      'stream_id': 42,
+      'topic_name': 'test topic',
+      'last_updated': 1234567890,
+    };
+
+    test('known visibility_policy values deserialize correctly', () {
+      check(UserTopicEvent.fromJson({...baseJson, 'visibility_policy': 0}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.none);
+      check(UserTopicEvent.fromJson({...baseJson, 'visibility_policy': 1}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.muted);
+      check(UserTopicEvent.fromJson({...baseJson, 'visibility_policy': 2}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.unmuted);
+      check(UserTopicEvent.fromJson({...baseJson, 'visibility_policy': 3}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.followed);
+    });
+
+    test('unknown visibility_policy value becomes null', () {
+      check(UserTopicEvent.fromJson({...baseJson, 'visibility_policy': 999}))
+        .visibilityPolicy.isNull();
+    });
+
+    test('missing visibility_policy field becomes null', () {
+      check(UserTopicEvent.fromJson(baseJson))
+        .visibilityPolicy.isNull();
+    });
+
+    test('explicit null visibility_policy remains null', () {
+      check(UserTopicEvent.fromJson({...baseJson, 'visibility_policy': null}))
+        .visibilityPolicy.isNull();
+    });
+  });
 }

--- a/test/api/model/initial_snapshot_test.dart
+++ b/test/api/model/initial_snapshot_test.dart
@@ -5,6 +5,7 @@ import 'package:zulip/api/model/model.dart';
 
 import '../../example_data.dart' as eg;
 import '../../stdlib_checks.dart';
+import 'model_checks.dart';
 
 void main() {
   test('UnreadMessagesSnapshot from json recognizes channels as streams', () {
@@ -71,5 +72,38 @@ void main() {
       final settings = UserSettings.fromJson(json);
       check(settings.emojiset).equals(Emojiset.unknown);
     }
+  });
+  group('UserTopicItem: visibility_policy unknown to null conversion', () {
+    final baseJson = {
+      'stream_id': 123,
+      'topic_name': 'test topic',
+      'last_updated': 1234567890,
+    };
+
+    test('known visibility_policy values deserialize correctly', () {
+      check(UserTopicItem.fromJson({...baseJson, 'visibility_policy': 0}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.none);
+      check(UserTopicItem.fromJson({...baseJson, 'visibility_policy': 1}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.muted);
+      check(UserTopicItem.fromJson({...baseJson, 'visibility_policy': 2}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.unmuted);
+      check(UserTopicItem.fromJson({...baseJson, 'visibility_policy': 3}))
+        .visibilityPolicy.equals(UserTopicVisibilityPolicy.followed);
+    });
+
+    test('unknown visibility_policy value becomes null', () {
+      check(UserTopicItem.fromJson({...baseJson, 'visibility_policy': 999}))
+        .visibilityPolicy.isNull();
+    });
+
+    test('missing visibility_policy field becomes null', () {
+      check(UserTopicItem.fromJson(baseJson))
+        .visibilityPolicy.isNull();
+    });
+
+    test('explicit null visibility_policy remains null', () {
+      check(UserTopicItem.fromJson({...baseJson, 'visibility_policy': null}))
+        .visibilityPolicy.isNull();
+    });
   });
 }

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -1,4 +1,5 @@
 import 'package:checks/checks.dart';
+import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/submessage.dart';
 import 'package:zulip/basic.dart';
@@ -155,6 +156,13 @@ extension ReactionChecks on Subject<Reaction> {
   Subject<String> get emojiCode => has((r) => r.emojiCode, 'emojiCode');
   Subject<ReactionType> get reactionType => has((r) => r.reactionType, 'reactionType');
   Subject<int> get userId => has((r) => r.userId, 'userId');
+}
+
+extension UserTopicItemChecks on Subject<UserTopicItem> {
+  Subject<int> get streamId => has((e) => e.streamId, 'streamId');
+  Subject<TopicName> get topicName => has((e) => e.topicName, 'topicName');
+  Subject<int> get lastUpdated => has((e) => e.lastUpdated, 'lastUpdated');
+  Subject<UserTopicVisibilityPolicy?> get visibilityPolicy => has((e) => e.visibilityPolicy, 'visibilityPolicy');
 }
 
 // TODO similar extensions for other types in model

--- a/test/api/route/channels_test.dart
+++ b/test/api/route/channels_test.dart
@@ -59,14 +59,6 @@ void main() {
     });
   });
 
-  test('updateUserTopic only accepts valid visibility policy', () {
-    return FakeApiConnection.with_((connection) async {
-      check(() => updateUserTopic(connection,
-        streamId: 1, topic: const TopicName('topic'),
-        visibilityPolicy: UserTopicVisibilityPolicy.unknown),
-      ).throws<AssertionError>();
-    });
-  });
 
   test('updateUserTopicCompat when FL >= 170', () {
     return FakeApiConnection.with_((connection) async {

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -616,7 +616,7 @@ TopicNarrow topicNarrow(int channelId, String topicName, {int? with_}) {
 }
 
 UserTopicItem userTopicItem(
-    ZulipStream stream, String topic, UserTopicVisibilityPolicy policy) {
+    ZulipStream stream, String topic, UserTopicVisibilityPolicy? policy) {
   return UserTopicItem(
     streamId: stream.streamId,
     topicName: TopicName(topic),
@@ -1007,7 +1007,7 @@ const _unreadMsgs = unreadMsgs;
 //
 
 UserTopicEvent userTopicEvent(
-    int streamId, String topic, UserTopicVisibilityPolicy visibilityPolicy) {
+    int streamId, String topic, UserTopicVisibilityPolicy? visibilityPolicy) {
   return UserTopicEvent(
     id: 1,
     streamId: streamId,

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -354,7 +354,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     await handleEvent(ChannelFolderAddEvent(id: 1, channelFolder: channelFolder));
   }
 
-  Future<void> setUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy visibilityPolicy) async {
+  Future<void> setUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy? visibilityPolicy) async {
     await handleEvent(eg.userTopicEvent(stream.streamId, topic, visibilityPolicy));
   }
 


### PR DESCRIPTION
Fixes: #1074

Changes made with reasoning:
1.  Made visibilityPolicy nullable at deserialization events.dart (UserTopicEvent) and initial_snapshot.dart - Did the same for UserTopicItem.visibilityPolicy so maps missing/unknown value to null
2.example_data.dart- made UserTopicVisibility needed to be made nullable so tests can construct null edge cases and normal cases. Same for store.dart
3 .channel.dart- changed position of  _warnInvalidVisibilityPolicy up to ChannelStore mixin so it can be accessed by all methods.

 handleUserTopicEvent- Separated null and .none handling here so that later if logging required can be done easier where skips adding any null entry to the map

willChangeIfTopicVisibleInStream and willChangeIfTopicVisible - Added null checks that return UserTopicVisibilityEffect.none when visibilityPolicy is null since its case for .none is just return (do nothing)

4. widgets-removed all unreachable cases with  UserTopicVisibilityPolicy.unknown so widgets only handle 4 valid enum values now
5. Similarly for tests (like channel_test): Changed tests and removed cases of UserTopicVisibilityPolicy.unknown and made UsertopicVisibility nullable with  UserTopicVisibilityPolicy?


Tests added:
1. events_test.dart - Check at boundary if UserTopicEvent.visibilityPolicy maps known JSON values to the correct enum cases and unknown/missing/null values to null. 
2. initial_snapshot_test- Same check but done for the initial snapshot
3.  channel_test.dart- Checks for null visibilityPolicy (also tested with caseinsensitive)
does not add a new entry with null for that topic
 if there was an old entry, it removes it from topicVisibility
 Checks to  check that invalid visibility_policy (null) does not cause any visibility change


 
 Passed all tests