### PR TITLE
compose_box: Use inline syntax on upload for image and audio

### DIFF
--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -257,6 +257,26 @@ String inlineLink(String visibleText, String destination) {
   return '[$visibleText]($destination)';
 }
 
+/// https://spec.commonmark.org/0.30/#image-description
+///
+/// Zulip uses the Markdown image syntax (`![](...)`) for server supported
+/// inline images and inline media such as audio. This emits that syntax for
+/// [visibleText] and [destination].
+///
+/// For supported audio and image types, see [supportedInlineAudioTypes] and
+/// [supportedInlineImageTypes] respectively.
+String imageAudioLink(String visibleText, String destination, {
+  required int zulipFeatureLevel,
+}) {
+  // While the Audio Inline syntax was introduced in server-11(FL-405),
+  // it is not recommended for widespread use until 12(FL-467). Discussion:
+  // https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/which.20FL.20for.20inline.20audio.20syntax/with/2429954
+  // TODO(server-12): simplify and remove comment
+  return zulipFeatureLevel >= 467
+    ? '![$visibleText]($destination)'
+    : '[$visibleText]($destination)';
+}
+
 const supportedInlineAudioTypes = [
   'audio/aac',
   'audio/flac',

--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -265,7 +265,13 @@ const supportedInlineAudioTypes = [
   'audio/vnd.wave',
   'audio/wav',
   'audio/webm',
-  'audio/x-wav'];
+  'audio/x-wav',
+  // mime package always assign files with `.flac` extension with depreciated
+  // flac MIME type, i.e 'audio/x-flac'. But, server only supports 'audio/flac'.
+  // We should 'audio/x-flac' into 'audio/flac' MIME type before sending the
+  // `contentType` of file to be uploaded. Discussion:
+  // https://chat.zulip.org/#narrow/channel/9-issues/topic/flutter.20client.20maps.20.2Eflac.20to.20.60audio.2Fx-flac.60.20MIME.20type/near/2436142
+  'audio/x-flac'];
 
 const supportedInlineImageTypes = [
   'image/avif',

--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -257,6 +257,32 @@ String inlineLink(String visibleText, String destination) {
   return '[$visibleText]($destination)';
 }
 
+const supportedInlineAudioTypes = [
+  'audio/aac',
+  'audio/flac',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/vnd.wave',
+  'audio/wav',
+  'audio/webm',
+  'audio/x-wav'];
+
+const supportedInlineImageTypes = [
+  'image/avif',
+  'image/gif',
+  'image/heic',
+  'image/jpeg',
+  'image/png',
+  'image/tiff',
+  'image/webp'];
+
+/// Whether a file with this mimeType has server support for inline formatting.
+///
+/// For supported audio and image types, see [supportedInlineAudioTypes] and
+/// [supportedInlineImageTypes] respectively.
+bool isSupportedInlineMedia({required String? mimeType}) =>
+    supportedInlineAudioTypes.contains(mimeType) || supportedInlineImageTypes.contains(mimeType);
+
 /// What we show while fetching the target message's raw Markdown.
 ///
 /// Like [quoteAndReply], but the message content is replaced with a placeholder.

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -253,7 +253,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   int _nextUploadTag = 0;
 
   final Map<int, ({int messageId, String placeholder})> _quoteAndReplies = {};
-  final Map<int, ({String filename, String placeholder})> _uploads = {};
+  final Map<int, ({String filename, String placeholder, bool isSupportedInlineAudioImage})> _uploads = {};
 
   /// A probably-reasonable place to insert Markdown, such as for a file upload.
   ///
@@ -353,12 +353,16 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   ///
   /// Returns an int "tag" that should be passed to registerUploadEnd on the
   /// upload's success or failure.
-  int registerUploadStart(String filename, ZulipLocalizations zulipLocalizations) {
+  int registerUploadStart(String filename, ZulipLocalizations zulipLocalizations,
+      bool isSupportedInlineAudioImage) {
     final tag = _nextUploadTag;
     _nextUploadTag += 1;
     final linkText = zulipLocalizations.composeBoxUploadingFilename(filename);
-    final placeholder = inlineLink(linkText, '');
-    _uploads[tag] = (filename: filename, placeholder: placeholder);
+    final placeholder = isSupportedInlineAudioImage
+      ? imageAudioLink(linkText, '', zulipFeatureLevel: store.zulipFeatureLevel)
+      : inlineLink(linkText, '');
+    _uploads[tag] = (filename: filename, placeholder: placeholder,
+      isSupportedInlineAudioImage: isSupportedInlineAudioImage);
     notifyListeners(); // _uploads change could affect validationErrors
     value = value.replaced(insertionIndex(), '$placeholder\n\n');
     return tag;
@@ -371,15 +375,22 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   void registerUploadEnd(int tag, String? url) {
     final val = _uploads[tag];
     assert(val != null, 'registerUploadEnd called twice for same tag');
-    final (:filename, :placeholder) = val!;
+    final (:filename, :placeholder, :isSupportedInlineAudioImage) = val!;
     final int startIndex = text.indexOf(placeholder);
     final replacementRange = startIndex >= 0
       ? TextRange(start: startIndex, end: startIndex + placeholder.length)
       : insertionIndex();
 
+    final replacement =
+      url != null
+      ? isSupportedInlineAudioImage
+        ? imageAudioLink(filename, url, zulipFeatureLevel: store.zulipFeatureLevel)
+        : inlineLink(filename, url)
+      : '';
+
     value = value.replaced(
       replacementRange,
-      url == null ? '' : inlineLink(filename, url));
+      replacement);
     _uploads.remove(tag);
     notifyListeners(); // _uploads change could affect validationErrors
   }
@@ -1009,7 +1020,7 @@ Future<void> _uploadFiles({
   final List<(int, FileToUpload)> uploadsInProgress = [];
   for (final file in rightSizeFiles) {
     final tag = contentController.registerUploadStart(file.filename,
-      zulipLocalizations);
+      zulipLocalizations, isSupportedInlineMedia(mimeType: file.mimeType));
     uploadsInProgress.add((tag, file));
   }
   if (shouldRequestFocus && !contentFocusNode.hasFocus) {
@@ -1019,12 +1030,17 @@ Future<void> _uploadFiles({
   for (final (tag, file) in uploadsInProgress) {
     final FileToUpload(:content, :length, :filename, :mimeType) = file;
     String? url;
+
+    // mime package maps '.flac' files to 'audio/x-flac' MIME type which is
+    // depreciated 'audio/x-flac', so we translate it to standard 'audio/flac'.
+    // Discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/flutter.20client.20maps.20.2Eflac.20to.20.60audio.2Fx-flac.60.20MIME.20type/near/2435827
+    final translatedMimeType = mimeType == 'audio/x-flac' ? 'audio/flac' : mimeType;
     try {
       final result = await uploadFile(store.connection,
         content: content,
         length: length,
         filename: filename,
-        contentType: mimeType,
+        contentType: translatedMimeType,
       );
       url = result.url;
     } catch (e) {

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -384,6 +384,29 @@ hello
     check(inlineLink('Uploading file.txt…', '')).equals('[Uploading file.txt…]()');
     check(inlineLink('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png'))
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
+    check(inlineLink('foo_bar.mp3', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/foo_bar.mp3'))
+      .equals('[foo_bar.mp3](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/foo_bar.mp3)');
+  });
+
+  test('imageAudioLink', () {
+    final store = eg.store();
+    check(imageAudioLink('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png',
+        zulipFeatureLevel: store.zulipFeatureLevel))
+      .equals('![IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
+    check(imageAudioLink('foo_bar.mp3', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/foo_bar.mp3',
+        zulipFeatureLevel: store.zulipFeatureLevel))
+      .equals('![foo_bar.mp3](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/foo_bar.mp3)');
+  });
+
+  test('imageAudioLink with FL<467', () { // TODO(server-12): remove this test
+    final store = eg.store(account: eg.account(user: eg.selfUser, zulipFeatureLevel: 466),
+      initialSnapshot: eg.initialSnapshot(zulipFeatureLevel: 466));
+    check(imageAudioLink('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png',
+        zulipFeatureLevel: store.zulipFeatureLevel))
+      .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
+    check(imageAudioLink('foo_bar.mp3', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/foo_bar.mp3',
+        zulipFeatureLevel: store.zulipFeatureLevel))
+      .equals('[foo_bar.mp3](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/foo_bar.mp3)');
   });
 
   test('isSupportedInlineImageAudio, image', () {

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -386,6 +386,16 @@ hello
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
   });
 
+  test('isSupportedInlineImageAudio, image', () {
+    check(isSupportedInlineMedia(mimeType: 'image/svg+xml')).isFalse();
+    check(isSupportedInlineMedia(mimeType: 'image/png')).isTrue();
+  });
+
+  test('isSupportedInlineImageAudio, audio', () {
+    check(isSupportedInlineMedia(mimeType: 'audio/ogg')).isFalse();
+    check(isSupportedInlineMedia(mimeType: 'audio/flac')).isTrue();
+  });
+
   test('quoteAndReply / quoteAndReplyPlaceholder', () async {
     final sender = eg.user(userId: 123, fullName: 'Full Name');
     final stream = eg.stream(streamId: 1, name: 'test here');

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -1423,6 +1423,15 @@ class ContentExample {
     ]),
   ]);
 
+  static const audioInlineFlac = ContentExample(
+    'audio file with .flac extension',
+    '![foo-bar.flac](/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/foo-bar.flac)',
+    '<p><audio controls preload="metadata" src="/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/foo-bar.flac"></audio></p>', [
+    ParagraphNode(links: null, nodes: [
+      LinkNode(url: '/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/foo-bar.flac', nodes: [TextNode('foo-bar.flac')]),
+    ]),
+  ]);
+
   static const websitePreviewSmoke = ContentExample(
     'website preview smoke',
     'https://pub-14f7b5e1308d42b69c4a46608442a50c.r2.dev/image+title+description.html',
@@ -2147,6 +2156,7 @@ void main() async {
 
   testParseExample(ContentExample.audioInline);
   testParseExample(ContentExample.audioInlineNoTitle);
+  testParseExample(ContentExample.audioInlineFlac);
 
   testParseExample(ContentExample.websitePreviewSmoke);
   testParseExample(ContentExample.websitePreviewWithoutTitle);

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1141,7 +1141,7 @@ void main() {
     }
 
     group('attach from media library', () {
-      testWidgets('success', (tester) async {
+      testWidgets('image success', (tester) async {
         await prepare(tester);
         checkAppearsLoading(tester, false);
 
@@ -1165,7 +1165,7 @@ void main() {
         checkNoDialog(tester);
 
         check(controller!.content.text)
-          .equals('see image: [Uploading image.jpg…]()\n\n');
+          .equals('see image: ![Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -1181,7 +1181,50 @@ void main() {
 
         await tester.pump(const Duration(seconds: 1));
         check(controller!.content.text)
-          .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          .equals('see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+        checkAppearsLoading(tester, false);
+      });
+
+      testWidgets('audio success', (tester) async {
+        await prepare(tester);
+        checkAppearsLoading(tester, false);
+
+        testBinding.pickFilesResult = FilePickerResult([PlatformFile(
+          readStream: Stream.fromIterable(['asdf'.codeUnits]),
+          // TODO test inference of MIME type from initial bytes, when
+          //   it can't be inferred from path
+          path: '/private/var/mobile/Containers/Data/Application/foo/tmp/audio.mp3',
+          name: 'audio.mp3',
+          size: 12345,
+        )]);
+        connection.prepare(delay: const Duration(seconds: 1), json:
+        UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/audio.mp3').toJson());
+
+        await tester.tap(find.byIcon(ZulipIcons.image));
+        await tester.pump();
+        final call = testBinding.takePickFilesCalls().single;
+        check(call.allowMultiple).equals(true);
+        check(call.type).equals(FileType.media);
+
+        checkNoDialog(tester);
+
+        check(controller!.content.text)
+            .equals('see image: ![Uploading audio.mp3…]()\n\n');
+        check(connection.lastRequest!).isA<http.MultipartRequest>()
+          ..method.equals('POST')
+          ..files.single.which((it) => it
+            ..field.equals('file')
+            ..length.equals(12345)
+            ..filename.equals('audio.mp3')
+            ..contentType.asString.equals('audio/mpeg')
+            ..has<Future<List<int>>>((f) => f.finalize().toBytes(), 'contents')
+                .completes((it) => it.deepEquals(['asdf'.codeUnits].expand((l) => l)))
+          );
+        checkAppearsLoading(tester, true);
+
+        await tester.pump(const Duration(seconds: 1));
+        check(controller!.content.text)
+            .equals('see image: ![audio.mp3](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/audio.mp3)\n\n');
         checkAppearsLoading(tester, false);
       });
 
@@ -1213,7 +1256,7 @@ void main() {
         checkNoDialog(tester);
 
         check(controller!.content.text)
-          .equals('see image: [Uploading image.jpg…]()\n\n');
+          .equals('see image: ![Uploading image.jpg…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -1229,7 +1272,7 @@ void main() {
 
         await tester.pump(const Duration(seconds: 1));
         check(controller!.content.text)
-          .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          .equals('see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         checkAppearsLoading(tester, false);
       });
 
@@ -1314,7 +1357,7 @@ void main() {
 
         await tester.pump();
         check(controller!.content.text)
-          .equals('see image: [Uploading test.gif…]()\n\n');
+          .equals('see image: ![Uploading test.gif…]()\n\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -1330,7 +1373,7 @@ void main() {
 
         await tester.pump(Duration.zero);
         check(controller!.content.text)
-          .equals('see image: [test.gif]($uploadUrl)\n\n');
+          .equals('see image: ![test.gif]($uploadUrl)\n\n');
         checkAppearsLoading(tester, false);
       });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1711,6 +1711,14 @@ void main() {
         wrapWithPerAccountStoreWidget: true);
     }
 
+    testWidgets('smoke: audio file with .flac extension', (tester) async {
+      await prepare(tester, ContentExample.audioInlineFlac.html);
+      check(find.text(
+          '![foo-bar.flac](/user_uploads/2/f2/a_WnijOXIeRnI6OSxo9F6gZM/foo-bar.flac)'))
+          .findsNothing();
+      check(find.text('foo-bar.flac')).findsOne();
+    });
+
     testWidgets('tapping on audio link opens it in browser', (tester) async {
       await prepare(tester, ContentExample.audioInline.html);
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);


### PR DESCRIPTION
Fixes #2178.
Fixes #2179.

<details>
  <summary>Changes</summary>

### Image Upload

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/7ef5b042-67d1-4d63-a061-3b4b26e49337" width="350" controls></video> | <video src="https://github.com/user-attachments/assets/cff4d689-39db-45c6-9eb3-05e702695416" width="350" controls></video> |

<br>

### Audio Upload (No visual changes)

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/2d8825a9-097e-4755-92d5-01ccc5a98816" width="350" controls></video> | <video src="https://github.com/user-attachments/assets/9f1d5db9-a17e-4a5a-83d8-4e1a7518d552" width="350" controls></video> |

</details>

### References

- General description: https://github.com/zulip/zulip-flutter/issues/2178
- Web PR: https://github.com/zulip/zulip/pull/38065
- Chat thread
    - [#design > Image and audio elements @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Image.20and.20audio.20elements/near/2391023)
    - [#mobile-dev-help > doubt in current implementation of inline audio input](https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/doubt.20in.20current.20implementation.20of.20inline.20audio.20input/with/2393800)
    - [#mobile > issue mislabled with server-12 than server-11](https://chat.zulip.org/#narrow/channel/48-mobile/topic/issue.20mislabled.20with.20server-12.20than.20server-11/with/2398267)