### PR TITLE
notif: On Android, use org name instead of URL as notif group summary

### DIFF
--- a/lib/api/notifications.dart
+++ b/lib/api/notifications.dart
@@ -67,6 +67,9 @@ sealed class FcmMessageWithIdentity extends FcmMessage {
   @JsonKey(readValue: _readRealmUrl) // TODO(server-9)
   final Uri realmUrl;
 
+  /// The realm's name.
+  final String? realmName; // TODO(server-8)
+
   /// This user's ID within the server.
   ///
   /// Useful mainly in the case where the user has multiple accounts in the
@@ -76,6 +79,7 @@ sealed class FcmMessageWithIdentity extends FcmMessage {
 
   FcmMessageWithIdentity({
     required this.realmUrl,
+    required this.realmName,
     required this.userId,
   });
 
@@ -120,6 +124,7 @@ class MessageFcmMessage extends FcmMessageWithIdentity {
 
   MessageFcmMessage({
     required super.realmUrl,
+    required super.realmName,
     required super.userId,
     required this.senderId,
     required this.senderAvatarUrl,
@@ -250,6 +255,7 @@ class RemoveFcmMessage extends FcmMessageWithIdentity {
 
   RemoveFcmMessage({
     required super.realmUrl,
+    required super.realmName,
     required super.userId,
     required this.messageIds,
   });

--- a/lib/api/notifications.g.dart
+++ b/lib/api/notifications.g.dart
@@ -13,6 +13,7 @@ MessageFcmMessage _$MessageFcmMessageFromJson(Map<String, dynamic> json) =>
       realmUrl: Uri.parse(
         FcmMessageWithIdentity._readRealmUrl(json, 'realm_url') as String,
       ),
+      realmName: json['realm_name'] as String?,
       userId: (_readIntOrString(json, 'user_id') as num).toInt(),
       senderId: (_readIntOrString(json, 'sender_id') as num).toInt(),
       senderAvatarUrl: Uri.parse(json['sender_avatar_url'] as String),
@@ -29,6 +30,7 @@ MessageFcmMessage _$MessageFcmMessageFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$MessageFcmMessageToJson(MessageFcmMessage instance) =>
     <String, dynamic>{
       'realm_url': instance.realmUrl.toString(),
+      'realm_name': instance.realmName,
       'user_id': instance.userId,
       'type': instance.type,
       'sender_id': instance.senderId,
@@ -56,6 +58,7 @@ RemoveFcmMessage _$RemoveFcmMessageFromJson(Map<String, dynamic> json) =>
       realmUrl: Uri.parse(
         FcmMessageWithIdentity._readRealmUrl(json, 'realm_url') as String,
       ),
+      realmName: json['realm_name'] as String?,
       userId: (_readIntOrString(json, 'user_id') as num).toInt(),
       messageIds:
           (RemoveFcmMessage._readMessageIds(json, 'message_ids')
@@ -67,6 +70,7 @@ RemoveFcmMessage _$RemoveFcmMessageFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$RemoveFcmMessageToJson(RemoveFcmMessage instance) =>
     <String, dynamic>{
       'realm_url': instance.realmUrl.toString(),
+      'realm_name': instance.realmName,
       'user_id': instance.userId,
       'type': instance.type,
       'message_ids': instance.messageIds,

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -353,8 +353,9 @@ class NotificationDisplayManager {
       // TODO vary notification icon for debug
       smallIconResourceName: 'zulip_notification', // This name must appear in keep.xml too: https://github.com/zulip/zulip-flutter/issues/528
       inboxStyle: InboxStyle(
-        // TODO(#570) Show organization name, not URL
-        summaryText: data.realmUrl.toString()),
+        summaryText: account.realmName
+          ?? data.realmName
+          ?? data.realmUrl.toString()),
 
       // On Android 11 and lower, if autoCancel is not specified,
       // the summary notification may linger even after all child

--- a/test/api/notifications_test.dart
+++ b/test/api/notifications_test.dart
@@ -8,6 +8,7 @@ import '../stdlib_checks.dart';
 void main() {
   final baseBaseJson = <String, Object?>{
     "realm_url": "https://zulip.example.com/",
+    "realm_name": "Example Organization",
     "user_id": 234,
   };
 
@@ -19,6 +20,7 @@ void main() {
     "realm_id": "4",
     "realm_uri": "https://zulip.example.com/",  // TODO(server-9)
     "realm_url": "https://zulip.example.com/",
+    "realm_name": "Example Organization",
     "user_id": "234",
   };
 
@@ -115,6 +117,7 @@ void main() {
       check(parse(streamJson))
         ..realmUrl.equals(Uri.parse(baseJson['realm_url'] as String))
         ..realmUrl.equals(Uri.parse(baseJsonPreE2ee['realm_uri'] as String)) // TODO(server-9)
+        ..realmName.equals(baseBaseJson['realm_name'] as String)
         ..userId.equals(234)
         ..senderId.equals(123)
         ..senderAvatarUrl.equals(Uri.parse(streamJson['sender_avatar_url'] as String))
@@ -137,6 +140,9 @@ void main() {
     });
 
     test('optional fields missing cause no error', () {
+      check(parse({ ...streamJson }..remove('realm_name')))
+        .realmName.isNull();
+
       check(parse({ ...streamJson }..remove('channel_name')))
         .recipient.isA<FcmMessageChannelRecipient>().which((it) => it
           ..channelId.equals(42)
@@ -260,6 +266,7 @@ void main() {
       check(parse(baseJson))
         ..realmUrl.equals(Uri.parse(baseJson['realm_url'] as String))
         ..realmUrl.equals(Uri.parse(preE2eeJson['realm_uri'] as String)) // TODO(server-9)
+        ..realmName.equals(baseJson['realm_name'] as String)
         ..userId.equals(234)
         ..messageIds.deepEquals([123, 234]);
     });
@@ -318,6 +325,7 @@ extension UnexpectedFcmMessageChecks on Subject<UnexpectedFcmMessage> {
 
 extension FcmMessageWithIdentityChecks on Subject<FcmMessageWithIdentity> {
   Subject<Uri> get realmUrl => has((x) => x.realmUrl, 'realmUrl');
+  Subject<String?> get realmName => has((x) => x.realmName, 'realmName');
   Subject<int> get userId => has((x) => x.userId, 'userId');
 }
 


### PR DESCRIPTION
Zulip Server 8 (FL 234) started sending realmName in the FCM payload:
  https://github.com/zulip/zulip/commit/a018f2611

So, we try to use the realm name from the account first, then fallback to notification data, and then finally fallback to displaying the realm URL.

Fixes: #570