### PR TITLE
Autocomplete: Reopen @-mention typeahead when editing inside `**`

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -72,16 +72,17 @@ extension ComposeContentAutocomplete on ComposeContentController {
       final ComposeAutocompleteQuery query;
       if (charAtPos == '@') {
         final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
-        if (match == null) continue;
-        query = MentionAutocompleteQuery(match[2] ?? match[3] ?? match[4]!, silent: match[1]! == '_');
+        if (match is! RegExpMatch) continue;
+        query = MentionAutocompleteQuery(match.namedGroup('mentionGroup')!,
+          silent: match[1]! == '_');
       } else if (charAtPos == ':') {
         final match = _emojiIntentRegex.matchAsPrefix(textUntilCursor, pos);
         if (match == null) continue;
         query = EmojiAutocompleteQuery(match[1]!);
       } else if (charAtPos == '#') {
         final match = _channelLinkIntentRegex.matchAsPrefix(textUntilCursor, pos);
-        if (match == null) continue;
-        query = ChannelLinkAutocompleteQuery(match[1] ?? match[2]!);
+        if (match is! RegExpMatch) continue;
+        query = ChannelLinkAutocompleteQuery(match.namedGroup('channelGroup')!);
       } else {
         continue;
       }
@@ -122,15 +123,15 @@ final RegExp _mentionIntentRegex = (() {
       // Case '@chris bobbe': No "*" before or after the query.
       // Reject on whitespace and "*" right after "@" or "@_". Emails can't start
       // with either, and full_name can't either (it's run through Python's `.strip()`).
-      + r'(?!\*|\s)([^' + fullNameAndEmailCharExclusions + r']*)'
+      + r'(?<mentionGroup>(?!\*|\s)([^' + fullNameAndEmailCharExclusions + r']*))'
       + r'|'
       // Case '@**chris bobbe': If query starts with "**" then reject if it does
       // have any "*" afterwards.
-      + r'\*\*(?!\s)([^' + fullNameAndEmailCharExclusions + r']*)'
+      + r'\*\*(?!\s)(?<mentionGroup>([^' + fullNameAndEmailCharExclusions + r']*))'
       + r'|'
       // Case '@**chris bobbe*': If query starts with "**" then it can end with a "*";
       // For the case when user backspaced through one star afer finishing an autocomplete.
-      + r'\*\*(?!\s)([^' + fullNameAndEmailCharExclusions + r']*)\*$'
+      + r'\*\*(?!\s)(?<mentionGroup>([^' + fullNameAndEmailCharExclusions + r']*))\*$'
     + r')$',
     unicode: true);
 })();
