### PR TITLE
message-list: Handle fetchInitial error with retry UI

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -329,6 +329,14 @@
   "@errorCouldNotFetchMessageSource": {
     "description": "Error message when the source of a message could not be fetched."
   },
+  "errorCouldNotLoadMessages": "Could not load messages.",
+  "@errorCouldNotLoadMessages": {
+    "description": "Error message when loading messages initially failed."
+  },
+  "tryAgainButton": "Try again",
+  "@tryAgainButton": {
+    "description": "Label for a button to retry a failed action."
+  },
   "errorCouldNotAccessUploadedFileTitle": "Could not access uploaded file",
   "@errorCouldNotAccessUploadedFileTitle": {
     "description": "Error title on failure in opening a file someone previously uploaded to Zulip"

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -605,6 +605,18 @@ abstract class ZulipLocalizations {
   /// **'Could not fetch message source.'**
   String get errorCouldNotFetchMessageSource;
 
+  /// Error message when loading messages initially failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load messages.'**
+  String get errorCouldNotLoadMessages;
+
+  /// Label for a button to retry a failed action.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get tryAgainButton;
+
   /// Error title on failure in opening a file someone previously uploaded to Zulip
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -287,6 +287,12 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'Konnte Nachrichtenquelle nicht abrufen.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Konnte nicht auf die hochgeladene Datei zugreifen';
 

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -289,6 +289,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Impossible de récupérer le message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Impossible d\'accéder au fichier téléversé';
 

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -287,6 +287,12 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
       'Impossibile recuperare l\'origine del messaggio.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -273,6 +273,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get errorCouldNotFetchMessageSource => 'メッセージのソースを取得できませんでした。';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'アップロードされたファイルにアクセスできませんでした';
 

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -289,6 +289,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Nie można uzyskać źródłowej wiadomości.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Brak dostępu do załadowanego pliku';
 

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -290,6 +290,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'Не удалось извлечь источник сообщения.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Не удалось получить доступ к загруженному файлу';
 

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -279,6 +279,12 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'Nepodarilo sa nahrať zdroj správy';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -287,6 +287,12 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
       'Ni bilo mogoče pridobiti vira sporočila.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Dostop do naložene datoteke ni mogoč';
 

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -288,6 +288,12 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
       'Не вдалося отримати джерело повідомлення.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Не вдалося отримати доступ до завантаженого файлу';
 

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -278,6 +278,12 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
       'Could not fetch message source.';
 
   @override
+  String get errorCouldNotLoadMessages => 'Could not load messages.';
+
+  @override
+  String get tryAgainButton => 'Try again';
+
+  @override
   String get errorCouldNotAccessUploadedFileTitle =>
       'Could not access uploaded file';
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1063,6 +1063,13 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
 
   @override
   Widget build(BuildContext context) {
+    if (model.fetchInitialError != null) {
+      return _FetchInitialErrorWidget(
+        error: model.fetchInitialError!,
+        onRetry: model.retryFetchInitial,
+      );
+    }
+
     if (!model.fetched) return const Center(child: CircularProgressIndicator());
 
     if (model.items.isEmpty && model.haveNewest && model.haveOldest) {
@@ -2591,5 +2598,44 @@ class _RestoreOutboxMessageGestureDetector extends StatelessWidget {
         composeBoxState.restoreMessageNotSent(localMessageId);
       },
       child: child);
+  }
+}
+
+/// Widget shown when the initial message fetch fails.
+class _FetchInitialErrorWidget extends StatelessWidget {
+  const _FetchInitialErrorWidget({
+    required this.error,
+    required this.onRetry,
+  });
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final designVariables = DesignVariables.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: designVariables.icon),
+            const SizedBox(height: 16),
+            Text(
+              zulipLocalizations.errorCouldNotLoadMessages,
+              style: const TextStyle(fontSize: 16),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: Text(zulipLocalizations.tryAgainButton),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
When the initial batch of messages fails to load (e.g., network error), the app currently shows an infinite loading spinner. This PR adds proper error handling to show an error message with a Try again button instead.

Manually tested by:
  1. Turning off network
  2. Navigating to a channel
  3. Verifying error UI appears after request times out
  4. Turning network back on
  5. Tapping "Try again" - messages load successfully
Fixes: #2085


<video src="https://github.com/user-attachments/assets/74794bd8-d63e-4110-880f-bd8686392441"/>

