### PR TITLE
app: Show realm icon and name in account list

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -494,7 +494,7 @@ class ChooseAccountPage extends StatelessWidget {
                     for (final (:accountId, :account) in globalStore.accountEntries)
                       _buildAccountItem(context,
                         accountId: accountId,
-                        title: Text(account.realmUrl.toString()),
+                        title: Text(account.realmName ?? account.realmUrl.toString()),
                         subtitle: Text(account.email)),
                   ]))),
                 const SizedBox(height: 12),

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -482,6 +482,12 @@ class ChooseAccountPage extends StatelessWidget {
     // > close button.
     final hasBackButton = ModalRoute.of(context)?.impliesAppBarDismissal ?? false;
 
+    final realmUrlCounts = <Uri, int>{};
+    for (final account in globalStore.accounts) {
+      realmUrlCounts[account.realmUrl] =
+        (realmUrlCounts[account.realmUrl] ?? 0) + 1;
+    }
+
     return MenuButtonTheme(
       data: MenuButtonThemeData(style: MenuItemButton.styleFrom(
         backgroundColor: colorScheme.secondaryContainer,
@@ -506,7 +512,9 @@ class ChooseAccountPage extends StatelessWidget {
                         realmIconUrl: account.realmIcon == null ? null
                           : account.realmUrl.resolveUri(account.realmIcon!),
                         title: Text(account.realmName ?? account.realmUrl.toString()),
-                        subtitle: Text(account.email)),
+                        subtitle: (realmUrlCounts[account.realmUrl]! > 1)
+                          ? Text(account.email)
+                          : null),
                   ]))),
                 const SizedBox(height: 12),
                 ElevatedButton(

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -13,10 +13,12 @@ import '../notifications/open.dart';
 import 'about_zulip.dart';
 import 'dialog.dart';
 import 'home.dart';
+import 'image.dart';
 import 'login.dart';
 import 'page.dart';
 import 'store.dart';
 import 'theme.dart';
+import 'user.dart';
 
 class ZulipApp extends StatefulWidget {
   const ZulipApp({super.key, this.navigatorObservers});
@@ -411,6 +413,7 @@ class ChooseAccountPage extends StatelessWidget {
   Widget _buildAccountItem(
     BuildContext context, {
     required int accountId,
+    required Uri? realmIconUrl,
     required Widget title,
     Widget? subtitle,
   }) {
@@ -421,6 +424,12 @@ class ChooseAccountPage extends StatelessWidget {
     return Card(
       clipBehavior: Clip.hardEdge,
       child: ListTile(
+        leading: realmIconUrl == null ? null : AvatarShape(
+          size: 28,
+          borderRadius: 4,
+          child: RealmIconNetworkImage(
+            realmIconUrl,
+            errorBuilder: (context, error, stackTrace) => const SizedBox.shrink())),
         title: title,
         subtitle: subtitle,
         tileColor: colorScheme.secondaryContainer,
@@ -494,6 +503,8 @@ class ChooseAccountPage extends StatelessWidget {
                     for (final (:accountId, :account) in globalStore.accountEntries)
                       _buildAccountItem(context,
                         accountId: accountId,
+                        realmIconUrl: account.realmIcon == null ? null
+                          : account.realmUrl.resolveUri(account.realmIcon!),
                         title: Text(account.realmName ?? account.realmUrl.toString()),
                         subtitle: Text(account.email)),
                   ]))),

--- a/lib/widgets/image.dart
+++ b/lib/widgets/image.dart
@@ -213,3 +213,45 @@ extension ImageThumbnailLocatorExtension on ImageThumbnailLocator {
     return result;
   }
 }
+
+/// Like [Image.network], but includes [userAgentHeader] for realm images.
+///
+/// Use this to display realm icons, avatars, or other images that don't
+/// require authentication. Unlike [RealmContentNetworkImage], this widget
+/// does not require a [PerAccountStoreWidget] ancestor and does not include
+/// authentication headers.
+///
+/// The image will be cached according to the cache behavior of [Image.network],
+/// which may mean the cache is shared between realms.
+///
+/// See also:
+///   * [RealmContentNetworkImage], which includes authentication headers for
+///     on-realm images and requires a [PerAccountStoreWidget] ancestor.
+class RealmIconNetworkImage extends StatelessWidget {
+  const RealmIconNetworkImage(
+    this.src, {
+    super.key,
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.errorBuilder,
+  });
+
+  final Uri src;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final ImageErrorWidgetBuilder? errorBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      src.toString(),
+      width: width,
+      height: height,
+      fit: fit,
+      filterQuality: FilterQuality.medium,
+      errorBuilder: errorBuilder,
+      headers: userAgentHeader());
+  }
+}

--- a/lib/widgets/share.dart
+++ b/lib/widgets/share.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:mime/mime.dart';
 
-import '../api/core.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../host/android_intents.dart';
 import '../log.dart';
@@ -388,11 +387,10 @@ class _ChooseAccountForShareModalState extends State<ChooseAccountForShareModal>
             borderRadius: 4,
             child: resolvedRealmIconUrl == null
               ? const SizedBox.shrink()
-              : Image.network(
-                  resolvedRealmIconUrl.toString(),
-                  headers: userAgentHeader(),
-                  filterQuality: FilterQuality.medium,
-                  fit: BoxFit.cover)),
+              : RealmIconNetworkImage(
+                  resolvedRealmIconUrl,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, _, _) => const SizedBox.shrink())),
           title: Text(account.realmName ?? account.realmUrl.toString()),
           subtitle: Text(account.email));
       });

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -411,6 +411,36 @@ void main() {
       check(find.byType(Image).evaluate()).isEmpty();
     });
 
