### PR TITLE
typeahead: Show pronouns in @-mention and New DM lists

### DIFF
--- a/lib/model/realm.dart
+++ b/lib/model/realm.dart
@@ -94,6 +94,12 @@ mixin RealmStore on PerAccountStoreBase, UserGroupStore {
 
   List<CustomProfileField> get customProfileFields;
 
+  /// The ID of the primary pronoun-type custom profile field, if any.
+  ///
+  /// If the realm has multiple pronoun fields, this is the first one
+  /// in [customProfileFields] order. Returns null if no pronoun field exists.
+  int? get primaryPronounFieldId;
+
   //|//////////////////////////////////////////////////////////////
   // Methods that examine the settings.
 
@@ -217,6 +223,8 @@ mixin ProxyRealmStore on RealmStore {
   @override
   List<CustomProfileField> get customProfileFields => realmStore.customProfileFields;
   @override
+  int? get primaryPronounFieldId => realmStore.primaryPronounFieldId;
+  @override
   bool selfHasPassedWaitingPeriod({required DateTime byDate}) =>
     realmStore.selfHasPassedWaitingPeriod(byDate: byDate);
   @override
@@ -270,7 +278,9 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
     realmDefaultExternalAccounts = initialSnapshot.realmDefaultExternalAccounts,
     maxChannelNameLength = initialSnapshot.maxChannelNameLength,
     maxTopicLength = initialSnapshot.maxTopicLength,
-    customProfileFields = _sortCustomProfileFields(initialSnapshot.customProfileFields);
+    customProfileFields = _sortCustomProfileFields(initialSnapshot.customProfileFields) {
+    primaryPronounFieldId = _computePrimaryPronounFieldId(customProfileFields);
+  }
 
   @override
   bool selfHasPassedWaitingPeriod({required DateTime byDate}) {
@@ -453,6 +463,16 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
   @override
   List<CustomProfileField> customProfileFields;
 
+  @override
+  late int? primaryPronounFieldId;
+
+  static int? _computePrimaryPronounFieldId(List<CustomProfileField> fields) {
+    for (final field in fields) {
+      if (field.type == CustomProfileFieldType.pronouns) return field.id;
+    }
+    return null;
+  }
+
   static List<CustomProfileField> _sortCustomProfileFields(List<CustomProfileField> initialCustomProfileFields) {
     // TODO(server): The realm-wide field objects have an `order` property,
     //   but the actual API appears to be that the fields should be shown in
@@ -487,6 +507,7 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
 
   void handleCustomProfileFieldsEvent(CustomProfileFieldsEvent event) {
     customProfileFields = _sortCustomProfileFields(event.fields);
+    primaryPronounFieldId = _computePrimaryPronounFieldId(customProfileFields);
   }
 
   void handleRealmUserUpdateEvent(RealmUserUpdateEvent event) {

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -116,6 +116,16 @@ mixin UserStore on PerAccountStoreBase, RealmStore {
   ///
   /// If no status is set for the user, returns [UserStatus.zero].
   UserStatus getUserStatus(int userId);
+
+  /// The pronoun text for [user] from the primary pronoun field, or null.
+  ///
+  /// Returns null if the realm has no pronoun-type custom profile field,
+  /// or if the user has no value for that field.
+  String? primaryPronounsFor(User user) {
+    final fieldId = primaryPronounFieldId;
+    if (fieldId == null) return null;
+    return user.profileData?[fieldId]?.value;
+  }
 }
 
 /// Whether and how a given [MutedUsersEvent] may affect the results

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -312,7 +312,11 @@ class MentionAutocompleteItem extends StatelessWidget {
         label = store.userDisplayName(userId);
         emoji = UserStatusEmoji(userId: userId, size: 18,
           padding: const EdgeInsetsDirectional.only(start: 5.0));
-        sublabel = store.getUser(userId)?.deliveryEmail;
+        final user = store.getUser(userId);
+        final pronouns = user != null ? store.primaryPronounsFor(user) : null;
+        final email = user?.deliveryEmail;
+        final parts = [?pronouns, ?email];
+        sublabel = parts.isEmpty ? null : parts.join(', ');
       case UserGroupMentionAutocompleteResult(:final groupId):
         final group = store.getGroup(groupId);
         avatar = SizedBox.square(dimension: 36,

--- a/lib/widgets/new_dm_sheet.dart
+++ b/lib/widgets/new_dm_sheet.dart
@@ -395,6 +395,8 @@ class _NewDmUserListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     final designVariables = DesignVariables.of(context);
+    final user = store.getUser(userId);
+    final pronouns = user != null ? store.primaryPronounsFor(user) : null;
     return Material(
       clipBehavior: Clip.antiAlias,
       borderRadius: BorderRadius.circular(10),
@@ -424,6 +426,9 @@ class _NewDmUserListItem extends StatelessWidget {
                 TextSpan(text: store.userDisplayName(userId), children: [
                   UserStatusEmoji.asWidgetSpan(userId: userId, fontSize: 17,
                     textScaler: MediaQuery.textScalerOf(context)),
+                  if (pronouns != null) TextSpan(text: ' ($pronouns)',
+                    style: TextStyle(
+                      color: designVariables.contextMenuItemMeta)),
                 ]),
                 style: TextStyle(
                   fontSize: 17,

--- a/test/model/realm_test.dart
+++ b/test/model/realm_test.dart
@@ -240,4 +240,48 @@ void main() {
       check(store.customProfileFields.map((f) => f.id)).deepEquals([2, 0, 1]);
     });
   });
+
+  group('primaryPronounFieldId', () {
+    test('null when no pronoun fields exist', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.shortText),
+          eg.customProfileField(1, CustomProfileFieldType.longText),
+        ]));
+      check(store.primaryPronounFieldId).isNull();
+    });
+
+    test('returns the one pronoun field', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.shortText),
+          eg.customProfileField(1, CustomProfileFieldType.pronouns),
+        ]));
+      check(store.primaryPronounFieldId).equals(1);
+    });
+
+    test('returns first pronoun field in list among multiple', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.pronouns, order: 3),
+          eg.customProfileField(1, CustomProfileFieldType.shortText, order: 2),
+          eg.customProfileField(2, CustomProfileFieldType.pronouns, order: 1),
+        ]));
+      check(store.primaryPronounFieldId).equals(0);
+    });
+
+    test('updates after CustomProfileFieldsEvent', () async {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.pronouns),
+        ]));
+      check(store.primaryPronounFieldId).equals(0);
+
+      await store.handleEvent(CustomProfileFieldsEvent(id: 0, fields: [
+        eg.customProfileField(1, CustomProfileFieldType.shortText),
+      ]));
+      check(store.primaryPronounFieldId).isNull();
+    });
+  });
+
 }

