### PR TITLE
ci: Skip redundant `flutter pub get` on analyze and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       run: flutter pub get
 
     - name: Run tools/check
-      run: TERM=dumb tools/check --all --output ci
+      run: TERM=dumb tools/check --no-pub --all --output ci

--- a/tools/check
+++ b/tools/check
@@ -66,8 +66,9 @@ What tests to run:
   --all       In the given suites, run on all files. If no list of suites
               was specified, run all suites.
 
-Extra things to do:
+Extra things to do, or skip doing:
   --fix       Fix issues found, where possible.
+  --no-pub    Tell \`flutter test\` et al. to skip \`flutter pub get\`.
 
 Modifying this script's output:
   --output STYLE
@@ -86,6 +87,7 @@ orig_cmdline="$0 $*"
 opt_files=branch
 opt_all=
 opt_fix=
+opt_no_pub=
 opt_output=default
 opt_suites=()
 while (( $# )); do
@@ -94,6 +96,7 @@ while (( $# )); do
         --all-files) opt_files=all; shift;;
         --all) opt_files=all; opt_all=1; shift;;
         --fix) opt_fix=1; shift;;
+        --no-pub) opt_no_pub=1; shift;;
         --output) shift; opt_output="$1"; shift;;
         --verbose) opt_output=verbose; shift;;
         analyze|test|flutter_version|build_runner|l10n|drift|pigeon|icons|android|shellcheck)
@@ -232,11 +235,14 @@ check_no_changes() {
 
 run_analyze() {
     # no `flutter analyze --verbose` even when $opt_verbose; it's *very* verbose
-    flutter analyze
+    flutter analyze ${opt_no_pub:+--no-pub}
 }
 
 run_test() {
-    local options=()
+    local options=(
+        ${opt_no_pub:+--no-pub}
+    )
+
     if [ "${opt_output}" = ci ]; then
         options+=( -r failures-only )
     fi


### PR DESCRIPTION
(Stacked atop #2141, excluding that PR's demo tip commit.)

I learned about this handy flag `flutter analyze --no-pub` the
other day, from Claude Code:
  https://github.com/zulip/zulip-flutter/pull/2142

And `flutter test` supports it too.

The flag saves a small amount of time: about 0.5s on my machine,
for each `flutter analyze` or `flutter test`.  Likely somewhat more
on the CI runners, because they tend to be slower.

More usefully, this cuts down a bunch of noise near the start of
the `tools/check` output: two blocks of currently 47 lines each.
Hopefully that helps in making the meaningful signal easier to see.

