### PR TITLE
home: Show unread count on Channels button in main menu

### DIFF
--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -756,6 +756,21 @@ class _ChannelsButton extends _NavigationBarMenuButton {
   }
 
   @override
+  Widget? buildTrailing(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+    final unreads = store.unreads;
+    final unreadCount =
+      unreads.countInCombinedFeedNarrow() - unreads.countInDms();
+    if (unreadCount == 0) return null;
+    return CounterBadge(
+      kind: CounterBadgeKind.unread,
+      style: CounterBadgeStyle.mainMenu,
+      count: unreadCount,
+      channelIdForBackground: null,
+    );
+  }
+
+  @override
   _HomePageTab get navigationTarget => _HomePageTab.channels;
 }
 

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -495,6 +495,52 @@ void main () {
       });
     });
 
+    group('_ChannelsButton counter', () {
+      final findButton = find.byWidgetPredicate((widget) =>
+        widget is MenuButton && widget.icon == ZulipIcons.hash_italic);
+
+      testWidgets('no badge when no unread channel messages', (tester) async {
+        await prepare(tester);
+        await tapOpenMenuAndAwait(tester);
+        check(find.descendant(
+          of: findButton, matching: find.byType(CounterBadge))).findsNothing();
+        debugNetworkImageHttpClientProvider = null;
+      });
+
+      testWidgets('shows unread channel message count', (tester) async {
+        await prepare(tester);
+        await addUnreadStreamMessage();
+        await tapOpenMenuAndAwait(tester);
+        check(find.descendant(
+          of: findButton, matching: find.text('1'))).findsOne();
+        debugNetworkImageHttpClientProvider = null;
+      });
+
+      testWidgets('does not count DM unreads', (tester) async {
+        await prepare(tester);
+        final dmMessage = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
+        await store.addMessage(dmMessage);
+        await tapOpenMenuAndAwait(tester);
+        check(find.descendant(
+          of: findButton, matching: find.byType(CounterBadge))).findsNothing();
+        debugNetworkImageHttpClientProvider = null;
+      });
+    });
+
+    group('_CombinedFeedButton', () {
+      final findButton = find.byWidgetPredicate((widget) =>
+        widget is MenuButton && widget.icon == ZulipIcons.message_feed);
+
+      testWidgets('no counter badge', (tester) async {
+        await prepare(tester);
+        await addUnreadStreamMessage();
+        await tapOpenMenuAndAwait(tester);
+        check(find.descendant(
+          of: findButton, matching: find.byType(CounterBadge))).findsNothing();
+        debugNetworkImageHttpClientProvider = null;
+      });
+    });
+
     group('_DirectMessagesButton counter', () {
       final findButton = find.byWidgetPredicate((widget) =>
         widget is MenuButton && widget.icon == ZulipIcons.two_person);


### PR DESCRIPTION
Marked as a draft as we're [yet to decide](https://github.com/zulip/zulip-flutter/issues/1088#issuecomment-4010047394) whether to include adding counts in the bottom nav bar in this PR or not.

Fixes: #1088

This adds the remaining pieces for unread counts in the main menu:

- Tests for the existing counter badges on Inbox, Combined feed, Mentions, Starred messages, and Direct messages buttons.
- Channels button count: Shows the unread channel message count, computed as the combined feed count minus the DM count. This matches what the web app shows for channel unreads.

<details>
<summary>Screenshoots</summary>

| Before | Channels unread count > 0 | Channels  unread count == 0 |
|------|------|------|
|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/dac085c3-7e54-4245-8db5-42e5845ed419" />|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/b00a605f-a65c-4115-8fe1-4afd365a8ecb" />|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/4f478b96-cd08-41c9-8ff9-2ac7d60b917d" />|

</details>

