### PR TITLE
home: Update navbar icon labels for `Feed` and `DMs`

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1231,6 +1231,10 @@
   "@recentDmConversationsPageTitle": {
     "description": "Title for the page with a list of DM conversations."
   },
+  "recentDmConversationsPageShortLabel": "DMs",
+  "@recentDmConversationsPageShortLabel": {
+    "description": "Short label for the recent-DMs page. Used in the bottom nav bar and for a tab in the share-to-Zulip sheet."
+  },
   "recentDmConversationsSectionHeader": "Direct messages",
   "@recentDmConversationsSectionHeader": {
     "description": "Heading for direct messages section on the 'Inbox' message view."
@@ -1383,6 +1387,10 @@
   "wildcardMentionTopicDescription": "Notify topic",
   "@wildcardMentionTopicDescription": {
     "description": "Description for \"@topic\" wildcard-mention autocomplete options when writing a channel message."
+  },
+  "navBarFeedLabel": "Feed",
+  "@navBarFeedLabel": {
+    "description": "Label for the Feed button on the bottom navigation bar."
   },
   "navBarMenuLabel": "Menu",
   "@navBarMenuLabel": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1808,6 +1808,12 @@ abstract class ZulipLocalizations {
   /// **'Direct messages'**
   String get recentDmConversationsPageTitle;
 
+  /// Short label for the recent-DMs page. Used in the bottom nav bar and for a tab in the share-to-Zulip sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'DMs'**
+  String get recentDmConversationsPageShortLabel;
+
   /// Heading for direct messages section on the 'Inbox' message view.
   ///
   /// In en, this message translates to:
@@ -2005,6 +2011,12 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Notify topic'**
   String get wildcardMentionTopicDescription;
+
+  /// Label for the Feed button on the bottom navigation bar.
+  ///
+  /// In en, this message translates to:
+  /// **'Feed'**
+  String get navBarFeedLabel;
 
   /// Label for the Menu button on the bottom navigation bar.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'إخطار الموضوع';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -1066,6 +1066,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direktnachrichten';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direktnachrichten';
 
   @override
@@ -1190,6 +1193,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Thema benachrichtigen';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menü';

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -1074,6 +1074,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Messages directs';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Messages directs';
 
   @override
@@ -1201,6 +1204,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   @override
   String get wildcardMentionTopicDescription =>
       'Notifier les participants à cette conversation';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -1055,6 +1055,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Messaggi diretti';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Messaggi diretti';
 
   @override
@@ -1179,6 +1182,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notifica argomento';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1016,6 +1016,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'ダイレクトメッセージ';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'ダイレクトメッセージ';
 
   @override
@@ -1138,6 +1141,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'トピック参加者に通知';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'メニュー';

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -1057,6 +1057,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Wiadomości bezpośrednie';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Wiadomości bezpośrednie';
 
   @override
@@ -1181,6 +1184,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Powiadom w wątku';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -1068,6 +1068,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Личные сообщения';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Личные сообщения';
 
   @override
@@ -1194,6 +1197,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Оповестить тему';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Меню';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -1042,6 +1042,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Priama správa';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1166,6 +1169,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -1075,6 +1075,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Neposredna sporočila';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Neposredna sporočila';
 
   @override
@@ -1201,6 +1204,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Obvesti udeležence teme';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -1059,6 +1059,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Особисті повідомлення';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Особисті повідомлення';
 
   @override
@@ -1183,6 +1186,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Повідомити канал';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Меню';

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -1040,6 +1040,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override
+  String get recentDmConversationsPageShortLabel => 'DMs';
+
+  @override
   String get recentDmConversationsSectionHeader => 'Direct messages';
 
   @override
@@ -1164,6 +1167,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
 
   @override
   String get wildcardMentionTopicDescription => 'Notify topic';
+
+  @override
+  String get navBarFeedLabel => 'Feed';
 
   @override
   String get navBarMenuLabel => 'Menu';

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -148,7 +148,7 @@ class _BottomNavBar extends StatelessWidget {
         icon: ZulipIcons.inbox,
         label: zulipLocalizations.inboxPageTitle),
       _NavigationBarButton(icon: ZulipIcons.message_feed,
-        label: zulipLocalizations.combinedFeedPageTitle,
+        label: zulipLocalizations.navBarFeedLabel,
         selected: false,
         onPressed: () => Navigator.push(context,
           MessageListPage.buildRoute(context: context,
@@ -159,7 +159,7 @@ class _BottomNavBar extends StatelessWidget {
       // TODO(#1094): Users
       _button(tab: _HomePageTab.directMessages,
         icon: ZulipIcons.two_person,
-        label: zulipLocalizations.recentDmConversationsPageTitle),
+        label: zulipLocalizations.recentDmConversationsPageShortLabel),
       _NavigationBarButton(icon: ZulipIcons.menu,
         label: zulipLocalizations.navBarMenuLabel,
         selected: false,

--- a/lib/widgets/share.dart
+++ b/lib/widgets/share.dart
@@ -275,7 +275,7 @@ class ShareSheet extends StatelessWidget {
                 text: zulipLocalizations.channelsPageTitle,
                 icon: ZulipIcons.hash_italic),
               mkTabLabel(
-                text: zulipLocalizations.recentDmConversationsPageTitle,
+                text: zulipLocalizations.recentDmConversationsPageShortLabel,
                 icon: ZulipIcons.two_person),
             ])),
         ]),

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -159,7 +159,7 @@ void main () {
         of: find.byType(ZulipAppBar),
         matching: find.text('Channels'))).findsOne();
 
-      await tester.tap(findInBottomNav(find.text('Direct messages')));
+      await tester.tap(findInBottomNav(find.text('DMs')));
       await tester.pump();
       check(find.descendant(
         of: find.byType(ZulipAppBar),


### PR DESCRIPTION
Fixes #2132.

Discussions:
- [#mobile > bottom nav button labels](https://chat.zulip.org/#narrow/channel/48-mobile/topic/bottom.20nav.20button.20labels/with/2377042)
- [#mobile > Flutter feedback - Icons in app @ 💬](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Flutter.20feedback.20-.20Icons.20in.20app/near/2219685)
- [#mobile-design > design/implementation inconsistency in share action sheet](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/design.2Fimplementation.20inconsistency.20in.20share.20action.20sheet/with/2385614)
- [#mobile-design > doubt regarding changing of labels in menu sheet](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/doubt.20regarding.20changing.20of.20labels.20in.20menu.20sheet/with/2385621)

<details>
<summary>Screenshot Comparison</summary>


| Before | After |
| ------------- | ------------- |
| <img width="792" height="1642" alt="image" src="https://github.com/user-attachments/assets/dff07f79-aaa6-4f81-b22b-6b1be2071e0b" /> | <img width="792" height="1662" alt="image" src="https://github.com/user-attachments/assets/3dbf01ad-6f21-49de-bbc4-e1f25a77c2f1" /> |


| Before | After |
| ------------- | ------------- |
| <img width="788" height="1661" alt="image" src="https://github.com/user-attachments/assets/cc0148f1-1fea-4bf7-bcde-1a9d55bdf3e1" />  | <img width="796" height="1646" alt="image" src="https://github.com/user-attachments/assets/2cd5a714-f2a1-424f-a057-46cc90088246" /> |



### Video Recording(Old) of implementation (Taken from implementation of the same from [here](https://github.com/zulip/zulip-flutter/pull/1879#issuecomment-3425466326))

https://github.com/user-attachments/assets/c67cd576-84cb-4078-915f-9ebc26699bb8

</details>