### PR TITLE
check: Fix `test` suite when ran without `--no-pub` flag

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -295,7 +295,11 @@ run_test() {
     fi
 
     # no `flutter test --verbose` even when $opt_verbose; it's *very* verbose
-    flutter test "${options[@]}"
+    if (( "${#options[@]}" )); then
+        flutter test "${options[@]}"
+    else
+        flutter test
+    fi
 }
 
 # Check the Flutter version in pubspec.yaml is commented with a commit ID,


### PR DESCRIPTION
`test` suite is failing when running without the `--no-pub` flag:

  $ tools/check test
  Running test...
  tools/check: line 298: options[@]: unbound variable

Fix that by adding a check around the variable expansion.