### PR TITLE
feat: add search button to home page app bar (#1854)

### DIFF
--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -104,7 +104,18 @@ class _HomePageState extends State<HomePage> {
         title: Semantics(
           identifier: HomePage.titleSemanticsIdentifier,
           namesRoute: true,
-          child: Text(_currentTabTitle))),
+          child: Text(_currentTabTitle)),
+        actions: [
+          IconButton(
+            icon: const Icon(ZulipIcons.search),
+            tooltip: ZulipLocalizations.of(context).searchMessagesPageTitle,
+            onPressed: () {
+              Navigator.of(context).push(MessageListPage.buildRoute(
+                context: context, narrow: KeywordSearchNarrow('')));
+            },
+          ),
+        ],
+      ),
       body: Semantics(
         role: SemanticsRole.tabPanel,
         identifier: HomePage.contentSemanticsIdentifier,


### PR DESCRIPTION
## Summary
This PR adds a search button to the HomePage app bar, providing quick access to message search functionality as requested in issue #1854.

## Changes Made
- **lib/widgets/home.dart**:
  - Added `actions` array to the AppBar widget
  - Added search IconButton with `ZulipIcons.search` icon
  - Uses localized tooltip from `ZulipLocalizations` for accessibility
  - On press, navigates to `MessageListPage` with empty `KeywordSearchNarrow`
  - Opens the search interface directly from the main navigation

## Rationale
Previously, users had to navigate through multiple steps to access search functionality. This change provides immediate access from the home screen, improving user experience and accessibility.

## Testing
1. Open the app and navigate to the home page
2. Observe the search icon in the top app bar
3. Tap the search icon
4. The search page should open with an empty search field ready for input
5. Verify tooltip appears on long-press for accessibility

## Accessibility
- Icon button includes tooltip with localized string
- Maintains existing semantics structure
- Search functionality is now discoverable from main navigation

## Closes
Fixes #1854