### PR TITLE
home: Show realm icon in app bar on main pages

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -41,7 +41,7 @@
   },
   "switchAccountButtonTooltip": "Switch account",
   "@switchAccountButtonTooltip": {
-    "description": "Tooltip message for main-menu button leading to the choose-account page."
+    "description": "Tooltip message for the realm icon in app bar and main-menu button, both leading to the choose-account page."
   },
   "tryAnotherAccountMessage": "Your account at {url} is taking a while to load.",
   "@tryAnotherAccountMessage": {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -210,7 +210,7 @@ abstract class ZulipLocalizations {
   /// **'Settings'**
   String get settingsPageTitle;
 
-  /// Tooltip message for main-menu button leading to the choose-account page.
+  /// Tooltip message for the realm icon in app bar and main-menu button, both leading to the choose-account page.
   ///
   /// In en, this message translates to:
   /// **'Switch account'**

--- a/lib/widgets/all_channels.dart
+++ b/lib/widgets/all_channels.dart
@@ -40,7 +40,8 @@ class AllChannelsPage extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     return Scaffold(
       appBar: ZulipAppBar(
-        title: Text(zulipLocalizations.allChannelsPageTitle)),
+        title: Text(zulipLocalizations.allChannelsPageTitle),
+        showRealmIcon: false),
       body: AllChannelsPageBody());
   }
 }

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -1,6 +1,13 @@
 import 'package:flutter/material.dart';
 
+import '../generated/l10n/zulip_localizations.dart';
+import 'app.dart';
+import 'home.dart';
+import 'image.dart';
+import 'page.dart';
 import 'store.dart';
+import 'theme.dart';
+import 'user.dart';
 
 /// A custom [AppBar] with a loading indicator.
 ///
@@ -19,16 +26,24 @@ class ZulipAppBar extends AppBar {
     super.titleSpacing,
     Widget? title,
     Widget Function(bool willCenterTitle)? buildTitle,
-    super.centerTitle,
+    bool? centerTitle,
     super.backgroundColor,
     super.shape,
     super.actions,
+    required bool showRealmIcon,
   }) :
     assert((title == null) != (buildTitle == null)),
     super(
+      leading: showRealmIcon ? const _RealmIcon() : null,
+      leadingWidth: showRealmIcon ? _realmIconWidth : null,
+      centerTitle: showRealmIcon ? true : centerTitle,
       bottom: _ZulipAppBarBottom(backgroundColor: backgroundColor),
-      title: title ?? _Title(centerTitle: centerTitle, actions: actions, buildTitle: buildTitle!)
+      title: title ?? _Title(
+        centerTitle: showRealmIcon ? true: centerTitle,
+        actions: actions,
+        buildTitle: buildTitle!)
     );
+    static const _realmIconWidth = 50.0;
 }
 
 class _Title extends StatelessWidget {
@@ -81,5 +96,49 @@ class _ZulipAppBarBottom extends StatelessWidget implements PreferredSizeWidget 
     final store = PerAccountStoreWidget.of(context);
     if (!store.isRecoveringEventStream) return const SizedBox.shrink();
     return LinearProgressIndicator(minHeight: 4.0, backgroundColor: backgroundColor);
+  }
+}
+
+class _RealmIcon extends StatelessWidget {
+  const _RealmIcon();
+
+  void _handleSwitchAccount(BuildContext context) {
+    Navigator.push(context,
+      MaterialWidgetRoute(page: const ChooseAccountPage()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: Tooltip(
+          message: zulipLocalizations.switchAccountButtonTooltip,
+          child: PressableOpacity(
+            onTap: () => _handleSwitchAccount(context),
+            child: Padding(
+              padding: const EdgeInsets.all(7),
+              child: AvatarShape(
+                size: 28,
+                borderRadius: 4,
+                child: RealmContentNetworkImage(
+                  store.resolvedRealmIcon,
+                  filterQuality: FilterQuality.medium,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, _, _) => const _RealmIconPlaceholder())))))));
+  }
+}
+
+class _RealmIconPlaceholder extends StatelessWidget {
+  const _RealmIconPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(color: designVariables.avatarPlaceholderBg));
   }
 }

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -122,6 +122,7 @@ class _HomePageState extends State<HomePage> {
           identifier: HomePage.titleSemanticsIdentifier,
           namesRoute: true,
           child: Text(_currentTabTitle)),
