### PR TITLE
content: Add `GroupMention` to render user group mentions dynamically

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1097,7 +1097,7 @@ class UserMentionNode extends MentionNode {
 
   /// The ID of the user being mentioned.
   ///
-  /// This is null for wildcard mentions, user group mentions,
+  /// This is null for wildcard mentions
   /// or when the user ID is unavailable in the HTML (e.g., legacy mentions).
   final int? userId;
 
@@ -1105,6 +1105,27 @@ class UserMentionNode extends MentionNode {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(IntProperty('userId', userId));
+  }
+}
+
+class UserGroupMentionNode extends MentionNode {
+  const UserGroupMentionNode({
+    super.debugHtmlNode,
+    required super.nodes,
+    required super.isSilent,
+    required this.userGroupId,
+  });
+
+  /// The ID of the user group being mentioned.
+  ///
+  /// This is non-nullable because user group mentions
+  /// always have data-user-group-id.
+  final int userGroupId;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IntProperty('userGroupId', userGroupId));
   }
 }
 
@@ -1325,15 +1346,16 @@ class _ZulipInlineContentParser {
       i++;
     }
 
+    String? mentionType;
     if (i >= classes.length) return null;
     if ((classes[i] == 'topic-mention' && !hasChannelWildcardClass)
         || classes[i] == 'user-mention'
         || (classes[i] == 'user-group-mention' && !hasChannelWildcardClass)) {
       // The class we already knew we'd find before we called this function.
-      // We ignore the distinction between these; see [UserMentionNode].
-      // Also, we don't expect "user-group-mention" and "channel-wildcard-mention"
+      // We don't expect "user-group-mention" and "channel-wildcard-mention"
       // to be in the list at the same time and neither we expect "topic-mention"
       // and "channel-wildcard-mention" to be in the list at the same time.
+      mentionType = classes[i];
       i++;
     }
 
@@ -1342,21 +1364,35 @@ class _ZulipInlineContentParser {
       return null;
     }
 
-    final userId = switch (element.attributes['data-user-id']) {
-      // For legacy, user group or wildcard mentions.
-      null || '*' => null,
-      final userIdString => int.tryParse(userIdString, radix: 10),
-    };
-
     // TODO assert MentionNode can't contain LinkNode;
     //   either a debug-mode check, or perhaps we can make expectations much
     //   tighter on a MentionNode's contents overall.
     final nodes = parseInlineContentList(element.nodes);
-    return UserMentionNode(
-      nodes: nodes,
-      userId: userId,
-      isSilent: isSilent,
-      debugHtmlNode: debugHtmlNode);
+
+    if (mentionType case 'user-group-mention') {
+      final userGroupId = int.tryParse(
+        element.attributes['data-user-group-id'] ?? '',
+        radix: 10);
+      if (userGroupId == null) {
+        return null;
+      }
+      return UserGroupMentionNode(
+        nodes: nodes,
+        isSilent: isSilent,
+        userGroupId: userGroupId,
+        debugHtmlNode: debugHtmlNode);
+    } else {
+      final userId = switch (element.attributes['data-user-id']) {
+        // For legacy or wildcard mentions.
+        null || '*' => null,
+        final userIdString => int.tryParse(userIdString, radix: 10),
+      };
+      return UserMentionNode(
+        nodes: nodes,
+        isSilent: isSilent,
+        userId: userId,
+        debugHtmlNode: debugHtmlNode);
+    }
   }
 
   /// The links found so far in the current block inline container.

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1338,7 +1338,7 @@ class _ZulipInlineContentParser {
     final userId = switch (element.attributes['data-user-id']) {
       // For legacy, user group or wildcard mentions.
       null || '*' => null,
-      final userIdString => int.tryParse(userIdString),
+      final userIdString => int.tryParse(userIdString, radix: 10),
     };
 
     // TODO assert UserMentionNode can't contain LinkNode;

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1071,14 +1071,28 @@ class LinkNode extends InlineContainerNode {
   }
 }
 
