### PR TITLE
patrol: Enhancements for "live" tests

### DIFF
--- a/docs/patrol.md
+++ b/docs/patrol.md
@@ -291,7 +291,7 @@ Upstream docs: https://patrol.leancode.co/documentation
 
 ### Live login credentials
 
-In order to run the tests in `patrol_test/live_test.dart`, create a
+In order to run the tests in `patrol_test/live/`, create a
 file `.patrol.env` at the root of the project tree, like so:
 ```
 REALM_URL=https://chat.example.com

--- a/docs/patrol.md
+++ b/docs/patrol.md
@@ -299,14 +299,18 @@ file `.patrol.env` at the root of the project tree, like so:
 ```
 REALM_URL=https://chat.example.com
 EMAIL=user@example.com
+USER_ID=123
+API_KEY=asdf1234
 PASSWORD=hunter2
 OTHER_EMAIL=other.user@example.com
-OTHER_API_KEY=asdf1234
+OTHER_API_KEY=qwer5678
 ```
 
 with the realm URL of some real Zulip server, and credentials for
 two different test accounts there.  (The second account is used for
-sending messages to the first account, to cause notifications.)
+sending messages to the first account, to cause notifications.
+The password is used in testing the login flow itself,
+and the API key otherwise.)
 
 The tests will log into those real accounts and interact there.
 Avoid using chat.zulip.org or any other realm that people use

--- a/docs/patrol.md
+++ b/docs/patrol.md
@@ -30,9 +30,12 @@ There are a few different types of Patrol tests we can write, based on
 the implementation of `ZulipBinding` they use:
 
  * *Live* Patrol tests use `LiveZulipBinding`, the same implementation
-   as the actual app.  This means they talk to a real Zulip server and
-   store their data in a real local database file, as well as using
-   the real device platform.
+   as the actual app.
+   (Specifically they use `PatrolLiveZulipBinding`, a subclass which
+   adds some convenience features.)
+   This means they talk to a real Zulip server
+   and store their data in a real local database file,
+   as well as using the real device platform.
 
    This is useful where the Zulip server, too, has complexity we're
    not entirely confident of modeling in our tests.  Zulip's main

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -410,6 +410,23 @@ class LiveZulipBinding extends ZulipBinding {
   }
   bool _debugCalledGetGlobalStoreUniquely = false;
 
+  @visibleForTesting
+  void debugResetStore() {
+    assert(!(_globalStoreFuture != null && _globalStore == null),
+      // If we proceeded naively without this check, then the previous
+      // LiveGlobalStore.load().then(…) could clobber _globalStore later.
+      // If necessary, we could add some logic to support canceling/ignoring
+      // that previous call.
+      "attempted debugResetStore while in the middle of loading store");
+    _globalStore?.dispose();
+    _globalStore = null;
+    _globalStoreFuture = null;
+    assert(() {
+      _debugCalledGetGlobalStoreUniquely = false;
+      return true;
+    }());
+  }
+
   @override
   Future<bool> canLaunchUrl(Uri url) => url_launcher.canLaunchUrl(url);
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1178,7 +1178,7 @@ class LiveGlobalStore extends GlobalStore {
     // we'd invest in this area more.  For example we'd try doing these
     // in parallel, or deferring some to be concurrent with loading server data.
     final stopwatch = Stopwatch()..start();
-    final file = await _dbFile();
+    final file = await dbFile();
     final db = AppDatabase(NativeDatabase.createInBackground(file));
     final t1 = stopwatch.elapsed;
     final globalSettings = await db.getGlobalSettings();
@@ -1217,7 +1217,7 @@ class LiveGlobalStore extends GlobalStore {
   }
 
   /// The file path to use for the app database.
-  static Future<File> _dbFile() async {
+  static Future<File> dbFile() async {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
         // On iOS, we store the database file in an iOS App Group container.

--- a/patrol_test/live/binding.dart
+++ b/patrol_test/live/binding.dart
@@ -2,10 +2,12 @@
 
 import 'dart:io';
 
+import 'package:zulip/api/core.dart';
 import 'package:zulip/model/binding.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/app.dart';
 
+import '../../test/example_data.dart' as eg;
 import '../../test/model/binding.dart';
 
 /// The binding instance used in live Patrol tests.
@@ -60,5 +62,54 @@ class PatrolLiveZulipBinding extends LiveZulipBinding {
     } on PathNotFoundException {
       // ignore
     }
+  }
+}
+
+/// The live Zulip credentials provided in the build environment.
+///
+/// In Patrol tests, these come from `.patrol.env` at the root of the tree.
+/// See `docs/patrol.md`.
+abstract class LiveCredentials {
+  static const realmUrlStr = String.fromEnvironment('REALM_URL');
+  static final realmUrl = Uri.parse(const String.fromEnvironment('REALM_URL'));
+
+  static const email = String.fromEnvironment('EMAIL');
+  static const password = String.fromEnvironment('PASSWORD');
+  static final userId = int.parse(const String.fromEnvironment('USER_ID'), radix: 10);
+  static const apiKey = String.fromEnvironment('API_KEY');
+
+  static const otherEmail = String.fromEnvironment('OTHER_EMAIL');
+  static const otherApiKey = String.fromEnvironment('OTHER_API_KEY');
+
+  static Account account({
+    int? id,
+    String? realmName,
+    Uri? realmIcon,
+    int? zulipFeatureLevel,
+    String? zulipVersion,
+    String? zulipMergeBase,
+  }) {
+    return eg.account(
+      realmUrl: realmUrl,
+      user: eg.user(
+        userId: userId,
+        deliveryEmail: email),
+      apiKey: apiKey,
+      id: id,
+      realmName: realmName,
+      realmIcon: realmIcon,
+      zulipFeatureLevel: zulipFeatureLevel,
+      zulipVersion: zulipVersion,
+      zulipMergeBase: zulipMergeBase,
+    );
+  }
+
+  static ApiConnection makeOtherConnection() {
+    return ApiConnection.live(
+      realmUrl: realmUrl,
+      email: otherEmail,
+      apiKey: otherApiKey,
+      zulipFeatureLevel: eg.recentZulipFeatureLevel, // TODO get real value from server
+    );
   }
 }

--- a/patrol_test/live/binding.dart
+++ b/patrol_test/live/binding.dart
@@ -9,6 +9,7 @@ import 'package:zulip/widgets/app.dart';
 
 import '../../test/example_data.dart' as eg;
 import '../../test/model/binding.dart';
+import '../../test/model/test_store.dart';
 
 /// The binding instance used in live Patrol tests.
 ///
@@ -62,6 +63,23 @@ class PatrolLiveZulipBinding extends LiveZulipBinding {
     } on PathNotFoundException {
       // ignore
     }
+  }
+
+  /// Add an account to the app's data, as if logging in.
+  ///
+  /// Returns the resulting [Account]
+  /// (which in particular will have its own account ID).
+  ///
+  /// Compare [TestGlobalStore.add].
+  Future<Account> addAccount(Account account, {
+    bool markLastVisited = true,
+  }) async {
+    final globalStore = await getGlobalStore();
+    final accountId = await globalStore.insertAccount(account.toCompanion(false));
+    if (markLastVisited) {
+      await globalStore.setLastVisitedAccount(accountId);
+    }
+    return globalStore.getAccount(accountId)!;
   }
 }
 

--- a/patrol_test/live/binding.dart
+++ b/patrol_test/live/binding.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:io';
+
+import 'package:zulip/model/binding.dart';
+import 'package:zulip/model/store.dart';
+import 'package:zulip/widgets/app.dart';
+
+import '../../test/model/binding.dart';
+
+/// The binding instance used in live Patrol tests.
+///
+/// Compare [testBinding].
+PatrolLiveZulipBinding get patrolLiveBinding => PatrolLiveZulipBinding.instance;
+
+/// A concrete [ZulipBinding] implementation for live Patrol tests.
+///
+/// This class is a subclass of [LiveZulipBinding], and provides all the
+/// "live" bindings from that class.
+/// This adds methods convenient for manipulating the state from tests.
+///
+/// Because this is a subclass of [LiveZulipBinding], calling [ensureInitialized]
+/// will also have the effect of [LiveZulipBinding.ensureInitialized].
+/// In live Patrol tests, call `PatrolLiveZulipBinding.ensureInitialized`
+/// before [mainInit].
+class PatrolLiveZulipBinding extends LiveZulipBinding {
+  /// Initialize the binding if necessary, and ensure it is a [PatrolLiveZulipBinding].
+  ///
+  /// This method is idempotent; calling it repeatedly simply returns the
+  /// existing binding.
+  ///
+  /// If there is an existing binding but it is not a [PatrolLiveZulipBinding],
+  /// this method throws an error.
+  static PatrolLiveZulipBinding ensureInitialized() {
+    if (_instance == null) {
+      PatrolLiveZulipBinding();
+    }
+    return instance;
+  }
+
+  /// The single instance of the binding.
+  static PatrolLiveZulipBinding get instance => ZulipBinding.checkInstance(_instance);
+  static PatrolLiveZulipBinding? _instance;
+
+  @override
+  void initInstance() {
+    super.initInstance();
+    _instance = this;
+  }
+
+  /// Reset all test data to a clean state.
+  ///
+  /// In particular this wipes the app's database.
+  Future<void> reset() async {
+    ZulipApp.debugReset();
+    debugResetStore();
+    final dbFile = await LiveGlobalStore.dbFile();
+    try {
+      await dbFile.delete();
+    } on PathNotFoundException {
+      // ignore
+    }
+  }
+}

--- a/patrol_test/live/login_test.dart
+++ b/patrol_test/live/login_test.dart
@@ -1,0 +1,59 @@
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'package:checks/checks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:zulip/main.dart';
+import 'package:zulip/model/binding.dart';
+import 'package:zulip/widgets/app.dart';
+
+void main() {
+  mainInit();
+
+  // Successive tests in this file interact with the same real server
+  // and the same real device platform, by the nature of live tests.
+  // So we might as well let them use the same real database and global store.
+  ZulipBinding.instance.debugRelaxGetGlobalStoreUniquely = true;
+
+  patrolTest('email/password', ($) async {
+    // This isn't especially useful as a test: it duplicates flows we have in
+    // our widget tests, and doesn't do anything where the real device platform
+    // would be expected to differ from the Flutter test environment.
+    //
+    // Given the importance of the login flow, though, and the fact that it's
+    // something we don't naturally manually test in the course of using the
+    // app ourselves day to day, this test has some marginal value in
+    // double-checking that we haven't missed something.
+
+    addTearDown(ZulipApp.debugReset);
+    await $.pumpWidget(ZulipApp());
+
+    await $.waitUntilVisible($('Choose account'));
+    check($('Choose account')).findsOne();
+
+    if (await $.platform.mobile.isPermissionDialogVisible()) {
+      await $.platform.mobile.grantPermissionWhenInUse();
+    }
+
+    await $.tap($('Add an account'));
+
+    await $(TextField).enterText(const String.fromEnvironment('REALM_URL'));
+    await $.tap($('Continue'));
+
+    final findUsernameInput = find.byWidgetPredicate((widget) =>
+      widget is TextField
+      && (widget.autofillHints ?? []).contains(AutofillHints.email));
+    final findPasswordInput = find.byWidgetPredicate((widget) =>
+      widget is TextField
+      && (widget.autofillHints ?? []).contains(AutofillHints.password));
+    await $(findUsernameInput).enterText(const String.fromEnvironment('EMAIL'));
+    await $(findPasswordInput).enterText(const String.fromEnvironment('PASSWORD'));
+    await $.tap($(find.widgetWithText(ElevatedButton, 'Log in')));
+
+    await $.waitUntilVisible($('Inbox'));
+  });
+
+  // TODO test web auth
+}

--- a/patrol_test/live/login_test.dart
+++ b/patrol_test/live/login_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     await $.tap($('Add an account'));
 
-    await $(TextField).enterText(const String.fromEnvironment('REALM_URL'));
+    await $(TextField).enterText(LiveCredentials.realmUrlStr);
     await $.tap($('Continue'));
 
     final findUsernameInput = find.byWidgetPredicate((widget) =>
@@ -45,8 +45,8 @@ void main() {
     final findPasswordInput = find.byWidgetPredicate((widget) =>
       widget is TextField
       && (widget.autofillHints ?? []).contains(AutofillHints.password));
-    await $(findUsernameInput).enterText(const String.fromEnvironment('EMAIL'));
-    await $(findPasswordInput).enterText(const String.fromEnvironment('PASSWORD'));
+    await $(findUsernameInput).enterText(LiveCredentials.email);
+    await $(findPasswordInput).enterText(LiveCredentials.password);
     await $.tap($(find.widgetWithText(ElevatedButton, 'Log in')));
 
     await $.waitUntilVisible($('Inbox'));

--- a/patrol_test/live/login_test.dart
+++ b/patrol_test/live/login_test.dart
@@ -6,16 +6,13 @@ import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import 'package:zulip/main.dart';
-import 'package:zulip/model/binding.dart';
 import 'package:zulip/widgets/app.dart';
 
-void main() {
-  mainInit();
+import 'binding.dart';
 
-  // Successive tests in this file interact with the same real server
-  // and the same real device platform, by the nature of live tests.
-  // So we might as well let them use the same real database and global store.
-  ZulipBinding.instance.debugRelaxGetGlobalStoreUniquely = true;
+void main() {
+  PatrolLiveZulipBinding.ensureInitialized();
+  mainInit();
 
   patrolTest('email/password', ($) async {
     // This isn't especially useful as a test: it duplicates flows we have in
@@ -27,7 +24,7 @@ void main() {
     // app ourselves day to day, this test has some marginal value in
     // double-checking that we haven't missed something.
 
-    addTearDown(ZulipApp.debugReset);
+    await patrolLiveBinding.reset();
     await $.pumpWidget(ZulipApp());
 
     await $.waitUntilVisible($('Choose account'));

--- a/patrol_test/live/notifications_test.dart
+++ b/patrol_test/live/notifications_test.dart
@@ -14,7 +14,7 @@ import 'package:zulip/model/binding.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/store.dart';
 
-import '../test/example_data.dart' as eg;
+import '../../test/example_data.dart' as eg;
 
 void main() {
   mainInit();

--- a/patrol_test/live/notifications_test.dart
+++ b/patrol_test/live/notifications_test.dart
@@ -4,39 +4,22 @@ import 'package:checks/checks.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
-import 'package:zulip/api/core.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/main.dart';
 import 'package:zulip/model/binding.dart';
 import 'package:zulip/widgets/app.dart';
 
 import 'binding.dart';
-import '../../test/example_data.dart' as eg;
 
 void main() {
   PatrolLiveZulipBinding.ensureInitialized();
   mainInit();
 
-  ApiConnection makeOtherConnection() {
-    return ApiConnection.live(
-      realmUrl: Uri.parse(const String.fromEnvironment('REALM_URL')),
-      email: const String.fromEnvironment('OTHER_EMAIL'),
-      apiKey: const String.fromEnvironment('OTHER_API_KEY'),
-      zulipFeatureLevel: eg.recentZulipFeatureLevel, // TODO get real value from server
-    );
-  }
-
   patrolTest('notification', ($) async {
     await patrolLiveBinding.reset();
 
     final globalStore = await ZulipBinding.instance.getGlobalStore();
-    await globalStore.insertAccount(eg.account(
-      realmUrl: Uri.parse(const String.fromEnvironment('REALM_URL')),
-      user: eg.user(
-        userId: int.parse(const String.fromEnvironment('USER_ID'), radix: 10),
-        deliveryEmail: const String.fromEnvironment('EMAIL')),
-      apiKey: const String.fromEnvironment('API_KEY'),
-    ).toCompanion(false));
+    await globalStore.insertAccount(LiveCredentials.account().toCompanion(false));
     final account = globalStore.accounts.single;
     await globalStore.setLastVisitedAccount(account.id);
 
@@ -60,7 +43,7 @@ void main() {
 
     final token = Random().nextInt(1 << 32).toRadixString(16).padLeft(8, '0');
     final content = 'hello $token';
-    final otherConnection = makeOtherConnection();
+    final otherConnection = LiveCredentials.makeOtherConnection();
     await sendMessage(otherConnection,
       destination: DmDestination(userIds: [store.userId]),
       content: content);

--- a/patrol_test/live/notifications_test.dart
+++ b/patrol_test/live/notifications_test.dart
@@ -1,9 +1,6 @@
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 import 'dart:math';
 
 import 'package:checks/checks.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -12,17 +9,13 @@ import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/main.dart';
 import 'package:zulip/model/binding.dart';
 import 'package:zulip/widgets/app.dart';
-import 'package:zulip/widgets/store.dart';
 
+import 'binding.dart';
 import '../../test/example_data.dart' as eg;
 
 void main() {
+  PatrolLiveZulipBinding.ensureInitialized();
   mainInit();
-
-  // Successive tests in this file interact with the same real server
-  // and the same real device platform, by the nature of live tests.
-  // So we might as well let them use the same real database and global store.
-  ZulipBinding.instance.debugRelaxGetGlobalStoreUniquely = true;
 
   ApiConnection makeOtherConnection() {
     return ApiConnection.live(
@@ -33,52 +26,30 @@ void main() {
     );
   }
 
-  patrolTest('login', ($) async {
-    addTearDown(ZulipApp.debugReset);
-    await $.pumpWidget(ZulipApp());
+  patrolTest('notification', ($) async {
+    await patrolLiveBinding.reset();
 
-    await $.waitUntilVisible($('Choose account'));
-    check($('Choose account')).findsOne();
+    final globalStore = await ZulipBinding.instance.getGlobalStore();
+    await globalStore.insertAccount(eg.account(
+      realmUrl: Uri.parse(const String.fromEnvironment('REALM_URL')),
+      user: eg.user(
+        userId: int.parse(const String.fromEnvironment('USER_ID'), radix: 10),
+        deliveryEmail: const String.fromEnvironment('EMAIL')),
+      apiKey: const String.fromEnvironment('API_KEY'),
+    ).toCompanion(false));
+    final account = globalStore.accounts.single;
+    await globalStore.setLastVisitedAccount(account.id);
+
+    await $.pumpWidget(ZulipApp());
+    await $.waitUntilVisible($('Inbox'));
 
     if (await $.platform.mobile.isPermissionDialogVisible()) {
       await $.platform.mobile.grantPermissionWhenInUse();
     }
 
-    await $.tap($('Add an account'));
-
-    await $(TextField).enterText(const String.fromEnvironment('REALM_URL'));
-    await $.tap($('Continue'));
-
-    final findUsernameInput = find.byWidgetPredicate((widget) =>
-      widget is TextField
-      && (widget.autofillHints ?? []).contains(AutofillHints.email));
-    final findPasswordInput = find.byWidgetPredicate((widget) =>
-      widget is TextField
-      && (widget.autofillHints ?? []).contains(AutofillHints.password));
-    await $(findUsernameInput).enterText(const String.fromEnvironment('EMAIL'));
-    await $(findPasswordInput).enterText(const String.fromEnvironment('PASSWORD'));
-    await $.tap($(find.widgetWithText(ElevatedButton, 'Log in')));
-  });
-
-  patrolTest('notification', ($) async {
-    // Already logged in by the test above; no need to set up the account again.
-    //
-    // ... At least that's how the Patrol docs say it should behave,
-    // and how it does often behave.  But sometimes `patrol test` instead
-    // uninstalls and reinstalls the app between test cases:
-    //   https://github.com/zulip/zulip-flutter/pull/2171#discussion_r2853854928
-    // We could work around that by repeating the login steps here.
-    // We'll introduce an easier way to do setup in an upcoming PR,
-    // which will also solve this problem.
-
-    addTearDown(ZulipApp.debugReset);
-    await $.pumpWidgetAndSettle(ZulipApp());
-
     final navigator = await ZulipApp.navigator;
     final context = navigator.context;
     if (!context.mounted) throw Error();
-    final globalStore = GlobalStoreWidget.of(context);
-    final account = globalStore.accounts.single;
     final store = globalStore.getAccount(account.id)!;
 
     await Future<void>.delayed(Duration(milliseconds: 500));

--- a/patrol_test/live/notifications_test.dart
+++ b/patrol_test/live/notifications_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/main.dart';
-import 'package:zulip/model/binding.dart';
 import 'package:zulip/widgets/app.dart';
 
 import 'binding.dart';
@@ -17,11 +16,7 @@ void main() {
 
   patrolTest('notification', ($) async {
     await patrolLiveBinding.reset();
-
-    final globalStore = await ZulipBinding.instance.getGlobalStore();
-    await globalStore.insertAccount(LiveCredentials.account().toCompanion(false));
-    final account = globalStore.accounts.single;
-    await globalStore.setLastVisitedAccount(account.id);
+    final account = await patrolLiveBinding.addAccount(LiveCredentials.account());
 
     await $.pumpWidget(ZulipApp());
     await $.waitUntilVisible($('Inbox'));
@@ -29,11 +24,6 @@ void main() {
     if (await $.platform.mobile.isPermissionDialogVisible()) {
       await $.platform.mobile.grantPermissionWhenInUse();
     }
-
-    final navigator = await ZulipApp.navigator;
-    final context = navigator.context;
-    if (!context.mounted) throw Error();
-    final store = globalStore.getAccount(account.id)!;
 
     await Future<void>.delayed(Duration(milliseconds: 500));
 
@@ -45,7 +35,7 @@ void main() {
     final content = 'hello $token';
     final otherConnection = LiveCredentials.makeOtherConnection();
     await sendMessage(otherConnection,
-      destination: DmDestination(userIds: [store.userId]),
+      destination: DmDestination(userIds: [account.userId]),
       content: content);
 
     await $.platform.mobile.openNotifications();


### PR DESCRIPTION
Stacked atop #2171.

This makes it easier and cleaner to write "live" Patrol tests, the kind that talk to a real Zulip server. The test file for notifications (which has one test of receiving a notification and opening it) goes from 91 lines to 46 lines.
