### PR TITLE
Add DM action sheet, with "View profile" and "Mark conversation as read" buttons

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -321,6 +321,29 @@
   "@actionSheetOptionCopyTopicLink": {
     "description": "Label for copy topic link button in action sheet."
   },
+  "actionSheetTitleDm": "DMs with {user}",
+  "@actionSheetTitleDm": {
+    "description": "The title of an action sheet for a 1:1 DM conversation with another user.",
+    "placeholders": {
+      "user": {"type": "String", "example": "Alice"}
+    }
+  },
+  "actionSheetTitleSelfDm": "DMs with yourself",
+  "@actionSheetTitleSelfDm": {
+    "description": "The title of an action sheet for the 1:1 DM conversation with yourself."
+  },
+  "actionSheetTitleGroupDm": "Group DM",
+  "@actionSheetTitleGroupDm": {
+    "description": "The title of an action sheet for a group DM conversation."
+  },
+  "actionSheetOptionViewProfile": "View profile",
+  "@actionSheetOptionViewProfile": {
+    "description": "Option to view the user's profile in the action sheet for a 1:1 DM conversation."
+  },
+  "actionSheetOptionMarkDmConversationAsRead": "Mark conversation as read",
+  "@actionSheetOptionMarkDmConversationAsRead": {
+    "description": "Option to mark a DM conversation as read in the action sheet."
+  },
   "errorWebAuthOperationalErrorTitle": "Something went wrong",
   "@errorWebAuthOperationalErrorTitle": {
     "description": "Error title when third-party authentication has an operational error (not necessarily caused by invalid credentials)."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -606,6 +606,36 @@ abstract class ZulipLocalizations {
   /// **'Copy link to topic'**
   String get actionSheetOptionCopyTopicLink;
 
+  /// The title of an action sheet for a 1:1 DM conversation with another user.
+  ///
+  /// In en, this message translates to:
+  /// **'DMs with {user}'**
+  String actionSheetTitleDm(String user);
+
+  /// The title of an action sheet for the 1:1 DM conversation with yourself.
+  ///
+  /// In en, this message translates to:
+  /// **'DMs with yourself'**
+  String get actionSheetTitleSelfDm;
+
+  /// The title of an action sheet for a group DM conversation.
+  ///
+  /// In en, this message translates to:
+  /// **'Group DM'**
+  String get actionSheetTitleGroupDm;
+
+  /// Option to view the user's profile in the action sheet for a 1:1 DM conversation.
+  ///
+  /// In en, this message translates to:
+  /// **'View profile'**
+  String get actionSheetOptionViewProfile;
+
+  /// Option to mark a DM conversation as read in the action sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark conversation as read'**
+  String get actionSheetOptionMarkDmConversationAsRead;
+
   /// Error title when third-party authentication has an operational error (not necessarily caused by invalid credentials).
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -280,6 +280,24 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Link zum Thema kopieren';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Etwas ist schiefgelaufen';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -274,6 +274,24 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -282,6 +282,24 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Copier le lien vers cette conversation';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Une erreur s\'est produite';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -284,6 +284,24 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copia link al topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Qualcosa è andato storto';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -268,6 +268,24 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'トピックのリンクをコピー';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => '問題が発生しました';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -283,6 +283,24 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Skopiuj odnośnik do wątku';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Coś poszło nie tak';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -284,6 +284,24 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Скопировать ссылку на тему';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Что-то пошло не так';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -273,6 +273,24 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Niečo sa pokazilo';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -280,6 +280,24 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Kopiraj povezavo do teme';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Nekaj je šlo narobe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -282,6 +282,24 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Копіювати посилання на тему';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Щось пішло не так';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -272,6 +272,24 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get actionSheetOptionCopyTopicLink => 'Copy link to topic';
 
   @override
+  String actionSheetTitleDm(String user) {
+    return 'DMs with $user';
+  }
+
+  @override
+  String get actionSheetTitleSelfDm => 'DMs with yourself';
+
+  @override
+  String get actionSheetTitleGroupDm => 'Group DM';
+
+  @override
+  String get actionSheetOptionViewProfile => 'View profile';
+
+  @override
+  String get actionSheetOptionMarkDmConversationAsRead =>
+      'Mark conversation as read';
+
+  @override
   String get errorWebAuthOperationalErrorTitle => 'Something went wrong';
 
   @override

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -841,12 +841,12 @@ void showTopicActionSheet(BuildContext context, {
     optionButtons.add(MarkTopicAsReadButton(
       channelId: channelId,
       topic: topic,
-      pageContext: context));
+      pageContext: pageContext));
   }
 
   optionButtons.add(CopyTopicLinkButton(
     narrow: TopicNarrow(channelId, topic, with_: someMessageIdInTopic),
-    pageContext: context));
+    pageContext: pageContext));
 
   final header = BottomSheetHeader(
     buildTitle: (baseStyle) => Text.rich(

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -29,11 +29,13 @@ import 'icons.dart';
 import 'inset_shadow.dart';
 import 'message_list.dart';
 import 'page.dart';
+import 'profile.dart';
 import 'read_receipts.dart';
 import 'store.dart';
 import 'text.dart';
 import 'theme.dart';
 import 'topic_list.dart';
+import 'user.dart';
 
 /// Show an action sheet with scrollable menu buttons
 /// and an optional scrollable header.
@@ -1103,6 +1105,104 @@ class CopyTopicLinkButton extends ActionSheetMenuItemButton {
     PlatformActions.copyWithPopup(context: pageContext,
       successContent: Text(zulipLocalizations.successTopicLinkCopied),
       data: ClipboardData(text: narrowLink(store, narrow).toString()));
+  }
+}
+
+/// Show a sheet of actions you can take on a DM conversation.
+///
+/// Needs a [PageRoot] ancestor.
+void showDmActionSheet(BuildContext context, {required DmNarrow narrow}) {
+  final pageContext = PageRoot.contextOf(context);
+  final zulipLocalizations = ZulipLocalizations.of(context);
+  final store = PerAccountStoreWidget.of(pageContext);
+
+  final otherRecipientIds = narrow.otherRecipientIds;
+  final unreadCount = store.unreads.countInDmNarrow(narrow);
+
+  final buttonSections = [
+    // TODO(#1534) Button to show list of participants as a separate page?
+
+    [
+      if (otherRecipientIds.isEmpty)
+        ViewProfileButton(pageContext: pageContext,
+          userId: store.selfUserId)
+      else if (otherRecipientIds.length == 1)
+        ViewProfileButton(pageContext: pageContext,
+          userId: otherRecipientIds.single),
+
+      if (unreadCount > 0)
+        MarkDmConversationAsReadButton(pageContext: pageContext, narrow: narrow),
+    ],
+
+    // TODO(#2113) Mute/unmute button
+  ];
+
+  final header = BottomSheetHeader(
+    title: switch (otherRecipientIds) {
+      [] => zulipLocalizations.actionSheetTitleSelfDm,
+      [final otherUserId] =>
+        zulipLocalizations.actionSheetTitleDm(
+          store.userDisplayName(otherUserId, replaceIfMuted: false)),
+      [...] => zulipLocalizations.actionSheetTitleGroupDm,
+    },
+    buildMessage: otherRecipientIds.length > 1
+      ? (_) => Wrap(
+          spacing: 6,
+          runSpacing: 4,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: otherRecipientIds.map((userId) =>
+            UserChip(
+              userId: userId,
+              onTap: () => Navigator.push(pageContext,
+                ProfilePage.buildRoute(context: pageContext, userId: userId)))).toList())
+     : null);
+
+  _showActionSheet(pageContext,
+    header: header,
+    headerScrollable: otherRecipientIds.length > 1,
+    buttonSections: buttonSections);
+}
+
+class ViewProfileButton extends ActionSheetMenuItemButton {
+  const ViewProfileButton({
+    super.key,
+    required super.pageContext,
+    required this.userId,
+  });
+
+  final int userId;
+
+  @override IconData get icon => ZulipIcons.person;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.actionSheetOptionViewProfile;
+  }
+
+  @override void onPressed() {
+    Navigator.push(pageContext,
+      ProfilePage.buildRoute(context: pageContext, userId: userId));
+  }
+}
+
+class MarkDmConversationAsReadButton extends ActionSheetMenuItemButton {
+  const MarkDmConversationAsReadButton({
+    super.key,
+    required super.pageContext,
+    required this.narrow,
+  });
+
+  final DmNarrow narrow;
+
+  @override IconData get icon => ZulipIcons.message_checked;
+
+  @override
+  String label(ZulipLocalizations zulipLocalizations) {
+    return zulipLocalizations.actionSheetOptionMarkDmConversationAsRead;
+  }
+
+  @override void onPressed() async {
+    await ZulipAction.markNarrowAsRead(pageContext, narrow);
   }
 }
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -47,9 +47,11 @@ void _showActionSheet(
   BuildContext pageContext, {
   Widget? header,
   bool headerScrollable = true,
+  bool shorterScrollableMaxHeight = false,
   required List<List<Widget>> buttonSections,
 }) {
   assert(header is! BottomSheetHeader || !header.outerVerticalPadding);
+  assert(headerScrollable || !shorterScrollableMaxHeight);
 
   // Could omit this if we need _showActionSheet outside a per-account context.
   final accountId = PerAccountStoreWidget.accountIdOf(pageContext);
@@ -76,12 +78,20 @@ void _showActionSheet(
               //   Needs support for separate properties like `flex-grow`
               //   and `flex-shrink`.
               flex: 1,
-              child: InsetShadowBox(
-                top: 8, bottom: 8,
-                color: designVariables.bgContextMenu,
-                child: SingleChildScrollView(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: header)))
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: shorterScrollableMaxHeight
+                    // Chosen so we show "4-ish lines rather than 6-ish" in the
+                    // DM action sheet header with group participant pills:
+                    //   https://chat.zulip.org/#narrow/channel/48-mobile/topic/abbreviated.20headings/near/2371840
+                    ? 160
+                    : double.infinity),
+                child: InsetShadowBox(
+                  top: 8, bottom: 8,
+                  color: designVariables.bgContextMenu,
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.symmetric(vertical: 8),
+                    child: header))))
           : Padding(
               padding: EdgeInsets.only(top: 16, bottom: 4),
               child: header);
