### PR TITLE
claude: Run analyzer at each edit; use --no-pub for tidy output

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ flutter test test/foo/bar_test.dart
 flutter test test/foo/bar_test.dart --name 'some test name'
 
 # Static analysis (type-checking + linting)
-flutter analyze
+flutter analyze --no-pub
 
 # Run all test suites (only changed files vs upstream main)
 tools/check
@@ -86,3 +86,9 @@ Uses Drift ORM with SQLite. Schema changes require running `tools/check --fix dr
 ### Design
 
 UI designs come from Figma (linked in issues). Match colors, padding, and font sizes exactly. Use `DesignVariables` and `ContentTheme` for theme values.
+
+
+## Developing changes
+
+- After every edit, run the Flutter analyzer to catch issues early.
+  Use this command: `flutter analyze --no-pub 2>&1 | head -20`


### PR DESCRIPTION
When I tried the `/insights` command in Claude Code, it suggested adding the following to settings.json :

    "hooks": {
      "postEdit": {
        "command": "flutter analyze --no-pub 2>&1 | head -20",
        "description": "Run Flutter analyzer after edits to catch issues early"
      }
    },

That... does not actually work.  There is no "postEdit" hook; in fact that isn't even the right capitalization convention, as the hooks that do exist are in PascalCase:
  https://code.claude.com/docs/en/hooks-guide

In short, Claude Code hallucinated a feature in its own settings.

I think it would be possible with more effort to get a similar effect using a PostToolUse hook.  But we can also put this step into the memory, and that should be effective too.  Do that.

In that suggested command, the `--no-pub` is a good idea, and a feature I hadn't known about.  It suppresses the preamble where a command like `flutter analyze` would otherwise list all the dependencies that could be updated.  Best to not have those there to potentially distract Claude from the main output of the analyzer.