### PR TITLE
notif test [nfc]: Use null-aware element

### DIFF
--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -44,7 +44,7 @@ MessageFcmMessage messageFcmMessage(
     "realm_id": "4",
     "realm_uri": account.realmUrl.toString(),
     "user_id": account.userId.toString(),
-    if (realmName != null) "realm_name": realmName,
+    "realm_name": ?realmName,
 
     "zulip_message_id": zulipMessage.id.toString(),
     "time": zulipMessage.timestamp.toString(),


### PR DESCRIPTION
This was introduced in aacf52af4 (#2136), after I rebased that PR and immediately merged.  The rebase went past 5705f833e (#2129), which had enabled the `use_null_aware_elements` lint rule, so this was effectively an indirect merge conflict.

/cc @rajveermalviya 