@@ -1157,9 +1167,11 @@ void showDmActionSheet(BuildContext context, {required DmNarrow narrow}) {
                 ProfilePage.buildRoute(context: pageContext, userId: userId)))).toList())
      : null);
 
+  final headerScrollable = otherRecipientIds.length > 1;
   _showActionSheet(pageContext,
     header: header,
-    headerScrollable: otherRecipientIds.length > 1,
+    headerScrollable: headerScrollable,
+    shorterScrollableMaxHeight: headerScrollable,
     buttonSections: buttonSections);
 }
 

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -338,6 +338,7 @@ class InboxDmItem extends StatelessWidget {
           Navigator.push(context,
             MessageListPage.buildRoute(context: context, narrow: narrow));
         },
+        onLongPress: () => showDmActionSheet(context, narrow: narrow),
         child: ConstrainedBox(constraints: const BoxConstraints(minHeight: 34),
           child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
             const SizedBox(width: 63),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -702,14 +702,28 @@ class MessageListAppBarTitle extends StatelessWidget {
 
       case DmNarrow(:var otherRecipientIds):
         final store = PerAccountStoreWidget.of(context);
+        final alignment = willCenterTitle
+          ? Alignment.center
+          : AlignmentDirectional.centerStart;
+
+        Widget child;
         if (otherRecipientIds.isEmpty) {
-          return Text(zulipLocalizations.dmsWithYourselfPageTitle);
+          child = Text(zulipLocalizations.dmsWithYourselfPageTitle);
         } else {
           final names = otherRecipientIds.map(store.userDisplayName);
           // TODO show avatars
-          return Text(
+          child = Text(
             zulipLocalizations.dmsWithOthersPageTitle(names.join(', ')));
         }
+
+        return SizedBox(
+          width: double.infinity,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onLongPress: () =>
+              showDmActionSheet(context, narrow: narrow as DmNarrow),
+            child: Align(alignment: alignment,
+              child: child)));
 
       case KeywordSearchNarrow():
         assert(!willCenterTitle);
@@ -1977,6 +1991,8 @@ class DmRecipientHeader extends StatelessWidget {
         : () => Navigator.push(context,
             MessageListPage.buildRoute(context: context,
               narrow: DmNarrow.ofMessage(message, selfUserId: store.selfUserId))),
+      onLongPress: () => showDmActionSheet(context,
+        narrow: DmNarrow.ofMessage(message, selfUserId: store.selfUserId)),
       child: ColoredBox(
         color: messageListTheme.dmRecipientHeaderBg,
         child: Padding(

--- a/lib/widgets/new_dm_sheet.dart
+++ b/lib/widgets/new_dm_sheet.dart
@@ -274,54 +274,13 @@ class _NewDmSearchBar extends StatelessWidget {
             crossAxisAlignment: WrapCrossAlignment.center,
             children: [
               for (final userId in selectedUserIds)
-                _SelectedUserChip(userId: userId, unselectUser: unselectUser),
+                UserChip(userId: userId, onTap: () => unselectUser(userId)),
               // The IntrinsicWidth lets the text field participate in the Wrap
               // when its content fits on the same line with a user chip,
               // by preventing it from expanding to fill the available width.  See:
               //   https://github.com/zulip/zulip-flutter/pull/1322#discussion_r2094112488
               IntrinsicWidth(child: _buildSearchField(context)),
             ]))));
-  }
-}
-
-class _SelectedUserChip extends StatelessWidget {
-  const _SelectedUserChip({
-    required this.userId,
-    required this.unselectUser,
-  });
-
-  final int userId;
-  final void Function(int) unselectUser;
-
-  @override
-  Widget build(BuildContext context) {
-    final designVariables = DesignVariables.of(context);
-    final store = PerAccountStoreWidget.of(context);
-    final clampedTextScaler = MediaQuery.textScalerOf(context)
-      .clamp(maxScaleFactor: 1.5);
-
-    return GestureDetector(
-      onTap: () => unselectUser(userId),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: designVariables.bgMenuButtonSelected,
-          borderRadius: BorderRadius.circular(3)),
-        child: Row(mainAxisSize: MainAxisSize.min, children: [
-          Avatar(userId: userId, size: clampedTextScaler.scale(22), borderRadius: 3),
-          Flexible(
-            child: Padding(
-              padding: const EdgeInsetsDirectional.fromSTEB(5, 3, 4, 3),
-              child: Text(store.userDisplayName(userId),
-                textScaler: clampedTextScaler,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: 16,
-                  height: 16 / 16,
-                  color: designVariables.labelMenuButton)))),
-          UserStatusEmoji(userId: userId, size: 16,
-            padding: EdgeInsetsDirectional.only(end: 4)),
-        ])));
   }
 }
 

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -478,6 +478,7 @@ class _TextWidget extends StatelessWidget {
   }
 }
 
