### PR TITLE
ci: Pin Flutter to the version we use in release, hackily for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         # TODO(upstream): make workaround unneeded
         git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
 
+        # TODO(#2139) do this more cleanly, and/or return to latest main
+        git -C ~/flutter reset --hard 055f3e5bf58354cb50eb55f7e35d03d8e15a6f07
+
     - name: Download Flutter SDK artifacts (flutter precache)
       run: flutter precache --universal
 

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -48,6 +48,9 @@ jobs:
           # TODO(upstream): make workaround unneeded
           git --git-dir ~/flutter/.git update-ref refs/remotes/origin/master origin/main
 
+          # TODO(#2139) do this more cleanly, and/or return to latest main
+          git -C ~/flutter reset --hard 055f3e5bf58354cb50eb55f7e35d03d8e15a6f07
+
       - name: Update generated code
         run: |
           mkdir -p build


### PR DESCRIPTION
Our CI is broken at the moment because of changes in recent Flutter commits upstream.  Usually we'd just upgrade to the latest and make any corresponding updates in our code.  That's blocked for a couple of reasons, including a change in the Android embedding:
  https://github.com/zulip/zulip-flutter/pull/2129#issuecomment-3879280784

While that's still getting resolved, fix CI by having it run on the same version that's in a comment in pubspec.yaml, which is the version we'd use when making a release.

Earlier today on a pairing call, @rajveermalviya and I developed a version of this that's more cleanly organized, including some refactoring.  He hasn't yet sent that branch as a PR, though, and it's night-time for him now.  I'll still be glad to have that refactoring, but the immediate priority is to get the CI fixed.

Also filed #2139 to track doing the upgrade and resolving this hack.