### PR TITLE
l10n [nfc]: Clarify "email address" vs "email message" in descriptions

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -857,11 +857,11 @@
   },
   "loginEmailLabel": "Email address",
   "@loginEmailLabel": {
-    "description": "Label for input when an email is required to log in."
+    "description": "Label for input when an email address is required to log in."
   },
   "loginErrorMissingEmail": "Please enter your email.",
   "@loginErrorMissingEmail": {
-    "description": "Error message when an empty email was provided."
+    "description": "Error message when an empty email address was provided."
   },
   "loginPasswordLabel": "Password",
   "@loginPasswordLabel": {
@@ -961,7 +961,7 @@
   },
   "serverUrlValidationErrorNoUseEmail": "Please enter the server URL, not your email.",
   "@serverUrlValidationErrorNoUseEmail": {
-    "description": "Error message when URL looks like an email"
+    "description": "Error message when URL looks like an email address"
   },
   "serverUrlValidationErrorUnsupportedScheme": "The server URL must start with http:// or https://.",
   "@serverUrlValidationErrorUnsupportedScheme": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1301,13 +1301,13 @@ abstract class ZulipLocalizations {
   /// **'Hide password'**
   String get loginHidePassword;
 
-  /// Label for input when an email is required to log in.
+  /// Label for input when an email address is required to log in.
   ///
   /// In en, this message translates to:
   /// **'Email address'**
   String get loginEmailLabel;
 
-  /// Error message when an empty email was provided.
+  /// Error message when an empty email address was provided.
   ///
   /// In en, this message translates to:
   /// **'Please enter your email.'**
@@ -1425,7 +1425,7 @@ abstract class ZulipLocalizations {
   /// **'Please enter a valid URL.'**
   String get serverUrlValidationErrorInvalidUrl;
 
-  /// Error message when URL looks like an email
+  /// Error message when URL looks like an email address
   ///
   /// In en, this message translates to:
   /// **'Please enter the server URL, not your email.'**


### PR DESCRIPTION
Thanks to Raphaël Hertzog for the report:
  https://chat.zulip.org/#narrow/channel/137-feedback/topic/Improving.20source.20strings.20for.20translations.20.28and.20for.20users.29/near/2363106