### PR TITLE
login: Hide email/password fields if email auth is disabled

### DIFF
--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -447,11 +447,14 @@ class _LoginPageState extends State<LoginPage> {
     final zulipLocalizations = ZulipLocalizations.of(context);
 
     final externalAuthenticationMethods = widget.serverSettings.externalAuthenticationMethods;
+    final emailAuthEnabled = widget.serverSettings.emailAuthEnabled;
 
     final loginContent = Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-      _UsernamePasswordForm(loginPageState: this),
+      if (emailAuthEnabled)
+        _UsernamePasswordForm(loginPageState: this),
       if (externalAuthenticationMethods.isNotEmpty) ...[
-        _AlternativeAuthDivider(),
+        if (emailAuthEnabled)
+          _AlternativeAuthDivider(),
         ...externalAuthenticationMethods.map((method) {
           final icon = method.displayIcon;
           return OutlinedButton.icon(

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -4,6 +4,7 @@ import 'package:checks/checks.dart';
 import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:zulip/api/core.dart';
@@ -372,6 +373,45 @@ void main() {
       // TODO test _getUserId case
       // TODO test handling failure in fetchApiKey request
       // TODO test _inProgress logic
+    });
+
+    group('email auth visibility', () { // another name for username/password auth
+      testWidgets('hides username/password fields and login button', (tester) async {
+        final serverSettings = eg.serverSettings(emailAuthEnabled: false);
+        await prepare(tester, serverSettings);
+        check(findUsernameInput).findsNothing();
+        check(findPasswordInput).findsNothing();
+        check(findSubmitButton).findsNothing();
+      });
+
+      testWidgets('shows external auth methods without divider', (tester) async {
+        prepareBoringImageHttpClient(); // icon on social-auth button
+        final serverSettings = eg.serverSettings(
+          emailAuthEnabled: false,
+          externalAuthenticationMethods: [googleAuthMethod]);
+        await prepare(tester, serverSettings);
+        check(find.textContaining('Google')).findsOne();
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        check(find.bySemanticsLabel(zulipLocalizations.loginMethodDividerSemanticLabel))
+          .findsNothing();
+        debugNetworkImageHttpClientProvider = null;
+      });
+
+      testWidgets('shows divider when email auth enabled with external methods', (tester) async {
+        prepareBoringImageHttpClient(); // icon on social-auth button
+        final serverSettings = eg.serverSettings(
+          emailAuthEnabled: true,
+          externalAuthenticationMethods: [googleAuthMethod]);
+        await prepare(tester, serverSettings);
+        check(findUsernameInput).findsOne();
+        check(findPasswordInput).findsOne();
+        check(findSubmitButton).findsOne();
+        check(find.textContaining('Google')).findsOne();
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        check(find.bySemanticsLabel(zulipLocalizations.loginMethodDividerSemanticLabel))
+          .findsOne();
+        debugNetworkImageHttpClientProvider = null;
+      });
     });
 
     group('web auth', () {


### PR DESCRIPTION
Fixes #745.

Use the email_auth_enabled server setting to conditionally render the username/password fields and the alternative auth divider.


<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/d3c76940-fc4d-4f88-a61c-3b238571eaba" alt="LTR" width="300"/>
      <p align="center"><strong>normal case</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/53da6e63-4cb0-44aa-819e-55c5a2a74996" alt="RTL" width="300"/>
      <p align="center"><strong>emailAuthEnabled==false</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/583012c7-41ae-448c-958c-089d02414163" alt="No external auth" width="300"/>
      <p align="center"><strong>externalAuthenticationMethods == [] &&<br>emailAuthEnabled == false</strong></p>
    </td>
  </tr>
</table>