+// TODO(design) use [UserChip] instead, like in the new-DM UI?
 class _UserWidget extends StatelessWidget {
   const _UserWidget({required this.userId});
 

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -4,6 +4,7 @@ import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
+import 'action_sheet.dart';
 import 'icons.dart';
 import 'message_list.dart';
 import 'new_dm_sheet.dart';
@@ -209,6 +210,7 @@ class RecentDmConversationsItem extends StatelessWidget {
       color: backgroundColor,
       child: InkWell(
         onTap: () => onDmSelect(narrow),
+        onLongPress: () => showDmActionSheet(context, narrow: narrow),
         child: ConstrainedBox(constraints: const BoxConstraints(minHeight: 48),
           child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
             Padding(padding: const EdgeInsetsDirectional.fromSTEB(12, 8, 0, 8),

--- a/lib/widgets/user.dart
+++ b/lib/widgets/user.dart
@@ -376,3 +376,46 @@ class UserStatusEmoji extends StatelessWidget {
 
 /// The position of the status emoji span relative to another text span.
 enum StatusEmojiPosition { before, after }
+
+/// A "chip" representing a user, with avatar/presence and display name.
+class UserChip extends StatelessWidget {
+  const UserChip({
+    super.key,
+    required this.userId,
+    required this.onTap,
+  });
+
+  final int userId;
+  final void Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    final store = PerAccountStoreWidget.of(context);
+    final clampedTextScaler = MediaQuery.textScalerOf(context)
+      .clamp(maxScaleFactor: 1.5);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: designVariables.bgMenuButtonSelected,
+          borderRadius: BorderRadius.circular(3)),
+        child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Avatar(userId: userId, size: clampedTextScaler.scale(22), borderRadius: 3),
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsetsDirectional.fromSTEB(5, 3, 4, 3),
+              child: Text(store.userDisplayName(userId),
+                textScaler: clampedTextScaler,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 16,
+                  height: 16 / 16,
+                  color: designVariables.labelMenuButton)))),
+          UserStatusEmoji(userId: userId, size: 16,
+            padding: EdgeInsetsDirectional.only(end: 4)),
+        ])));
+  }
+}

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -32,6 +32,7 @@ import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:share_plus_platform_interface/method_channel/method_channel_share.dart';
+import 'package:zulip/widgets/profile.dart';
 import 'package:zulip/widgets/read_receipts.dart';
 import 'package:zulip/widgets/subscription_list.dart';
 import 'package:zulip/widgets/topic_list.dart';