+        showRealmIcon: true,
         actions: _currentTabAppBarActions),
       body: Semantics(
         role: SemanticsRole.tabPanel,

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -510,7 +510,7 @@ abstract class _MessageListAppBar {
       shape: removeAppBarBottomBorder
         ? const Border()
         : null, // i.e., inherit
-    );
+      showRealmIcon: false);
   }
 }
 

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -135,7 +135,8 @@ class ProfilePage extends StatelessWidget {
     return Scaffold(
       appBar: ZulipAppBar(
         // TODO write a test where the user is muted
-        title: Text(store.userDisplayName(userId, replaceIfMuted: false))),
+        title: Text(store.userDisplayName(userId, replaceIfMuted: false)),
+        showRealmIcon: false),
       body: SingleChildScrollView(
         child: Center(
           child: ConstrainedBox(
@@ -318,7 +319,9 @@ class _ProfileErrorPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
     return Scaffold(
-      appBar: ZulipAppBar(title: Text(zulipLocalizations.errorDialogTitle)),
+      appBar: ZulipAppBar(
+        title: Text(zulipLocalizations.errorDialogTitle),
+        showRealmIcon: false),
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 32),

--- a/lib/widgets/set_status.dart
+++ b/lib/widgets/set_status.dart
@@ -182,7 +182,7 @@ class _SetStatusPageState extends State<SetStatusPage> {
                 });
             }),
         ],
-      ),
+        showRealmIcon: false),
       body: SafeArea(
         bottom: false,
         minimum: EdgeInsets.symmetric(horizontal: 8),

--- a/lib/widgets/settings.dart
+++ b/lib/widgets/settings.dart
@@ -19,7 +19,8 @@ class SettingsPage extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     return Scaffold(
       appBar: ZulipAppBar(
-        title: Text(zulipLocalizations.settingsPageTitle)),
+        title: Text(zulipLocalizations.settingsPageTitle),
+        showRealmIcon: false),
       body: ListView(children: [
         const _ThemeSetting(),
         const _BrowserPreferenceSetting(),

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -50,7 +50,8 @@ class TopicListPage extends StatelessWidget {
             onPressed: () => Navigator.push(context,
               MessageListPage.buildRoute(context: context,
                 narrow: ChannelNarrow(streamId)))),
-        ]),
+        ],
+        showRealmIcon: false),
       body: _TopicList(streamId: streamId)));
   }
 }

--- a/test/widgets/app_bar_test.dart
+++ b/test/widgets/app_bar_test.dart
@@ -3,12 +3,15 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/app_bar.dart';
+import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/profile.dart';
 
 import '../example_data.dart' as eg;
 import '../model/binding.dart';
 import '../model/test_store.dart';
+import '../test_images.dart';
 import 'test_app.dart';
 
 void main() {
@@ -93,7 +96,8 @@ void main() {
             buildTitle: (willCenterTitle) {
               result = willCenterTitle;
               return const Text('a');
-            }))));
+            },
+            showRealmIcon: false))));
 
       await tester.pumpWidget(widget);
       await tester.pump(); // global store
