### PR TITLE
check: In CI, show only failing tests, not passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       run: flutter pub get
 
     - name: Run tools/check
-      run: TERM=dumb tools/check --all --verbose
+      run: TERM=dumb tools/check --all --output ci

--- a/tools/check
+++ b/tools/check
@@ -74,6 +74,8 @@ Modifying this script's output:
               Print output in the given style.  Styles are:
                 default    The default style.
                 verbose    More details about everything.
+                ci         Like verbose, but adapted to a log
+                           rather than a terminal.
   --verbose   Equivalent to \`--output verbose\`.
 EOF
     exit 2
@@ -104,6 +106,7 @@ opt_verbose=
 case "${opt_output}" in
     default) ;;
     verbose) opt_verbose=1;;
+    ci) opt_verbose=1;;
     *) usage;;
 esac
 
@@ -233,8 +236,13 @@ run_analyze() {
 }
 
 run_test() {
+    local options=()
+    if [ "${opt_output}" = ci ]; then
+        options+=( -r failures-only )
+    fi
+
     # no `flutter test --verbose` even when $opt_verbose; it's *very* verbose
-    flutter test
+    flutter test "${options[@]}"
 }
 
 # Check the Flutter version in pubspec.yaml is commented with a commit ID,


### PR DESCRIPTION
(NOTE: The tip commit breaks some tests, in order to demonstrate the effect of this PR. That commit should be dropped before merging.)

Currently the output of our `test` suite, running `flutter test`,
ends with:

  🎉 3502 tests passed, 9 skipped.

That's preceded by about 3511 lines of test output, one for each
test case.  That's a lot of output, and the GitHub Actions log
viewer can be pretty slow to get through it.

In particular, when a test breaks somewhere in this suite in CI, it
can be rather a pain to get to the details of the failure.  It's
there in the log, but somewhere amidst 3500+ lines of other output.

Instead, in CI, tell `flutter test` to skip printing anything for
all the passing and skipped tests.  This is a feature that the Dart
test runner grew a couple of years ago, for exactly this purpose:
  https://github.com/flutter/flutter/issues/27845
  https://github.com/dart-lang/test/issues/829
  https://github.com/flutter/flutter/pull/148739

Don't have the check script use this flag by default, though,
because it's usually not desirable for interactive use in a
terminal.  There, the test runner already makes good use of the
medium: it constantly replaces a single line of output as it
progresses through all the non-failing tests.