--- a/test/model/user_test.dart
+++ b/test/model/user_test.dart
@@ -228,4 +228,50 @@ void main() {
       doTest('mixed (all replaced)', [1], [2], MutedUsersVisibilityEffect.mixed);
     });
   });
+
+  group('primaryPronounsFor', () {
+    test('returns pronoun value when present', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.pronouns),
+        ]));
+      final user = eg.user(profileData: {
+        0: ProfileFieldUserData(value: 'he/him'),
+      });
+      check(store.primaryPronounsFor(user)).equals('he/him');
+    });
+
+    test('returns null when no pronoun field exists', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.shortText),
+        ]));
+      final user = eg.user(profileData: {
+        0: ProfileFieldUserData(value: 'some text'),
+      });
+      check(store.primaryPronounsFor(user)).isNull();
+    });
+
+    test('returns null when user has no profile data for field', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.pronouns),
+        ]));
+      final user = eg.user();
+      check(store.primaryPronounsFor(user)).isNull();
+    });
+
+    test('uses first pronoun field in list among multiple', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        customProfileFields: [
+          eg.customProfileField(0, CustomProfileFieldType.pronouns, order: 2),
+          eg.customProfileField(1, CustomProfileFieldType.pronouns, order: 1),
+        ]));
+      final user = eg.user(profileData: {
+        0: ProfileFieldUserData(value: 'he/him'),
+        1: ProfileFieldUserData(value: 'they/them'),
+      });
+      check(store.primaryPronounsFor(user)).equals('he/him');
+    });
+  });
 }

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -303,9 +303,16 @@ void main() {
         return find.descendant(of: itemColumn, matching: find.byType(Text));
       }
 
