### PR TITLE
Write inline-image widget code more like image-preview widget code

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1309,14 +1309,6 @@ class InlineImage extends StatelessWidget {
         if (onTap == null) return child;
         return GestureDetector(onTap: onTap, child: child);
       });
-    if (node.alt != null) {
-      child = Tooltip(
-        message: node.alt,
-        // (Instead of setting a semantics label here,
-        // we give the alt text to [RealmContentNetworkImage].)
-        excludeFromSemantics: true,
-        child: child);
-    }
 
     return Padding(
       // Separate images vertically when they flow onto separate lines.
@@ -1488,7 +1480,7 @@ class _Image extends StatelessWidget {
     final resolvedOriginalSrc = node.originalSrc == null ? null
       : store.tryResolveUrl(node.originalSrc!);
 
-    final child = switch ((node.loading, resolvedSrc)) {
+    Widget child = switch ((node.loading, resolvedSrc)) {
       // resolvedSrc would be a "spinner" image URL.
       // Use our own progress indicator instead.
       (true, _) => const CupertinoActivityIndicator(),
@@ -1503,6 +1495,15 @@ class _Image extends StatelessWidget {
         semanticLabel: node.alt,
         resolvedSrc!),
     };
+
+    if (node.alt != null) {
+      child = Tooltip(
+        message: node.alt,
+        // (Instead of setting a semantics label here,
+        // we give the alt text to [RealmContentNetworkImage].)
+        excludeFromSemantics: true,
+        child: child);
+    }
 
     final lightboxDisplayUrl = (node.loading || node.src is ImageNodeSrcThumbnail)
       ? resolvedOriginalSrc


### PR DESCRIPTION
Greg suggested in https://github.com/zulip/zulip-flutter/pull/2067#discussion_r2729283619 :

> Perhaps as a followup PR, so while this is still fresh in mind but without blocking us merging and releasing the feature: this InlineImage is doing very nearly the same things as the MessageImagePreview widget, especially here in the _buildContent method, but the code looks more different than it is. It'd be nice to refactor them to look more similar so that the real differences are easier to spot.
> 
> Ideally, the logic here in _buildContent would become a helper widget that's shared between InlineImage and MessageImagePreview.

This PR is meant to resolve the first paragraph, with the helper-widget suggestion in the second paragraph left for a future PR.

There are two behavior changes that are just about future-proofing in case servers start producing the inline-image HTML form for external images too:

9748f1ab2 content: Anticipate external images in how we choose lightbox thumbnailUrl
684834a31 content: Anticipate external image URLs in how we choose lightbox src

And one behavior change that affects behavior with current servers:

d85daeff4 content: In inline images, also offer the lightbox when `node.loading`