### PR TITLE
api: Add warning banner for unsupported servers

### DIFF
--- a/assets/l10n/app_de.arb
+++ b/assets/l10n/app_de.arb
@@ -618,10 +618,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1487,7 +1487,7 @@
   "errorRequestFailed": "Netzwerkanfrage fehlgeschlagen: HTTP Status {httpStatus}",
   "errorResolveTopicFailedTitle": "Thema konnte nicht als gelöst markiert werden",
   "errorServerMessage": "Der Server sagte:\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} nutzt Zulip Server {zulipVersion}, welche nicht unterstützt wird. Die unterstützte Mindestversion ist Zulip Server {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} nutzt Zulip Server {zulipVersion}, welche nicht unterstützt wird. Die unterstützte Mindestversion ist Zulip Server {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Es ist kein Konto angemeldet. Bitte logge dich in ein Konto ein und versuche es erneut.",
   "errorSharingFailed": "Teilen fehlgeschlagen",
   "errorSharingTitle": "Teilen des Inhalts fehlgeschlagen",

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -952,13 +952,13 @@
   "@errorContentToInsertIsEmpty": {
     "description": "Error message when the rich content to be inserted is empty or cannot be accessed."
   },
-  "errorServerVersionUnsupportedMessage": "{url} is running Zulip Server {zulipVersion}, which is unsupported. The minimum supported version is Zulip Server {minSupportedZulipVersion}.",
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "errorServerVersionNotAllowedMessage": "{url} is running Zulip Server {zulipVersion}, which is unsupported. The minimum supported version is Zulip Server {minAllowedZulipVersion}.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
       "url": {"type": "String", "example": "http://chat.example.com/"},
       "zulipVersion": {"type": "String", "example": "3.2"},
-      "minSupportedZulipVersion": {"type": "String", "example": "4.0"}
+      "minAllowedZulipVersion": {"type": "String", "example": "4.0"}
     }
   },
   "errorInvalidApiKeyMessage": "Your account at {url} could not be authenticated. Please try logging in again or use another account.",

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -961,6 +961,30 @@
       "minAllowedZulipVersion": {"type": "String", "example": "4.0"}
     }
   },
+  "serverCompatBannerAdminMessage": "{url} is running Zulip Server {zulipVersion}, which is unsupported. Please upgrade your server as soon as possible.",
+  "@serverCompatBannerAdminMessage": {
+    "description": "Banner message shown to server admins when the server version is no longer supported.",
+    "placeholders": {
+      "url": {"type": "String", "example": "http://chat.example.com/"},
+      "zulipVersion": {"type": "String", "example": "9.0"}
+    }
+  },
+  "serverCompatBannerUserMessage": "{url} is running Zulip Server {zulipVersion}, which is unsupported. Please contact your server administrator about upgrading.",
+  "@serverCompatBannerUserMessage": {
+    "description": "Banner message shown to non-admin users when the server version is no longer supported.",
+    "placeholders": {
+      "url": {"type": "String", "example": "http://chat.example.com/"},
+      "zulipVersion": {"type": "String", "example": "9.0"}
+    }
+  },
+  "serverCompatBannerDismissLabel": "Dismiss",
+  "@serverCompatBannerDismissLabel": {
+    "description": "Label for the button that dismisses the server compatibility warning banner."
+  },
+  "serverCompatBannerLearnMoreLabel": "Learn more",
+  "@serverCompatBannerLearnMoreLabel": {
+    "description": "Label for the button in the server compatibility warning banner that opens the support policy doc."
+  },
   "errorInvalidApiKeyMessage": "Your account at {url} could not be authenticated. Please try logging in again or use another account.",
   "@errorInvalidApiKeyMessage": {
     "description": "Error message in the dialog for invalid API key.",

--- a/assets/l10n/app_fr.arb
+++ b/assets/l10n/app_fr.arb
@@ -636,10 +636,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1565,7 +1565,7 @@
   "errorRequestFailed": "Échec de la requête réseau : statut HTTP {httpStatus}",
   "errorResolveTopicFailedTitle": "La conversation n'a pas pu être marquée comme résolue",
   "errorServerMessage": "Message d'erreur du serveur :\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} exploite Zulip Server en version {zulipVersion}, qui n'est pas supportée. La version minimum supportée est Zulip Server {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} exploite Zulip Server en version {zulipVersion}, qui n'est pas supportée. La version minimum supportée est Zulip Server {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Il n'y a pas de compte connecté. Merci de vous connecter à un compte et d'essayer à nouveau.",
   "errorSharingFailed": "Échec du partage",
   "errorSharingTitle": "Échec du partage du contenu",

--- a/assets/l10n/app_it.arb
+++ b/assets/l10n/app_it.arb
@@ -636,10 +636,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1559,7 +1559,7 @@
   "errorRequestFailed": "Richiesta di rete non riuscita: stato HTTP {httpStatus}",
   "errorResolveTopicFailedTitle": "Impossibile contrassegnare l'argomento come risolto",
   "errorServerMessage": "Il server ha detto:\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} sta usando Zulip Server {zulipVersion}, che non è supportato. La versione minima supportata è Zulip Server {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} sta usando Zulip Server {zulipVersion}, che non è supportato. La versione minima supportata è Zulip Server {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Non è stato effettuato l'accesso a nessun account. Accedi a un account e riprova.",
   "errorSharingFailed": "Condivisione fallita",
   "errorSharingTitle": "Condivisione dei contenuti non riuscita",

--- a/assets/l10n/app_ja.arb
+++ b/assets/l10n/app_ja.arb
@@ -630,10 +630,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1532,7 +1532,7 @@
   "errorRequestFailed": "ネットワークリクエストに失敗しました：HTTP ステータス {httpStatus}",
   "errorResolveTopicFailedTitle": "トピックを解決済みにできませんでした",
   "errorServerMessage": "サーバーからの応答：\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} で動作している Zulip Server {zulipVersion} はサポート対象外です。サポートされる最小バージョンは Zulip Server {minSupportedZulipVersion} です。",
+  "errorServerVersionNotAllowedMessage": "{url} で動作している Zulip Server {zulipVersion} はサポート対象外です。サポートされる最小バージョンは Zulip Server {minAllowedZulipVersion} です。",
   "errorSharingAccountNotLoggedIn": "ログインしていません。アカウントにログインしてから、もう一度お試しください。",
   "errorSharingFailed": "共有に失敗しました",
   "errorSharingTitle": "コンテンツを共有できませんでした",

--- a/assets/l10n/app_pl.arb
+++ b/assets/l10n/app_pl.arb
@@ -636,10 +636,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1529,7 +1529,7 @@
   "errorRequestFailed": "Błąd uzyskania sieci: status HTTP {httpStatus}",
   "errorResolveTopicFailedTitle": "Nie udało się oznaczyć jako rozwiązany",
   "errorServerMessage": "Odpowiedź serwera:\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} uruchamia Zulip Server {zulipVersion}, który nie jest obsługiwany. Minimalna obsługiwana wersja to Zulip Server {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} uruchamia Zulip Server {zulipVersion}, który nie jest obsługiwany. Minimalna obsługiwana wersja to Zulip Server {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Brak zalogowanego użytkownika. Proszę zaloguj się i spróbuj ponownie.",
   "errorSharingFailed": "Udostępnianie bez powodzenia",
   "errorSharingTitle": "Udostępnianie zawartości bez powodzenia",

--- a/assets/l10n/app_ru.arb
+++ b/assets/l10n/app_ru.arb
@@ -636,10 +636,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1559,7 +1559,7 @@
   "errorRequestFailed": "Сбой сетевого запроса: HTTP-статус {httpStatus}",
   "errorResolveTopicFailedTitle": "Не удалось отметить тему как решенную",
   "errorServerMessage": "Ответ сервера:\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} использует Zulip Server {zulipVersion}, который не поддерживается. Минимальная поддерживаемая версия — Zulip Server {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} использует Zulip Server {zulipVersion}, который не поддерживается. Минимальная поддерживаемая версия — Zulip Server {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Не выполнен вход с учетной записью. Пожалуйста, войдите в систему и повторите попытку.",
   "errorSharingFailed": "Не удалось поделиться",
   "errorSharingTitle": "Не удалось поделиться содержанием",

--- a/assets/l10n/app_sl.arb
+++ b/assets/l10n/app_sl.arb
@@ -555,10 +555,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1394,7 +1394,7 @@
   "errorRequestFailed": "Omrežna zahteva je spodletela: Stanje HTTP {httpStatus}",
   "errorResolveTopicFailedTitle": "Neuspela označitev teme kot razrešene",
   "errorServerMessage": "Strežnik je sporočil:\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} uporablja strežnik Zulip {zulipVersion}, ki ni podprt. Najnižja podprta različica je strežnik Zulip {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} uporablja strežnik Zulip {zulipVersion}, ki ni podprt. Najnižja podprta različica je strežnik Zulip {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Noben račun ni prijavljen. Prijavite se v račun in poskusite znova.",
   "errorSharingFailed": "Deljenje ni uspelo",
   "errorSharingTitle": "Deljenje vsebine ni uspelo",

--- a/assets/l10n/app_uk.arb
+++ b/assets/l10n/app_uk.arb
@@ -627,10 +627,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1514,7 +1514,7 @@
   "errorRequestFailed": "Помилка мережевого запиту: статус HTTP {httpStatus}",
   "errorResolveTopicFailedTitle": "Не вдалося позначити тему як вирішену",
   "errorServerMessage": "Сервер сказав:\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} використовує Zulip Server {zulipVersion}, який не підтримується. Мінімальною підтримуваною версією є Zulip Server {minSupportedZulipVersion}.",
+  "errorServerVersionNotAllowedMessage": "{url} використовує Zulip Server {zulipVersion}, який не підтримується. Мінімальною підтримуваною версією є Zulip Server {minAllowedZulipVersion}.",
   "errorSharingAccountNotLoggedIn": "Немає облікового запису, в який ви ввійшли. Будь ласка, увійдіть в обліковий запис і спробуйте ще раз..",
   "errorSharingFailed": "Поширення не вдалося",
   "errorSharingTitle": "Не вдалося поділитися контентом",

--- a/assets/l10n/app_zh_Hans_CN.arb
+++ b/assets/l10n/app_zh_Hans_CN.arb
@@ -540,10 +540,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1364,7 +1364,7 @@
   "errorRequestFailed": "网络请求失败；HTTP 状态码 {httpStatus}",
   "errorResolveTopicFailedTitle": "未能将话题标记为解决",
   "errorServerMessage": "服务器：\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} 运行的 Zulip 服务器版本 {zulipVersion} 过低。该客户端只支持 {minSupportedZulipVersion} 及以后的服务器版本。",
+  "errorServerVersionNotAllowedMessage": "{url} 运行的 Zulip 服务器版本 {zulipVersion} 过低。该客户端只支持 {minAllowedZulipVersion} 及以后的服务器版本。",
   "errorSharingAccountNotLoggedIn": "尚未登录任何账号。请登录账号后再次尝试。",
   "errorSharingFailed": "分享失败",
   "errorSharingTitle": "分享内容失败",

--- a/assets/l10n/app_zh_Hant_TW.arb
+++ b/assets/l10n/app_zh_Hant_TW.arb
@@ -636,10 +636,10 @@
       }
     }
   },