-      testWidgets('no sublabel when delivery email is unavailable', (tester) async {
-        final user = eg.user(fullName: 'User One', deliveryEmail: null);
+      Future<void> checkUserMentionSublabel(WidgetTester tester, {
+        required User user,
+        List<CustomProfileField>? customProfileFields,
+        required String? expectedSublabel,
+      }) async {
         final composeInputFinder = await setupToComposeInput(tester, users: [user]);
+        if (customProfileFields != null) {
+          await store.handleEvent(CustomProfileFieldsEvent(
+            id: 0, fields: customProfileFields));
+        }
 
         // TODO(#226): Remove this extra edit when this bug is fixed.
         await tester.enterText(composeInputFinder, 'hello @user ');
@@ -313,28 +320,46 @@ void main() {
         await tester.pumpAndSettle(); // async computation; options appear
 
         checkUserShown(user, expected: true);
-        check(find.text(user.email)).findsNothing();
-        check(findLabelsForItem(
-          itemFinder: find.text(user.fullName))).findsOne();
-
+        final labelsFinder = findLabelsForItem(
+          itemFinder: find.text(user.fullName));
+        if (expectedSublabel == null) {
+          check(labelsFinder).findsOne();
+        } else {
+          check(find.text(expectedSublabel)).findsOne();
+          check(labelsFinder).findsExactly(2);
+        }
         debugNetworkImageHttpClientProvider = null;
+      }
+
+      testWidgets('no sublabel when delivery email and pronouns are unavailable',
+          (tester) async {
+        await checkUserMentionSublabel(tester,
+          user: eg.user(fullName: 'User One', deliveryEmail: null),
+          expectedSublabel: null);
       });
 
       testWidgets('show sublabel when delivery email is available', (tester) async {
         final user = eg.user(fullName: 'User One', deliveryEmail: 'email1@email.com');
-        final composeInputFinder = await setupToComposeInput(tester, users: [user]);
+        await checkUserMentionSublabel(tester,
+          user: user,
+          expectedSublabel: user.deliveryEmail);
+      });
 
-        // TODO(#226): Remove this extra edit when this bug is fixed.
-        await tester.enterText(composeInputFinder, 'hello @user ');
-        await tester.enterText(composeInputFinder, 'hello @user o');
-        await tester.pumpAndSettle(); // async computation; options appear
+      testWidgets('show pronouns in sublabel when available', (tester) async {
+        await checkUserMentionSublabel(tester,
+          user: eg.user(fullName: 'User One', deliveryEmail: null,
+            profileData: {0: ProfileFieldUserData(value: 'he/him')}),
+          customProfileFields: [eg.customProfileField(0, CustomProfileFieldType.pronouns)],
+          expectedSublabel: 'he/him');
+      });
 
-        checkUserShown(user, expected: true);
-        check(find.text(user.deliveryEmail!)).findsOne();
-        check(findLabelsForItem(
-          itemFinder: find.text(user.fullName))).findsExactly(2);
-
-        debugNetworkImageHttpClientProvider = null;
+      testWidgets('show pronouns with email in sublabel', (tester) async {
+        await checkUserMentionSublabel(tester,
+          user: eg.user(fullName: 'User One',
+            deliveryEmail: 'email@example.com',
+            profileData: {0: ProfileFieldUserData(value: 'she/her')}),
+          customProfileFields: [eg.customProfileField(0, CustomProfileFieldType.pronouns)],
+          expectedSublabel: 'she/her, email@example.com');
       });
 
       testWidgets('show sublabel for wildcard mention items', (tester) async {

--- a/test/widgets/new_dm_sheet_test.dart
+++ b/test/widgets/new_dm_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/basic.dart';
 import 'package:zulip/model/store.dart';
@@ -405,6 +406,41 @@ void main() {
       check(findUserTile(user)).findsOne();
       check(findUserChip(user)).findsOne();
       check(find.textContaining('Busy')).findsNothing();
+    });
+  });
+
+  group('pronouns in user list item', () {
+    testWidgets('shows pronouns when available', (tester) async {
+      final user = eg.user(fullName: 'User One', profileData: {
+        0: ProfileFieldUserData(value: 'he/him', renderedValue: null),
+      });
+      await setupSheet(tester, users: [user]);
+      await store.handleEvent(CustomProfileFieldsEvent(id: 0, fields: [
+        eg.customProfileField(0, CustomProfileFieldType.pronouns),
+      ]));
+      await tester.pump();
+
+      check(find.textContaining('(he/him)')).findsOne();
+    });
+
+    testWidgets('no pronouns when field is empty', (tester) async {
+      final user = eg.user(fullName: 'User One', profileData: {
+        0: ProfileFieldUserData(value: '', renderedValue: null),
+      });
+      await setupSheet(tester, users: [user]);
+      await store.handleEvent(CustomProfileFieldsEvent(id: 0, fields: [
+        eg.customProfileField(0, CustomProfileFieldType.pronouns),
+      ]));
+      await tester.pump();
+
+      check(find.textContaining('(')).findsNothing();
+    });
+
+    testWidgets('no pronouns when no pronoun field exists', (tester) async {
+      final user = eg.user(fullName: 'User One');
+      await setupSheet(tester, users: [user]);
+
+      check(find.textContaining('(')).findsNothing();
     });
   });
 


### PR DESCRIPTION
Fixes #313

Implement logic to display user pronouns in the compose box typeahead and the New DM search sheet.

To determine which pronouns to show, we select the primary pronoun field (type 8) with the lowest 'order' value in the realm. This ensures consistency across the organization.

This commit adds `primaryPronounFieldId` and `primaryPronounsFor` to RealmStore to handle this retrieval. Pronouns are displayed after the status emoji but before the email.

Includes unit tests for the RealmStore sorting logic and the updated widget rendering in autocomplete and the New DM sheet.

<!-- Before vs After -->
<table>
  <caption><strong>Before vs After</strong></caption>
  <tbody>
    <tr>
      <td align="center">
        <strong>Before</strong><br />
        <img
          src="https://github.com/user-attachments/assets/543983d5-a874-4182-8733-907c00ae130d"
          width="300"
          alt="Before state"
        />
      </td>
      <td align="center">
        <strong>After</strong><br />
        <img
          src="https://github.com/user-attachments/assets/4b867035-c6d0-44a7-90d0-b31034b61ffd"
          width="300"
          alt="After state"
        />
      </td>
    </tr>
  </tbody>
</table>

<!-- Before vs After -->
<table>
  <caption><strong>Before vs After</strong></caption>
  <tbody>
    <tr>
      <td align="center">
        <strong>Before</strong><br />
        <img
          src="https://github.com/user-attachments/assets/bcd8bf97-7994-4f03-90e5-998548cb0ea7"
          width="300"
          alt="Before state"
        />
      </td>
      <td align="center">
        <strong>After</strong><br />
        <img
          src="https://github.com/user-attachments/assets/3e2cf4f1-1d82-4d6f-922a-a8fb50ba181b"
          width="300"
          alt="After state"
        />
      </td>
    </tr>
  </tbody>
</table>

<table>
  <caption><strong>Before vs After</strong></caption>
  <tbody>
    <tr>
      <td align="center">
        <strong>Before</strong><br />
        <img
          src="https://github.com/user-attachments/assets/b2e6e931-5e61-4d1d-9091-219de812368f"
          width="300"
          alt="Before state"
        />
      </td>
      <td align="center">
        <strong>After</strong><br />
        <img
          src="https://github.com/user-attachments/assets/9ed49c7f-2827-4646-ba5e-72fd68a1a7d1"
          width="300"
          alt="After state"
        />
      </td>
    </tr>
  </tbody>
</table>

<!-- Before vs After -->
<table>
  <caption><strong>Before vs After</strong></caption>
  <tbody>
    <tr>
      <td align="center">
        <strong>Before</strong><br />
        <img
          src="https://github.com/user-attachments/assets/52bcff14-11d1-4e5b-9a01-a38f409e172c"
          width="300"
          alt="Before state"
        />
      </td>
      <td align="center">
        <strong>After</strong><br />
        <img
          src="https://github.com/user-attachments/assets/f5128e84-be58-44dd-80ab-185ef34e1282"
          width="300"
          alt="After state"
        />
      </td>
    </tr>
  </tbody>
</table>

