### PR TITLE
theme: Set app bar height to 42px

### DIFF
--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -198,6 +198,7 @@ class _LightboxPageLayoutState extends State<_LightboxPageLayout> {
         backgroundColor: appBarBackgroundColor,
         shape: const Border(), // Remove bottom border from [AppBarTheme]
         elevation: appBarElevation,
+        toolbarHeight: 56, 
         title: Row(children: [
           Avatar(
             size: 36,

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -99,9 +99,8 @@ ThemeData zulipThemeData(BuildContext context) {
         .merge(weightVariableTextStyle(context, wght: 600)),
       titleSpacing: 4,
 
-      // TODO Figma has height 42; we should try `toolbarHeight: 42` and test
-      //   that it looks reasonable with different system text-size settings.
-      //   Also the back button will look too big and need adjusting.
+      // Figma design specifies 42px instead of the Material default (56px).
+      toolbarHeight: 42,
 
       shape: Border(bottom: BorderSide(
         color: designVariables.borderBar,


### PR DESCRIPTION
Fixes #2106.
This sets the app bar `toolbarHeight` to 42px in `AppBarTheme` to match the Figma design.

The lightbox app bar is kept at 56px as mentioned in the issue.

AFTER
<img src="https://github.com/user-attachments/assets/1b5625da-a8f7-4a3c-aaa7-011a23eef6ad" height= 400/>
BEFORE
 <img src="https://github.com/user-attachments/assets/46674b60-eec6-4b4c-951e-8bbf757c739e"  height= 400/>

