### PR TITLE
Fix inconsistent channel icon size and spacing in channel feed and topic list

### DIFF
--- a/lib/widgets/icons.dart
+++ b/lib/widgets/icons.dart
@@ -239,3 +239,26 @@ IconData? iconDataForTopicVisibilityPolicy(UserTopicVisibilityPolicy policy) {
       return null;
   }
 }
+
+/// An icon representing a Zulip stream.
+class StreamIcon extends StatelessWidget {
+  const StreamIcon({
+    super.key,
+    required this.stream,
+    this.size = 18,
+    this.color,
+  });
+
+  final ZulipStream? stream;
+  final double size;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      stream != null ? iconDataForStream(stream!) : null,
+      size: size,
+      color: color,
+    );
+  }
+}

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -567,14 +567,9 @@ class MessageListAppBarTitle extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    // A null [Icon.icon] makes a blank space.
-    IconData? icon;
-    Color? iconColor;
-    if (stream != null) {
-      icon = iconDataForStream(stream);
-      iconColor = colorSwatchFor(context, store.subscriptions[stream.streamId])
-        .iconOnBarBackground;
-    }
+    final swatch = stream != null
+      ? colorSwatchFor(context, store.subscriptions[stream.streamId])
+      : null;
 
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -583,8 +578,8 @@ class MessageListAppBarTitle extends StatelessWidget {
       //     https://github.com/zulip/zulip-flutter/pull/219#discussion_r1281024746
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Icon(size: 16, color: iconColor, icon),
-        const SizedBox(width: 4),
+        StreamIcon(stream: stream, size: 18, color: swatch?.iconOnBarBackground),
+        const SizedBox(width: 5),
         Flexible(child: Text(
           stream?.name ?? zulipLocalizations.unknownChannelName)),
       ]);

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -71,11 +71,8 @@ class _TopicListAppBarTitle extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
     final store = PerAccountStoreWidget.of(context);
     final stream = store.streams[streamId];
-    final channelIconColor = colorSwatchFor(context,
-      store.subscriptions[streamId]).iconOnBarBackground;
+    final swatch = colorSwatchFor(context, store.subscriptions[streamId]);
 
-    // A null [Icon.icon] makes a blank space.
-    final icon = stream != null ? iconDataForStream(stream) : null;
     return Row(
       mainAxisSize: MainAxisSize.min,
       // TODO(design): The vertical alignment of the stream privacy icon is a bit ad hoc.
@@ -83,8 +80,8 @@ class _TopicListAppBarTitle extends StatelessWidget {
       //     https://github.com/zulip/zulip-flutter/pull/219#discussion_r1281024746
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Padding(padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 6),
-          child: Icon(size: 18, icon, color: channelIconColor)),
+        StreamIcon(stream: stream, size: 18, color: swatch.iconOnBarBackground),
+        const SizedBox(width: 5),
         Flexible(child: Text(
           stream?.name ?? zulipLocalizations.unknownChannelName,
           style: TextStyle(


### PR DESCRIPTION
Fixes #2107

Use a shared StreamIcon widget to ensure consistent rendering of
channel/topic icons across the channel feed and topic list pages.

This change:
- Introduces a reusable StreamIcon widget
- Removes duplicate icon rendering
- Normalizes spacing to 5px between icon and stream name
- Keeps the diff minimal and localized to the relevant widgets
