### PR TITLE
content: Add localized rendering of system-group names in @-mentions

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1388,6 +1388,38 @@
   "@wildcardMentionTopicDescription": {
     "description": "Description for \"@topic\" wildcard-mention autocomplete options when writing a channel message."
   },
+  "systemGroupNameEveryoneOnInternet": "Everyone on the internet",
+  "@systemGroupNameEveryoneOnInternet": {
+    "description": "Display name for the system group that includes everyone on the internet."
+  },
+  "systemGroupNameEveryone": "Everyone including guests",
+  "@systemGroupNameEveryone": {
+    "description": "Display name for the system group that includes all users including guests."
+  },
+  "systemGroupNameMembers": "Everyone except guests",
+  "@systemGroupNameMembers": {
+    "description": "Display name for the system group that includes all users excluding guests."
+  },
+  "systemGroupNameFullMembers": "Full members",
+  "@systemGroupNameFullMembers": {
+    "description": "Display name for the system group that includes all full members of the organization."
+  },
+  "systemGroupNameModerators": "Moderators",
+  "@systemGroupNameModerators": {
+    "description": "Display name for the system group that includes all users with at least the moderator role."
+  },
+  "systemGroupNameAdministrators": "Administrators",
+  "@systemGroupNameAdministrators": {
+    "description": "Display name for the system group that includes all users with at least the administrator role."
+  },
+  "systemGroupNameOwners": "Owners",
+  "@systemGroupNameOwners": {
+    "description": "Display name for the system group that includes all users with the owner role."
+  },
+  "systemGroupNameNobody": "Nobody",
+  "@systemGroupNameNobody": {
+    "description": "Display name for the system group that includes nobody."
+  },
   "navBarFeedLabel": "Feed",
   "@navBarFeedLabel": {
     "description": "Label for the Feed button on the bottom navigation bar."

--- a/lib/api/model/permission.dart
+++ b/lib/api/model/permission.dart
@@ -1,5 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import '../../generated/l10n/zulip_localizations.dart';
+
 part 'permission.g.dart';
 
 /// Metadata about how to interpret the various group-based permission settings.
@@ -351,4 +353,27 @@ enum SystemGroupName implements DefaultGroupName {
 
   @override
   String toJson() => _$SystemGroupNameEnumMap[this]!;
+
+  /// Get the display name to use in the UI for this system group.
+  ///
+  /// Display names mirror the web app's display name strings.
+  /// See `system_user_groups_list` in web/src/settings_config.ts.
+  String displayName(ZulipLocalizations zulipLocalizations) => switch (this) {
+    SystemGroupName.everyoneOnInternet =>
+      zulipLocalizations.systemGroupNameEveryoneOnInternet,
+    SystemGroupName.everyone =>
+      zulipLocalizations.systemGroupNameEveryone,
+    SystemGroupName.members =>
+      zulipLocalizations.systemGroupNameMembers,
+    SystemGroupName.fullMembers =>
+      zulipLocalizations.systemGroupNameFullMembers,
+    SystemGroupName.moderators =>
+      zulipLocalizations.systemGroupNameModerators,
+    SystemGroupName.administrators =>
+      zulipLocalizations.systemGroupNameAdministrators,
+    SystemGroupName.owners =>
+      zulipLocalizations.systemGroupNameOwners,
+    SystemGroupName.nobody =>
+      zulipLocalizations.systemGroupNameNobody,
+  };
 }

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -2012,6 +2012,54 @@ abstract class ZulipLocalizations {
   /// **'Notify topic'**
   String get wildcardMentionTopicDescription;
 
+  /// Display name for the system group that includes everyone on the internet.
+  ///
+  /// In en, this message translates to:
+  /// **'Everyone on the internet'**
+  String get systemGroupNameEveryoneOnInternet;
+
+  /// Display name for the system group that includes all users including guests.
+  ///
+  /// In en, this message translates to:
+  /// **'Everyone including guests'**
+  String get systemGroupNameEveryone;
+
+  /// Display name for the system group that includes all users excluding guests.
+  ///
+  /// In en, this message translates to:
+  /// **'Everyone except guests'**
+  String get systemGroupNameMembers;
+
+  /// Display name for the system group that includes all full members of the organization.
+  ///
+  /// In en, this message translates to:
+  /// **'Full members'**
+  String get systemGroupNameFullMembers;
+
+  /// Display name for the system group that includes all users with at least the moderator role.
+  ///
+  /// In en, this message translates to:
+  /// **'Moderators'**
+  String get systemGroupNameModerators;
+
+  /// Display name for the system group that includes all users with at least the administrator role.
+  ///
+  /// In en, this message translates to:
+  /// **'Administrators'**
+  String get systemGroupNameAdministrators;
+
+  /// Display name for the system group that includes all users with the owner role.
+  ///
+  /// In en, this message translates to:
+  /// **'Owners'**
+  String get systemGroupNameOwners;
+
+  /// Display name for the system group that includes nobody.
+  ///
+  /// In en, this message translates to:
+  /// **'Nobody'**
+  String get systemGroupNameNobody;
+
   /// Label for the Feed button on the bottom navigation bar.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'إخطار الموضوع';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -1195,6 +1195,30 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Thema benachrichtigen';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -1206,6 +1206,30 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Notifier les participants à cette conversation';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -1184,6 +1184,30 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notifica argomento';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1143,6 +1143,30 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'トピック参加者に通知';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -1186,6 +1186,30 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Powiadom w wątku';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -1199,6 +1199,30 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Оповестить тему';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -1171,6 +1171,30 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -1206,6 +1206,30 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Obvesti udeležence teme';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -1188,6 +1188,30 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Повідомити канал';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -1169,6 +1169,30 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
+
+  @override
+  String get systemGroupNameEveryone => 'Everyone including guests';
+
+  @override
+  String get systemGroupNameMembers => 'Everyone except guests';
+
+  @override
+  String get systemGroupNameFullMembers => 'Full members';
+
+  @override
+  String get systemGroupNameModerators => 'Moderators';
+
+  @override
+  String get systemGroupNameAdministrators => 'Administrators';
+
+  @override
+  String get systemGroupNameOwners => 'Owners';
+
+  @override
+  String get systemGroupNameNobody => 'Nobody';
+
+  @override
   String get navBarFeedLabel => 'Feed';
 
   @override

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1149,6 +1149,37 @@ void main() {
         check(find.text('new-name')).findsOne();
         check(find.text('@new-name')).findsNothing();
       });
+
+      for (final (apiName, displayName) in const [
+        ('role:internet',       'Everyone on the internet'),
+        ('role:everyone',       'Everyone including guests'),
+        ('role:members',        'Everyone except guests'),
+        ('role:fullmembers',    'Full members'),
+        ('role:moderators',     'Moderators'),
+        ('role:administrators', 'Administrators'),
+        ('role:owners',         'Owners'),
+        ('role:nobody',         'Nobody'),
+      ]) {
+        testWidgets('shows localized display name for system group $apiName',
+            (tester) async {
+          await prepare(
+            tester: tester,
+            html: '<p><span class="user-group-mention"'
+              ' data-user-group-id="5">@$apiName</span></p>',
+            userGroups: [eg.userGroup(id: 5, name: apiName, isSystemGroup: true)]);
+          check(find.text('@$displayName')).findsOne();
+          check(find.text('@$apiName')).findsNothing();
+        });
+      }
+
+      testWidgets('shows localized display name for silent system group mention', (tester) async {
+        await prepare(
+          tester: tester,
+          html: '<p><span class="user-group-mention silent" data-user-group-id="5">role:administrators</span></p>',
+          userGroups: [eg.userGroup(id: 5, name: 'role:administrators', isSystemGroup: true)]);
+        check(find.text('Administrators')).findsOne();
+        check(find.text('@Administrators')).findsNothing();
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #1260.

|Before|After|
|----|----|
|<img width="1080" height="2400" alt="Screenshot_20260224-213442 Zulip" src="https://github.com/user-attachments/assets/0ae295e9-38a3-4866-b7c8-238a9b9aadf0" />|<img width="1080" height="2400" alt="Screenshot_20260224-200945 Zulip" src="https://github.com/user-attachments/assets/c95bc49c-1d92-4628-a6ae-9990f2cc4cd8" />|
|<img width="1080" height="2400" alt="Screenshot_20260224-213456 Zulip" src="https://github.com/user-attachments/assets/1d7334a2-4c63-44db-90a7-920e850587d1" />|<img width="1080" height="2400" alt="Screenshot_20260224-200955 Zulip" src="https://github.com/user-attachments/assets/6d21b57b-0be6-49fb-a4d7-4d752fee7dcd" />|

Changes made:
1. Added system group name strings to app_en.arb.
2. Added function `displayName` to `SystemGroupName` to get translated string for current system group.
3. Changed `Mention` widget to fetch system group display name using the current user group mention name (treating the name as api value). If the system group doesn't exist, it falls back to the user group mention name.
4. Added tests.