@@ -1389,6 +1390,297 @@ void main() {
         check(expectedLink.toString().contains('/with/')).isFalse();
         check((await Clipboard.getData('text/plain'))!)
           .text.equals(expectedLink.toString());
+      });
+    });
+  });
+
+  group('DM action sheet', () {
+    Future<void> prepare({
+      List<User>? usersExcludingSelf,
+      List<DmMessage>? unreadMessages,
+    }) async {
+      addTearDown(testBinding.reset);
+
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+        realmUsers: [eg.selfUser, ...?usersExcludingSelf]));
+      store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      connection = store.connection as FakeApiConnection;
+
+      if (unreadMessages != null) {
+        for (final message in unreadMessages) {
+          await store.addMessage(message);
+          check(store.unreads.isUnread(message.id)).isNotNull().isTrue();
+        }
+      }
+    }
+
+    /// Show the action sheet by long-pressing a DM item in the inbox.
+    ///
+    /// The helper will long-press at `find.textContaining(textInDmItem)`
+    /// within the inbox page.
+    Future<void> showFromInbox(WidgetTester tester, {
+      required DmNarrow narrow,
+      required String textInDmItem,
+    }) async {
+      final hasDmWithUnreads = store.unreads.countInDmNarrow(narrow) > 0;
+      if (!hasDmWithUnreads) {
+        throw FlutterError.fromParts([
+          ErrorSummary('showFromInbox called without an unread message'),
+          ErrorHint(
+            'Before calling showFromInbox, ensure that [Unreads] '
+            'has an unread message in the relevant DM narrow.',
+          ),
+        ]);
+      }
+
+      transitionDurationObserver = TransitionDurationObserver();
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          navigatorObservers: [transitionDurationObserver],
+          child: const HomePage()));
+      await tester.pump();
+      check(find.byType(InboxPageBody)).findsOne();
+
+      await tester.longPress(find.descendant(
+        of: find.byType(InboxPageBody),
+        matching: find.textContaining(textInDmItem)));
+      await transitionDurationObserver.pumpPastTransition(tester);
+    }
+
+    /// Show the action sheet by long-pressing the message-list app bar
+    /// for a DM narrow.
+    ///
+    /// The helper will long-press at `find.textContaining(textInAppBarTitle)`
+    /// within the app bar.
+    Future<void> showFromAppBar(WidgetTester tester, {
+      required DmNarrow narrow,
+      required String textInAppBarTitle,
+    }) async {
+      transitionDurationObserver = TransitionDurationObserver();
+      connection.prepare(json: eg.newestGetMessagesResult(
+        foundOldest: true, messages: []).toJson());
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          navigatorObservers: [transitionDurationObserver],
+          child: MessageListPage(initNarrow: narrow)));
+      await tester.pump();
+
+      await tester.longPress(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.textContaining(textInAppBarTitle)));
+      await transitionDurationObserver.pumpPastTransition(tester);
+    }
+
+    /// Show the action sheet by long-pressing a recipient header for a DM
+    /// in the combined feed.
+    ///
+    /// The helper will long-press at `find.textContaining(textInRecipientHeader)`
+    /// within the recipient header.
+    Future<void> showFromRecipientHeader(WidgetTester tester, {
+      required DmNarrow narrow,
+      required DmMessage message,
+      required String textInRecipientHeader,
+    }) async {
+      assert(narrow.containsMessage(message));
+
+      connection.prepare(json: eg.newestGetMessagesResult(
+        foundOldest: true, messages: [message]).toJson());
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          navigatorObservers: [transitionDurationObserver],
+          child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.descendant(
+        of: find.byType(RecipientHeader),
+        matching: find.textContaining(textInRecipientHeader)));
+      await transitionDurationObserver.pumpPastTransition(tester);
+    }
+
+    final actionSheetFinder = find.byType(BottomSheet);
+    Finder findButtonForLabel(String label) =>
+      find.descendant(of: actionSheetFinder, matching: find.text(label));
+
+    void checkButton(String label) {
+      check(findButtonForLabel(label)).findsOne();
+    }
+
+    Finder findInHeader(Finder finder) {
+      // We could target this finder more precisely to the header,
+      // if there's risk of confusion with the buttons.
+      return find.descendant(
+        of: actionSheetFinder,
+        matching: finder);
+    }
+
+    group('show from inbox', () {
+      testWidgets('1:1 DM (not self)', (tester) async {
+        final unreadMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
+        await prepare(
+          usersExcludingSelf: [eg.otherUser],
+          unreadMessages: [unreadMessage]);
+        final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+          eg.otherUser.userId);
+        await showFromInbox(tester,
+          narrow: narrow, textInDmItem: eg.otherUser.fullName);
+        check(findInHeader(find.text('DMs with ${eg.otherUser.fullName}')))
+          .findsOne();
+        checkButton('View profile');
+      });
+
+      testWidgets('self-DM', (tester) async {
+        final unreadMessage = eg.dmMessage(from: eg.selfUser, to: []);
+        await prepare(unreadMessages: [unreadMessage]);
+        final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+          eg.selfUser.userId);
+        await showFromInbox(tester,
+          narrow: narrow, textInDmItem: eg.selfUser.fullName);
+        check(findInHeader(find.text('DMs with yourself'))).findsOne();
+        checkButton('View profile');
+      });
+
+      testWidgets('group DM', (tester) async {
+        final unreadMessage = eg.dmMessage(
+          from: eg.thirdUser, to: [eg.selfUser, eg.otherUser]);
+        await prepare(
+          usersExcludingSelf: [eg.otherUser, eg.thirdUser],
+          unreadMessages: [unreadMessage]);
+        final narrow = DmNarrow.withUsers(selfUserId: eg.selfUser.userId,
+          [eg.otherUser.userId, eg.thirdUser.userId]);
+        await showFromInbox(tester,
+          narrow: narrow, textInDmItem: eg.thirdUser.fullName);
+        findInHeader(find.text('Group DM'));
+        check(tester.widgetList(findInHeader(find.byType(UserChip))))
+          .deepEquals(<Condition<Object?>>[
+            (it) => it.isA<UserChip>().userId.equals(eg.otherUser.userId),
+            (it) => it.isA<UserChip>().userId.equals(eg.thirdUser.userId),
+          ]);
+
+        // Tapping a user in the header leads to their profile.
+        await tester.tap(find.widgetWithText(UserChip, eg.otherUser.fullName));
+        await transitionDurationObserver.pumpPastTransition(tester);
+        final profilePageFinder = find.byWidgetPredicate((widget) =>
+          widget is ProfilePage && widget.userId == eg.otherUser.userId);
+        check(profilePageFinder).findsOne();
+      });
+    });
+
+    testWidgets('from app bar (1:1 DM)', (tester) async {
+      await prepare(usersExcludingSelf: [eg.otherUser]);
+      final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+        eg.otherUser.userId);
+      await showFromAppBar(tester,
+        narrow: narrow, textInAppBarTitle: eg.otherUser.fullName);
+      check(findInHeader(find.text('DMs with ${eg.otherUser.fullName}')))
+        .findsOne();
+      checkButton('View profile');
+    });
+
+    testWidgets('from recipient header (1:1 DM)', (tester) async {
+      final message = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
+      await prepare(usersExcludingSelf: [eg.otherUser]);
+      await store.addMessage(message);
+      final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+        eg.otherUser.userId);
+      await showFromRecipientHeader(tester,
+        narrow: narrow,
+        message: message,
+        textInRecipientHeader: eg.otherUser.fullName);
+      check(findInHeader(find.text('DMs with ${eg.otherUser.fullName}')))
+        .findsOne();
+      checkButton('View profile');
+    });
+
+    group('ViewProfileButton', () {
+      testWidgets('self', (tester) async {
+        final unreadMessage = eg.dmMessage(from: eg.selfUser, to: []);
+        await prepare(unreadMessages: [unreadMessage]);
+        final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+          eg.selfUser.userId);
+        await showFromInbox(tester,
+          narrow: narrow, textInDmItem: eg.selfUser.fullName);
+        check(findInHeader(find.text('DMs with yourself'))).findsOne();
+
+        await tester.tap(findButtonForLabel('View profile'));
+
+        // The DM action sheet exits and the profile page enters.
+        //
+        // This just pumps through twice the duration of the latest transition.
+        // Ideally we'd check that the two expected transitions were triggered
+        // and that they started at the same time, and pump through the
+        // longer of the two durations.
+        // TODO(upstream) support this in TransitionDurationObserver
+        await transitionDurationObserver.pumpPastTransition(tester);
+        await transitionDurationObserver.pumpPastTransition(tester);
+
+        final profilePageFinder = find.byWidgetPredicate((widget) =>
+          widget is ProfilePage && widget.userId == eg.selfUser.userId);
+        check(profilePageFinder).findsOne();
+      });
+
+      testWidgets('other', (tester) async {
+        final unreadMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
+        await prepare(
+          usersExcludingSelf: [eg.otherUser],
+          unreadMessages: [unreadMessage]);
+        final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+          eg.otherUser.userId);
+        await showFromInbox(tester,
+          narrow: narrow, textInDmItem: eg.otherUser.fullName);
+        check(findInHeader(find.text('DMs with ${eg.otherUser.fullName}'))).findsOne();
+
+        await tester.tap(findButtonForLabel('View profile'));
+        await transitionDurationObserver.pumpPastTransition(tester);
+        await transitionDurationObserver.pumpPastTransition(tester);
+        final profilePageFinder = find.byWidgetPredicate((widget) =>
+          widget is ProfilePage && widget.userId == eg.otherUser.userId);
+        check(profilePageFinder).findsOne();
+      });
+    });
+
+    group('MarkDmConversationAsReadButton', () {
+      testWidgets('if there are unreads, button is visible and marks as read when tapped', (tester) async {
+        final unreadMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
+        await prepare(
+          usersExcludingSelf: [eg.otherUser],
+          unreadMessages: [unreadMessage]);
+        final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+          eg.otherUser.userId);
+        await showFromInbox(tester,
+          narrow: narrow, textInDmItem: eg.otherUser.fullName);
+        check(findInHeader(find.text('DMs with ${eg.otherUser.fullName}')))
+          .findsOne();
+
+        connection.prepare(json: UpdateMessageFlagsForNarrowResult(
+          processedCount: 1, updatedCount: 1,
+          firstProcessedId: unreadMessage.id, lastProcessedId: unreadMessage.id,
+          foundOldest: true, foundNewest: true).toJson());
+        await tester.tap(findButtonForLabel('Mark conversation as read'));
+        await tester.pump();
+        check(connection.lastRequest).isA<http.Request>()
+          ..url.path.equals('/api/v1/messages/flags/narrow')
+          ..bodyFields['narrow'].equals(jsonEncode([
+              ...resolveApiNarrowForServer(
+                narrow.apiEncode(),
+                connection.zulipFeatureLevel!),
+              ApiNarrowIs(IsOperand.unread),
+            ]))
+          ..bodyFields['op'].equals('add')
+          ..bodyFields['flag'].equals('read');
+        // (action sheet closes)
+        await transitionDurationObserver.pumpPastTransition(tester);
+      });
+
+      testWidgets('if no unreads, button not visible', (tester) async {
+        await prepare(usersExcludingSelf: [eg.otherUser]);
+        final narrow = DmNarrow.withUser(selfUserId: eg.selfUser.userId,
+          eg.otherUser.userId);
+        await showFromAppBar(tester,
+          narrow: narrow, textInAppBarTitle: eg.otherUser.fullName);
+        check(findInHeader(find.text('DMs with ${eg.otherUser.fullName}')))
+          .findsOne();
+        check(store.unreads.countInDmNarrow(narrow)).equals(0);
+        check(findButtonForLabel('Mark conversation as read')).findsNothing();
       });
     });
   });

