### PR TITLE
narrow [nfc]: Rename ChannelNarrow.streamId and TopicNarrow.streamId to channelId

### DIFF
--- a/lib/api/route/channels.dart
+++ b/lib/api/route/channels.dart
@@ -100,7 +100,7 @@ class GetChannelTopicsEntry {
 /// This encapsulates a server-feature check.
 // TODO(server-7): remove this and just use updateUserTopic
 Future<void> updateUserTopicCompat(ApiConnection connection, {
-  required int streamId,
+  required int channelId,
   required TopicName topic,
   required UserTopicVisibilityPolicy visibilityPolicy,
 }) {
@@ -113,13 +113,13 @@ Future<void> updateUserTopicCompat(ApiConnection connection, {
     };
     // https://zulip.com/api/mute-topic
     return connection.patch('muteTopic', (_) {}, 'users/me/subscriptions/muted_topics', {
-      'stream_id': streamId,
+      'stream_id': channelId,
       'topic': RawParameter(topic.apiName),
       'op': RawParameter(op),
     });
   } else {
     return updateUserTopic(connection,
-      streamId: streamId,
+      channelId: channelId,
       topic: topic,
       visibilityPolicy: visibilityPolicy);
   }
@@ -130,14 +130,14 @@ Future<void> updateUserTopicCompat(ApiConnection connection, {
 /// This binding only supports feature levels 170+.
 // TODO(server-7) remove FL 170+ mention in doc, and the related `assert`
 Future<void> updateUserTopic(ApiConnection connection, {
-  required int streamId,
+  required int channelId,
   required TopicName topic,
   required UserTopicVisibilityPolicy visibilityPolicy,
 }) {
   assert(visibilityPolicy != UserTopicVisibilityPolicy.unknown);
   assert(connection.zulipFeatureLevel! >= 170);
   return connection.post('updateUserTopic', (_) {}, 'user_topics', {
-    'stream_id': streamId,
+    'stream_id': channelId,
     'topic': RawParameter(topic.apiName),
     'visibility_policy': visibilityPolicy,
   });

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -563,9 +563,9 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     TopicName? topic;
     switch (narrow) {
       case ChannelNarrow():
-        streamId = narrow.streamId;
+        streamId = narrow.channelId;
       case TopicNarrow():
-        streamId = narrow.streamId;
+        streamId = narrow.channelId;
         topic = narrow.topic;
       case DmNarrow():
         break;
@@ -1374,9 +1374,10 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
 
     int? channelId;
     switch (narrow) {
-      case ChannelNarrow(:var streamId):
-      case TopicNarrow(:var streamId):
-        channelId = streamId;
+      case ChannelNarrow():
+        channelId = narrow.channelId;
+      case TopicNarrow():
+        channelId = narrow.channelId;
       case DmNarrow():
         break;
       case CombinedFeedNarrow():

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -559,13 +559,13 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     // See also [MentionAutocompleteQuery._rankUserResult];
     // that ranking takes precedence over this.
 
-    int? streamId;
+    int? channelId;
     TopicName? topic;
     switch (narrow) {
       case ChannelNarrow():
-        streamId = narrow.channelId;
+        channelId = narrow.channelId;
       case TopicNarrow():
-        streamId = narrow.channelId;
+        channelId = narrow.channelId;
         topic = narrow.topic;
       case DmNarrow():
         break;
@@ -578,27 +578,27 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
 
     // The [TopicKeyedMap] lookup calls [TopicName.canonicalize] each time,
     // so do it once here rather than O(n log n) times in the sort.
-    final getRecencyInTopic = (streamId != null && topic != null)
+    final getRecencyInTopic = (channelId != null && topic != null)
       ? store.recentSenders.latestMessageIdBySenderInTopic(
-          streamId: streamId, topic: topic)
+          channelId: channelId, topic: topic)
       : null;
 
     return (userA, userB) => _compareByRelevance(userA, userB,
-      streamId: streamId,
+      channelId: channelId,
       getRecencyInTopic: getRecencyInTopic,
       store: store);
   }
 
   static int _compareByRelevance(User userA, User userB, {
-    required int? streamId,
+    required int? channelId,
     required int? Function(int senderId)? getRecencyInTopic,
     required PerAccountStore store,
   }) {
     // TODO(#618): give preference to subscribed users first
 
-    if (streamId != null) {
+    if (channelId != null) {
       final recencyResult = compareByRecency(userA, userB,
-        streamId: streamId,
+        channelId: channelId,
         getRecencyInTopic: getRecencyInTopic,
         store: store);
       if (recencyResult != 0) return recencyResult;
@@ -620,7 +620,7 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   ///
   /// If [getRecencyInTopic] is not provided,
   /// or neither user has sent messages in the topic,
-  /// then checks for the activity in the channel with [streamId].
+  /// then checks for the activity in the channel with [channelId].
   ///
   /// Returns a negative number if [userA] has more recent activity than [userB],
   /// returns a positive number if [userB] has more recent activity than [userA],
@@ -629,7 +629,7 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   /// See [RecentSenders.latestMessageIdBySenderInTopic].
   @visibleForTesting
   static int compareByRecency(User userA, User userB, {
-    required int streamId,
+    required int channelId,
     required int? Function(int senderId)? getRecencyInTopic,
     required PerAccountStore store,
   }) {
@@ -641,10 +641,10 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     }
 
     return -compareRecentMessageIds(
-      store.recentSenders.latestMessageIdOfSenderInStream(
-        streamId: streamId, senderId: userA.userId),
-      store.recentSenders.latestMessageIdOfSenderInStream(
-        streamId: streamId, senderId: userB.userId));
+      store.recentSenders.latestMessageIdOfSenderInChannel(
+        channelId: channelId, senderId: userA.userId),
+      store.recentSenders.latestMessageIdOfSenderInChannel(
+        channelId: channelId, senderId: userB.userId));
   }
 
   /// Determines which of the two users is more recent in DM conversations.

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -1231,20 +1231,20 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
   TopicAutocompleteView._({
     required super.store,
     required super.query,
-    required this.streamId,
+    required this.channelId,
   });
 
   factory TopicAutocompleteView.init({
     required PerAccountStore store,
-    required int streamId,
+    required int channelId,
     required TopicAutocompleteQuery query,
   }) {
-    return TopicAutocompleteView._(store: store, streamId: streamId, query: query)
+    return TopicAutocompleteView._(store: store, channelId: channelId, query: query)
       .._fetch();
   }
 
   /// The channel/stream the eventual message will be sent to.
-  final int streamId;
+  final int channelId;
 
   Iterable<TopicName> _topics = [];
 
@@ -1255,7 +1255,7 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
   /// fetched topics.
   Future<void> _fetch() async {
     // TODO: handle fetch failure
-    _topics = (await store.topics.getChannelTopics(streamId)).map((e) => e.name);
+    _topics = (await store.topics.getChannelTopics(channelId)).map((e) => e.name);
     return _startSearch();
   }
 

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -84,10 +84,10 @@ String narrowLinkFragment(PerAccountStore store, Narrow narrow, {int? nearMessag
 
     switch (element) {
       case ApiNarrowChannel():
-        final streamId = element.operand;
-        final name = store.streams[streamId]?.name ?? 'unknown';
+        final channelId = element.operand;
+        final name = store.streams[channelId]?.name ?? 'unknown';
         final slugifiedName = _encodeHashComponent(name.replaceAll(' ', '-'));
-        fragment.write('$streamId-$slugifiedName');
+        fragment.write('$channelId-$slugifiedName');
       case ApiNarrowTopic():
         fragment.write(_encodeHashComponent(element.operand.apiName));
       case ApiNarrowDmModern():

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -692,11 +692,11 @@ class MessageListView with ChangeNotifier, _MessageSequence {
             DmNarrow.ofConversation(conversation, selfUserId: store.selfUserId)),
         };
 
-      case ChannelNarrow(:final streamId):
+      case ChannelNarrow(:final channelId):
         assert(message is MessageBase<StreamConversation>
-               && message.conversation.streamId == streamId);
+               && message.conversation.streamId == channelId);
         if (message is! MessageBase<StreamConversation>) return false;
-        return store.isTopicVisibleInStream(streamId, message.conversation.topic);
+        return store.isTopicVisibleInStream(channelId, message.conversation.topic);
 
       case TopicNarrow():
         assert((narrow as TopicNarrow).containsMessage(message));
@@ -767,8 +767,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       case CombinedFeedNarrow():
         return store.willChangeIfTopicVisible(event);
 
-      case ChannelNarrow(:final streamId):
-        if (event.streamId != streamId) return UserTopicVisibilityEffect.none;
+      case ChannelNarrow(:final channelId):
+        if (event.streamId != channelId) return UserTopicVisibilityEffect.none;
         return store.willChangeIfTopicVisibleInStream(event);
 
       case TopicNarrow():
@@ -1252,17 +1252,17 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         // without asking the server.
         _messagesMovedInternally(messageIds);
 
-      case ChannelNarrow(:final streamId):
-        switch ((origStreamId == streamId, newStreamId == streamId)) {
+      case ChannelNarrow(:final channelId):
+        switch ((origStreamId == channelId, newStreamId == channelId)) {
           case (false, false): return;
           case (true,  true ): _messagesMovedInternally(messageIds);
           case (false, true ): _messagesMovedIntoNarrow();
           case (true,  false): _messagesMovedFromNarrow(messageIds);
         }
 
-      case TopicNarrow(:final streamId, :final topic):
-        final oldMatch = (origStreamId == streamId && origTopic.isSameAs(topic));
-        final newMatch = (newStreamId == streamId && newTopic.isSameAs(topic));
+      case TopicNarrow(:final channelId, :final topic):
+        final oldMatch = (origStreamId == channelId && origTopic.isSameAs(topic));
+        final newMatch = (newStreamId == channelId && newTopic.isSameAs(topic));
         switch ((oldMatch, newMatch)) {
           case (false, false): return;
           case (true,  true ): return; // TODO(log) when no-op move

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -69,66 +69,66 @@ class CombinedFeedNarrow extends Narrow {
 }
 
 class ChannelNarrow extends Narrow {
-  const ChannelNarrow(this.streamId);
+  const ChannelNarrow(this.channelId);
 
-  final int streamId;
+  final int channelId;
 
   @override
   bool containsMessage(MessageBase message) {
     final conversation = message.conversation;
-    return conversation is StreamConversation && conversation.streamId == streamId;
+    return conversation is StreamConversation && conversation.streamId == channelId;
   }
 
   @override
-  ApiNarrow apiEncode() => [ApiNarrowChannel(streamId)];
+  ApiNarrow apiEncode() => [ApiNarrowChannel(channelId)];
 
   @override
-  String toString() => 'ChannelNarrow($streamId)';
+  String toString() => 'ChannelNarrow($channelId)';
 
   @override
   bool operator ==(Object other) {
     if (other is! ChannelNarrow) return false;
-    return other.streamId == streamId;
+    return other.channelId == channelId;
   }
 
   @override
-  int get hashCode => Object.hash('ChannelNarrow', streamId);
+  int get hashCode => Object.hash('ChannelNarrow', channelId);
 }
 
 class TopicNarrow extends Narrow implements SendableNarrow {
-  const TopicNarrow(this.streamId, this.topic, {this.with_});
+  const TopicNarrow(this.channelId, this.topic, {this.with_});
 
   factory TopicNarrow.ofMessage(MessageBase<StreamConversation> message) {
     return TopicNarrow(message.conversation.streamId, message.conversation.topic);
   }
 
-  final int streamId;
+  final int channelId;
   final TopicName topic;
   final int? with_;
 
-  TopicNarrow sansWith() => TopicNarrow(streamId, topic);
+  TopicNarrow sansWith() => TopicNarrow(channelId, topic);
 
   @override
   bool containsMessage(MessageBase message) {
     final conversation = message.conversation;
     return conversation is StreamConversation
-      && conversation.streamId == streamId && conversation.topic.isSameAs(topic);
+      && conversation.streamId == channelId && conversation.topic.isSameAs(topic);
   }
 
   @override
   ApiNarrow apiEncode() => [
-    ApiNarrowChannel(streamId),
+    ApiNarrowChannel(channelId),
     ApiNarrowTopic(topic),
     if (with_ != null) ApiNarrowWith(with_!),
   ];
 
   @override
-  StreamDestination get destination => StreamDestination(streamId, topic);
+  StreamDestination get destination => StreamDestination(channelId, topic);
 
   @override
   String toString() {
     final fields = [
-      streamId.toString(),
+      channelId.toString(),
       topic.displayName,
       if (with_ != null) 'with: ${with_!}',
     ];
@@ -139,17 +139,17 @@ class TopicNarrow extends Narrow implements SendableNarrow {
   /// case-insensitively, using [TopicName.isSameAs].
   bool isSameAs(Narrow other) {
     if (other is! TopicNarrow) return false;
-    return other.streamId == streamId && other.topic.isSameAs(topic) && other.with_ == with_;
+    return other.channelId == channelId && other.topic.isSameAs(topic) && other.with_ == with_;
   }
 
   @override
   bool operator ==(Object other) {
     if (other is! TopicNarrow) return false;
-    return other.streamId == streamId && other.topic == topic && other.with_ == with_;
+    return other.channelId == channelId && other.topic == topic && other.with_ == with_;
   }
 
   @override
-  int get hashCode => Object.hash('TopicNarrow', streamId, topic, with_);
+  int get hashCode => Object.hash('TopicNarrow', channelId, topic, with_);
 }
 
 /// The narrow for a direct-message conversation.

--- a/lib/model/recent_senders.dart
+++ b/lib/model/recent_senders.dart
@@ -6,25 +6,25 @@ import '../api/model/model.dart';
 import 'algorithms.dart';
 import 'channel.dart';
 
-/// Tracks the latest messages sent by each user, in each stream and topic.
+/// Tracks the latest messages sent by each user, in each channel and topic.
 ///
-/// Use [latestMessageIdOfSenderInStream] and [latestMessageIdOfSenderInTopic]
+/// Use [latestMessageIdOfSenderInChannel] and [latestMessageIdOfSenderInTopic]
 /// for queries.
 class RecentSenders {
-  // streamSenders[streamId][senderId] = MessageIdTracker
+  // channelSenders[channelId][senderId] = MessageIdTracker
   @visibleForTesting
-  final Map<int, Map<int, MessageIdTracker>> streamSenders = {};
+  final Map<int, Map<int, MessageIdTracker>> channelSenders = {};
 
-  // topicSenders[streamId][topic][senderId] = MessageIdTracker
+  // topicSenders[channelId][topic][senderId] = MessageIdTracker
   @visibleForTesting
   final Map<int, TopicKeyedMap<Map<int, MessageIdTracker>>> topicSenders = {};
 
-  /// The latest message the given user sent to the given stream,
+  /// The latest message the given user sent to the given channel,
   /// or null if no such message is known.
-  int? latestMessageIdOfSenderInStream({
-    required int streamId,
+  int? latestMessageIdOfSenderInChannel({
+    required int channelId,
     required int senderId,
-  }) => streamSenders[streamId]?[senderId]?.maxId;
+  }) => channelSenders[channelId]?[senderId]?.maxId;
 
   /// The latest message the given user sent to the given topic,
   /// or null if no such message is known.
@@ -43,10 +43,10 @@ class RecentSenders {
   /// Like [latestMessageIdOfSenderInTopic], but returns a reusable function
   /// for the given topic.
   int? Function(int senderId)? latestMessageIdBySenderInTopic({
-    required int streamId,
+    required int channelId,
     required TopicName topic,
   }) {
-    final senders = topicSenders[streamId]?[topic];
+    final senders = topicSenders[channelId]?[topic];
     if (senders == null) return null;
     return (senderId) => senders[senderId]?.maxId;
   }
@@ -66,7 +66,7 @@ class RecentSenders {
 
     for (final entry in messagesByUserInStream.entries) {
       final (streamId, senderId) = entry.key;
-      ((streamSenders[streamId] ??= {})
+      ((channelSenders[streamId] ??= {})
         [senderId] ??= MessageIdTracker()).addAll(entry.value);
     }
     for (final entry in messagesByUserInTopic.entries) {
@@ -80,7 +80,7 @@ class RecentSenders {
   void handleMessage(Message message) {
     if (message is! StreamMessage) return;
     final StreamMessage(:streamId, :topic, :senderId, id: int messageId) = message;
-    ((streamSenders[streamId] ??= {})
+    ((channelSenders[streamId] ??= {})
       [senderId] ??= MessageIdTracker()).add(messageId);
     (((topicSenders[streamId] ??= makeTopicKeyedMap())[topic] ??= {})
       [senderId] ??= MessageIdTracker()).add(messageId);
@@ -97,7 +97,7 @@ class RecentSenders {
     }
 
     final DeleteMessageEvent(:streamId!, :topic!) = event;
-    final sendersInStream = streamSenders[streamId];
+    final sendersInStream = channelSenders[streamId];
     final topicsInStream = topicSenders[streamId];
     final sendersInTopic = topicsInStream?[topic];
     for (final entry in messagesByUser.entries) {
@@ -111,7 +111,7 @@ class RecentSenders {
       topicTracker?.removeAll(messages);
       if (topicTracker?.maxId == null) sendersInTopic?.remove(senderId);
     }
-    if (sendersInStream?.isEmpty ?? false) streamSenders.remove(streamId);
+    if (sendersInStream?.isEmpty ?? false) channelSenders.remove(streamId);
     if (sendersInTopic?.isEmpty ?? false) topicsInStream?.remove(topic);
     if (topicsInStream?.isEmpty ?? false) topicSenders.remove(streamId);
   }

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -269,9 +269,9 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
       case CombinedFeedNarrow():
         return countInCombinedFeedNarrow();
       case ChannelNarrow():
-        return countInChannelNarrow(narrow.streamId);
+        return countInChannelNarrow(narrow.channelId);
       case TopicNarrow():
-        return countInTopicNarrow(narrow.streamId, narrow.topic);
+        return countInTopicNarrow(narrow.channelId, narrow.topic);
       case DmNarrow():
         return countInDmNarrow(narrow);
       case MentionsNarrow():
@@ -582,7 +582,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
           if (expectOnlyDms) {
             // TODO(log)?
           }
-          _removeAllInStreamTopic(ids, narrow.streamId, narrow.topic);
+          _removeAllInStreamTopic(ids, narrow.channelId, narrow.topic);
         case DmNarrow():
           final messageIds = dms[narrow];
           if (messageIds == null) return;

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -201,20 +201,20 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
   /// For a count that's appropriate in UI contexts that are not already
   /// focused on this channel, see [countInChannel].
   // TODO(#370): maintain this count incrementally, rather than recomputing from scratch
-  int countInChannelNarrow(int streamId) {
-    final topics = streams[streamId];
+  int countInChannelNarrow(int channelId) {
+    final topics = streams[channelId];
     if (topics == null) return 0;
     int c = 0;
     for (final entry in topics.entries) {
-      if (channelStore.isTopicVisibleInStream(streamId, entry.key)) {
+      if (channelStore.isTopicVisibleInStream(channelId, entry.key)) {
         c = c + entry.value.length;
       }
     }
     return c;
   }
 
-  int countInTopicNarrow(int streamId, TopicName topic) {
-    final topics = streams[streamId];
+  int countInTopicNarrow(int channelId, TopicName topic) {
+    final topics = streams[channelId];
     return topics?[topic]?.length ?? 0;
   }
 
@@ -596,8 +596,8 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
     }
   }
 
-  void _removeAllInStreamTopic(Set<int> incomingMessageIds, int streamId, TopicName topic) {
-    final topics = streams[streamId];
+  void _removeAllInStreamTopic(Set<int> incomingMessageIds, int channelId, TopicName topic) {
+    final topics = streams[channelId];
     if (topics == null) return;
     final messageIds = topics[topic];
     if (messageIds == null) return;
@@ -607,7 +607,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
     if (messageIds.isEmpty) {
       topics.remove(topic);
       if (topics.isEmpty) {
-        streams.remove(streamId);
+        streams.remove(channelId);
       }
     }
   }

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -387,7 +387,7 @@ class NotificationOpenPayload {
         'realm_url': realmUrl.toString(),
         'user_id': userId.toString(),
         ...(switch (narrow) {
-          TopicNarrow(streamId: var channelId, :var topic) => {
+          TopicNarrow(:var channelId, :var topic) => {
             'narrow_type': 'topic',
             'channel_id': channelId.toString(),
             'topic': topic.apiName,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -612,7 +612,7 @@ class TopicListButton extends ActionSheetMenuItemButton {
   @override
   void onPressed() {
     Navigator.push(pageContext,
-      TopicListPage.buildRoute(context: pageContext, streamId: channelId));
+      TopicListPage.buildRoute(context: pageContext, channelId: channelId));
   }
 }
 

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -960,7 +960,7 @@ class UserTopicUpdateButton extends ActionSheetMenuItemButton {
     try {
       await updateUserTopicCompat(
         PerAccountStoreWidget.of(pageContext).connection,
-        streamId: narrow.channelId,
+        channelId: narrow.channelId,
         topic: narrow.topic,
         visibilityPolicy: newVisibilityPolicy);
     } catch (e) {

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -497,7 +497,7 @@ void showChannelActionSheet(BuildContext context, {
 
   final messageListPageNarrow = messageListPageState?.narrow;
   final isOnChannelFeed = messageListPageNarrow is ChannelNarrow
-    && messageListPageNarrow.streamId == channelId;
+    && messageListPageNarrow.channelId == channelId;
 
   final unreadCount = store.unreads.countInChannelNarrow(channelId);
   final channel = store.streams[channelId];
@@ -960,7 +960,7 @@ class UserTopicUpdateButton extends ActionSheetMenuItemButton {
     try {
       await updateUserTopicCompat(
         PerAccountStoreWidget.of(pageContext).connection,
-        streamId: narrow.streamId,
+        streamId: narrow.channelId,
         topic: narrow.topic,
         visibilityPolicy: newVisibilityPolicy);
     } catch (e) {

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -463,7 +463,7 @@ class EmojiAutocompleteItem extends StatelessWidget {
 class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicAutocompleteResult> {
   const TopicAutocomplete({
     super.key,
-    required this.streamId,
+    required this.channelId,
     required ComposeTopicController super.controller,
     required super.focusNode,
     required this.contentFocusNode,
@@ -472,7 +472,7 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
 
   final FocusNode contentFocusNode;
 
-  final int streamId;
+  final int channelId;
 
   @override
   ComposeTopicController get controller => super.controller as ComposeTopicController;
@@ -483,7 +483,7 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
   @override
   TopicAutocompleteView initViewModel(BuildContext context, TopicAutocompleteQuery query) {
     final store = PerAccountStoreWidget.of(context);
-    return TopicAutocompleteView.init(store: store, streamId: streamId, query: query);
+    return TopicAutocompleteView.init(store: store, channelId: channelId, query: query);
   }
 
   void _onTapOption(BuildContext context, TopicAutocompleteResult option) {

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -716,7 +716,7 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    final streamName = store.streams[widget.narrow.channelId]?.name
+    final channelName = store.streams[widget.narrow.channelId]?.name
       ?? zulipLocalizations.unknownChannelName;
     final hintTopic = _hintTopic();
     final hintDestination = hintTopic == null
@@ -724,8 +724,8 @@ class _StreamContentInputState extends State<_StreamContentInput> {
       // Zulip expresses channels and topics, not any normal English punctuation,
       // so don't make sense to translate. See:
       //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-      ? '#$streamName'
-      : '#$streamName > ${hintTopic.displayName ?? store.realmEmptyTopicDisplayName}';
+      ? '#$channelName'
+      : '#$channelName > ${hintTopic.displayName ?? store.realmEmptyTopicDisplayName}';
 
     return _TypingNotifier(
       destination: TopicNarrow(widget.narrow.channelId,
@@ -891,14 +891,14 @@ class _FixedDestinationContentInput extends StatelessWidget {
     switch (narrow) {
       case TopicNarrow(:final channelId, :final topic):
         final store = PerAccountStoreWidget.of(context);
-        final streamName = store.streams[channelId]?.name
+        final channelName = store.streams[channelId]?.name
           ?? zulipLocalizations.unknownChannelName;
         return zulipLocalizations.composeBoxChannelContentHint(
           // No i18n of this use of "#" and ">" string; those are part of how
           // Zulip expresses channels and topics, not any normal English punctuation,
           // so don't make sense to translate. See:
           //   https://github.com/zulip/zulip-flutter/pull/1148#discussion_r1941990585
-          '#$streamName > ${topic.displayName ?? store.realmEmptyTopicDisplayName}');
+          '#$channelName > ${topic.displayName ?? store.realmEmptyTopicDisplayName}');
 
       case DmNarrow(otherRecipientIds: []): // The self-1:1 thread.
         return zulipLocalizations.composeBoxSelfDmContentHint;

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -716,7 +716,7 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    final streamName = store.streams[widget.narrow.streamId]?.name
+    final streamName = store.streams[widget.narrow.channelId]?.name
       ?? zulipLocalizations.unknownChannelName;
     final hintTopic = _hintTopic();
     final hintDestination = hintTopic == null
@@ -728,7 +728,7 @@ class _StreamContentInputState extends State<_StreamContentInput> {
       : '#$streamName > ${hintTopic.displayName ?? store.realmEmptyTopicDisplayName}';
 
     return _TypingNotifier(
-      destination: TopicNarrow(widget.narrow.streamId,
+      destination: TopicNarrow(widget.narrow.channelId,
         TopicName(widget.controller.topic.textNormalized)),
       controller: widget.controller,
       child: _ContentInput(
@@ -889,9 +889,9 @@ class _FixedDestinationContentInput extends StatelessWidget {
   String _hintText(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
     switch (narrow) {
-      case TopicNarrow(:final streamId, :final topic):
+      case TopicNarrow(:final channelId, :final topic):
         final store = PerAccountStoreWidget.of(context);
-        final streamName = store.streams[streamId]?.name
+        final streamName = store.streams[channelId]?.name
           ?? zulipLocalizations.unknownChannelName;
         return zulipLocalizations.composeBoxChannelContentHint(
           // No i18n of this use of "#" and ">" string; those are part of how
@@ -1536,7 +1536,7 @@ class _StreamComposeBoxBody extends _ComposeBoxBody {
   final StreamComposeBoxController controller;
 
   @override Widget buildTopicInput() => _TopicInput(
-    streamId: narrow.streamId,
+    streamId: narrow.channelId,
     controller: controller,
   );
 
@@ -1550,7 +1550,7 @@ class _StreamComposeBoxBody extends _ComposeBoxBody {
   @override Widget buildSendButton() => _SendButton(
     controller: controller,
     getDestination: () => StreamDestination(
-      narrow.streamId, TopicName(controller.topic.textNormalized)),
+      narrow.channelId, TopicName(controller.topic.textNormalized)),
   );
 }
 
@@ -2249,9 +2249,9 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
     switch (widget.narrow) {
-      case ChannelNarrow(:final streamId):
-      case TopicNarrow(:final streamId):
-        final channel = store.streams[streamId];
+      case ChannelNarrow(:final channelId):
+      case TopicNarrow(:final channelId):
+        final channel = store.streams[channelId];
         if (channel == null || !store.selfHasContentAccess(channel)) {
           return _Banner(
             intent: _BannerIntent.info,
@@ -2277,7 +2277,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
                 intent: _BannerIntent.warning,
                 label: zulipLocalizations.composeBoxBannerLabelUnsubscribedWhenCannotSend,
                 useSmallerText: true,
-                trailing: _UnsubscribedChannelBannerTrailing(channelId: streamId));
+                trailing: _UnsubscribedChannelBannerTrailing(channelId: channelId));
         }
 
       case DmNarrow(:final otherRecipientIds):
@@ -2321,19 +2321,19 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
 
     final narrow = widget.narrow;
     switch (narrow) {
-      case ChannelNarrow(:final streamId):
-      case TopicNarrow(:final streamId):
-        final channel = store.streams[streamId];
+      case ChannelNarrow(:final channelId):
+      case TopicNarrow(:final channelId):
+        final channel = store.streams[channelId];
         // (If the channel is unknown, we should have already decided
         // what to show.)
         assert(channel != null);
-        final subscription = store.subscriptions[streamId];
+        final subscription = store.subscriptions[channelId];
         if (channel != null && subscription == null) {
           banner = _Banner(
             intent: _BannerIntent.warning,
             label: zulipLocalizations.composeBoxBannerLabelUnsubscribed,
             useSmallerText: true,
-            trailing: _UnsubscribedChannelBannerTrailing(channelId: streamId));
+            trailing: _UnsubscribedChannelBannerTrailing(channelId: channelId));
         }
 
       case DmNarrow():

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -739,9 +739,9 @@ class _StreamContentInputState extends State<_StreamContentInput> {
 }
 
 class _TopicInput extends StatefulWidget {
-  const _TopicInput({required this.streamId, required this.controller});
+  const _TopicInput({required this.channelId, required this.controller});
 
-  final int streamId;
+  final int channelId;
   final StreamComposeBoxController controller;
 
   @override
@@ -864,7 +864,7 @@ class _TopicInputState extends State<_TopicInput> {
         width: 1,
         color: designVariables.foreground.withFadedAlpha(0.2)))),
       child: TopicAutocomplete(
-        streamId: widget.streamId,
+        channelId: widget.channelId,
         controller: widget.controller.topic,
         focusNode: widget.controller.topicFocusNode,
         contentFocusNode: widget.controller.contentFocusNode,
@@ -1536,7 +1536,7 @@ class _StreamComposeBoxBody extends _ComposeBoxBody {
   final StreamComposeBoxController controller;
 
   @override Widget buildTopicInput() => _TopicInput(
-    streamId: narrow.channelId,
+    channelId: narrow.channelId,
     controller: controller,
   );
 

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -465,9 +465,9 @@ abstract class _MessageListAppBar {
       case KeywordSearchNarrow():
         appBarBackgroundColor = null; // i.e., inherit
 
-      case ChannelNarrow(:final streamId):
-      case TopicNarrow(:final streamId):
-        final subscription = store.subscriptions[streamId];
+      case ChannelNarrow(:final channelId):
+      case TopicNarrow(:final channelId):
+        final subscription = store.subscriptions[channelId];
         appBarBackgroundColor =
           colorSwatchFor(context, subscription).barBackground;
         // All recipient headers will match this color; remove distracting line
@@ -495,16 +495,16 @@ abstract class _MessageListAppBar {
       case KeywordSearchNarrow():
       case DmNarrow():
         break;
-      case ChannelNarrow(:final streamId):
-        actions.add(_TopicListButton(streamId: streamId));
-      case TopicNarrow(:final streamId):
+      case ChannelNarrow(:final channelId):
+        actions.add(_TopicListButton(streamId: channelId));
+      case TopicNarrow(:final channelId):
         actions.add(IconButton(
           icon: const Icon(ZulipIcons.message_feed),
           tooltip: zulipLocalizations.channelFeedButtonTooltip,
           onPressed: () => Navigator.push(context,
             MessageListPage.buildRoute(context: context,
-              narrow: ChannelNarrow(streamId)))));
-        actions.add(_TopicListButton(streamId: streamId));
+              narrow: ChannelNarrow(channelId)))));
+        actions.add(_TopicListButton(streamId: channelId));
     }
 
     return ZulipAppBar(
@@ -647,9 +647,9 @@ class MessageListAppBarTitle extends StatelessWidget {
       case StarredMessagesNarrow():
         return Text(zulipLocalizations.starredMessagesPageTitle);
 
-      case ChannelNarrow(:var streamId):
+      case ChannelNarrow(:var channelId):
         final store = PerAccountStoreWidget.of(context);
-        final stream = store.streams[streamId];
+        final stream = store.streams[channelId];
         final alignment = willCenterTitle
           ? Alignment.center
           : AlignmentDirectional.centerStart;
@@ -658,14 +658,14 @@ class MessageListAppBarTitle extends StatelessWidget {
           child: GestureDetector(
             behavior: HitTestBehavior.translucent,
             onLongPress: () {
-              showChannelActionSheet(context, channelId: streamId);
+              showChannelActionSheet(context, channelId: channelId);
             },
             child: Align(alignment: alignment,
               child: _buildStreamRow(context, stream: stream))));
 
-      case TopicNarrow(:var streamId, :var topic):
+      case TopicNarrow(:var channelId, :var topic):
         final store = PerAccountStoreWidget.of(context);
-        final stream = store.streams[streamId];
+        final stream = store.streams[channelId];
         final alignment = willCenterTitle
           ? Alignment.center
           : AlignmentDirectional.centerStart;
@@ -675,7 +675,7 @@ class MessageListAppBarTitle extends StatelessWidget {
             GestureDetector(
               behavior: HitTestBehavior.translucent,
               onLongPress: () {
-                showChannelActionSheet(context, channelId: streamId);
+                showChannelActionSheet(context, channelId: channelId);
               },
               child: Align(alignment: alignment,
                 child: _buildStreamRow(context, stream: stream))),
@@ -691,7 +691,7 @@ class MessageListAppBarTitle extends StatelessWidget {
                 // act on anyway.
                 assert(someMessage == null || narrow.containsMessage(someMessage)!);
                 showTopicActionSheet(context,
-                  channelId: streamId,
+                  channelId: channelId,
                   topic: topic,
                   someMessageIdInTopic: someMessage?.id);
               },
@@ -878,7 +878,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
     var narrow = widget.narrow;
     if (narrow is TopicNarrow) {
       // Normalize topic name.  See #1717.
-      narrow = TopicNarrow(narrow.streamId,
+      narrow = TopicNarrow(narrow.channelId,
         store.processTopicLikeServer(narrow.topic),
         with_: narrow.with_);
       if (narrow != widget.narrow) {
@@ -1326,8 +1326,8 @@ class _EmptyMessageListPlaceholder extends StatelessWidget {
         return PageBodyEmptyContentPlaceholder(
           header: zulipLocalizations.emptyMessageListCombinedFeed);
 
-      case ChannelNarrow(:final streamId) || TopicNarrow(:final streamId):
-        final channel = store.streams[streamId];
+      case ChannelNarrow(:final channelId) || TopicNarrow(:final channelId):
+        final channel = store.streams[channelId];
         if (channel == null) {
           return PageBodyEmptyContentPlaceholder(
             header: zulipLocalizations.emptyMessageListChannelUnavailable);

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -496,7 +496,7 @@ abstract class _MessageListAppBar {
       case DmNarrow():
         break;
       case ChannelNarrow(:final channelId):
-        actions.add(_TopicListButton(streamId: channelId));
+        actions.add(_TopicListButton(channelId: channelId));
       case TopicNarrow(:final channelId):
         actions.add(IconButton(
           icon: const Icon(ZulipIcons.message_feed),
@@ -504,7 +504,7 @@ abstract class _MessageListAppBar {
           onPressed: () => Navigator.push(context,
             MessageListPage.buildRoute(context: context,
               narrow: ChannelNarrow(channelId)))));
-        actions.add(_TopicListButton(streamId: channelId));
+        actions.add(_TopicListButton(channelId: channelId));
     }
 
     return ZulipAppBar(
@@ -554,9 +554,9 @@ class _RevealedMutedMessagesProvider extends InheritedNotifier<RevealedMutedMess
 }
 
 class _TopicListButton extends StatelessWidget {
-  const _TopicListButton({required this.streamId});
+  const _TopicListButton({required this.channelId});
 
-  final int streamId;
+  final int channelId;
 
   @override
   Widget build(BuildContext context) {
@@ -566,7 +566,7 @@ class _TopicListButton extends StatelessWidget {
       tooltip: zulipLocalizations.topicsButtonTooltip,
       onPressed: () => Navigator.push(context,
         TopicListPage.buildRoute(context: context,
-          streamId: streamId)));
+          channelId: channelId)));
   }
 }
 

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -18,17 +18,17 @@ import 'theme.dart';
 import 'counter_badge.dart';
 
 class TopicListPage extends StatelessWidget {
-  const TopicListPage({super.key, required this.streamId});
+  const TopicListPage({super.key, required this.channelId});
 
-  final int streamId;
+  final int channelId;
 
   static AccountRoute<void> buildRoute({
     required BuildContext context,
-    required int streamId,
+    required int channelId,
   }) {
     return MaterialAccountWidgetRoute(
       context: context,
-      page: TopicListPage(streamId: streamId));
+      page: TopicListPage(channelId: channelId));
   }
 
   @override
@@ -36,33 +36,33 @@ class TopicListPage extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
     final appBarBackgroundColor = colorSwatchFor(
-      context, store.subscriptions[streamId]).barBackground;
+      context, store.subscriptions[channelId]).barBackground;
 
     return PageRoot(child: Scaffold(
       appBar: ZulipAppBar(
         backgroundColor: appBarBackgroundColor,
         buildTitle: (willCenterTitle) =>
-          _TopicListAppBarTitle(streamId: streamId, willCenterTitle: willCenterTitle),
+          _TopicListAppBarTitle(channelId: channelId, willCenterTitle: willCenterTitle),
         actions: [
           IconButton(
             icon: const Icon(ZulipIcons.message_feed),
             tooltip: zulipLocalizations.channelFeedButtonTooltip,
             onPressed: () => Navigator.push(context,
               MessageListPage.buildRoute(context: context,
-                narrow: ChannelNarrow(streamId)))),
+                narrow: ChannelNarrow(channelId)))),
         ]),
-      body: _TopicList(streamId: streamId)));
+      body: _TopicList(channelId: channelId)));
   }
 }
 
 // This is adapted from [MessageListAppBarTitle].
 class _TopicListAppBarTitle extends StatelessWidget {
   const _TopicListAppBarTitle({
-    required this.streamId,
+    required this.channelId,
     required this.willCenterTitle,
   });
 
-  final int streamId;
+  final int channelId;
   final bool willCenterTitle;
 
   Widget _buildStreamRow(BuildContext context) {
@@ -70,9 +70,9 @@ class _TopicListAppBarTitle extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
     final store = PerAccountStoreWidget.of(context);
-    final stream = store.streams[streamId];
+    final stream = store.streams[channelId];
     final channelIconColor = colorSwatchFor(context,
-      store.subscriptions[streamId]).iconOnBarBackground;
+      store.subscriptions[channelId]).iconOnBarBackground;
 
     // A null [Icon.icon] makes a blank space.
     final icon = stream != null ? iconDataForStream(stream) : null;
@@ -106,7 +106,7 @@ class _TopicListAppBarTitle extends StatelessWidget {
         behavior: HitTestBehavior.translucent,
         onLongPress: () {
           showChannelActionSheet(context,
-            channelId: streamId,
+            channelId: channelId,
             // We're already on the topic list.
             showTopicListButton: false);
         },
@@ -116,9 +116,9 @@ class _TopicListAppBarTitle extends StatelessWidget {
 }
 
 class _TopicList extends StatefulWidget {
-  const _TopicList({required this.streamId});
+  const _TopicList({required this.channelId});
 
-  final int streamId;
+  final int channelId;
 
   @override
   State<_TopicList> createState() => _TopicListState();
@@ -156,12 +156,12 @@ class _TopicListState extends State<_TopicList> with PerAccountStoreAwareStateMi
     // Do nothing when the fetch fails; the topic-list will stay on
     // the loading screen, until the user navigates away and back.
     // TODO(design) show a nice error message on screen when this fails
-    await topicsModel!.getChannelTopics(widget.streamId);
+    await topicsModel!.getChannelTopics(widget.channelId);
   }
 
   @override
   Widget build(BuildContext context) {
-    final channelTopics = topicsModel!.channelTopics(widget.streamId);
+    final channelTopics = topicsModel!.channelTopics(widget.channelId);
     if (channelTopics == null) {
       return const Center(child: CircularProgressIndicator());
     }
@@ -176,7 +176,7 @@ class _TopicListState extends State<_TopicList> with PerAccountStoreAwareStateMi
     final topicItems = <_TopicItemData>[];
     for (final GetChannelTopicsEntry(:maxId, name: topic) in channelTopics) {
       final unreadMessageIds =
-        unreadsModel!.streams[widget.streamId]?[topic] ?? <int>[];
+        unreadsModel!.streams[widget.channelId]?[topic] ?? <int>[];
       final countInTopic = unreadMessageIds.length;
       final hasMention = unreadMessageIds.any((messageId) =>
         unreadsModel!.mentions.contains(messageId));
@@ -194,7 +194,7 @@ class _TopicListState extends State<_TopicList> with PerAccountStoreAwareStateMi
       child: ListView.builder(
         itemCount: topicItems.length,
         itemBuilder: (context, index) =>
-          _TopicItem(streamId: widget.streamId, data: topicItems[index])),
+          _TopicItem(channelId: widget.channelId, data: topicItems[index])),
     );
   }
 }
@@ -216,9 +216,9 @@ class _TopicItemData {
 // This is adapted from `_TopicItem` in lib/widgets/inbox.dart.
 // TODO(#1527) see if we can reuse this in redesign
 class _TopicItem extends StatelessWidget {
-  const _TopicItem({required this.streamId, required this.data});
+  const _TopicItem({required this.channelId, required this.data});
 
-  final int streamId;
+  final int channelId;
   final _TopicItemData data;
 
   @override
@@ -234,11 +234,11 @@ class _TopicItem extends StatelessWidget {
     // if not, we just won't have `someMessageIdInTopic` for the action sheet.
     final maxIdMessage = store.messages[maxId];
     final someMessageIdInTopic =
-      (maxIdMessage != null && TopicNarrow(streamId, topic).containsMessage(maxIdMessage))
+      (maxIdMessage != null && TopicNarrow(channelId, topic).containsMessage(maxIdMessage))
         ? maxIdMessage.id
         : null;
 
-    final visibilityPolicy = store.topicVisibilityPolicy(streamId, topic);
+    final visibilityPolicy = store.topicVisibilityPolicy(channelId, topic);
     final double opacity;
     switch (visibilityPolicy) {
       case UserTopicVisibilityPolicy.muted:
@@ -258,12 +258,12 @@ class _TopicItem extends StatelessWidget {
       color: designVariables.bgMessageRegular,
       child: InkWell(
         onTap: () {
-          final narrow = TopicNarrow(streamId, topic);
+          final narrow = TopicNarrow(channelId, topic);
           Navigator.push(context,
             MessageListPage.buildRoute(context: context, narrow: narrow));
         },
         onLongPress: () => showTopicActionSheet(context,
-          channelId: streamId,
+          channelId: channelId,
           topic: topic,
           someMessageIdInTopic: someMessageIdInTopic),
         splashFactory: NoSplash.splashFactory,

--- a/test/api/route/channels_test.dart
+++ b/test/api/route/channels_test.dart
@@ -46,7 +46,7 @@ void main() {
     return FakeApiConnection.with_((connection) async {
       connection.prepare(json: {});
       await updateUserTopic(connection,
-        streamId: 1, topic: const TopicName('topic'),
+        channelId: 1, topic: const TopicName('topic'),
         visibilityPolicy: UserTopicVisibilityPolicy.followed);
       check(connection.takeRequests()).single.isA<http.Request>()
         ..method.equals('POST')
@@ -62,7 +62,7 @@ void main() {
   test('updateUserTopic only accepts valid visibility policy', () {
     return FakeApiConnection.with_((connection) async {
       check(() => updateUserTopic(connection,
-        streamId: 1, topic: const TopicName('topic'),
+        channelId: 1, topic: const TopicName('topic'),
         visibilityPolicy: UserTopicVisibilityPolicy.unknown),
       ).throws<AssertionError>();
     });
@@ -72,7 +72,7 @@ void main() {
     return FakeApiConnection.with_((connection) async {
       connection.prepare(json: {});
       await updateUserTopicCompat(connection,
-        streamId: 1, topic: const TopicName('topic'),
+        channelId: 1, topic: const TopicName('topic'),
         visibilityPolicy: UserTopicVisibilityPolicy.followed);
       check(connection.takeRequests()).single.isA<http.Request>()
         ..method.equals('POST')
@@ -89,7 +89,7 @@ void main() {
     test('updateUserTopic throws AssertionError when FL < 170', () {
       return FakeApiConnection.with_(zulipFeatureLevel: 169, (connection) async {
         check(() => updateUserTopic(connection,
-          streamId: 1, topic: const TopicName('topic'),
+          channelId: 1, topic: const TopicName('topic'),
           visibilityPolicy: UserTopicVisibilityPolicy.muted),
         ).throws<AssertionError>();
       });
@@ -98,7 +98,7 @@ void main() {
     test('updateUserTopicCompat throws UnsupportedError on unsupported policy', () {
       return FakeApiConnection.with_(zulipFeatureLevel: 169, (connection) async {
         check(() => updateUserTopicCompat(connection,
-          streamId: 1, topic: const TopicName('topic'),
+          channelId: 1, topic: const TopicName('topic'),
           visibilityPolicy: UserTopicVisibilityPolicy.followed),
         ).throws<UnsupportedError>();
       });
@@ -108,7 +108,7 @@ void main() {
       return FakeApiConnection.with_(zulipFeatureLevel: 169, (connection) async {
         connection.prepare(json: {});
         await updateUserTopicCompat(connection,
-          streamId: 1, topic: const TopicName('topic'),
+          channelId: 1, topic: const TopicName('topic'),
           visibilityPolicy: UserTopicVisibilityPolicy.none);
         check(connection.takeRequests()).single.isA<http.Request>()
           ..method.equals('PATCH')
@@ -125,7 +125,7 @@ void main() {
       return FakeApiConnection.with_(zulipFeatureLevel: 169, (connection) async {
         connection.prepare(json: {});
         await updateUserTopicCompat(connection,
-          streamId: 1, topic: const TopicName('topic'),
+          channelId: 1, topic: const TopicName('topic'),
           visibilityPolicy: UserTopicVisibilityPolicy.muted);
         check(connection.takeRequests()).single.isA<http.Request>()
           ..method.equals('PATCH')

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1283,7 +1283,7 @@ TypingEvent typingEvent(SendableNarrow narrow, TypingOp op, int senderId) {
     case TopicNarrow():
       return TypingEvent(id: 0, op: op, senderId: senderId,
         messageType: MessageType.stream,
-        streamId: narrow.streamId,
+        streamId: narrow.channelId,
         topic: narrow.topic,
         recipientIds: null);
     case DmNarrow():

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -583,13 +583,13 @@ void main() {
         final realTopic = topic == null ? null : TopicName(topic);
         final getRecencyInTopic = realTopic == null ? null
           : store.recentSenders.latestMessageIdBySenderInTopic(
-              streamId: stream.streamId, topic: realTopic);
+              channelId: stream.streamId, topic: realTopic);
         final resultAB = MentionAutocompleteView.compareByRecency(userA, userB,
-          streamId: stream.streamId,
+          channelId: stream.streamId,
           getRecencyInTopic: getRecencyInTopic,
           store: store);
         final resultBA = MentionAutocompleteView.compareByRecency(userB, userA,
-          streamId: stream.streamId,
+          channelId: stream.streamId,
           getRecencyInTopic: getRecencyInTopic,
           store: store);
         switch (resultAB) {

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -1352,7 +1352,7 @@ void main() {
 
     final view = TopicAutocompleteView.init(
       store: store,
-      streamId: eg.stream().streamId,
+      channelId: eg.stream().streamId,
       query: TopicAutocompleteQuery('Third'));
     bool done = false;
     view.addListener(() { done = true; });
@@ -1373,7 +1373,7 @@ void main() {
 
     final view = TopicAutocompleteView.init(
       store: store,
-      streamId: eg.stream().streamId,
+      channelId: eg.stream().streamId,
       query: TopicAutocompleteQuery('te'));
     bool done = false;
     view.addListener(() { done = true; });
@@ -1391,7 +1391,7 @@ void main() {
     final topic2 = eg.getChannelTopicsEntry(maxId: 10, name: 'mobile releases');
 
     connection.prepare(json: GetChannelTopicsResult(topics: [topic1, topic2]).toJson());
-    final view1 = TopicAutocompleteView.init(store: store, streamId: 1000,
+    final view1 = TopicAutocompleteView.init(store: store, channelId: 1000,
       query: TopicAutocompleteQuery(''));
     bool done = false;
     view1.addListener(() { done = true; });
@@ -1413,7 +1413,7 @@ void main() {
     view1.dispose();
 
     // No need to prepare a response as there will be no request made.
-    final view2 = TopicAutocompleteView.init(store: store, streamId: 1000,
+    final view2 = TopicAutocompleteView.init(store: store, channelId: 1000,
       query: TopicAutocompleteQuery('mobile'));
     done = false;
     view2.addListener(() { done = true; });

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -65,7 +65,7 @@ void main() {
 
     group('ChannelNarrow / TopicNarrow', () {
       void checkNarrow(String expectedFragment, {
-        required int streamId,
+        required int channelId,
         required String name,
         String? topic,
         int? nearMessageId,
@@ -73,37 +73,37 @@ void main() {
       }) async {
         assert(expectedFragment.startsWith('#'), 'wrong-looking expectedFragment');
         final store = eg.store()..connection.zulipFeatureLevel = zulipFeatureLevel;
-        await store.addStream(eg.stream(streamId: streamId, name: name));
+        await store.addStream(eg.stream(streamId: channelId, name: name));
         final narrow = topic == null
-          ? ChannelNarrow(streamId)
-          : eg.topicNarrow(streamId, topic);
+          ? ChannelNarrow(channelId)
+          : eg.topicNarrow(channelId, topic);
         check(narrowLink(store, narrow, nearMessageId: nearMessageId))
           .equals(store.realmUrl.resolve(expectedFragment));
       }
 
       test('modern including "channel" operator', () {
-        checkNarrow(streamId: 1,   name: 'announce',       '#narrow/channel/1-announce');
-        checkNarrow(streamId: 378, name: 'api design',     '#narrow/channel/378-api-design');
-        checkNarrow(streamId: 391, name: 'Outreachy',      '#narrow/channel/391-Outreachy');
-        checkNarrow(streamId: 415, name: 'chat.zulip.org', '#narrow/channel/415-chat.2Ezulip.2Eorg');
-        checkNarrow(streamId: 419, name: 'français',       '#narrow/channel/419-fran.C3.A7ais');
-        checkNarrow(streamId: 403, name: 'Hshs[™~}(.',     '#narrow/channel/403-Hshs.5B.E2.84.A2~.7D.28.2E');
-        checkNarrow(streamId: 60,  name: 'twitter', nearMessageId: 1570686, '#narrow/channel/60-twitter/near/1570686');
+        checkNarrow(channelId: 1,   name: 'announce',       '#narrow/channel/1-announce');
+        checkNarrow(channelId: 378, name: 'api design',     '#narrow/channel/378-api-design');
+        checkNarrow(channelId: 391, name: 'Outreachy',      '#narrow/channel/391-Outreachy');
+        checkNarrow(channelId: 415, name: 'chat.zulip.org', '#narrow/channel/415-chat.2Ezulip.2Eorg');
+        checkNarrow(channelId: 419, name: 'français',       '#narrow/channel/419-fran.C3.A7ais');
+        checkNarrow(channelId: 403, name: 'Hshs[™~}(.',     '#narrow/channel/403-Hshs.5B.E2.84.A2~.7D.28.2E');
+        checkNarrow(channelId: 60,  name: 'twitter', nearMessageId: 1570686, '#narrow/channel/60-twitter/near/1570686');
 
-        checkNarrow(streamId: 48,  name: 'mobile', topic: 'Welcome screen UI',
+        checkNarrow(channelId: 48,  name: 'mobile', topic: 'Welcome screen UI',
                     '#narrow/channel/48-mobile/topic/Welcome.20screen.20UI');
-        checkNarrow(streamId: 243, name: 'mobile-team', topic: 'Podfile.lock clash #F92',
+        checkNarrow(channelId: 243, name: 'mobile-team', topic: 'Podfile.lock clash #F92',
                     '#narrow/channel/243-mobile-team/topic/Podfile.2Elock.20clash.20.23F92');
-        checkNarrow(streamId: 377, name: 'translation/zh_tw', topic: '翻譯 "stream"',
+        checkNarrow(channelId: 377, name: 'translation/zh_tw', topic: '翻譯 "stream"',
                     '#narrow/channel/377-translation.2Fzh_tw/topic/.E7.BF.BB.E8.AD.AF.20.22stream.22');
-        checkNarrow(streamId: 42,  name: 'Outreachy 2016-2017', topic: '2017-18 Stream?', nearMessageId: 302690,
+        checkNarrow(channelId: 42,  name: 'Outreachy 2016-2017', topic: '2017-18 Stream?', nearMessageId: 302690,
                     '#narrow/channel/42-Outreachy-2016-2017/topic/2017-18.20Stream.3F/near/302690');
       });
 
       test('legacy including "stream" operator', () {
-        checkNarrow(streamId: 1,   name: 'announce',       zulipFeatureLevel: 249,
+        checkNarrow(channelId: 1,   name: 'announce',       zulipFeatureLevel: 249,
                     '#narrow/stream/1-announce');
-        checkNarrow(streamId: 48,  name: 'mobile-team', topic: 'Welcome screen UI',
+        checkNarrow(channelId: 48,  name: 'mobile-team', topic: 'Welcome screen UI',
                     zulipFeatureLevel: 249,
                     '#narrow/stream/48-mobile-team/topic/Welcome.20screen.20UI');
       });

--- a/test/model/narrow_checks.dart
+++ b/test/model/narrow_checks.dart
@@ -14,7 +14,7 @@ extension DmNarrowChecks on Subject<DmNarrow> {
 }
 
 extension TopicNarrowChecks on Subject<TopicNarrow> {
-  Subject<int> get streamId => has((x) => x.streamId, 'streamId');
+  Subject<int> get channelId => has((x) => x.channelId, 'channelId');
   Subject<TopicName> get topic => has((x) => x.topic, 'topic');
   Subject<int?> get with_ => has((x) => x.with_, 'with_');
 }

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -24,7 +24,7 @@ void checkMatchesMessages(RecentSenders model, List<Message> messages) {
       [senderId] ??= {}).add(messageId);
   }
 
-  final actualMessagesByUserInStream = model.streamSenders.map((streamId, sendersByStream) =>
+  final actualMessagesByUserInStream = model.channelSenders.map((streamId, sendersByStream) =>
     MapEntry(streamId, sendersByStream.map((senderId, tracker) =>
       MapEntry(senderId, Set<int>.from(tracker.ids)))));
   final actualMessagesByUserInTopic = model.topicSenders.map((streamId, topicsByStream) =>
@@ -199,14 +199,14 @@ void main() {
 
     model.handleMessages(messages);
 
-    check(model.latestMessageIdOfSenderInStream(
-      streamId: 1, senderId: 10)).equals(300);
+    check(model.latestMessageIdOfSenderInChannel(
+      channelId: 1, senderId: 10)).equals(300);
     // No message of user 20 in stream1.
-    check(model.latestMessageIdOfSenderInStream(
-      streamId: 1, senderId: 20)).equals(null);
+    check(model.latestMessageIdOfSenderInChannel(
+      channelId: 1, senderId: 20)).equals(null);
     // No message in stream 2 at all.
-    check(model.latestMessageIdOfSenderInStream(
-      streamId: 2, senderId: 10)).equals(null);
+    check(model.latestMessageIdOfSenderInChannel(
+      channelId: 2, senderId: 10)).equals(null);
   });
 
   test('RecentSenders.latestMessageIdOfSenderInTopic', () {

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -34,7 +34,7 @@ void checkSetTypingStatusRequests(
         TopicNarrow() => conditionTypingRequest({
           'type': 'channel',
           'op': op.toJson(),
-          'stream_id': narrow.streamId.toString(),
+          'stream_id': narrow.channelId.toString(),
           'topic': narrow.topic.apiName}),
         DmNarrow() => conditionTypingRequest({
           'type': 'direct',

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -108,9 +108,9 @@ MessageFcmMessage messageFcmMessage(
     "sender_full_name": zulipMessage.senderFullName.toString(),
 
     ...(switch (narrow) {
-      TopicNarrow(:var streamId, :var topic) => {
+      TopicNarrow(:var channelId, :var topic) => {
         "recipient_type": "stream",
-        "stream_id": streamId.toString(),
+        "stream_id": channelId.toString(),
         "stream": ?streamName,
         "topic": topic,
       },

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -612,7 +612,7 @@ void main() {
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<TopicNarrow>()
-            ..streamId.equals(1)
+            ..channelId.equals(1)
             ..topic.equals(TopicName('topic A')));
       });
     });
@@ -688,7 +688,7 @@ void main() {
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<TopicNarrow>()
-            ..streamId.equals(1)
+            ..channelId.equals(1)
             ..topic.equals(eg.t('topic A')));
       });
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -267,18 +267,18 @@ void main() {
       await tester.pump(const Duration(milliseconds: 250));
     }
 
-    Future<void> showFromTopicListAppBar(WidgetTester tester, {int? streamId}) async {
-      streamId ??= someChannel.streamId;
+    Future<void> showFromTopicListAppBar(WidgetTester tester, {int? channelId}) async {
+      channelId ??= someChannel.streamId;
       final transitionDurationObserver = TransitionDurationObserver();
 
       connection.prepare(json: GetChannelTopicsResult(topics: []).toJson());
       await tester.pumpWidget(TestZulipApp(
         navigatorObservers: [transitionDurationObserver],
         accountId: eg.selfAccount.id,
-        child: TopicListPage(streamId: streamId)));
+        child: TopicListPage(channelId: channelId)));
       await tester.pump();
 
-      final titleText = store.streams[streamId]?.name ?? '(unknown channel)';
+      final titleText = store.streams[channelId]?.name ?? '(unknown channel)';
       await tester.longPress(find.descendant(
         of: find.byType(ZulipAppBar),
         matching: find.text(titleText)));

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -228,7 +228,7 @@ void main() {
         foundOldest: true,
         messages: narrow is ChannelNarrow
           ? () {
-              assert(channel != null && channel.streamId == narrow.streamId);
+              assert(channel != null && channel.streamId == narrow.channelId);
               // Include one message so that we don't auto-focus the topic input,
               // which would trigger a topic-list fetch for topic autocomplete.
               // That's helpful for the test that opens the topic-list page.
@@ -414,7 +414,7 @@ void main() {
       testWidgets('channel not subscribed, with content access', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        await store.removeSubscription(narrow.streamId);
+        await store.removeSubscription(narrow.channelId);
         check(store.selfHasContentAccess(someChannel)).isTrue();
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkButton('Subscribe');
@@ -438,7 +438,7 @@ void main() {
       testWidgets('channel subscribed', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        check(store.subscriptions[narrow.streamId]).isNotNull();
+        check(store.subscriptions[narrow.channelId]).isNotNull();
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkNoButton('Subscribe');
       });
@@ -446,7 +446,7 @@ void main() {
       testWidgets('smoke', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        await store.removeSubscription(narrow.streamId);
+        await store.removeSubscription(narrow.channelId);
         await showFromMsglistAppBar(tester, narrow: narrow);
 
         connection.prepare(json: {});
@@ -640,7 +640,7 @@ void main() {
       testWidgets('channel subscribed, not pinned', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        check(store.subscriptions[narrow.streamId]).isNotNull()
+        check(store.subscriptions[narrow.channelId]).isNotNull()
           .pinToTop.isFalse();
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkButton('Pin to top');
@@ -652,7 +652,7 @@ void main() {
         await store.removeSubscription(someChannel.streamId);
         await store.addSubscription(eg.subscription(someChannel, pinToTop: true));
         final narrow = ChannelNarrow(someChannel.streamId);
-        check(store.subscriptions[narrow.streamId]).isNotNull()
+        check(store.subscriptions[narrow.channelId]).isNotNull()
           .pinToTop.isTrue();
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkNoButton('Pin to top');
@@ -662,7 +662,7 @@ void main() {
       testWidgets('channel not subscribed', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        await store.removeSubscription(narrow.streamId);
+        await store.removeSubscription(narrow.channelId);
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkNoButton('Pin to top');
         checkNoButton('Unpin from top');
@@ -721,7 +721,7 @@ void main() {
       testWidgets('channel subscribed', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        check(store.subscriptions[narrow.streamId]).isNotNull();
+        check(store.subscriptions[narrow.channelId]).isNotNull();
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkButton('Unsubscribe');
       });
@@ -729,7 +729,7 @@ void main() {
       testWidgets('channel not subscribed', (tester) async {
         await prepare();
         final narrow = ChannelNarrow(someChannel.streamId);
-        await store.removeSubscription(narrow.streamId);
+        await store.removeSubscription(narrow.channelId);
         await showFromMsglistAppBar(tester, narrow: narrow);
         checkNoButton('Unsubscribe');
       });

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -65,12 +65,12 @@ Future<Finder> setupToComposeInput(WidgetTester tester, {
   switch(narrow) {
     case DmNarrow():
       message = eg.dmMessage(from: eg.selfUser, to: [eg.otherUser]);
-    case ChannelNarrow(:final streamId):
-      final stream = eg.stream(streamId: streamId);
+    case ChannelNarrow(:final channelId):
+      final stream = eg.stream(streamId: channelId);
       message = eg.streamMessage(stream: stream);
       await store.addStream(stream);
-    case TopicNarrow(:final streamId, :final topic):
-      final stream = eg.stream(streamId: streamId);
+    case TopicNarrow(:final channelId, :final topic):
+      final stream = eg.stream(streamId: channelId);
       message = eg.streamMessage(stream: stream, topic: topic.apiName);
       await store.addStream(stream);
     default: throw StateError('unexpected narrow type');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -70,10 +70,10 @@ void main() {
   }) async {
     streams ??= subscriptions;
 
-    if (narrow case ChannelNarrow(:var streamId) || TopicNarrow(: var streamId)) {
-      final channel = streams.firstWhereOrNull((s) => s.streamId == streamId);
+    if (narrow case ChannelNarrow(:var channelId) || TopicNarrow(:var channelId)) {
+      final channel = streams.firstWhereOrNull((s) => s.streamId == channelId);
       assert(channel != null,
-        'Add a channel with "streamId" the same as of $narrow.streamId to the store.');
+        'Add a channel with "streamId" the same as of $narrow.channelId to the store.');
       if (narrow is ChannelNarrow) {
         // By default, bypass the complexity where the topic input is autofocused
         // on an empty fetch, by making the fetch not empty. (In particular that
@@ -132,7 +132,7 @@ void main() {
     await tester.enterText(topicInputFinder, topic);
     check(connection.takeRequests()).single
       ..method.equals('GET')
-      ..url.path.equals('/api/v1/users/me/${narrow.streamId}/topics');
+      ..url.path.equals('/api/v1/users/me/${narrow.channelId}/topics');
   }
 
   /// A [Finder] for the content input.
@@ -798,7 +798,7 @@ void main() {
 
     testWidgets('smoke ChannelNarrow', (tester) async {
       final narrow = ChannelNarrow(channel.streamId);
-      final destinationNarrow = eg.topicNarrow(narrow.streamId, 'test topic');
+      final destinationNarrow = eg.topicNarrow(narrow.channelId, 'test topic');
       await prepareComposeBox(tester,
         narrow: narrow, subscriptions: [eg.subscription(channel)]);
       await enterTopic(tester, narrow: narrow, topic: 'test topic');
@@ -870,7 +870,7 @@ void main() {
 
     testWidgets('for content input, unfocusing sends a "typing stopped" notice', (tester) async {
       final narrow = ChannelNarrow(channel.streamId);
-      final destinationNarrow = eg.topicNarrow(narrow.streamId, 'test topic');
+      final destinationNarrow = eg.topicNarrow(narrow.channelId, 'test topic');
       await prepareComposeBox(tester,
         narrow: narrow, subscriptions: [eg.subscription(channel)]);
       await enterTopic(tester, narrow: narrow, topic: 'test topic');

--- a/test/widgets/topic_list_test.dart
+++ b/test/widgets/topic_list_test.dart
@@ -52,7 +52,7 @@ void main() {
     connection.prepare(json: GetChannelTopicsResult(topics: topics).toJson());
     await tester.pumpWidget(TestZulipApp(
       accountId: eg.selfAccount.id,
-      child: TopicListPage(streamId: channel.streamId)));
+      child: TopicListPage(channelId: channel.streamId)));
     await tester.pump();
     await tester.pump(Duration.zero);
     check(connection.takeRequests()).single.isA<http.Request>()
@@ -72,7 +72,7 @@ void main() {
         json: GetChannelTopicsResult(topics: []).toJson());
       await tester.pumpWidget(TestZulipApp(
         accountId: eg.selfAccount.id,
-        child: TopicListPage(streamId: channel.streamId)));
+        child: TopicListPage(channelId: channel.streamId)));
       await tester.pump();
       await tester.pump(Duration.zero);
       check(find.widgetWithText(ZulipAppBar, '(unknown channel)')).findsOne();
@@ -116,7 +116,7 @@ void main() {
     );
     await tester.pumpWidget(TestZulipApp(
       accountId: eg.selfAccount.id,
-      child: TopicListPage(streamId: channel.streamId)));
+      child: TopicListPage(channelId: channel.streamId)));
     await tester.pump();
     check(find.byType(CircularProgressIndicator)).findsOne();
 


### PR DESCRIPTION
And rename all the fields, local variables, and parameters that hold a channel ID sourced from a `ChannelNarrow.channelId` or `TopicNarrow.channelId`.

Related: #631