### PR TITLE
deps: Upgrade Flutter to 3.41.0-1.0.pre-283

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -606,7 +606,7 @@ class _SpoilerState extends State<Spoiler> with TickerProviderStateMixin {
               SizeTransition(
                 sizeFactor: _animation,
                 axis: Axis.vertical,
-                axisAlignment: -1,
+                alignment: AlignmentDirectional.topStart,
                 child: Padding(
                   padding: const EdgeInsets.all(5),
                   child: BlockContentList(nodes: widget.node.content))),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -690,10 +690,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -1047,26 +1047,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.29.0"
   test_api:
     dependency: "direct dev"
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -1323,5 +1323,5 @@ packages:
     source: path
     version: "0.0.1"
 sdks:
-  dart: ">=3.11.0-296.2.beta <4.0.0"
-  flutter: ">=3.40.0-1.0.pre-487"
+  dart: ">=3.12.0-72.0.dev <4.0.0"
+  flutter: ">=3.41.0-1.0.pre-283"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ environment:
   # We use a recent version of Flutter from its main channel, and
   # the corresponding recent version of the Dart SDK.
   # Feel free to update these regularly; see README.md for instructions.
-  sdk: '>=3.11.0-296.2.beta <4.0.0'
-  flutter: '>=3.40.0-1.0.pre-487'  # 8cb340cd7a9b0127f8c2a4dda0523b22c3f6a54e
+  sdk: '>=3.12.0-72.0.dev <4.0.0'
+  flutter: '>=3.41.0-1.0.pre-283'  # 055f3e5bf58354cb50eb55f7e35d03d8e15a6f07
 
 # To update dependencies, see instructions in README.md.
 dependencies:


### PR DESCRIPTION
And update Flutter's supporting libraries to match.

--- 
Additionally includes a fix for deprecation of `SizeTransition.axisAlignment` in favor of `SizeTransition.alignment`.
CZO discussion: https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/SizeTransition.2EaxisAlignment.20deprecated/with/2364008