-enum UserMentionType { user, userGroup }
+sealed class MentionNode extends InlineContainerNode {
+  const MentionNode({
+    super.debugHtmlNode,
+    required super.nodes,
+    required this.isSilent,
+  });
 
-class UserMentionNode extends InlineContainerNode {
+  final bool isSilent; // TODO(#647)
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('isSilent', value: isSilent, ifTrue: "is silent"));
+  }
+}
+
+class UserMentionNode extends MentionNode {
   const UserMentionNode({
     super.debugHtmlNode,
     required super.nodes,
+    required super.isSilent,
     required this.userId,
-    required this.isSilent,
   });
 
   /// The ID of the user being mentioned.
@@ -1087,21 +1101,14 @@ class UserMentionNode extends InlineContainerNode {
   /// or when the user ID is unavailable in the HTML (e.g., legacy mentions).
   final int? userId;
 
-  final bool isSilent; // TODO(#647)
-
-  // For the legacy design, we don't need this information in code; instead,
-  // the inner text already shows how to communicate it to the user
-  // and we show that text in the same style for all types of @-mention.
-  // We'll need these for implementing the post-2023 Zulip design, though.
-  //   final UserMentionType mentionType; // TODO(#646)
-
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(IntProperty('userId', userId));
-    properties.add(FlagProperty('isSilent', value: isSilent, ifTrue: "is silent"));
   }
 }
+
+// TODO(#646) add WildcardMentionNode
 
 sealed class EmojiNode extends InlineContentNode {
   const EmojiNode({super.debugHtmlNode});
@@ -1292,7 +1299,7 @@ class _ZulipInlineContentParser {
       debugSoftFailReason: kDebugMode ? parsed.softFailReason : null);
   }
 
