### PR TITLE
inbox: Use ZulipIcons.check to indicate topic is resolved

### DIFF
--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -587,12 +587,16 @@ class _IconMarker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
+    final textScaler = MediaQuery.textScalerOf(context);
     // Design for icon markers based on Figma screen:
     //   https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?type=design&node-id=224-16386&mode=design&t=JsNndFQ8fKFH0SjS-0
     return Padding(
       padding: const EdgeInsetsDirectional.only(end: 4),
       // This color comes from the Figma screen for the "@" marker, but not
       // the topic visibility markers.
-      child: Icon(icon, size: 14, color: designVariables.inboxItemIconMarker));
+      child: Icon(
+        size: textScaler.clamp(maxScaleFactor: 1.5).scale(16),
+        color: designVariables.inboxItemIconMarker,
+        icon));
   }
 }

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -537,6 +537,8 @@ class _TopicItem extends StatelessWidget {
     final visibilityIcon = iconDataForTopicVisibilityPolicy(
       store.topicVisibilityPolicy(streamId, topic));
 
+    final unresolvedTopic = topic.unresolve();
+
     return Material(
       color: designVariables.background, // TODO(design) check if this is the right variable
       child: InkWell(
@@ -551,20 +553,32 @@ class _TopicItem extends StatelessWidget {
           someMessageIdInTopic: lastUnreadId),
         child: ConstrainedBox(constraints: const BoxConstraints(minHeight: 34),
           child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
-            const SizedBox(width: 63),
+            SizedBox(
+              width: 55,
+              child: Align(
+                // End-align so that the icon grows startward as the device
+                // text-size setting increases, instead of shrinking the space
+                // available for the topic text.
+                alignment: AlignmentDirectional.centerEnd,
+                child: topic.isResolved
+                  ? _IconMarker(icon: ZulipIcons.check, padEnd: false)
+                  : null)),
+            const SizedBox(width: 8),
             Expanded(child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 4),
               child: Text(
                 style: TextStyle(
                   fontSize: 17,
                   height: (20 / 17),
-                  fontStyle: topic.displayName == null ? FontStyle.italic : null,
+                  fontStyle: unresolvedTopic.displayName == null
+                    ? FontStyle.italic
+                    : null,
                   // TODO(design) check if this is the right variable
                   color: designVariables.labelMenuButton,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                topic.displayName ?? store.realmEmptyTopicDisplayName))),
+                unresolvedTopic.displayName ?? store.realmEmptyTopicDisplayName))),
             const SizedBox(width: 12),
             if (hasMention) const _IconMarker(icon: ZulipIcons.at_sign),
             // TODO(design) copies the "@" marker color; is there a better color?
@@ -580,9 +594,10 @@ class _TopicItem extends StatelessWidget {
 }
 
 class _IconMarker extends StatelessWidget {
-  const _IconMarker({required this.icon});
+  const _IconMarker({required this.icon, this.padEnd = true});
 
   final IconData icon;
+  final bool padEnd;
 
   @override
   Widget build(BuildContext context) {
@@ -590,13 +605,17 @@ class _IconMarker extends StatelessWidget {
     final textScaler = MediaQuery.textScalerOf(context);
     // Design for icon markers based on Figma screen:
     //   https://www.figma.com/file/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?type=design&node-id=224-16386&mode=design&t=JsNndFQ8fKFH0SjS-0
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(end: 4),
+    Widget result = Icon(
+      size: textScaler.clamp(maxScaleFactor: 1.5).scale(16),
       // This color comes from the Figma screen for the "@" marker, but not
       // the topic visibility markers.
-      child: Icon(
-        size: textScaler.clamp(maxScaleFactor: 1.5).scale(16),
-        color: designVariables.inboxItemIconMarker,
-        icon));
+      color: designVariables.inboxItemIconMarker,
+      icon);
+    if (padEnd) {
+      result = Padding(
+        padding: const EdgeInsetsDirectional.only(end: 4),
+        child: result);
+    }
+    return result;
   }
 }

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -8,7 +8,6 @@ import '../model/topics.dart';
 import '../model/unreads.dart';
 import 'action_sheet.dart';
 import 'app_bar.dart';
-import 'color.dart';
 import 'icons.dart';
 import 'message_list.dart';
 import 'page.dart';
@@ -328,6 +327,6 @@ class _IconMarker extends StatelessWidget {
     // from the Figma design is omitted.
     return Icon(icon,
       size: textScaler.clamp(maxScaleFactor: 1.5).scale(16),
-      color: designVariables.textMessage.withFadedAlpha(0.4));
+      color: designVariables.inboxItemIconMarker);
   }
 }

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -422,6 +422,30 @@ void main() {
       });
     });
 
+    testWidgets('check icon present/absent as topic is resolved/unresolved', (tester) async {
+      final channel = eg.stream();
+      const topic = '✔ resolved topic';
+      final message = eg.streamMessage(stream: channel, topic: topic);
+
+      await setupPage(tester,
+        streams: [channel],
+        subscriptions: [eg.subscription(channel)],
+        unreadMessages: [message]);
+      await tester.pump();
+      check(hasIcon(tester,
+        parent: findRowByLabel(tester, 'resolved topic'),
+        icon: ZulipIcons.check)).isTrue();
+      check(find.textContaining('✔')).findsNothing();
+
+      await store.handleEvent(
+        eg.updateMessageEventMoveFrom(origMessages: [message],
+          newTopic: eg.t('unresolved topic')));
+      await tester.pump();
+      check(hasIcon(tester,
+        parent: findRowByLabel(tester, 'unresolved topic'),
+        icon: ZulipIcons.check)).isFalse();
+    });
+
     group('collapsing', () {
       Icon findHeaderCollapseIcon(WidgetTester tester, Widget headerRow) {
         return tester.widget(


### PR DESCRIPTION
Following the Figma:
  https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=6038-294822&m=dev

(This PR is stacked on #2109.)

| Before (well, after #2109) | After |
| --- | --- |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/2fbc3e1f-00e6-4051-b1bb-c4176376af22" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/fb4d20b5-08ae-488e-86f9-f09f6819487d" /> |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/0c70c901-0e89-4cb0-b050-7ff78989632e" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/76729a3b-2c88-48d8-bfd5-a796c50c9e41" /> |