### PR TITLE
connectivity: Added connectivity_plus Listener and AppLifecycleListener to UpdateMachine

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -194,6 +194,22 @@ packages:
       url: "https://github.com/gaaclarke/color_models.git"
     source: git
     version: "1.3.3"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   convert:
     dependency: "direct main"
     description:
@@ -734,6 +750,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.4"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   crypto: ^3.0.3
   csslib: ^1.0.2
   device_info_plus: ^12.0.0
+  connectivity_plus: ^6.1.4
   drift: ^2.23.0
   file_picker: ^10.1.2
   firebase_core: ^4.0.0

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -32,6 +32,7 @@ import 'test_store.dart';
 void main() {
   TestZulipBinding.ensureInitialized();
   Presence.debugEnable = false;
+  UpdateMachine.debugEnableAppLifecycleListener = false;
 
   final account1 = eg.selfAccount.copyWith(id: 1);
   final account2 = eg.otherAccount.copyWith(id: 2);


### PR DESCRIPTION
When the app returns from background or the network reconnects after failures, the event polling may be stuck in a backoff wait.This causes users to see a loading indicator even though connectivity has been restored. 

This PR aborts the backoff wait when:
- The app resumes from background using AppLifecycleListener
- Network connectivity is restored using connectivity_plus

**Testing done:**

1.Turn off wifi and turn on. ==> connects immediately
2.Aeroplane mode on then off. ==> connects immediatelyy after wifi reconnects 
3.Go to Home screen and return to the App within 4 second(3999ms) app remains already connected.
4.Go to Home screen and open the app after 4 second(3999ms) the app connects immediately. (backoff aborted)
5.Lock screen (not possible with screen recording on physical device) but same as the test done on Home screen.(backoff aborted.)
The testing-
<video src="https://github.com/user-attachments/assets/0ad1e633-37f8-472a-a890-0618edb57b89"/>




Fixes: #1884 