-  UserMentionNode? parseUserMention(dom.Element element) {
+  MentionNode? parseMention(dom.Element element) {
     assert(element.localName == 'span');
     final debugHtmlNode = kDebugMode ? element : null;
 
@@ -1341,9 +1348,9 @@ class _ZulipInlineContentParser {
       final userIdString => int.tryParse(userIdString, radix: 10),
     };
 
-    // TODO assert UserMentionNode can't contain LinkNode;
+    // TODO assert MentionNode can't contain LinkNode;
     //   either a debug-mode check, or perhaps we can make expectations much
-    //   tighter on a UserMentionNode's contents overall.
+    //   tighter on a MentionNode's contents overall.
     final nodes = parseInlineContentList(element.nodes);
     return UserMentionNode(
       nodes: nodes,
@@ -1364,11 +1371,11 @@ class _ZulipInlineContentParser {
     return result;
   }
 
-  /// Matches all className values that could be a UserMentionNode,
+  /// Matches all className values that could be a subclass of MentionNode,
   /// and no className values that could be any other type of node.
   // Specifically, checks for `user-mention` or `user-group-mention`
   // or `topic-mention` as a member of the list.
-  static final _userMentionClassNameRegexp = RegExp(
+  static final _mentionClassNameRegexp = RegExp(
     r"(^| )" r"(?:user(?:-group)?|topic)-mention" r"( |$)");
 
   static final _emojiClassNameRegexp = () {
@@ -1422,8 +1429,8 @@ class _ZulipInlineContentParser {
     }
 
     if (localName == 'span'
-        && _userMentionClassNameRegexp.hasMatch(className)) {
-      return parseUserMention(element) ?? unimplemented();
+        && _mentionClassNameRegexp.hasMatch(className)) {
+      return parseMention(element) ?? unimplemented();
     }
 
     if (localName == 'span'

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1217,8 +1217,7 @@ class UserMention extends StatelessWidget {
         linkRecognizers: null,
 
         // TODO(#647) when self-user is non-silently mentioned, make bold, and:
-        // TODO(#646) when self-user is non-silently mentioned,
-        //   distinguish font color between direct and wildcard mentions
+        // TODO(#646) distinguish font color between direct and wildcard mentions
         style: ambientTextStyle,
 
         nodes: nodes));

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1096,7 +1096,7 @@ class _InlineContentBuilder {
       case InlineCodeNode():
         return _buildInlineCode(node);
 
-      case UserMentionNode():
+      case MentionNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
           child: UserMention(ambientTextStyle: widget.style, node: node));
 
@@ -1190,14 +1190,14 @@ class UserMention extends StatelessWidget {
   });
 
   final TextStyle ambientTextStyle;
-  final UserMentionNode node;
+  final MentionNode node;
 
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     final contentTheme = ContentTheme.of(context);
     var nodes = node.nodes;
-    if (node.userId case final userId?) {
+    if (node case UserMentionNode(:final userId?)) {
       final user = store.getUser(userId);
       if (user case User(:final fullName)) {
         nodes = [TextNode(node.isSilent ? fullName : '@$fullName')];
@@ -1213,7 +1213,7 @@ class UserMention extends StatelessWidget {
         // If an @-mention is inside a link, let the @-mention override it.
         recognizer: null,  // TODO(#1867) make @-mentions tappable, for info on user
         // One hopes an @-mention can't contain an embedded link.
-        // (The parser on creating a UserMentionNode has a TODO to check that.)
+        // (The parser on creating a MentionNode has a TODO to check that.)
         linkRecognizers: null,
 
         // TODO(#647) when self-user is non-silently mentioned, make bold, and:

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1196,13 +1196,23 @@ class Mention extends StatelessWidget {
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     final contentTheme = ContentTheme.of(context);
+
     var nodes = node.nodes;
-    if (node case UserMentionNode(:final userId?)) {
-      final user = store.getUser(userId);
-      if (user case User(:final fullName)) {
-        nodes = [TextNode(node.isSilent ? fullName : '@$fullName')];
-      }
+    switch (node) {
+      case UserGroupMentionNode(:final userGroupId):
+        final userGroup = store.getGroup(userGroupId);
+        if (userGroup case UserGroup(:final name)) {
+          // TODO(#1260) Get display name for system groups using localization
+          nodes = [TextNode(node.isSilent ? name : '@$name')];
+        }
+      case UserMentionNode(:final userId?):
+        final user = store.getUser(userId);
+        if (user case User(:final fullName)) {
+          nodes = [TextNode(node.isSilent ? fullName : '@$fullName')];
+        }
+      case UserMentionNode(userId: null):
     }
+
     return Container(
       decoration: BoxDecoration(
         // TODO(#646) different for wildcard mentions

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1098,7 +1098,7 @@ class _InlineContentBuilder {
 
       case MentionNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
-          child: UserMention(ambientTextStyle: widget.style, node: node));
+          child: Mention(ambientTextStyle: widget.style, node: node));
 
       case UnicodeEmojiNode():
         return TextSpan(text: node.emojiUnicode, recognizer: _recognizer,
@@ -1182,8 +1182,8 @@ class _InlineContentBuilder {
 
 const kInlineCodeFontSizeFactor = 0.825;
 
-class UserMention extends StatelessWidget {
-  const UserMention({
+class Mention extends StatelessWidget {
+  const Mention({
     super.key,
     required this.ambientTextStyle,
     required this.node,

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -132,21 +132,21 @@ class ContentExample {
     "@*test-empty*",
     expectedText: '@test-empty',
     '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('@test-empty')], isSilent: false, userId: null));
+    const UserGroupMentionNode(nodes: [TextNode('@test-empty')], isSilent: false, userGroupId: 186));
 
   static final groupMentionSilent = ContentExample.inline(
     'silent group @-mention',
     "@_*test-empty*",
     expectedText: 'test-empty',
     '<p><span class="user-group-mention silent" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')], isSilent: true, userId: null));
+    const UserGroupMentionNode(nodes: [TextNode('test-empty')], isSilent: true, userGroupId: 186));
 
   static final groupMentionSilentClassOrderReversed = ContentExample.inline(
     'silent group @-mention, class order reversed',
     "@_*test-empty*", // (hypothetical server variation)
     expectedText: 'test-empty',
     '<p><span class="silent user-group-mention" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')], isSilent: true, userId: null));
+    const UserGroupMentionNode(nodes: [TextNode('test-empty')], isSilent: true, userGroupId: 186));
 
   static final channelWildcardMentionPlain = ContentExample.inline(
     'plain channel wildcard @-mention',

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -111,105 +111,105 @@ class ContentExample {
     "@**Greg Price**",
     expectedText: '@Greg Price',
     '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('@Greg Price')], userId: 2187, isSilent: false));
+    const UserMentionNode(nodes: [TextNode('@Greg Price')], isSilent: false, userId: 2187));
 
   static final userMentionSilent = ContentExample.inline(
     'silent user @-mention',
     "@_**Greg Price**",
     expectedText: 'Greg Price',
     '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('Greg Price')], isSilent: true, userId: 2187));
 
   static final userMentionSilentClassOrderReversed = ContentExample.inline(
     'silent user @-mention, class order reversed',
     "@_**Greg Price**", // (hypothetical server variation)
     expectedText: 'Greg Price',
     '<p><span class="silent user-mention" data-user-id="2187">Greg Price</span></p>',
-    const UserMentionNode(nodes: [TextNode('Greg Price')], userId: 2187, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('Greg Price')], isSilent: true, userId: 2187));
 
   static final groupMentionPlain = ContentExample.inline(
     'plain group @-mention',
     "@*test-empty*",
     expectedText: '@test-empty',
     '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('@test-empty')], userId: null, isSilent: false));
+    const UserMentionNode(nodes: [TextNode('@test-empty')], isSilent: false, userId: null));
 
   static final groupMentionSilent = ContentExample.inline(
     'silent group @-mention',
     "@_*test-empty*",
     expectedText: 'test-empty',
     '<p><span class="user-group-mention silent" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('test-empty')], isSilent: true, userId: null));
 
   static final groupMentionSilentClassOrderReversed = ContentExample.inline(
     'silent group @-mention, class order reversed',
     "@_*test-empty*", // (hypothetical server variation)
     expectedText: 'test-empty',
     '<p><span class="silent user-group-mention" data-user-group-id="186">test-empty</span></p>',
-    const UserMentionNode(nodes: [TextNode('test-empty')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('test-empty')], isSilent: true, userId: null));
 
   static final channelWildcardMentionPlain = ContentExample.inline(
     'plain channel wildcard @-mention',
     "@**all**",
     expectedText: '@all',
     '<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span></p>',
-    const UserMentionNode(nodes: [TextNode('@all')], userId: null, isSilent: false));
+    const UserMentionNode(nodes: [TextNode('@all')], isSilent: false, userId: null));
 
   static final channelWildcardMentionSilent = ContentExample.inline(
     'silent channel wildcard @-mention',
     "@_**everyone**",
     expectedText: 'everyone',
     '<p><span class="user-mention channel-wildcard-mention silent" data-user-id="*">everyone</span></p>',
-    const UserMentionNode(nodes: [TextNode('everyone')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('everyone')], isSilent: true, userId: null));
 
   static final channelWildcardMentionSilentClassOrderReversed = ContentExample.inline(
     'silent channel wildcard @-mention, class order reversed',
     "@_**channel**", // (hypothetical server variation)
     expectedText: 'channel',
     '<p><span class="silent user-mention channel-wildcard-mention" data-user-id="*">channel</span></p>',
-    const UserMentionNode(nodes: [TextNode('channel')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('channel')], isSilent: true, userId: null));
 
   static final legacyChannelWildcardMentionPlain = ContentExample.inline(
     'legacy plain channel wildcard @-mention',
     "@**channel**",
     expectedText: '@channel',
     '<p><span class="user-mention" data-user-id="*">@channel</span></p>',
-    const UserMentionNode(nodes: [TextNode('@channel')], userId: null, isSilent: false));
+    const UserMentionNode(nodes: [TextNode('@channel')], isSilent: false, userId: null));
 
   static final legacyChannelWildcardMentionSilent = ContentExample.inline(
     'legacy silent channel wildcard @-mention',
     "@_**stream**",
     expectedText: 'stream',
     '<p><span class="user-mention silent" data-user-id="*">stream</span></p>',
-    const UserMentionNode(nodes: [TextNode('stream')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('stream')], isSilent: true, userId: null));
 
   static final legacyChannelWildcardMentionSilentClassOrderReversed = ContentExample.inline(
     'legacy silent channel wildcard @-mention, class order reversed',
     "@_**all**", // (hypothetical server variation)
     expectedText: 'all',
     '<p><span class="silent user-mention" data-user-id="*">all</span></p>',
-    const UserMentionNode(nodes: [TextNode('all')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('all')], isSilent: true, userId: null));
 
   static final topicMentionPlain = ContentExample.inline(
     'plain @-topic',
     "@**topic**",
     expectedText: '@topic',
     '<p><span class="topic-mention">@topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('@topic')], userId: null, isSilent: false));
+    const UserMentionNode(nodes: [TextNode('@topic')], isSilent: false, userId: null));
 
   static final topicMentionSilent = ContentExample.inline(
     'silent @-topic',
     "@_**topic**",
     expectedText: 'topic',
     '<p><span class="topic-mention silent">topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('topic')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('topic')], isSilent: true, userId: null));
 
   static final topicMentionSilentClassOrderReversed = ContentExample.inline(
     'silent @-topic, class order reversed',
     "@_**topic**", // (hypothetical server variation)
     expectedText: 'topic',
     '<p><span class="silent topic-mention">topic</span></p>',
-    const UserMentionNode(nodes: [TextNode('topic')], userId: null, isSilent: true));
+    const UserMentionNode(nodes: [TextNode('topic')], isSilent: true, userId: null));
 
   static final emojiUnicode = ContentExample.inline(
     'Unicode emoji, encoded in span element',

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -1429,7 +1429,7 @@ void main() {
         checkSenderAndTimestampShown(tester, senderId: message.senderId);
         check(find.descendant(
           of: find.byType(BottomSheet),
-          matching: find.byType(UserMention))
+          matching: find.byType(Mention))
         ).findsOne();
       });
 
@@ -1452,7 +1452,7 @@ void main() {
         checkSenderAndTimestampShown(tester, senderId: message.senderId);
         check(find.descendant(
           of: find.byType(BottomSheet),
-          matching: find.byType(UserMention))
+          matching: find.byType(Mention))
         ).findsOne();
       });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -980,7 +980,7 @@ void main() {
     });
   });
 
-  group('UserMention', () {
+  group('Mention', () {
     testContentSmoke(ContentExample.userMentionPlain,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.userMentionSilent,
@@ -1008,10 +1008,10 @@ void main() {
     testContentSmoke(ContentExample.topicMentionSilentClassOrderReversed,
       wrapWithPerAccountStoreWidget: true);
 
-    UserMention? findUserMentionInSpan(InlineSpan rootSpan) {
-      UserMention? result;
+    Mention? findMentionInSpan(InlineSpan rootSpan) {
+      Mention? result;
       rootSpan.visitChildren((span) {
-        if (span case (WidgetSpan(child: UserMention() && var widget))) {
+        if (span case (WidgetSpan(child: Mention() && var widget))) {
           result = widget;
           return false;
         }
@@ -1020,7 +1020,7 @@ void main() {
       return result;
     }
 
-    TextStyle textStyleFromWidget(WidgetTester tester, UserMention widget, String mentionText) {
+    TextStyle textStyleFromWidget(WidgetTester tester, Mention widget, String mentionText) {
       return mergedStyleOf(tester,
         findAncestor: find.byWidget(widget), mentionText)!;
     }
@@ -1030,7 +1030,7 @@ void main() {
         targetHtml: '<span class="user-mention" data-user-id="13313">@Chris Bobbe</span>',
         wrapWithPerAccountStoreWidget: true,
         targetFontSizeFinder: (rootSpan) {
-          final widget = findUserMentionInSpan(rootSpan);
+          final widget = findMentionInSpan(rootSpan);
           final style = textStyleFromWidget(tester, widget!, '@Chris Bobbe');
           return style.fontSize!;
         });
@@ -1044,7 +1044,7 @@ void main() {
       wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
-          tester.widget(find.byType(UserMention)), 'Greg Price');
+          tester.widget(find.byType(Mention)), 'Greg Price');
       });
 
     // TODO(#647):
@@ -1059,14 +1059,14 @@ void main() {
       wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
-          tester.widget(find.byType(UserMention)), 'Chris Bobbe');
+          tester.widget(find.byType(Mention)), 'Chris Bobbe');
       });
 
     // TODO(#647):
     //  testFontWeight('non-silent self-user mention in bold context',
     //    expectedWght: 800, // [etc.]
 
-    group('dynamic name resolution', () {
+    group('user mention dynamic name resolution', () {
       Future<void> prepare({
         required WidgetTester tester,
         required String html,


### PR DESCRIPTION
Fixes #1259.

| Before | After |
|--------|-------|
|![old_light](https://github.com/user-attachments/assets/89a437f3-07a1-4ed9-a7c0-0050abe17dc6)|![new_light](https://github.com/user-attachments/assets/2b86c2da-118a-4ae0-85d9-85dc935e6821)|
|![old_dark](https://github.com/user-attachments/assets/0e4ad22f-5767-4cb5-97bc-cbbb26faacb5)|![new_dark](https://github.com/user-attachments/assets/da4991f0-f190-41eb-be67-830ea0604b6c)|

Changes Made:

1. Added sealed class 'MentionNode' and refactored variables, cleaned comments accordingly.
2. Added 'GroupMentionNode' class
3. Added 'GroupMention' Widget. Created this separate widget instead of keeping the singular UserMention widget to introduce changes in the future (#646 will introduce separate styling, maybe in the future, user group mentions might become tappable, etc.). It is also in line with the sealed class implementation.
4. Updated and added tests

Doubts:

1. Between the 2nd and 3rd commits, I have made a temporary implementation of GroupMentionNode case and added a TODO comment in the content widget file to separate the commits. Is this practice correct?
2. In 1st commit, I have fixed one old comment (description of TODO issue 646) in the content widget file. Is that the way to change old comments that might be incorrect?