-  "@errorServerVersionUnsupportedMessage": {
-    "description": "Error message in the dialog for when the Zulip Server version is unsupported.",
+  "@errorServerVersionNotAllowedMessage": {
+    "description": "Error message in the dialog for when the Zulip Server version is not allowed.",
     "placeholders": {
-      "minSupportedZulipVersion": {
+      "minAllowedZulipVersion": {
         "example": "4.0",
         "type": "String"
       },
@@ -1526,7 +1526,7 @@
   "errorRequestFailed": "網路請求失敗：HTTP 狀態碼為 {httpStatus}",
   "errorResolveTopicFailedTitle": "無法標註話題為已解決",
   "errorServerMessage": "伺服器回應：\n\n{message}",
-  "errorServerVersionUnsupportedMessage": "{url} 執行的 Zulip Server 為 {zulipVersion}，此版本已不受支援。最低支援版本為 Zulip Server {minSupportedZulipVersion}。",
+  "errorServerVersionNotAllowedMessage": "{url} 執行的 Zulip Server 為 {zulipVersion}，此版本已不受支援。最低支援版本為 Zulip Server {minAllowedZulipVersion}。",
   "errorSharingAccountNotLoggedIn": "尚未登入任何帳號。請登入帳號後再試一次。",
   "errorSharingFailed": "分享失敗",
   "errorSharingTitle": "分享內容失敗",

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -23,6 +23,21 @@ const kMinAllowedZulipVersion = '7.0';
 ///   https://zulip.com/api/changelog
 const kMinAllowedZulipFeatureLevel = 185;
 
+/// The oldest Zulip Server version we currently support.
+///
+/// Should match the policy stated at [kServerSupportDocUrl]:
+/// all versions below this should be older than 18 months.
+///
+/// See also [kMinAllowedZulipVersion], for the version below
+/// which we just refuse to connect.
+const kMinSupportedZulipVersion = '9.2';
+
+/// The Zulip feature level reserved for the [kMinSupportedZulipVersion] release.
+///
+/// For this value, see the API changelog:
+///   https://zulip.com/api/changelog
+const kMinSupportedZulipFeatureLevel = 278;
+
 /// The doc stating our oldest supported server version.
 // TODO: Instead, link to new Help Center doc once we have it:
 //   https://github.com/zulip/zulip/issues/23842

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -12,16 +12,16 @@ import 'exception.dart';
 
 /// The Zulip Server version below which we should refuse to connect.
 ///
-/// When updating this, also update [kMinSupportedZulipFeatureLevel]
+/// When updating this, also update [kMinAllowedZulipFeatureLevel]
 /// and the README.
 // TODO(#1838) address all TODO(server-7)
-const kMinSupportedZulipVersion = '7.0';
+const kMinAllowedZulipVersion = '7.0';
 
-/// The Zulip feature level reserved for the [kMinSupportedZulipVersion] release.
+/// The Zulip feature level reserved for the [kMinAllowedZulipVersion] release.
 ///
 /// For this value, see the API changelog:
 ///   https://zulip.com/api/changelog
-const kMinSupportedZulipFeatureLevel = 185;
+const kMinAllowedZulipFeatureLevel = 185;
 
 /// The doc stating our oldest supported server version.
 // TODO: Instead, link to new Help Center doc once we have it:

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1442,14 +1442,14 @@ abstract class ZulipLocalizations {
   /// **'The file to be inserted is empty or cannot be accessed.'**
   String get errorContentToInsertIsEmpty;
 
-  /// Error message in the dialog for when the Zulip Server version is unsupported.
+  /// Error message in the dialog for when the Zulip Server version is not allowed.
   ///
   /// In en, this message translates to:
-  /// **'{url} is running Zulip Server {zulipVersion}, which is unsupported. The minimum supported version is Zulip Server {minSupportedZulipVersion}.'**
-  String errorServerVersionUnsupportedMessage(
+  /// **'{url} is running Zulip Server {zulipVersion}, which is unsupported. The minimum supported version is Zulip Server {minAllowedZulipVersion}.'**
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   );
 
   /// Error message in the dialog for invalid API key.

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1452,6 +1452,30 @@ abstract class ZulipLocalizations {
     String minAllowedZulipVersion,
   );
 
+  /// Banner message shown to server admins when the server version is no longer supported.
+  ///
+  /// In en, this message translates to:
+  /// **'{url} is running Zulip Server {zulipVersion}, which is unsupported. Please upgrade your server as soon as possible.'**
+  String serverCompatBannerAdminMessage(String url, String zulipVersion);
+
+  /// Banner message shown to non-admin users when the server version is no longer supported.
+  ///
+  /// In en, this message translates to:
+  /// **'{url} is running Zulip Server {zulipVersion}, which is unsupported. Please contact your server administrator about upgrading.'**
+  String serverCompatBannerUserMessage(String url, String zulipVersion);
+
+  /// Label for the button that dismisses the server compatibility warning banner.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get serverCompatBannerDismissLabel;
+
+  /// Label for the button in the server compatibility warning banner that opens the support policy doc.
+  ///
+  /// In en, this message translates to:
+  /// **'Learn more'**
+  String get serverCompatBannerLearnMoreLabel;
+
   /// Error message in the dialog for invalid API key.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -810,12 +810,12 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'Die einzufügende Datei ist leer oder kann nicht geöffnet werden.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url nutzt Zulip Server $zulipVersion, welche nicht unterstützt wird. Die unterstützte Mindestversion ist Zulip Server $minSupportedZulipVersion.';
+    return '$url nutzt Zulip Server $zulipVersion, welche nicht unterstützt wird. Die unterstützte Mindestversion ist Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -819,6 +819,22 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Dein Account bei $url konnte nicht authentifiziert werden. Bitte wiederhole die Anmeldung oder verwende einen anderen Account.';
   }

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -792,12 +792,12 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -801,6 +801,22 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -828,6 +828,22 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Votre compte à l\'adresse $url n\'a pas pu être authentifié. Merci d\'essayer de vous reconnecter ou utilisez un autre compte.';
   }

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -819,12 +819,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Le fichier à insérer est vide ou ne peut pas être récupéré.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url exploite Zulip Server en version $zulipVersion, qui n\'est pas supportée. La version minimum supportée est Zulip Server $minSupportedZulipVersion.';
+    return '$url exploite Zulip Server en version $zulipVersion, qui n\'est pas supportée. La version minimum supportée est Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -818,6 +818,22 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'L\'account su $url non è stato autenticato. Riprovare ad accedere o provare a usare un altro account.';
   }

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -809,12 +809,12 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
       'Il file da inserire è vuoto o non è accessibile.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url sta usando Zulip Server $zulipVersion, che non è supportato. La versione minima supportata è Zulip Server $minSupportedZulipVersion.';
+    return '$url sta usando Zulip Server $zulipVersion, che non è supportato. La versione minima supportata è Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -780,6 +780,22 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return '$url のアカウントを認証できませんでした。もう一度ログインするか、別のアカウントを使用してください。';
   }

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -771,12 +771,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get errorContentToInsertIsEmpty => '挿入しようとしたファイルが空、またはアクセスできません。';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url で動作している Zulip Server $zulipVersion はサポート対象外です。サポートされる最小バージョンは Zulip Server $minSupportedZulipVersion です。';
+    return '$url で動作している Zulip Server $zulipVersion はサポート対象外です。サポートされる最小バージョンは Zulip Server $minAllowedZulipVersion です。';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -814,6 +814,22 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Konto w ramach $url nie zostało przyjęte. Spróbuj ponownie lub skorzystaj z innego konta.';
   }

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -805,12 +805,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Plik do dodania jest pusty lub nie ma do niego dostępu.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url uruchamia Zulip Server $zulipVersion, który nie jest obsługiwany. Minimalna obsługiwana wersja to Zulip Server $minSupportedZulipVersion.';
+    return '$url uruchamia Zulip Server $zulipVersion, który nie jest obsługiwany. Minimalna obsługiwana wersja to Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -808,12 +808,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'Файл для вставки пустой, или к нему нет доступа.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url использует Zulip Server $zulipVersion, который не поддерживается. Минимальная поддерживаемая версия — Zulip Server $minSupportedZulipVersion.';
+    return '$url использует Zulip Server $zulipVersion, который не поддерживается. Минимальная поддерживаемая версия — Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -817,6 +817,22 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Не удалось войти в вашу учётную запись $url. Попробуйте ещё раз или используйте другую учётную запись.';
   }

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -824,6 +824,22 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Vašega računa na $url ni bilo mogoče overiti. Poskusite se znova prijaviti ali uporabite drug račun.';
   }

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -815,12 +815,12 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
       'Datoteka za vstavljanje je prazna ali nedostopna.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url uporablja strežnik Zulip $zulipVersion, ki ni podprt. Najnižja podprta različica je strežnik Zulip $minSupportedZulipVersion.';
