### PR TITLE
claude/testing: Say to factor out boring data

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -267,7 +267,14 @@ PushKey mkKey(int createdTimestamp, {int? supersededTimestamp}) {
   );
 }
 ```
-This keeps test bodies focused on what varies.
+
+Even if a given type of data appears only once,
+determine whether it has more than two or three fields
+containing boring data
+(data where the details aren't relevant to understanding the test).
+If it does, then factor it out to a helper.
+
+This keeps test bodies focused on just the data that's important.
 
 
 ### Controlling time and async with `awaitFakeAsync`


### PR DESCRIPTION
This comes from some experiments I did over the past couple of days with having Claude (Opus 4.6) write tests.  Most of the experiments were done by just having it review some tests I'd previously had it write, with this prompt:

❯ Please look at the tests in test/model/push_key_test.dart. Review those as newly-written tests, and make any edits.

That prompt successfully caused it to look through this file and either find something to edit, or write some text showing it had evaluated the given code on many of the points in this file.

With that prompt, these new instructions were pretty consistently effective on "high effort".  Using "medium effort" was mostly not effective.

---

Some notes which might be useful in writing future instructions:

Claude seems to have a strong presumption that something should only be factored out if it occurs repeatedly.  It took some doing to convince Claude that I really mean it when I say this sort of thing should be factored out even when it appears only once.  Elements that were important in making that work include:

 * The concrete threshold "two or three fields".  A previous draft said "contains a lot of boring data", and Claude repeatedly decided that didn't apply even with 4 lines of setting irrelevant fields to null.

 * A previous draft said "consider whether it has" rather than "determine".  (It also had a later instruction saying "If you find any [of these], consider factoring it out".) Claude said, effectively, "OK, I'll consider it; nope, not doing it".  So this version is more directive.

---

For "high effort", I did some further experiments to try to find a way to write down, in general, that that's how Claude should do reviews (since it seems to be essential to getting a good result). Tried saying "always use high effort", tried "ultrathink", tried "work very thoroughly"; tried putting it in CLAUDE.md, tried making a "skill".

I didn't find anything that was effective: if the session was at medium effort, the results always reflected medium effort, in particular never successfully applying the instructions from this commit.  If the session was at high effort, it always applied these instructions.  So for now, when asking Claude to review its work, just be sure to always do so in "high effort" mode.