+    testWidgets('shows email when multiple accounts on same realm', (tester) async {
+      final account1 = eg.account(
+        id: 1,
+        realmUrl: Uri.parse('https://example.com'),
+        user: eg.user());
+      final account2 = eg.account(
+        id: 2,
+        realmUrl: Uri.parse('https://example.com'),
+        user: eg.user());
+      await setupChooseAccountPage(tester, accounts: [account1, account2]);
+
+      check(find.text(account1.email).evaluate()).length.equals(1);
+      check(find.text(account2.email).evaluate()).length.equals(1);
+    });
+
+    testWidgets('does not show email when accounts are on different realms', (tester) async {
+      final account1 = eg.account(
+        id: 1,
+        realmUrl: Uri.parse('https://realm1.example.com'),
+        user: eg.user());
+      final account2 = eg.account(
+        id: 2,
+        realmUrl: Uri.parse('https://realm2.example.com'),
+        user: eg.user());
+      await setupChooseAccountPage(tester, accounts: [account1, account2]);
+
+      check(find.text(account1.email).evaluate()).isEmpty();
+      check(find.text(account2.email).evaluate()).isEmpty();
+    });
+
     group('log out', () {
       Future<(Widget, Widget)> prepare(WidgetTester tester, {required Account account}) async {
         await setupChooseAccountPage(tester, accounts: [account]);

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -224,13 +224,15 @@ void main() {
         final id = i+1;
         return eg.account(
           id: id,
+          realmUrl: Uri.parse('https://example-$id.com'),
+          realmName: 'Realm $id',
           user: eg.user(fullName: 'User $id', email: 'user$id@example'),
           apiKey: 'user${id}apikey',
         );
       });
     }
 
-    Finder findAccount(Account account) => find.text(account.email).hitTestable();
+    Finder findAccount(Account account) => find.text(account.realmName ?? account.realmUrl.toString()).hitTestable();
 
     Finder findButton<T extends ButtonStyleButton>({required String withText}) {
       return find
@@ -366,12 +368,44 @@ void main() {
       check(testBinding.globalStore).lastVisitedAccount.equals(eg.otherAccount);
     });
 
+    testWidgets('shows realm name when realmName is non-null', (tester) async {
+      final account = eg.account(
+        user: eg.user(),
+        realmName: 'Example Realm',
+        realmUrl: Uri.parse('https://example.com'));
+      await setupChooseAccountPage(tester, accounts: [account]);
+
+      check(find.text(account.realmName!).evaluate()).isNotEmpty();
+    });
+
+    testWidgets('fallback: shows URL when realmName is null, no image when realmIcon is null', (tester) async {
+      final realmUrl = Uri.parse('https://example.com');
+      // Not using eg.account here because it provides default values for realmName and realmIcon,
+      // even when explicitly set to null. Using Account() directly to test the fallback behavior
+      // when realmName and realmIcon are null.
+      final account = Account(
+        id: 1000,
+        realmUrl: realmUrl,
+        realmName: null,
+        realmIcon:null,
+        email: "test@example.com",
+        apiKey: 'aeouasdf',
+        userId: eg.user().userId,
+        zulipFeatureLevel: 468,
+        zulipVersion: '11.0',
+        possibleLegacyPushToken: false);
+      await setupChooseAccountPage(tester, accounts: [account]);
+
+      check(find.text(account.realmUrl.toString()).evaluate()).isNotEmpty();
+      check(find.byType(Image).evaluate()).isEmpty();
+    });
+
     group('log out', () {
       Future<(Widget, Widget)> prepare(WidgetTester tester, {required Account account}) async {
         await setupChooseAccountPage(tester, accounts: [account]);
 
         final findThreeDotsButton = find.descendant(
-          of: find.widgetWithText(Card, eg.selfAccount.realmUrl.toString()),
+          of: find.widgetWithText(Card, eg.selfAccount.realmName ?? eg.selfAccount.realmUrl.toString()),
           matching: find.byIcon(Icons.adaptive.more));
 
         await tester.tap(findThreeDotsButton);

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -8,6 +8,7 @@ import 'package:zulip/model/actions.dart';
 import 'package:zulip/model/database.dart';
 import 'package:zulip/widgets/app.dart';
 import 'package:zulip/widgets/home.dart';
+import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/page.dart';
 
 import '../example_data.dart' as eg;
@@ -366,6 +367,16 @@ void main() {
       await tester.tap(find.text(eg.otherAccount.email));
       await tester.pump();
       check(testBinding.globalStore).lastVisitedAccount.equals(eg.otherAccount);
+    });
+
+    testWidgets('shows icon image when realmIcon is non-null', (tester) async {
+      final account = eg.account(
+        user: eg.user(),
+        realmIcon: Uri.parse('https://example.com/icon.png'),
+        realmName: 'Example Realm');
+      await setupChooseAccountPage(tester, accounts: [account]);
+
+      check(find.byType(RealmIconNetworkImage).evaluate()).isNotEmpty();
     });
 
     testWidgets('shows realm name when realmName is non-null', (tester) async {


### PR DESCRIPTION
Show each account’s realm using its **icon and name** instead of the realm URL.  

Hide the user's email by default, and only display it when multiple accounts exist on the same realm so they can be distinguished.

Fixes #1943.

### Screenshots

| Before | After | After (multiple accounts on same realm) |
|------|------|------|
| <img width="250" src="https://github.com/user-attachments/assets/8fe27af5-9587-44bc-a5e0-b350c050cf74"> | <img width="250" src="https://github.com/user-attachments/assets/4cb2a0a3-4364-4543-94ac-658cb2b27324"> | <img width="250" src="https://github.com/user-attachments/assets/57198f6d-e231-4f65-a5d5-b9b6ffed8283"> |