+    return '$url uporablja strežnik Zulip $zulipVersion, ki ni podprt. Najnižja podprta različica je strežnik Zulip $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -815,6 +815,22 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Ваш обліковий запис на $url не вдалося автентифікувати. Спробуйте увійти ще раз або скористайтеся іншим обліковим записом.';
   }

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -806,12 +806,12 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
       'Файл, який потрібно вставити, порожній або до нього немає доступу.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url використовує Zulip Server $zulipVersion, який не підтримується. Мінімальною підтримуваною версією є Zulip Server $minSupportedZulipVersion.';
+    return '$url використовує Zulip Server $zulipVersion, який не підтримується. Мінімальною підтримуваною версією є Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -799,6 +799,22 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   }
 
   @override
+  String serverCompatBannerAdminMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please upgrade your server as soon as possible.';
+  }
+
+  @override
+  String serverCompatBannerUserMessage(String url, String zulipVersion) {
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. Please contact your server administrator about upgrading.';
+  }
+
+  @override
+  String get serverCompatBannerDismissLabel => 'Dismiss';
+
+  @override
+  String get serverCompatBannerLearnMoreLabel => 'Learn more';
+
+  @override
   String errorInvalidApiKeyMessage(String url) {
     return 'Your account at $url could not be authenticated. Please try logging in again or use another account.';
   }

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -790,12 +790,12 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
       'The file to be inserted is empty or cannot be accessed.';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minSupportedZulipVersion.';
+    return '$url is running Zulip Server $zulipVersion, which is unsupported. The minimum supported version is Zulip Server $minAllowedZulipVersion.';
   }
 
   @override