@@ -156,5 +160,73 @@ void main() {
 
     doTest('ios, two actions but param true', true, platform: iOS, paramValue: true, actions: twoButtons);
     doTest('ios, two actions but theme true', true, platform: iOS, themeValue: true, actions: twoButtons);
+  });
+
+  group('realm icon', () {
+    Future<void> setupPage(WidgetTester tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+
+      prepareBoringImageHttpClient();
+
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        child: Builder(builder: (context) => Scaffold(
+          appBar: ZulipAppBar(
+            showRealmIcon: true,
+            buildTitle: (_) => const Text('Inbox'))))));
+
+      await tester.pump();
+      await tester.pump();
+    }
+
+    testWidgets('shows realm icon when showRealmIcon is true', (tester) async {
+      await setupPage(tester);
+
+      check(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.byType(RealmContentNetworkImage))).findsOne();
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('no realm icon when showRealmIcon is false', (tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        child: Builder(builder: (context) => Scaffold(
+          appBar: ZulipAppBar(
+            buildTitle: (_) => const Text('Inbox'),
+            showRealmIcon: false)))));
+
+      await tester.pump();
+      await tester.pump();
+
+      check(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.byType(RealmContentNetworkImage))).findsNothing();
+    });
+
+    testWidgets('realm icon tap navigates to ChooseAccountPage', (tester) async {
+      await setupPage(tester);
+
+      await tester.tap(find.byType(RealmContentNetworkImage));
+      await tester.pumpAndSettle();
+
+      check(find.byType(ChooseAccountPage)).findsOne();
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('appbar height unaffected by loading indicator', (tester) async {
+      await setupPage(tester);
+
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      final rectBefore = tester.getRect(find.byType(ZulipAppBar));
+
+      store.isRecoveringEventStream = true;
+      await tester.pump();
+
+      check(tester.getRect(find.byType(ZulipAppBar))).equals(rectBefore);
+      debugNetworkImageHttpClientProvider = null;
+    });
   });
 }

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -14,6 +14,7 @@ import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/app_bar.dart';
 import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
+import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
@@ -436,6 +437,31 @@ void main () {
       await tester.ensureVisible(find.byIcon(ZulipIcons.info));
       await tapButtonAndAwaitTransition(tester, find.byIcon(ZulipIcons.info));
       check(find.byType(AboutZulipPage)).findsOne();
+      debugNetworkImageHttpClientProvider = null;
+    });
+  });
+
+  group('_RealmIcon', () {
+    testWidgets('realm icon is shown in app bar', (tester) async {
+      prepareBoringImageHttpClient();
+      await prepare(tester);
+
+      check(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.byType(RealmContentNetworkImage))).findsOne();
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('tapping realm icon navigates to choose-account page', (tester) async {
+      prepareBoringImageHttpClient();
+      await prepare(tester);
+
+      await tester.tap(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.byType(RealmContentNetworkImage)));
+      await tester.pumpAndSettle();
+
+      check(find.byType(ChooseAccountPage)).findsOne();
       debugNetworkImageHttpClientProvider = null;
     });
   });


### PR DESCRIPTION
Fixes #1606.

Show the current organization's icon in the app bar on the main home pages (Inbox, Channels, and Direct messages). This makes it easier for users with multiple accounts to quickly identify which organization they are currently in.

This follows the design shown in Figma.

Figma:

- Inbox: https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=5966-178689
- Channels: https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=6205-25955
- Direct messages: https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=5956-115859
### Screenshots

#### Light mode

Inbox | Channels | Direct messages
--- | --- | ---
<img src="https://github.com/user-attachments/assets/b6172357-94ab-4f9a-ada4-ab4c1ed64207" width="250"> | <img src="https://github.com/user-attachments/assets/ad4080f6-1cc4-49c1-88f9-847104332f43" width="250"> | <img src="https://github.com/user-attachments/assets/7aff06b7-f936-4f62-8f25-baf5786e47b7" width="250">

#### Dark mode

Inbox | Channels | Direct messages
--- | --- | ---
<img src="https://github.com/user-attachments/assets/03ff2aa1-cdc6-46bd-97a6-8eae9544c8af" width="250"> | <img src="https://github.com/user-attachments/assets/f9278bc2-5fff-4448-a76d-576b164f6292" width="250"> | <img src="https://github.com/user-attachments/assets/af3f88d4-a0a2-4779-b61a-0668cc237c84" width="250">

### Square icon example

<img width="250" alt="SQUARE_ICON_SCREENSHOT" src="https://github.com/user-attachments/assets/8c362877-d6eb-496b-a584-ae6575d01cf5" />