--- a/test/widgets/checks.dart
+++ b/test/widgets/checks.dart
@@ -67,6 +67,10 @@ extension AvatarShapeChecks on Subject<AvatarShape> {
   Subject<Widget> get child => has((i) => i.child, 'child');
 }
 
+extension UserChipChecks on Subject<UserChip> {
+  Subject<int> get userId => has((x) => x.userId, 'userId');
+}
+
 extension MessageListPageChecks on Subject<MessageListPage> {
   Subject<Narrow> get initNarrow => has((x) => x.initNarrow, 'initNarrow');
   Subject<int?> get initAnchorMessageId => has((x) => x.initAnchorMessageId, 'initAnchorMessageId');


### PR DESCRIPTION
Fixes #1272.

~~(This is a draft because there's an open discussion; see the "scrollable when long" screenshots and the CZO link there.)~~

The action sheet is offered in all four places mentioned in the issue:

> It should be reachable by long-pressing any of these:
> - A DM row in the Inbox
> - A recipient header in the message list
> - The area of the message-list app bar that identifies the narrow
> - The "Direct messages" (recent DMs) page

Self-DM:

| Light | Dark |
| --- | --- |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/c4e2cb10-8909-48ed-bee0-18344f17b25a" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/b93f9c2e-8000-47a6-8b83-2873576f135b" /> |

1:1 DM:

| Light | Dark |
| --- | --- |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/390a200d-d1ec-4346-8e2a-78af320990a7" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/49d489d0-fff3-4c8b-8422-a85ae8f43620" /> |

Group DM:

| Light | Dark |
| --- | --- |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/c26eeab2-0485-4ea6-9b27-c55324247c8f" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/b01a3593-8921-4162-b206-5167801f18c4" /> |

List of users in group DM, which is scrollable when long. We might still prefer a different page for this list (#1534); see [#mobile > abbreviated headings @ 💬](https://chat.zulip.org/#narrow/channel/48-mobile/topic/abbreviated.20headings/near/2366774):

| Light | Dark |
| --- | --- |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/ad42893c-ff4b-44d7-9818-9fb79235f510" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/0d60f2c5-29e2-4437-8957-6c419275014d" /> |