### PR TITLE
Add handling for `topic_wildcard-mentioned` and `stream_wildcard_mentioned` flags

### DIFF
--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -779,6 +779,8 @@ const _$MessageFlagEnumMap = {
   MessageFlag.starred: 'starred',
   MessageFlag.collapsed: 'collapsed',
   MessageFlag.mentioned: 'mentioned',
+  MessageFlag.topicWildcardMentioned: 'topic_wildcard_mentioned',
+  MessageFlag.streamWildcardMentioned: 'stream_wildcard_mentioned',
   MessageFlag.wildcardMentioned: 'wildcard_mentioned',
   MessageFlag.hasAlertWord: 'has_alert_word',
   MessageFlag.historical: 'historical',

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1236,7 +1236,9 @@ enum MessageFlag {
   starred,
   collapsed,
   mentioned,
-  wildcardMentioned,
+  topicWildcardMentioned,
+  streamWildcardMentioned,
+  wildcardMentioned, // TODO(server-8) Remove deprecated flag.
   hasAlertWord,
   historical,
   unknown;
@@ -1246,7 +1248,7 @@ enum MessageFlag {
   /// Will be [MessageFlag.unknown] if we don't recognize the string.
   ///
   /// Example:
-  ///   'wildcard_mentioned' -> Flag.wildcardMentioned
+  ///   'topic_wildcard_mentioned' -> Flag.topicWildcardMentioned
   static MessageFlag fromRawString(String raw) => _byRawString[raw] ?? unknown;
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.snake`
@@ -1257,6 +1259,8 @@ enum MessageFlag {
   bool get isMentionFlag {
     switch (this) {
       case MessageFlag.mentioned:
+      case MessageFlag.topicWildcardMentioned:
+      case MessageFlag.streamWildcardMentioned:
       case MessageFlag.wildcardMentioned:
         return true;
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1253,6 +1253,22 @@ enum MessageFlag {
   static final _byRawString = _$MessageFlagEnumMap.map((key, value) => MapEntry(value, key));
 
   String toJson() => _$MessageFlagEnumMap[this]!;
+
+  bool get isMentionFlag {
+    switch (this) {
+      case MessageFlag.mentioned:
+      case MessageFlag.wildcardMentioned:
+        return true;
+
+      case MessageFlag.read:
+      case MessageFlag.starred:
+      case MessageFlag.collapsed:
+      case MessageFlag.hasAlertWord:
+      case MessageFlag.historical:
+      case MessageFlag.unknown:
+        return false;
+    }
+  }
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -581,6 +581,8 @@ const _$MessageFlagEnumMap = {
   MessageFlag.starred: 'starred',
   MessageFlag.collapsed: 'collapsed',
   MessageFlag.mentioned: 'mentioned',
+  MessageFlag.topicWildcardMentioned: 'topic_wildcard_mentioned',
+  MessageFlag.streamWildcardMentioned: 'stream_wildcard_mentioned',
   MessageFlag.wildcardMentioned: 'wildcard_mentioned',
   MessageFlag.hasAlertWord: 'has_alert_word',
   MessageFlag.historical: 'historical',

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -325,21 +325,7 @@ class MentionsNarrow extends Narrow {
   @override
   bool containsMessage(MessageBase message) {
     if (message is! Message) return false;
-    return message.flags.any((flag) {
-      switch (flag) {
-        case MessageFlag.mentioned:
-        case MessageFlag.wildcardMentioned:
-          return true;
-
-        case MessageFlag.read:
-        case MessageFlag.starred:
-        case MessageFlag.collapsed:
-        case MessageFlag.hasAlertWord:
-        case MessageFlag.historical:
-        case MessageFlag.unknown:
-          return false;
-      }
-    });
+    return message.flags.any((flag) => flag.isMentionFlag);
   }
 
   @override

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -308,10 +308,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
         locatorMap[event.message.id] = narrow;
         _addLastInDm(message.id, narrow);
     }
-    if (
-      message.flags.contains(MessageFlag.mentioned)
-      || message.flags.contains(MessageFlag.wildcardMentioned)
-    ) {
+    if (message.flags.any((flag) => flag.isMentionFlag)) {
       mentions.add(message.id);
     }
     notifyListeners();
@@ -324,9 +321,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
     // [messageId] message when its content is edited; so, handle that.
     // (As of writing, we don't expect such changes to be signaled by
     // an [UpdateMessageFlagsEvent].)
-    final bool isMentioned = event.flags.any(
-      (f) => f == MessageFlag.mentioned || f == MessageFlag.wildcardMentioned,
-    );
+    final bool isMentioned = event.flags.any((flag) => flag.isMentionFlag);
 
     // We expect the event's 'read' flag to be boring,
     // matching the message's local unread state.

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -440,6 +440,8 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
         return;
 
       case MessageFlag.mentioned:
+      case MessageFlag.topicWildcardMentioned:
+      case MessageFlag.streamWildcardMentioned:
       case MessageFlag.wildcardMentioned:
         // Empirically, we don't seem to get these events when a message is edited
         // to add/remove an @-mention, even though @-mention state is represented

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1177,8 +1177,7 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
     flag: flag,
     messages: messages.map((m) => m.id).toList(),
     messageDetails: Map.fromEntries(messages.map((message) {
-      final mentioned = message.flags.contains(MessageFlag.mentioned)
-        || message.flags.contains(MessageFlag.wildcardMentioned);
+      final mentioned = message.flags.any((flag) => flag.isMentionFlag);
       return MapEntry(
         message.id,
         switch (message) {

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -2432,28 +2432,32 @@ void main() {
 
       List<Message> getMessages(int startingId) => [
         eg.streamMessage(id: startingId,
-          stream: stream, topic: mutedTopic, flags: [MessageFlag.wildcardMentioned]),
+          stream: stream, topic: mutedTopic, flags: [MessageFlag.topicWildcardMentioned]),
         eg.streamMessage(id: startingId + 1,
+          stream: stream, topic: mutedTopic, flags: [MessageFlag.streamWildcardMentioned]),
+        eg.streamMessage(id: startingId + 2,
+          stream: stream, topic: mutedTopic, flags: [MessageFlag.wildcardMentioned]),
+        eg.streamMessage(id: startingId + 3,
           stream: stream, topic: mutedTopic, flags: [MessageFlag.mentioned]),
-        eg.dmMessage(id: startingId + 2,
+        eg.dmMessage(id: startingId + 4,
           from: eg.otherUser, to: [eg.selfUser], flags: [MessageFlag.mentioned]),
       ];
 
       // Check filtering on fetchInitial…
       await prepareMessages(foundOldest: false, messages: getMessages(201));
       final expected = <int>[];
-      checkHasMessageIds(expected..addAll([201, 202, 203]));
+      checkHasMessageIds(expected..addAll([201, 202, 203, 204, 205]));
 
       // … and on fetchOlder…
       connection.prepare(json: olderResult(
         anchor: 201, foundOldest: true, messages: getMessages(101)).toJson());
       await model.fetchOlder();
       checkNotified(count: 2);
-      checkHasMessageIds(expected..insertAll(0, [101, 102, 103]));
+      checkHasMessageIds(expected..insertAll(0, [101, 102, 103, 104, 105]));
 
       // … and on MessageEvent.
       final messages = getMessages(301);
-      for (var i = 0; i < 3; i += 1) {
+      for (var i = 0; i < messages.length; i += 1) {
         await store.addMessage(messages[i]);
         checkNotifiedOnce();
         checkHasMessageIds(expected..add(301 + i));

--- a/test/model/narrow_test.dart
+++ b/test/model/narrow_test.dart
@@ -223,6 +223,10 @@ void main() {
       check(narrow.containsMessage(
         eg.streamMessage(flags:[MessageFlag.mentioned]))).isTrue();
       check(narrow.containsMessage(
+        eg.streamMessage(flags: [MessageFlag.topicWildcardMentioned]))).isTrue();
+      check(narrow.containsMessage(
+        eg.streamMessage(flags: [MessageFlag.streamWildcardMentioned]))).isTrue();
+      check(narrow.containsMessage(
         eg.streamMessage(flags: [MessageFlag.wildcardMentioned]))).isTrue();
 
       check(narrow.containsMessage(

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -387,24 +387,12 @@ void main() {
   });
 
   group('handleMessageEvent', () {
-    for (final (isUnread, isStream, isDirectMentioned, isWildcardMentioned) in [
-      (true,  true,  true,  true ),
-      (true,  true,  true,  false),
-      (true,  true,  false, true ),
-      (true,  true,  false, false),
-      (true,  false, true,  true ),
-      (true,  false, true,  false),
-      (true,  false, false, true ),
-      (true,  false, false, false),
-      (false, true,  true,  true ),
-      (false, true,  true,  false),
-      (false, true,  false, true ),
-      (false, true,  false, false),
-      (false, false, true,  true ),
-      (false, false, true,  false),
-      (false, false, false, true ),
-      (false, false, false, false),
-    ]) {
+    void testFlagCombination(
+      bool isUnread,
+      bool isStream,
+      bool isDirectMentioned,
+      bool isWildcardMentioned,
+    ) {
       final description = [
         isUnread ? 'unread' : 'read',
         isStream ? 'stream' : 'dm',
@@ -427,6 +415,20 @@ void main() {
         }
         checkMatchesMessages([message]);
       });
+    }
+
+    for (final isUnread in [true, false]) {
+      for (final isStream in [true, false]) {
+        for (final isDirectMentioned in [true, false]) {
+          for (final isWildcardMentioned in [true, false]) {
+            testFlagCombination(
+              isUnread,
+              isStream,
+              isDirectMentioned,
+              isWildcardMentioned);
+          }
+        }
+      }
     }
 
     group('stream messages', () {

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -98,10 +98,7 @@ void main() {
           final messageIds = expectedDms[narrow] ??= QueueList();
           messageIds.add(message.id);
       }
-      if (
-        message.flags.contains(MessageFlag.mentioned)
-        || message.flags.contains(MessageFlag.wildcardMentioned)
-      ) {
+      if (message.flags.any((flag) => flag.isMentionFlag)) {
         expectedMentions.add(message.id);
       }
     }
@@ -573,9 +570,8 @@ void main() {
                 if (
                   isRead
                   || (
-                    // TODO make less verbose
-                    (message.flags.contains(MessageFlag.mentioned) || message.flags.contains(MessageFlag.wildcardMentioned))
-                      == (newFlags.contains(MessageFlag.mentioned) || newFlags.contains(MessageFlag.wildcardMentioned))
+                    (message.flags.any((flag) => flag.isMentionFlag))
+                      == (newFlags.any((flag) => flag.isMentionFlag))
                   )
                 ) {
                   checkNotNotified();


### PR DESCRIPTION
Fixes #894.

Questions:
1. Regarding the fallbacks, should I code explicit fallbacks for each and every instance of the deprecated flag 'wildcardMentioned'? Currently, removing the code involving the 'wildcardMentioned' flag is not difficult, so I don't think adding explicit fallbacks is worth it.
2. Should I add the "TODO(server-8)" comment near every instance of the 'wildcardMentioned' flag? Currently, it is only present near where the flag is defined in the 'MessageFlagEnum'.