### PR TITLE
android: Exclude all data from backup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,11 @@
    <application
         android:label="Zulip"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/full_backup_content"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        >
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Exclude all data from device backup.  For motivation, see:
+       https://github.com/zulip/zulip-flutter/issues/2158
+       https://github.com/zulip/zulip-flutter/issues/2159
+     The data that's essential to exclude is in our database,
+     at `domain="file" path="zulip.db"`.  But once that's excluded,
+     including any stray other data would at best cause a confusing
+     mixed state, if it has any effect at all.  So exclude it all.
+
+     Docs for this file:
+       https://developer.android.com/identity/data/autobackup#include-exclude-android-12
+  -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="root" />
+        <exclude domain="device_file" />
+        <exclude domain="device_database" />
+        <exclude domain="device_sharedpref" />
+        <exclude domain="device_root" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="root" />
+        <exclude domain="device_file" />
+        <exclude domain="device_database" />
+        <exclude domain="device_sharedpref" />
+        <exclude domain="device_root" />
+    </device-transfer>
+    <cross-platform-transfer platform="ios">
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="root" />
+        <exclude domain="device_file" />
+        <exclude domain="device_database" />
+        <exclude domain="device_sharedpref" />
+        <exclude domain="device_root" />
+    </cross-platform-transfer>
+</data-extraction-rules>

--- a/android/app/src/main/res/xml/full_backup_content.xml
+++ b/android/app/src/main/res/xml/full_backup_content.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Exclude all data from device backup.
+     For background, see `data_extraction_rules.xml`.
+
+     It's not clear this file has any effect: for Android 12 and up,
+     the `data_extraction_rules.xml` file
+     (`android:dataExtractionRules` in the manifest)
+     is supposed to take precedence.
+     And for Android 11 and older, the `android:allowBackup="false"`
+     which we also set is supposed to prevent backups completely.
+
+     But including this extra file is cheap.  And from experience,
+     we don't trust Android's documentation to be 100% accurate;
+     maybe there's some situation where it helps after all.
+
+     Docs for this file:
+       https://developer.android.com/identity/data/autobackup#include-exclude-android-11
+  -->
+<full-backup-content>
+    <exclude domain="file" />
+    <exclude domain="database" />
+    <exclude domain="sharedpref" />
+    <exclude domain="external" />
+    <exclude domain="root" />
+    <exclude domain="device_file" />
+    <exclude domain="device_database" />
+    <exclude domain="device_sharedpref" />
+    <exclude domain="device_root" />
+</full-backup-content>


### PR DESCRIPTION
Fixes part of #2158, namely for Android.

Android (like iOS) has a feature automatically back up apps' data into the cloud, and a related feature to transfer data directly from one device to another (typically when first setting up a new device).

These features have some value when it comes to Zulip, but not a lot: the great bulk of the app's data comes from the user's Zulip server(s) anyway.  And conversely, there is some data that shouldn't be backed up, because it shouldn't be duplicated off the device.

Right now, that describes the user's API keys: it's convenient not to have to log in again, but also potentially a security risk depending on how the backup is managed.

With the new "devices" and "push keys" APIs being introduced for end-to-end encrypted push notifications #1764, this will become a bigger issue:

  * If a new device restores a backup from an old device that's still online, then the two real devices will compete over what the push key and push token should be for the "device" object.

  * If a backup includes push keys, then it makes the security of the end-to-end encryption dependent on the security of the backup.

So just disable the backup feature entirely.  We have a followup issue #2159 to track selectively re-enabling it where appropriate.

Upstream Android docs:
  https://developer.android.com/identity/data/backup
  https://developer.android.com/identity/data/autobackup#EnablingAutoBackup