@@ -1995,12 +1995,12 @@ class ZulipLocalizationsZhHansCn extends ZulipLocalizationsZh {
   String get errorContentToInsertIsEmpty => '要插入的文件为空或无法访问。';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url 运行的 Zulip 服务器版本 $zulipVersion 过低。该客户端只支持 $minSupportedZulipVersion 及以后的服务器版本。';
+    return '$url 运行的 Zulip 服务器版本 $zulipVersion 过低。该客户端只支持 $minAllowedZulipVersion 及以后的服务器版本。';
   }
 
   @override
@@ -3182,12 +3182,12 @@ class ZulipLocalizationsZhHantTw extends ZulipLocalizationsZh {
   String get errorContentToInsertIsEmpty => '要插入的檔案為空或無法存取。';
 
   @override
-  String errorServerVersionUnsupportedMessage(
+  String errorServerVersionNotAllowedMessage(
     String url,
     String zulipVersion,
-    String minSupportedZulipVersion,
+    String minAllowedZulipVersion,
   ) {
-    return '$url 執行的 Zulip Server 為 $zulipVersion，此版本已不受支援。最低支援版本為 Zulip Server $minSupportedZulipVersion。';
+    return '$url 執行的 Zulip Server 為 $zulipVersion，此版本已不受支援。最低支援版本為 Zulip Server $minAllowedZulipVersion。';
   }
 
   @override

--- a/lib/model/server_support.dart
+++ b/lib/model/server_support.dart
@@ -61,11 +61,11 @@ class ZulipVersionData {
     && zulipMergeBase == account.zulipMergeBase
     && zulipFeatureLevel == account.zulipFeatureLevel;
 
-  bool get isUnsupported => zulipFeatureLevel < kMinSupportedZulipFeatureLevel;
+  bool get isNotAllowed => zulipFeatureLevel < kMinAllowedZulipFeatureLevel;
 }
 
-class ServerVersionUnsupportedException implements Exception {
+class ServerVersionNotAllowedException implements Exception {
   final ZulipVersionData data;
 
-  ServerVersionUnsupportedException(this.data);
+  ServerVersionNotAllowedException(this.data);
 }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -461,6 +461,28 @@ abstract class GlobalStore extends ChangeNotifier {
   /// Remove an account from the underlying data store.
   Future<void> doRemoveAccount(int accountId);
 
+  //|//////////////////////////////////////////////////////////////
+  // Session data that lasts through the lifetime of this [GlobalStore].
+  //
+
+  /// The account IDs for which the server-compat banner has been dismissed.
+  final Set<int> _serverCompatBannerDismissedForAccounts = {};
+
+  /// Whether the server-compat banner has been dismissed for `accountId`.
+  ///
+  /// This dismissal only lasts through the current app session.
+  bool getServerCompatBannerDismissed(int accountId) {
+    return _serverCompatBannerDismissedForAccounts.contains(accountId);
+  }
+
+  /// Mark the server-compat banner as dismissed for `accountId`.
+  ///
+  /// This dismissal only lasts through the current app session.
+  void setServerCompatBannerDismissed(int accountId) {
+    _serverCompatBannerDismissedForAccounts.add(accountId);
+    notifyListeners();
+  }
+
   //
   // End of data.
   //|//////////////////////////////////////////////////////////////

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -239,13 +239,13 @@ abstract class GlobalStore extends ChangeNotifier {
       assert(account != null); // doLoadPerAccount would have thrown AccountNotFoundException
       final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
       switch (e) {
-        case ServerVersionUnsupportedException():
+        case ServerVersionNotAllowedException():
           reportErrorToUserModally(
             zulipLocalizations.errorCouldNotConnectTitle,
-            message: zulipLocalizations.errorServerVersionUnsupportedMessage(
+            message: zulipLocalizations.errorServerVersionNotAllowedMessage(
               account!.realmUrl.toString(),
               e.data.zulipVersion,
-              kMinSupportedZulipVersion),
+              kMinAllowedZulipVersion),
             learnMoreButtonUrl: kServerSupportDocUrl);
           // The important thing is to tear down per-account UI,
           // and logOutAccount conveniently handles that already.
@@ -379,9 +379,9 @@ abstract class GlobalStore extends ChangeNotifier {
   /// Fetches the server settings for the given [realmUrl].
   ///
   /// The caller is responsible for checking if the returned
-  /// [GetServerSettingsResult] represents a supported version, by
+  /// [GetServerSettingsResult] represents an allowed version, by
   /// parsing it via [ZulipVersionData.fromServerSettings] and checking
-  /// [ZulipVersionData.isUnsupported].
+  /// [ZulipVersionData.isNotAllowed].
   Future<GetServerSettingsResult> fetchServerSettings(Uri realmUrl) async {
     final connection = apiConnection(
       realmUrl: realmUrl,
@@ -390,8 +390,8 @@ abstract class GlobalStore extends ChangeNotifier {
       return await getServerSettings(connection);
     } on MalformedServerResponseException catch (e) {
       final zulipVersionData = ZulipVersionData.fromMalformedServerResponseException(e);
-      if (zulipVersionData != null && zulipVersionData.isUnsupported) {
-        throw ServerVersionUnsupportedException(zulipVersionData);
+      if (zulipVersionData != null && zulipVersionData.isNotAllowed) {
+        throw ServerVersionNotAllowedException(zulipVersionData);
       }
       rethrow;
     } finally {
@@ -1405,9 +1405,9 @@ class UpdateMachine {
     try {
       initialSnapshot = await _registerQueueWithRetry(connection,
         stopAndThrowIfNoAccount: stopAndThrowIfNoAccount);
-    } on ServerVersionUnsupportedException catch (e) {
+    } on ServerVersionNotAllowedException catch (e) {
       // `!` is OK because _registerQueueWithRetry would have thrown a
-      // not-ServerVersionUnsupportedException if no account
+      // not-ServerVersionNotAllowedException if no account
       final account = globalStore.getAccount(accountId)!;
       if (!e.data.matchesAccount(account)) {
         await globalStore.updateZulipVersionData(accountId, e.data);
@@ -1469,8 +1469,8 @@ class UpdateMachine {
         switch (e) {
           case MalformedServerResponseException()
             when (zulipVersionData = ZulipVersionData.fromMalformedServerResponseException(e))
-              ?.isUnsupported == true:
-            throw ServerVersionUnsupportedException(zulipVersionData!);
+              ?.isNotAllowed == true:
+            throw ServerVersionNotAllowedException(zulipVersionData!);
           case HttpException(httpStatus: 401):
             // We cannot recover from this error through retrying.
             // Leave it to [GlobalStore.loadPerAccount].
@@ -1502,8 +1502,8 @@ class UpdateMachine {
       if (result != null) {
         stopAndThrowIfNoAccount();
         final zulipVersionData = ZulipVersionData.fromInitialSnapshot(result);
-        if (zulipVersionData.isUnsupported) {
-          throw ServerVersionUnsupportedException(zulipVersionData);
+        if (zulipVersionData.isNotAllowed) {
+          throw ServerVersionNotAllowedException(zulipVersionData);
         }
         return result;
       }

--- a/lib/widgets/banner.dart
+++ b/lib/widgets/banner.dart
@@ -1,0 +1,108 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'button.dart';
+import 'text.dart';
+import 'theme.dart';
+
+/// A banner to show below the app bar.
+///
+/// This is an evolution of the banner specced for the compose box:
+///   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=4010-6425&t=3wvxqQHzHPij90MI-0
+///   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=4031-17025&t=3wvxqQHzHPij90MI-0
+/// to serve the server-compat banner on the home page.
+///
+/// It's a bit like Zulip Web UI Kit's "Banner top" component:
+///   https://www.figma.com/design/msWyAJ8cnMHgOMPxi7BUvA/Zulip-Web-UI-kit?node-id=694-3997&m=dev
+/// in particular by using regular weight for the text.
+/// But the text and action buttons are aligned differently;
+/// there may be other differences.
+///
+/// Relevant design discussion:
+///   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Design.20of.20banner.20for.20unsupported.20server/near/2428017
+class ZulipBanner extends StatelessWidget {
+  const ZulipBanner({
+    super.key,
+    required this.intent,
+    required this.label,
+    required this.actions,
+  });
+
+  final ZulipBannerIntent intent;
+  final String label;
+
+  /// A list of actions to show below the label.
+  ///
+  /// It should include vertical but not horizontal outer padding
+  /// for spacing/positioning.
+  ///
+  /// An interactive element's touchable area should have height at least 44px,
+  /// with some of that as "slop" vertical outer padding above and below
+  /// what gets painted:
+  ///   https://github.com/zulip/zulip-flutter/pull/1432#discussion_r2023907300
+  ///
+  /// It is recommended to pass a list of [ZulipWebUiKitButton]
+  /// with [ZulipWebUiKitButtonSize.small] for this field.
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    final (labelColor, backgroundColor, semanticsRole) = switch (intent) {
+      ZulipBannerIntent.info => (
+        designVariables.bannerTextIntInfo,
+        designVariables.bannerBgIntInfo,
+        SemanticsRole.status),
+      ZulipBannerIntent.warning => (
+        designVariables.btnLabelAttMediumIntWarning,
+        designVariables.bannerBgIntWarning,
+        SemanticsRole.alert),
+      ZulipBannerIntent.danger => (
+        designVariables.btnLabelAttMediumIntDanger,
+        designVariables.bannerBgIntDanger,
+        SemanticsRole.alert),
+    };
+
+    Widget result = DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border(
+          bottom: BorderSide(width: 1, color: designVariables.borderBar))),
+      child: SafeArea(
+        minimum: EdgeInsets.symmetric(horizontal: 8),
+        top: false,
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(start: 8),
+          child: Column(crossAxisAlignment: .start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 9),
+                child: Text(
+                  style: TextStyle(
+                    fontSize: 16,
+                    height: 18 / 16,
+                    color: labelColor,
+                  ).merge(weightVariableTextStyle(context, wght: 400)),
+                  textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+                  label)),
+              Row(mainAxisAlignment: .end, spacing: 8,
+                children: actions),
+            ]))));
+
+    result = Semantics(
+      container: true,
+      role: semanticsRole,
+      child: result);
+
+    return result;
+  }
+}
+
+enum ZulipBannerIntent {
+  info,
+  warning,
+  danger,
+}

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -40,9 +40,11 @@ class ZulipWebUiKitButton extends StatelessWidget {
           WidgetState.pressed: designVariables.neutralButtonBg.withFadedAlpha(0.3),
           ~WidgetState.pressed: designVariables.neutralButtonBg.withAlpha(0),
         });
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.warning):
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.warning):
         throw UnimplementedError();
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.warning):
         return WidgetStateColor.fromMap({
@@ -54,7 +56,21 @@ class ZulipWebUiKitButton extends StatelessWidget {
           WidgetState.pressed: designVariables.btnBgAttHighIntWarningActive,
           ~WidgetState.pressed: designVariables.btnBgAttHighIntWarningNormal,
         });
+      case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.danger):
+        throw UnimplementedError();
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.danger):
+        return WidgetStateColor.fromMap({
+          WidgetState.pressed: designVariables.btnBgAttLowIntDangerActive,
+          ~WidgetState.pressed: designVariables.btnBgAttLowIntDangerActive.withAlpha(0),
+        });
+      case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.danger):
+        return WidgetStateColor.fromMap({
+          WidgetState.pressed: designVariables.btnBgAttMediumIntDangerActive,
+          ~WidgetState.pressed: designVariables.btnBgAttMediumIntDangerNormal,
+        });
+      case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.danger):
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.info):
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.info):
         throw UnimplementedError();
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.info):
         return WidgetStateColor.fromMap({
@@ -74,15 +90,25 @@ class ZulipWebUiKitButton extends StatelessWidget {
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.neutral):
         // TODO nit: don't fade in pressed state
         return designVariables.neutralButtonLabel.withFadedAlpha(0.85);
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.neutral):
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.warning):
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.warning):
         throw UnimplementedError();
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.warning):
         return designVariables.btnLabelAttMediumIntWarning;
       case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.warning):
         return designVariables.btnLabelAttHighIntWarning;
