### PR TITLE
Reconcile some text-input style differences, toward reusable code for the report-message form

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -875,9 +875,9 @@
   "@loginAddAnAccountPageTitle": {
     "description": "Title for page to add a Zulip account."
   },
-  "loginServerUrlLabel": "Your Zulip server URL",
-  "@loginServerUrlLabel": {
-    "description": "Label in login page for Zulip server URL entry."
+  "loginRealmUrlLabel": "Your Zulip organization URL",
+  "@loginRealmUrlLabel": {
+    "description": "Label in login page for Zulip realm/org URL entry."
   },
   "loginHidePassword": "Hide password",
   "@loginHidePassword": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1340,11 +1340,11 @@ abstract class ZulipLocalizations {
   /// **'Add an account'**
   String get loginAddAnAccountPageTitle;
 
-  /// Label in login page for Zulip server URL entry.
+  /// Label in login page for Zulip realm/org URL entry.
   ///
   /// In en, this message translates to:
-  /// **'Your Zulip server URL'**
-  String get loginServerUrlLabel;
+  /// **'Your Zulip organization URL'**
+  String get loginRealmUrlLabel;
 
   /// Icon label for button to hide password in input form.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -746,7 +746,7 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Account hinzufügen';
 
   @override
-  String get loginServerUrlLabel => 'Deine Zulip Server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Passwort verstecken';

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -728,7 +728,7 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Peida salasõna';

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -753,7 +753,7 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Ajouter un compte';
 
   @override
-  String get loginServerUrlLabel => 'L\'URL de votre serveur Zulip';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Cacher le mot de passe';

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -745,7 +745,7 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Aggiungi account';
 
   @override
-  String get loginServerUrlLabel => 'URL del server Zulip';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Nascondi password';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -709,7 +709,7 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'アカウントを追加';
 
   @override
-  String get loginServerUrlLabel => 'Zulip サーバーのURL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'パスワードを非表示';

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -740,7 +740,7 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Dodaj konto';
 
   @override
-  String get loginServerUrlLabel => 'URL serwera Zulip';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Ukryj hasło';

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -740,7 +740,7 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Добавление учетной записи';
 
   @override
-  String get loginServerUrlLabel => 'URL вашего сервера Zulip';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Скрыть пароль';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Pridať účet';
 
   @override
-  String get loginServerUrlLabel => 'Adresa vášho Zulip servera';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Skryť heslo';

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -751,7 +751,7 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Dodaj račun';
 
   @override
-  String get loginServerUrlLabel => 'URL strežnika Zulip';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Skrij geslo';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -741,7 +741,7 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Додати обліковий запис';
 
   @override
-  String get loginServerUrlLabel => 'URL-адреса вашого сервера Zulip';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Приховати пароль';

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -726,7 +726,7 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get loginAddAnAccountPageTitle => 'Add an account';
 
   @override
-  String get loginServerUrlLabel => 'Your Zulip server URL';
+  String get loginRealmUrlLabel => 'Your Zulip organization URL';
 
   @override
   String get loginHidePassword => 'Hide password';
@@ -1942,9 +1942,6 @@ class ZulipLocalizationsZhHansCn extends ZulipLocalizationsZh {
   String get loginAddAnAccountPageTitle => '添加账号';
 
   @override
-  String get loginServerUrlLabel => 'Zulip 服务器网址';
-
-  @override
   String get loginHidePassword => '隐藏密码';
 
   @override
@@ -3124,9 +3121,6 @@ class ZulipLocalizationsZhHantTw extends ZulipLocalizationsZh {
 
   @override
   String get loginAddAnAccountPageTitle => '增添帳號';
-
-  @override
-  String get loginServerUrlLabel => '您的 Zulip 伺服器網址';
 
   @override
   String get loginHidePassword => '隱藏密碼';

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -15,6 +15,7 @@ import 'color.dart';
 import 'dialog.dart';
 import 'emoji.dart';
 import 'inset_shadow.dart';
+import 'input.dart';
 import 'page.dart';
 import 'profile.dart';
 import 'store.dart';
@@ -493,15 +494,8 @@ class _EmojiPickerState extends State<EmojiPicker> with PerAccountStoreAwareStat
             child: TextField(
               controller: _controller,
               autofocus: true,
-              decoration: InputDecoration(
-                hintText: zulipLocalizations.emojiPickerSearchEmoji,
-                contentPadding: const EdgeInsetsDirectional.only(start: 10, top: 6),
-                filled: true,
-                fillColor: designVariables.bgSearchInput,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(10),
-                  borderSide: BorderSide.none),
-                hintStyle: TextStyle(color: designVariables.textMessage)),
+              decoration: baseFilledInputDecoration(designVariables)
+                .copyWith(hintText: zulipLocalizations.emojiPickerSearchEmoji),
               style: const TextStyle(fontSize: 19, height: 26 / 19)))),
           TextButton(
             onPressed: () => Navigator.pop(context),

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -494,9 +494,9 @@ class _EmojiPickerState extends State<EmojiPicker> with PerAccountStoreAwareStat
             child: TextField(
               controller: _controller,
               autofocus: true,
+              style: filledInputTextStyle(designVariables),
               decoration: baseFilledInputDecoration(designVariables)
-                .copyWith(hintText: zulipLocalizations.emojiPickerSearchEmoji),
-              style: const TextStyle(fontSize: 19, height: 26 / 19)))),
+                .copyWith(hintText: zulipLocalizations.emojiPickerSearchEmoji)))),
           TextButton(
             onPressed: () => Navigator.pop(context),
             style: TextButton.styleFrom(

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -3,6 +3,38 @@ import 'package:flutter/material.dart';
 import 'inset_shadow.dart';
 import 'theme.dart';
 
+/// A base [InputDecoration] for "filled"-style text inputs.
+///
+/// Callers should use [InputDecoration.copyWith] to add field-specific
+/// properties like [InputDecoration.hintText] or [InputDecoration.suffixIcon].
+///
+/// The returned decoration won't configure a "label" above the input,
+/// for callers building a form, even though [InputDecoration] supports that.
+/// That's because we don't have a Figma design for form fields with labels,
+/// and we expect it to be quite different from Material's defaults;
+/// that's https://github.com/zulip/zulip-flutter/issues/2183 .
+/// Until we have that design, callers shouldn't spend significant effort
+/// wrangling [InputDecoration.labelStyle] and its friends.
+/// Consider whether hint text by itself is enough,
+/// or if Material's default styling is OK temporarily.
+// TODO(#2183) review dartdoc and implementation
+InputDecoration baseFilledInputDecoration(DesignVariables designVariables) {
+  return InputDecoration(
+    hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
+    isDense: true,
+    contentPadding: EdgeInsets.symmetric(
+      vertical: 8,
+      // Subtracting 4 pixels to account for the internal
+      // 4-pixel horizontal padding (_kInputExtraPadding in InputDecorator).
+      horizontal: 10 - 4,
+    ),
+    filled: true,
+    fillColor: designVariables.bgSearchInput,
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(10),
+      borderSide: BorderSide.none));
+}
+
 /// A space to use for [InputDecoration.helperText] so the layout doesn't jump.
 ///
 /// In particular, U+200B ZERO WIDTH SPACE.

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -6,18 +6,8 @@ import 'theme.dart';
 /// A base [InputDecoration] for "filled"-style text inputs.
 ///
 /// Callers should use [InputDecoration.copyWith] to add field-specific
-/// properties like [InputDecoration.hintText] or [InputDecoration.suffixIcon].
-///
-/// The returned decoration won't configure a "label" above the input,
-/// for callers building a form, even though [InputDecoration] supports that.
-/// That's because we don't have a Figma design for form fields with labels,
-/// and we expect it to be quite different from Material's defaults;
-/// that's https://github.com/zulip/zulip-flutter/issues/2183 .
-/// Until we have that design, callers shouldn't spend significant effort
-/// wrangling [InputDecoration.labelStyle] and its friends.
-/// Consider whether hint text by itself is enough,
-/// or if Material's default styling is OK temporarily.
-// TODO(#2183) review dartdoc and implementation
+/// properties like [InputDecoration.hintText], [InputDecoration.labelText],
+/// or [InputDecoration.suffixIcon].
 InputDecoration baseFilledInputDecoration(DesignVariables designVariables) {
   return InputDecoration(
     hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
@@ -30,7 +20,17 @@ InputDecoration baseFilledInputDecoration(DesignVariables designVariables) {
     ),
     filled: true,
     fillColor: designVariables.bgSearchInput,
-    border: OutlineInputBorder(
+
+    // "underline" not because we want an underline (we unset it using
+    // [BorderSide.none]) but because it causes [InputDecorator] to handle the
+    // label text's "floating" state by putting the label in a reserved space
+    // inside the input's filled area (see `filled: true`) instead of making it
+    // straddle the top edge of the filled area. Requested by Alya:
+    //   https://github.com/zulip/zulip-flutter/pull/2184#issuecomment-3993219258
+    // When no label text is specified (see [InputDecoration.labelText]),
+    // the extra space is not reserved.
+    // TODO(#2183) revisit if changing
+    border: UnderlineInputBorder(
       borderRadius: BorderRadius.circular(10),
       borderSide: BorderSide.none));
 }

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -48,6 +48,9 @@ TextStyle filledInputTextStyle(DesignVariables designVariables) => TextStyle(
   //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=10806-25228&m=dev
   fontSize: 19,
   height: 26 / 19,
+
+  // https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=10867-99284&m=dev
+  color: designVariables.textInput,
 );
 
 /// A space to use for [InputDecoration.helperText] so the layout doesn't jump.

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -11,6 +11,8 @@ import 'theme.dart';
 InputDecoration baseFilledInputDecoration(DesignVariables designVariables) {
   return InputDecoration(
     hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
+    // TODO(design) is this the right variable?
+    errorStyle: TextStyle(color: designVariables.contextMenuItemTextDanger),
     isDense: true,
     contentPadding: EdgeInsets.symmetric(
       vertical: 8,

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -8,6 +8,9 @@ import 'theme.dart';
 /// Callers should use [InputDecoration.copyWith] to add field-specific
 /// properties like [InputDecoration.hintText], [InputDecoration.labelText],
 /// or [InputDecoration.suffixIcon].
+///
+/// [filledInputTextStyle] is recommended for styling the text-input's value,
+/// i.e., the text the user has typed. That's not a job of [InputDecoration].
 InputDecoration baseFilledInputDecoration(DesignVariables designVariables) {
   return InputDecoration(
     hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
@@ -36,6 +39,16 @@ InputDecoration baseFilledInputDecoration(DesignVariables designVariables) {
       borderRadius: BorderRadius.circular(10),
       borderSide: BorderSide.none));
 }
+
+/// A [TextStyle] for the user-entered text in "filled"-style text inputs.
+///
+/// This is intended to be paired with [baseFilledInputDecoration].
+TextStyle filledInputTextStyle(DesignVariables designVariables) => TextStyle(
+  // Font size and height from
+  //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=10806-25228&m=dev
+  fontSize: 19,
+  height: 26 / 19,
+);
 
 /// A space to use for [InputDecoration.helperText] so the layout doesn't jump.
 ///

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -223,6 +223,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
   Widget build(BuildContext context) {
     assert(!PerAccountStoreWidget.debugExistsOf(context));
     final zulipLocalizations = ZulipLocalizations.of(context);
+    final designVariables = DesignVariables.of(context);
     final error = _parseResult.error;
     final errorText = error == null || error.shouldDeferFeedback()
       ? null
@@ -253,11 +254,15 @@ class _AddAccountPageState extends State<AddAccountPage> {
                   _controller.clearComposing();
                   // …but leave out unfocusing the input in case more editing is needed.
                 },
-                decoration: InputDecoration(
-                  labelText: zulipLocalizations.loginServerUrlLabel,
-                  errorText: errorText,
-                  helperText: kLayoutPinningHelperText,
-                  hintText: AddAccountPage._serverUrlHint)),
+                decoration: baseFilledInputDecoration(designVariables)
+                  .copyWith(
+                    // TODO(#2183) follow design for label text
+                    //   (or don't use it here?)
+                    labelText: zulipLocalizations.loginServerUrlLabel,
+                    errorText: errorText,
+                    helperText: kLayoutPinningHelperText,
+                    hintText: AddAccountPage._serverUrlHint,
+                  )),
               const SizedBox(height: 8),
               ElevatedButton(
                 onPressed: !_inProgress && errorText == null
@@ -584,6 +589,7 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
   @override
   Widget build(BuildContext context) {
     assert(!PerAccountStoreWidget.debugExistsOf(context));
+    final designVariables = DesignVariables.of(context);
     final serverSettings = widget.loginPageState.widget.serverSettings;
     final zulipLocalizations = ZulipLocalizations.of(context);
     final requireEmailFormatUsernames = serverSettings.requireEmailFormatUsernames;
@@ -610,7 +616,7 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
         return null;
       },
       textInputAction: TextInputAction.next,
-      decoration: InputDecoration(
+      decoration: baseFilledInputDecoration(designVariables).copyWith(
         labelText: requireEmailFormatUsernames
           ? zulipLocalizations.loginEmailLabel
           : zulipLocalizations.loginUsernameLabel,
@@ -631,7 +637,7 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
       },
       textInputAction: TextInputAction.go,
       onFieldSubmitted: (value) => _submit(),
-      decoration: InputDecoration(
+      decoration: baseFilledInputDecoration(designVariables).copyWith(
         labelText: zulipLocalizations.loginPasswordLabel,
         helperText: kLayoutPinningHelperText,
         suffixIcon: IconButton(

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -259,7 +259,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
                   .copyWith(
                     // TODO(#2183) follow design for label text
                     //   (or don't use it here?)
-                    labelText: zulipLocalizations.loginServerUrlLabel,
+                    labelText: zulipLocalizations.loginRealmUrlLabel,
                     errorText: errorText,
                     helperText: kLayoutPinningHelperText,
                     hintText: AddAccountPage._serverUrlHint,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -254,6 +254,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
                   _controller.clearComposing();
                   // …but leave out unfocusing the input in case more editing is needed.
                 },
+                style: filledInputTextStyle(designVariables),
                 decoration: baseFilledInputDecoration(designVariables)
                   .copyWith(
                     // TODO(#2183) follow design for label text
@@ -616,6 +617,7 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
         return null;
       },
       textInputAction: TextInputAction.next,
+      style: filledInputTextStyle(designVariables),
       decoration: baseFilledInputDecoration(designVariables).copyWith(
         labelText: requireEmailFormatUsernames
           ? zulipLocalizations.loginEmailLabel
@@ -637,6 +639,7 @@ class _UsernamePasswordFormState extends State<_UsernamePasswordForm> {
       },
       textInputAction: TextInputAction.go,
       onFieldSubmitted: (value) => _submit(),
+      style: filledInputTextStyle(designVariables),
       decoration: baseFilledInputDecoration(designVariables).copyWith(
         labelText: zulipLocalizations.loginPasswordLabel,
         helperText: kLayoutPinningHelperText,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -25,6 +25,7 @@ import 'compose_box.dart';
 import 'content.dart';
 import 'emoji_reaction.dart';
 import 'icons.dart';
+import 'input.dart';
 import 'page.dart';
 import 'profile.dart';
 import 'scrolling.dart';
@@ -772,36 +773,28 @@ class _SearchBarState extends State<_SearchBar> {
         height: 28 / 19,
       ),
       textInputAction: TextInputAction.search,
-      decoration: InputDecoration(
-        isDense: true,
-        hintText: zulipLocalizations.searchMessagesHintText,
-        hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
-        prefixIcon: Padding(
-          padding: const EdgeInsetsDirectional.fromSTEB(8, 8, 0, 8),
-          child: Icon(size: 24, ZulipIcons.search)),
-        prefixIconColor: designVariables.labelSearchPrompt,
-        prefixIconConstraints: BoxConstraints(),
-        suffixIcon: IconButton(
-          tooltip: zulipLocalizations.searchMessagesClearButtonTooltip,
-          onPressed: _clearInput,
-          // This and `suffixIconConstraints` allow 42px square touch target.
-          visualDensity: VisualDensity.compact,
-          highlightColor: Colors.transparent,
-          style: ButtonStyle(
-            padding: WidgetStatePropertyAll(EdgeInsets.zero),
-            splashFactory: NoSplash.splashFactory,
-          ),
-          iconSize: 24,
-          icon: Icon(ZulipIcons.remove)),
-        suffixIconColor: designVariables.textMessageMuted,
-        suffixIconConstraints: BoxConstraints(minWidth: 42, minHeight: 42),
-        contentPadding: const EdgeInsetsDirectional.symmetric(vertical: 7),
-        filled: true,
-        fillColor: designVariables.bgSearchInput,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: BorderSide.none),
-      ));
+      decoration: baseFilledInputDecoration(designVariables)
+        .copyWith(
+          hintText: zulipLocalizations.searchMessagesHintText,
+          prefixIcon: Padding(
+            padding: const EdgeInsetsDirectional.fromSTEB(8, 8, 0, 8),
+            child: Icon(size: 24, ZulipIcons.search)),
+          prefixIconColor: designVariables.labelSearchPrompt,
+          prefixIconConstraints: BoxConstraints(),
+          suffixIcon: IconButton(
+            tooltip: zulipLocalizations.searchMessagesClearButtonTooltip,
+            onPressed: _clearInput,
+            // This and `suffixIconConstraints` allow 42px square touch target.
+            visualDensity: VisualDensity.compact,
+            highlightColor: Colors.transparent,
+            style: ButtonStyle(
+              padding: WidgetStatePropertyAll(EdgeInsets.zero),
+              splashFactory: NoSplash.splashFactory,
+            ),
+            iconSize: 24,
+            icon: Icon(ZulipIcons.remove)),
+          suffixIconColor: designVariables.textMessageMuted,
+          suffixIconConstraints: BoxConstraints(minWidth: 42, minHeight: 42)));
   }
 }
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -767,11 +767,8 @@ class _SearchBarState extends State<_SearchBar> {
       autofocus: true,
       onSubmitted: _handleSubmitted,
       cursorColor: designVariables.textInput,
-      style: TextStyle(
-        color: designVariables.textInput,
-        fontSize: 19,
-        height: 28 / 19,
-      ),
+      style: filledInputTextStyle(designVariables)
+        .copyWith(color: designVariables.textInput),
       textInputAction: TextInputAction.search,
       decoration: baseFilledInputDecoration(designVariables)
         .copyWith(

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -767,8 +767,7 @@ class _SearchBarState extends State<_SearchBar> {
       autofocus: true,
       onSubmitted: _handleSubmitted,
       cursorColor: designVariables.textInput,
-      style: filledInputTextStyle(designVariables)
-        .copyWith(color: designVariables.textInput),
+      style: filledInputTextStyle(designVariables),
       textInputAction: TextInputAction.search,
       decoration: baseFilledInputDecoration(designVariables)
         .copyWith(

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -766,7 +766,6 @@ class _SearchBarState extends State<_SearchBar> {
 
       autofocus: true,
       onSubmitted: _handleSubmitted,
-      cursorColor: designVariables.textInput,
       style: filledInputTextStyle(designVariables),
       textInputAction: TextInputAction.search,
       decoration: baseFilledInputDecoration(designVariables)

--- a/lib/widgets/new_dm_sheet.dart
+++ b/lib/widgets/new_dm_sheet.dart
@@ -241,7 +241,6 @@ class _NewDmSearchBar extends StatelessWidget {
     return TextField(
       controller: controller,
       autofocus: true,
-      cursorColor: designVariables.foreground,
       style: TextStyle(
         color: designVariables.textMessage,
         fontSize: 17,

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -12,6 +12,7 @@ import 'emoji_reaction.dart';
 import 'icons.dart';
 import 'image.dart';
 import 'inset_shadow.dart';
+import 'input.dart';
 import 'page.dart';
 import 'store.dart';
 import 'text.dart';
@@ -234,25 +235,12 @@ class _SetStatusPageState extends State<SetStatusPage> {
                   cursorColor: designVariables.textInput,
                   textCapitalization: TextCapitalization.sentences,
                   style: TextStyle(fontSize: 19, height: 24 / 19),
-                  decoration: InputDecoration(
-                    // TODO: display a counter as suggested in CZO discussion:
-                    //   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Set.20user.20status/near/2224549
-                    counterText: '',
-                    hintText: zulipLocalizations.statusTextHint,
-                    hintStyle: TextStyle(color: designVariables.labelSearchPrompt),
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      vertical: 8,
-                      // Subtracting 4 pixels to account for the internal
-                      // 4-pixel horizontal padding.
-                      horizontal: 10 - 4,
-                    ),
-                    filled: true,
-                    fillColor: designVariables.bgSearchInput,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: BorderSide.none,
-                    )))),
+                  decoration: baseFilledInputDecoration(designVariables)
+                    .copyWith(
+                      // TODO: display a counter as suggested in CZO discussion:
+                      //   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Set.20user.20status/near/2224549
+                      counterText: '',
+                      hintText: zulipLocalizations.statusTextHint))),
               ]),
           ),
           Expanded(child: InsetShadowBox(

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -232,7 +232,6 @@ class _SetStatusPageState extends State<SetStatusPage> {
                   // The limit on the size of the status text is 60 characters.
                   // See: https://zulip.com/api/update-status#parameter-status_text
                   maxLength: 60,
-                  cursorColor: designVariables.textInput,
                   textCapitalization: TextCapitalization.sentences,
                   style: filledInputTextStyle(designVariables),
                   decoration: baseFilledInputDecoration(designVariables)

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -234,7 +234,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
                   maxLength: 60,
                   cursorColor: designVariables.textInput,
                   textCapitalization: TextCapitalization.sentences,
-                  style: TextStyle(fontSize: 19, height: 24 / 19),
+                  style: filledInputTextStyle(designVariables),
                   decoration: baseFilledInputDecoration(designVariables)
                     .copyWith(
                       // TODO: display a counter as suggested in CZO discussion:

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -110,6 +110,12 @@ ThemeData zulipThemeData(BuildContext context) {
     ),
     colorScheme: colorScheme,
     scaffoldBackgroundColor: designVariables.mainBackground,
+    textSelectionTheme: TextSelectionThemeData(
+      // As in Figma:
+      //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=11011-18859&m=dev
+      cursorColor: designVariables.textInput,
+      // TODO(design) selectionColor, selectionHandleColor?
+    ),
     tooltipTheme: const TooltipThemeData(preferBelow: false),
     bottomSheetTheme: BottomSheetThemeData(
       clipBehavior: Clip.antiAlias,


### PR DESCRIPTION
I'd like to try styling the report-message form fields similarly to some existing text fields in the app. To prepare for that, here's a PR that reconciles some differences that have crept in among similarly-styled text inputs, and pulls out some reusable code to prevent drift like that in the future.

Oh! And also restyles the hacky-looking Material-styled inputs in the login flow. 🙂 

There will be a lot of screenshots, so I'll group them into separate GitHub comments. When looking at the cursor color, please note that the cursor blink is a fade animation, and sometimes I didn't catch its fully-faded-in appearance in the screenshot; apologies for that.

cc @alya 