@@ -214,8 +215,6 @@ final RegExp _channelLinkIntentRegex = () {
   // TODO: match the server constraints
   const nameCharExclusions = r'\r\n';
 
-  // TODO(upstream): maybe use duplicate-named capture groups for better readability?
-  //   https://github.com/dart-lang/sdk/issues/61337
   return RegExp(unicode: true,
     before
     + r'#'
@@ -226,20 +225,20 @@ final RegExp _channelLinkIntentRegex = () {
     // option, instead of clearing the entire query and starting from scratch.
     + r'(?:'
       // Case '#channel': right after '#', reject whitespace as well as '**'.
-      + r'(?!\s|\*\*)([^' + nameCharExclusions + r']*)'
+      + r'(?<channelGroup>(?!\s|\*\*)([^' + nameCharExclusions + r']*))'
       + r'|'
       // Case '#**channel': right after '#**', reject whitespace.
       // Also, make sure that the remaining query doesn't contain '**',
       // otherwise '#**channel**' (which is a completed channel link syntax) and
       // any text followed by that will always match.
       + r'\*\*(?!\s)'
-      + r'((?:'
+      + r'(?<channelGroup>((?:'
         + r'[^*' + nameCharExclusions + r']'
         + r'|'
         + r'\*[^*' + nameCharExclusions + r']'
         + r'|'
         + r'\*$'
-      + r')*)'
+      + r')*))'
     + r')$');
 }();
 

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -21,7 +21,7 @@ extension ComposeContentAutocomplete on ComposeContentController {
   // in long messages, we bound how far back we look for the intent's start.
   int get _maxLookbackForAutocompleteIntent {
     return 1 // intent character, e.g. "#"
-      + 2 // some optional characters e.g., "_" for silent mention or "**"
+      + 3 // some optional characters e.g., "_" for silent mention or "**"
 
       // Per the API doc, maxChannelNameLength is in Unicode code points.
       // We walk the string by UTF-16 code units, and there might be one or two
@@ -73,7 +73,7 @@ extension ComposeContentAutocomplete on ComposeContentController {
       if (charAtPos == '@') {
         final match = _mentionIntentRegex.matchAsPrefix(textUntilCursor, pos);
         if (match == null) continue;
-        query = MentionAutocompleteQuery(match[2]!, silent: match[1]! == '_');
+        query = MentionAutocompleteQuery(match[2] ?? match[3] ?? match[4]!, silent: match[1]! == '_');
       } else if (charAtPos == ':') {
         final match = _emojiIntentRegex.matchAsPrefix(textUntilCursor, pos);
         if (match == null) continue;
@@ -115,15 +115,22 @@ final RegExp _mentionIntentRegex = (() {
   // full_name, find uses of UserProfile.NAME_INVALID_CHARS in zulip/zulip.)
   const fullNameAndEmailCharExclusions = r'\*`\\>"\p{Other}';
 
-  // TODO(#1967): ignore immediate "**" after '@' sign
   return RegExp(
     beforeAtSign
     + r'@(_?)' // capture, so we can distinguish silent mentions
-    + r'(|'
-      // Reject on whitespace right after "@" or "@_". Emails can't start with
-      // it, and full_name can't either (it's run through Python's `.strip()`).
-      + r'[^\s' + fullNameAndEmailCharExclusions + r']'
-      + r'[^'   + fullNameAndEmailCharExclusions + r']*'
+    + r'(?:'
+      // Case '@chris bobbe': No "*" before or after the query.
+      // Reject on whitespace and "*" right after "@" or "@_". Emails can't start
+      // with either, and full_name can't either (it's run through Python's `.strip()`).
+      + r'(?!\*|\s)([^' + fullNameAndEmailCharExclusions + r']*)'
+      + r'|'
+      // Case '@**chris bobbe': If query starts with "**" then reject if it does
+      // have any "*" afterwards.
+      + r'\*\*(?!\s)([^' + fullNameAndEmailCharExclusions + r']*)'
+      + r'|'
+      // Case '@**chris bobbe*': If query starts with "**" then it can end with a "*";
+      // For the case when user backspaced through one star afer finishing an autocomplete.
+      + r'\*\*(?!\s)([^' + fullNameAndEmailCharExclusions + r']*)\*$'
     + r')$',
     unicode: true);
 })();

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -137,10 +137,82 @@ void main() {
     doTest('email support@ with details of the issue^', null);
     doTest('email support@^ with details of the issue', null);
 
-    doTest('Ask @**Chris Bobbe**^', null); doTest('Ask @_**Chris Bobbe**^', null);
-    doTest('Ask @**Chris Bobbe^**', null); doTest('Ask @_**Chris Bobbe^**', null);
-    doTest('Ask @**Chris^ Bobbe**', null); doTest('Ask @_**Chris^ Bobbe**', null);
-    doTest('Ask @**^Chris Bobbe**', null); doTest('Ask @_**^Chris Bobbe**', null);
+    // Accept syntax like "@**foo**" (as from the user finishing an autocomplete
+    // and then scrolling back to edit it), but leave the starting "**" and ending
+    // "**" out of the query.
+    doTest('Ask @**Chris Bobbe**^', null);
+    doTest('Ask @_**Chris Bobbe**^', null);
+    doTest('Ask ~@**Chris Bobbe^**', mention('Chris Bobbe'));
+    doTest('Ask ~@_**Chris Bobbe^**', silentMention('Chris Bobbe'));
+    doTest('Ask ~@**Chris^ Bobbe**', mention('Chris'));
+    doTest('Ask ~@_**Chris^ Bobbe**', silentMention('Chris'));
+    doTest('Ask ~@**^Chris Bobbe**', mention(''));
+    doTest('Ask ~@_**^Chris Bobbe**', silentMention(''));
+
+    // Accept syntax like "@**foo" (as from the user finishing an autocomplete
+    // and then hitting backspace to edit it), but leave the "**" out of the query.
+    doTest('Ask ~@**Chris Bobbe^', mention('Chris Bobbe'));
+    doTest('Ask ~@_**Chris Bobbe^', silentMention('Chris Bobbe'));
+    doTest('Ask ~@**Chris^ Bobbe', mention('Chris'));
+    doTest('Ask ~@_**Chris^ Bobbe', silentMention('Chris'));
+    doTest('Ask ~@**^Chris Bobbe', mention(''));
+    doTest('Ask ~@_**^Chris Bobbe', silentMention(''));
+    doTest('Ask ~@**Chris  Bobbe^', mention('Chris  Bobbe'));
+    doTest('Ask ~@_**Chris  Bobbe^', silentMention('Chris  Bobbe'));
+
+    // "*" at the very end of the string should be valid.
+    doTest('Ask ~@**Chris*^', mention('Chris'));
+    doTest('Ask ~@_**Chris*^', silentMention('Chris'));
+
+    doTest('Ask @** ^', null);
+    doTest('Ask @_** ^', null);
+    doTest('Ask @** Chris^', null);
+    doTest('Ask ~@**Chris ^', mention('Chris '));
+
+    // Tests for `fullNameAndEmailCharExclusions`
+    doTest('Ask @**Chris`^', null);
+    doTest('Ask @**Chris`Bobbe^', null);
+    doTest('Ask @**Chris\\^', null);
+    doTest('Ask @**Chris\\Bobbe^', null);
+    doTest('Ask @**Chris>^', null);
+    doTest('Ask @**Chris>Bobbe^', null);
+    doTest('Ask @**Chris"^', null);
+    doTest('Ask @**Chris"Bobbe^', null);
+    doTest('Ask @**Chr*is^', null);
+    doTest('Ask @_**Chr*is^', null);
+
+    // Three asterisks
+    doTest('Ask ~@***^', mention(''));
+    doTest('Ask ~@_***^', silentMention(''));
+
+    // Four asterisks
+    doTest('Ask @****^', null);
+    doTest('Ask @_****^', null);
+
+    // "**" are not allowed inside the query.
+    doTest('Ask @**Chris**Bobbe^', null);
+
+    doTest('~@_**ab^', silentMention('ab'), maxChannelName: 1);
+    doTest('~@**abc^', mention('abc'), maxChannelName: 1);
+    doTest('~@**ab^', mention('ab'), maxChannelName: 1);
+
+    // Three asterisks but fully closed.
+    doTest('Ask ~@***^**', mention(''));
+    doTest('Ask ~@_***^**', silentMention(''));
+
+    // " ' " (Apostrophe) and "-" are allowed inside the query.
+    doTest('Ask ~@**O\'Connor^', mention('O\'Connor'));
+    doTest('Ask ~@**Mary-Jane^', mention('Mary-Jane'));
+    doTest('Ask ~@**Jean-Luc Picard^', mention('Jean-Luc Picard'));
+
+    // "\n" not allowed inside the query.
+    doTest('Ask @**Chris\nBobbe^', null);
+    doTest('Ask @**\nChris^', null);
+
+    // Cursor placed before should be invalid query.
+    doTest('Ask ^@**Chris Bobbe', null);
+    doTest('Ask @*^*Chris Bobbe', null);
+
 
     doTest('`@chris^', null); doTest('`@_chris^', null);
 
@@ -187,12 +259,17 @@ void main() {
     doTest('~@Родион Романович Раскольников^', mention('Родион Романович Раскольников'));
     doTest('~@_Родион Романович Раскольнико^', silentMention('Родион Романович Раскольнико'));
 
-    // "@" sign can be (3 + 2 * maxChannelName) utf-16 code units
+    // "@" sign can be (4 + 2 * maxChannelName) utf-16 code units
     // away to the left of the cursor.
     doTest('If ~@chris^ is around, please ask him.', mention('chris'), maxChannelName: 10);
     doTest('If ~@_chris is^ around, please ask him.', silentMention('chris is'), maxChannelName: 10);
     doTest('If @chris is around, please ask him.^', null, maxChannelName: 10);
     doTest('If @_chris is around, please ask him.^', null, maxChannelName: 10);
+    // "🙂" is 2 utf-16 code units.
+    doTest('Ask ~@**Chris 🙂^', mention('Chris 🙂'), maxChannelName: 8);
+    doTest('Ask ~@_**Chris 🙂^', silentMention('Chris 🙂'), maxChannelName: 8);
+    doTest('Ask ~@**🙂🙂^', mention('🙂🙂'), maxChannelName: 4);
+    doTest('~@**🙂^', mention('🙂'), maxChannelName: 1);
 
     // Emoji (":smile:").
 
@@ -350,7 +427,8 @@ void main() {
     // away to the left of the cursor.
     doTest('check ~#**mobile dev^ team', channelLink('mobile dev'), maxChannelName: 5);
     doTest('check ~#mobile dev t^eam', channelLink('mobile dev t'), maxChannelName: 5);
-    doTest('check #mobile dev te^am', null, maxChannelName: 5);
+    doTest('check ~#mobile dev te^am', channelLink('mobile dev te'), maxChannelName: 5);
+    doTest('check #mobile dev tea^m', null, maxChannelName: 5);
     doTest('check #mobile dev team for more info^', null, maxChannelName: 5);
     // '🙂' is 2 utf-16 code units.
     doTest('check ~#**🙂🙂🙂🙂🙂^', channelLink('🙂🙂🙂🙂🙂'), maxChannelName: 5);


### PR DESCRIPTION
Fixes #1967.

<details>
  <summary>Changes</summary>

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/b9a97d53-d4d5-4122-86af-79be595089f9" width="350" controls></video> | <video src="https://github.com/user-attachments/assets/042f2d7c-03d7-4a74-bf2b-247d2cfbd5c6" width="350" controls></video> |

</details>