+      case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.danger):
+        throw UnimplementedError();
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.danger):
+        return designVariables.btnLabelAttLowIntDanger;
+      case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.danger):
+        return designVariables.btnLabelAttMediumIntDanger;
+      case (ZulipWebUiKitButtonAttention.high, ZulipWebUiKitButtonIntent.danger):
       case (ZulipWebUiKitButtonAttention.minimal, ZulipWebUiKitButtonIntent.info):
+      case (ZulipWebUiKitButtonAttention.low, ZulipWebUiKitButtonIntent.info):
         throw UnimplementedError();
       case (ZulipWebUiKitButtonAttention.medium, ZulipWebUiKitButtonIntent.info):
         return designVariables.btnLabelAttMediumIntInfo;
@@ -117,6 +143,7 @@ class ZulipWebUiKitButton extends StatelessWidget {
   BorderSide _borderSide(DesignVariables designVariables) {
     switch (attention) {
       case ZulipWebUiKitButtonAttention.minimal:
+      case ZulipWebUiKitButtonAttention.low:
         return BorderSide.none;
       case ZulipWebUiKitButtonAttention.medium:
         // TODO inner shadow effect like `box-shadow: inset`, following Figma;
@@ -201,10 +228,16 @@ class ZulipWebUiKitButton extends StatelessWidget {
   }
 }
 
+// TODO follow web's rename of "attention" to "variant":
+//   low, medium, high -> text, subtle, solid
+// See web PR:
+//   https://github.com/zulip/zulip/pull/37424
+// and discussion:
+//   https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Design.20of.20banner.20for.20unsupported.20server/near/2412680
 enum ZulipWebUiKitButtonAttention {
   high,
   medium,
-  // low,
+  low,
 
   /// An ad hoc value for the "Reveal message" button
   /// on a message from a muted sender:
@@ -215,7 +248,7 @@ enum ZulipWebUiKitButtonAttention {
 enum ZulipWebUiKitButtonIntent {
   neutral,
   warning,
-  // danger,
+  danger,
   info,
   // success,
   // brand,

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -3,12 +3,16 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+import '../api/core.dart';
+import '../api/model/model.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/narrow.dart';
 import 'about_zulip.dart';
 import 'action_sheet.dart';
+import 'actions.dart';
 import 'app.dart';
 import 'app_bar.dart';
+import 'banner.dart';
 import 'button.dart';
 import 'color.dart';
 import 'icons.dart';
@@ -123,16 +127,21 @@ class _HomePageState extends State<HomePage> {
           namesRoute: true,
           child: Text(_currentTabTitle)),
         actions: _currentTabAppBarActions),
-      body: Semantics(
-        role: SemanticsRole.tabPanel,
-        identifier: HomePage.contentSemanticsIdentifier,
-        container: true,
-        explicitChildNodes: true,
-        child: Stack(
-          children: [
-            for (final (tab, body) in pageBodies)
-              Offstage(offstage: tab != _tab.value, child: body),
-          ])),
+      body: Column(
+        children: [
+          _ServerCompatBanner(),
+          Expanded(
+            child: Semantics(
+              role: SemanticsRole.tabPanel,
+              identifier: HomePage.contentSemanticsIdentifier,
+              container: true,
+              explicitChildNodes: true,
+              child: Stack(
+                children: [
+                  for (final (tab, body) in pageBodies)
+                    Offstage(offstage: tab != _tab.value, child: body),
+                ]))),
+        ]),
       bottomNavigationBar: _BottomNavBar(tabNotifier: _tab));
   }
 }
@@ -848,5 +857,44 @@ class _AboutZulipButton extends MenuButton {
   @override
   void onPressed(BuildContext context) {
     Navigator.of(context).push(AboutZulipPage.buildRoute(context));
+  }
+}
+
+class _ServerCompatBanner extends StatelessWidget {
+  const _ServerCompatBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final globalStore = GlobalStoreWidget.of(context);
+    final store = PerAccountStoreWidget.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final showCompatBanner =
+      store.zulipFeatureLevel < kMinSupportedZulipFeatureLevel
+      && !globalStore.getServerCompatBannerDismissed(store.accountId);
+    final isAtLeastAdmin = store.selfUser.role.isAtLeast(UserRole.administrator);
+    final label = isAtLeastAdmin
+      ? zulipLocalizations.serverCompatBannerAdminMessage(
+          store.realmUrl.toString(), store.zulipVersion)
+      : zulipLocalizations.serverCompatBannerUserMessage(
+          store.realmUrl.toString(), store.zulipVersion);
+    if (!showCompatBanner) return const SizedBox.shrink();
+    return ZulipBanner(
+      intent: .danger,
+      label: label,
+      actions: [
+        ZulipWebUiKitButton(
+          label: zulipLocalizations.serverCompatBannerLearnMoreLabel,
+          size: .small,
+          intent: .danger,
+          attention: .low,
+          onPressed: () => PlatformActions.launchUrl(context, kServerSupportDocUrl)),
+        ZulipWebUiKitButton(
+          label: zulipLocalizations.serverCompatBannerDismissLabel,
+          size: .small,
+          intent: .danger,
+          attention: .medium,
+          onPressed: () => globalStore
+            .setServerCompatBannerDismissed(store.accountId)),
+      ]);
   }
 }

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -182,8 +182,8 @@ class _AddAccountPageState extends State<AddAccountPage> {
         serverSettings = await globalStore.fetchServerSettings(url!);
 
         final zulipVersionData = ZulipVersionData.fromServerSettings(serverSettings);
-        if (zulipVersionData.isUnsupported) {
-          throw ServerVersionUnsupportedException(zulipVersionData);
+        if (zulipVersionData.isNotAllowed) {
+          throw ServerVersionNotAllowedException(zulipVersionData);
         }
       } catch (e) {
         if (!context.mounted) return;
@@ -191,11 +191,11 @@ class _AddAccountPageState extends State<AddAccountPage> {
         String? message;
         Uri? learnMoreButtonUrl;
         switch (e) {
-          case ServerVersionUnsupportedException(:final data):
-            message = zulipLocalizations.errorServerVersionUnsupportedMessage(
+          case ServerVersionNotAllowedException(:final data):
+            message = zulipLocalizations.errorServerVersionNotAllowedMessage(
               url.toString(),
               data.zulipVersion,
-              kMinSupportedZulipVersion);
+              kMinAllowedZulipVersion);
             learnMoreButtonUrl = kServerSupportDocUrl;
           default:
             // TODO(#105) give more helpful feedback; see `fetchServerSettings`

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -160,6 +160,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     btnBgAttHighIntInfoNormal: const Color(0xff3c6bff),
     btnBgAttHighIntWarningActive: const Color(0xffeba002),
     btnBgAttHighIntWarningNormal: const Color(0xfffebe3d),
+    btnBgAttLowIntDangerActive: const Color(0xffc0070a).withValues(alpha: 0.13),
+    btnBgAttMediumIntDangerActive: const Color(0xffe1392e).withValues(alpha: 0.23),
+    btnBgAttMediumIntDangerNormal: const Color(0xffe1392e).withValues(alpha: 0.13),
     btnBgAttMediumIntInfoActive: const Color(0xff3c6bff).withValues(alpha: 0.22),
     btnBgAttMediumIntInfoNormal: const Color(0xff3c6bff).withValues(alpha: 0.12),
     btnBgAttMediumIntWarningActive: const Color(0xffeba001).withValues(alpha: 0.28),
@@ -265,6 +268,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     btnBgAttHighIntInfoNormal: const Color(0xff1e41d3),
     btnBgAttHighIntWarningActive: const Color(0xffdb920d),
     btnBgAttHighIntWarningNormal: const Color(0xffdb920d),
+    btnBgAttLowIntDangerActive: const Color(0xfff34c3e).withValues(alpha: 0.17),
+    btnBgAttMediumIntDangerActive: const Color(0xfffd5f50).withValues(alpha: 0.12),
+    btnBgAttMediumIntDangerNormal: const Color(0xfffd5f50).withValues(alpha: 0.12),
     btnBgAttMediumIntInfoActive: const Color(0xff97b6fe).withValues(alpha: 0.12),
     btnBgAttMediumIntInfoNormal: const Color(0xff97b6fe).withValues(alpha: 0.12),
     btnBgAttMediumIntWarningActive: const Color(0xffdb920d).withValues(alpha: 0.12),
@@ -379,6 +385,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.btnBgAttHighIntInfoNormal,
     required this.btnBgAttHighIntWarningActive,
     required this.btnBgAttHighIntWarningNormal,
+    required this.btnBgAttLowIntDangerActive,
+    required this.btnBgAttMediumIntDangerActive,
+    required this.btnBgAttMediumIntDangerNormal,
     required this.btnBgAttMediumIntInfoActive,
     required this.btnBgAttMediumIntInfoNormal,
     required this.btnBgAttMediumIntWarningActive,
@@ -485,6 +494,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color btnBgAttHighIntInfoNormal;
   final Color btnBgAttHighIntWarningActive;
   final Color btnBgAttHighIntWarningNormal;
+  final Color btnBgAttLowIntDangerActive;
+  final Color btnBgAttMediumIntDangerActive;
+  final Color btnBgAttMediumIntDangerNormal;
   final Color btnBgAttMediumIntInfoActive;
   final Color btnBgAttMediumIntInfoNormal;
   final Color btnBgAttMediumIntWarningActive;
@@ -585,6 +597,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? btnBgAttHighIntInfoNormal,
     Color? btnBgAttHighIntWarningActive,
     Color? btnBgAttHighIntWarningNormal,
+    Color? btnBgAttLowIntDangerActive,
+    Color? btnBgAttMediumIntDangerActive,
+    Color? btnBgAttMediumIntDangerNormal,
     Color? btnBgAttMediumIntInfoActive,
     Color? btnBgAttMediumIntInfoNormal,
     Color? btnBgAttMediumIntWarningActive,
@@ -680,6 +695,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       btnBgAttHighIntInfoNormal: btnBgAttHighIntInfoNormal ?? this.btnBgAttHighIntInfoNormal,
       btnBgAttHighIntWarningActive: btnBgAttHighIntWarningActive ?? this.btnBgAttHighIntWarningActive,
       btnBgAttHighIntWarningNormal: btnBgAttHighIntWarningNormal ?? this.btnBgAttHighIntWarningNormal,
+      btnBgAttLowIntDangerActive: btnBgAttLowIntDangerActive ?? this.btnBgAttLowIntDangerActive,
+      btnBgAttMediumIntDangerActive: btnBgAttMediumIntDangerActive ?? this.btnBgAttMediumIntDangerActive,
+      btnBgAttMediumIntDangerNormal: btnBgAttMediumIntDangerNormal ?? this.btnBgAttMediumIntDangerNormal,
       btnBgAttMediumIntInfoActive: btnBgAttMediumIntInfoActive ?? this.btnBgAttMediumIntInfoActive,
       btnBgAttMediumIntInfoNormal: btnBgAttMediumIntInfoNormal ?? this.btnBgAttMediumIntInfoNormal,
       btnBgAttMediumIntWarningActive: btnBgAttMediumIntWarningActive ?? this.btnBgAttMediumIntWarningActive,
@@ -782,6 +800,9 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       btnBgAttHighIntInfoNormal: Color.lerp(btnBgAttHighIntInfoNormal, other.btnBgAttHighIntInfoNormal, t)!,
       btnBgAttHighIntWarningActive: Color.lerp(btnBgAttHighIntWarningActive, other.btnBgAttHighIntWarningActive, t)!,
       btnBgAttHighIntWarningNormal: Color.lerp(btnBgAttHighIntWarningNormal, other.btnBgAttHighIntWarningNormal, t)!,
+      btnBgAttLowIntDangerActive: Color.lerp(btnBgAttLowIntDangerActive, other.btnBgAttLowIntDangerActive, t)!,
+      btnBgAttMediumIntDangerActive: Color.lerp(btnBgAttMediumIntDangerActive, other.btnBgAttMediumIntDangerActive, t)!,
+      btnBgAttMediumIntDangerNormal: Color.lerp(btnBgAttMediumIntDangerNormal, other.btnBgAttMediumIntDangerNormal, t)!,
       btnBgAttMediumIntInfoActive: Color.lerp(btnBgAttMediumIntInfoActive, other.btnBgAttMediumIntInfoActive, t)!,
       btnBgAttMediumIntInfoNormal: Color.lerp(btnBgAttMediumIntInfoNormal, other.btnBgAttMediumIntInfoNormal, t)!,
       btnBgAttMediumIntWarningActive: Color.lerp(btnBgAttMediumIntWarningActive, other.btnBgAttMediumIntWarningActive, t)!,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -100,7 +100,7 @@ Uri get _realmIcon => realmIcon;
 const String recentZulipVersion = '11.0';
 const int recentZulipFeatureLevel = 476;
 const int futureZulipFeatureLevel = 9999;
-const int ancientZulipFeatureLevel = kMinSupportedZulipFeatureLevel - 1;
+const int ancientZulipFeatureLevel = kMinAllowedZulipFeatureLevel - 1;
 
 AuthenticationMethods authMethods({
   bool ldap = false,

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -125,6 +125,14 @@ void main() {
     check(completers(1)).length.equals(1);
   });
 
+  test('GlobalStore get/setServerCompatBannerDismissed', () async {
+    final globalStore = eg.globalStore(accounts: [account1]);
+
+    check(globalStore.getServerCompatBannerDismissed(account1.id)).isFalse();
+    globalStore.setServerCompatBannerDismissed(account1.id);
+    check(globalStore.getServerCompatBannerDismissed(account1.id)).isTrue();
+  });
+
   test('GlobalStore.perAccount loading fails with HTTP status code 401', () => awaitFakeAsync((async) async {
     final globalStore = LoadingTestGlobalStore(accounts: [eg.selfAccount]);
     final future = globalStore.perAccount(eg.selfAccount.id);

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -4,14 +4,18 @@ import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:zulip/api/core.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/actions.dart';
+import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/about_zulip.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/app_bar.dart';
+import 'package:zulip/widgets/banner.dart';
 import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/inbox.dart';
@@ -683,4 +687,162 @@ void main () {
   // TODO end-to-end widget test that checks the error dialog when connecting
   //   to an ancient server:
   //     https://github.com/zulip/zulip-flutter/pull/1410#discussion_r1999991512
+
+  group('server compatibility banner', () {
+    Future<void> prepareBanner(WidgetTester tester, {
+      int? zulipFeatureLevel,
+      String? zulipVersion,
+      User? selfUser,
+      Account? selfAccount,
+      Account? otherAccount,
+    }) async {
+      assert(selfAccount != null ||
+        (zulipFeatureLevel != null && zulipVersion != null));
+      addTearDown(testBinding.reset);
+      selfUser ??= eg.selfUser;
+      selfAccount ??= eg.account(
+        user: selfUser,
+        zulipFeatureLevel: zulipFeatureLevel,
+        zulipVersion: zulipVersion);
+      await testBinding.globalStore.add(
+        selfAccount,
+        eg.initialSnapshot(
+          zulipFeatureLevel: selfAccount.zulipFeatureLevel,
+          zulipVersion: selfAccount.zulipVersion,
+          realmUsers: [selfUser]));
+
+      if (otherAccount != null) {
+        await testBinding.globalStore.add(
+          otherAccount,
+          eg.initialSnapshot(
+            zulipFeatureLevel: otherAccount.zulipFeatureLevel,
+            zulipVersion: otherAccount.zulipVersion,
+            realmUsers: [eg.otherUser]),
+          markLastVisited: false);
+      }
+
+      await tester.pumpWidget(ZulipApp(navigatorObservers: [testNavObserver]));
+      await tester.pump(Duration.zero); // wait for the loading page
+      await tester.pump(); // wait for store
+    }
+
+    Future<void> switchToAccount(WidgetTester tester, Account account) async {
+      await tester.tap(find.byIcon(ZulipIcons.menu));
+      await tester.pump();
+      final topRouteAfterPress = topRoute as ModalBottomSheetRoute<void>;
+      await tester.pump(topRouteAfterPress.transitionDuration);
+
+      await tester.tap(find.byIcon(ZulipIcons.arrow_left_right));
+      await tester.pump(Duration.zero);
+
+      final sheetPopDuration = topRouteAfterPress.reverseTransitionDuration;
+      await tester.pump(sheetPopDuration + Duration(milliseconds: 1));
+
+      lastPoppedRoute = null;
+      await tester.tap(find.text(account.email));
+      await tester.pump();
+      final popDuration = (lastPoppedRoute as TransitionRoute).reverseTransitionDuration;
+      final pushDuration = (topRoute as TransitionRoute).transitionDuration;
+      final animationDuration = popDuration > pushDuration ? popDuration : pushDuration;
+      await tester.pump(animationDuration + Duration(milliseconds: 1));
+    }
+
+    final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+    final sampleRealmUrl = eg.realmUrl.toString();
+    final unsupportedFeatureLevel = kMinSupportedZulipFeatureLevel - 1;
+    final unsupportedVersion = '3.0';
+
+    testWidgets('not shown when server is at supported feature level', (tester) async {
+      await prepareBanner(tester,
+        zulipFeatureLevel: kMinSupportedZulipFeatureLevel,
+        zulipVersion: kMinSupportedZulipVersion);
+      check(find.byType(ZulipBanner)).findsNothing();
+    });
+
+    testWidgets('shown for administrator when server is below supported feature level', (tester) async {
+      await prepareBanner(tester,
+        zulipFeatureLevel: unsupportedFeatureLevel,
+        zulipVersion: unsupportedVersion,
+        selfUser: eg.user(role: UserRole.administrator));
+      check(find.text(zulipLocalizations.serverCompatBannerAdminMessage(
+        sampleRealmUrl, unsupportedVersion))).findsOne();
+    });
+
+    testWidgets('shown for owner when server is below supported feature level', (tester) async {
+      await prepareBanner(tester,
+        zulipFeatureLevel: unsupportedFeatureLevel,
+        zulipVersion: unsupportedVersion,
+        selfUser: eg.user(role: UserRole.owner));
+      check(find.text(zulipLocalizations.serverCompatBannerAdminMessage(
+        sampleRealmUrl, unsupportedVersion))).findsOne();
+    });
+
+    testWidgets('shown for member when server is below supported feature level', (tester) async {
+      await prepareBanner(tester,
+        zulipFeatureLevel: unsupportedFeatureLevel,
+        zulipVersion: unsupportedVersion);
+      check(find.text(zulipLocalizations.serverCompatBannerUserMessage(
+        sampleRealmUrl, unsupportedVersion))).findsOne();
+    });
+
+    testWidgets('banner has alert semantics role', (tester) async {
+      final findBannerSemantics = find.byWidgetPredicate((widget) =>
+        widget is Semantics && widget.properties.role == SemanticsRole.alert);
+      await prepareBanner(tester,
+        zulipFeatureLevel: unsupportedFeatureLevel,
+        zulipVersion: unsupportedVersion);
+      check(find.descendant(
+        of: find.byType(ZulipBanner),
+        matching: findBannerSemantics)
+      ).findsOne();
+    });
+
+    testWidgets('banner dismiss state persists when switching account away and back', (tester) async {
+      prepareBoringImageHttpClient();
+
+      final accountA = eg.selfAccount.copyWith(
+        zulipFeatureLevel: unsupportedFeatureLevel,
+        zulipVersion: unsupportedVersion);
+      final accountB = eg.otherAccount.copyWith(
+        zulipFeatureLevel: kMinSupportedZulipFeatureLevel,
+        zulipVersion: kMinSupportedZulipVersion);
+
+      await prepareBanner(tester,
+        selfAccount: accountA,
+        otherAccount: accountB);
+      checkOnHomePage(tester, expectedAccount: accountA);
+      check(find.byType(ZulipBanner)).findsOne();
+
+      await switchToAccount(tester, accountB);
+      checkOnHomePage(tester, expectedAccount: accountB);
+
+      await switchToAccount(tester, accountA);
+      checkOnHomePage(tester, expectedAccount: accountA);
+      // Banner reappears after switching accounts.
+      check(find.byType(ZulipBanner)).findsOne();
+
+      await tester.tap(find.text(zulipLocalizations.serverCompatBannerDismissLabel));
+      await tester.pump();
+      check(find.byType(ZulipBanner)).findsNothing();
+
+      await switchToAccount(tester, accountB);
+      checkOnHomePage(tester, expectedAccount: accountB);
+
+      await switchToAccount(tester, accountA);
+      checkOnHomePage(tester, expectedAccount: accountA);
+      // Dismissal persists after switching accounts.
+      check(find.byType(ZulipBanner)).findsNothing();
+
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('learn more opens kServerSupportDocUrl', (tester) async {
+      await prepareBanner(tester,
+        zulipFeatureLevel: unsupportedFeatureLevel,
+        zulipVersion: unsupportedVersion);
+      await tester.tap(find.text(zulipLocalizations.serverCompatBannerLearnMoreLabel));
+      check(testBinding.takeLaunchUrlCalls()).single
+        .equals((url: kServerSupportDocUrl, mode: LaunchMode.inAppBrowserView));
+    });
+  });
 }

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -133,7 +133,7 @@ void main() {
       await attempt(tester, serverSettings.realmUrl, serverSettings.toJson());
       checkErrorDialog(tester,
         expectedTitle: 'Could not connect',
-        expectedMessage: '${serverSettings.realmUrl} is running Zulip Server 3.0, which is unsupported. The minimum supported version is Zulip Server $kMinSupportedZulipVersion.');
+        expectedMessage: '${serverSettings.realmUrl} is running Zulip Server 3.0, which is unsupported. The minimum supported version is Zulip Server $kMinAllowedZulipVersion.');
       // i.e., not the login route
       check(takePushedRoutes()).single.isA<DialogRoute<void>>();
     });
@@ -151,7 +151,7 @@ void main() {
       await attempt(tester, serverSettings.realmUrl, serverSettingsMalformedJson);
       checkErrorDialog(tester,
         expectedTitle: 'Could not connect',
-        expectedMessage: '${serverSettings.realmUrl} is running Zulip Server 3.0, which is unsupported. The minimum supported version is Zulip Server $kMinSupportedZulipVersion.');
+        expectedMessage: '${serverSettings.realmUrl} is running Zulip Server 3.0, which is unsupported. The minimum supported version is Zulip Server $kMinAllowedZulipVersion.');
       // i.e., not the login route
       check(takePushedRoutes()).single.isA<DialogRoute<void>>();
     });


### PR DESCRIPTION
Fixes #1457.

<details>
<summary>Screenshots</summary>

|Light|Dark|
|-----|-----|
|<img width="1080" height="2400" alt="Screenshot_20260227-213959 Zulip" src="https://github.com/user-attachments/assets/77cc287d-745e-4d1b-9f4e-60530f7d1c1d" />|<img width="1080" height="2400" alt="Screenshot_20260227-214547 Zulip" src="https://github.com/user-attachments/assets/672ecf86-787b-4b0a-adfd-49430eb23055" />|
|<img width="1080" height="2400" alt="Screenshot_20260227-214005 Zulip" src="https://github.com/user-attachments/assets/ebf5dd45-7ad4-4ac7-9eef-3b6b36836563" />|<img width="1080" height="2400" alt="Screenshot_20260227-214550 Zulip" src="https://github.com/user-attachments/assets/751daca0-f435-48ba-a1e3-6ee56821dfce" />|
|<img width="1080" height="2400" alt="Screenshot_20260227-214007 Zulip" src="https://github.com/user-attachments/assets/ca1f6626-a954-4b1f-b256-a4deff77a9e9" />|<img width="1080" height="2400" alt="Screenshot_20260227-214552 Zulip" src="https://github.com/user-attachments/assets/41faa025-3553-422e-a3a9-76bac4ea054d" />|

</details>

### Changes Made:
1. Added `kMinOfficiallySupportedZulipVersion` and `kMinOfficiallySupportedZulipFeatureLevel` to track officially supported versions.
2. Added required strings in translations
3. Added warning banner at the top of the home screen using `MaterialBanner` following default Material3 styling. See discussion:
    [#mobile-design > Design of banner for unsupported server](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Design.20of.20banner.20for.20unsupported.20server/with/2393380)
4. Added tests for the banner.