### PR TITLE
notif ios: Buffer notification tap events; same as on Android

### DIFF
--- a/android/app/src/main/kotlin/com/zulip/flutter/notifications/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/notifications/Notifications.g.kt
@@ -14,26 +14,6 @@ import io.flutter.plugin.common.StandardMessageCodec
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 private object NotificationsPigeonUtils {
-
-  fun wrapResult(result: Any?): List<Any?> {
-    return listOf(result)
-  }
-
-  fun wrapError(exception: Throwable): List<Any?> {
-    return if (exception is FlutterError) {
-      listOf(
-        exception.code,
-        exception.message,
-        exception.details
-      )
-    } else {
-      listOf(
-        exception.javaClass.simpleName,
-        exception.toString(),
-        "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception)
-      )
-    }
-  }
   fun deepEquals(a: Any?, b: Any?): Boolean {
     if (a is ByteArray && b is ByteArray) {
         return a.contentEquals(b)
@@ -77,40 +57,6 @@ class FlutterError (
   override val message: String? = null,
   val details: Any? = null
 ) : Throwable()
-
-/** Generated class from Pigeon that represents data sent in messages. */
-data class NotificationDataFromLaunch (
-  /**
-   * The raw payload that is attached to the notification,
-   * holding the information required to carry out the navigation.
-   *
-   * See [NotificationHostApi.getNotificationDataFromLaunch].
-   */
-  val payload: Map<Any?, Any?>
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): NotificationDataFromLaunch {
-      val payload = pigeonVar_list[0] as Map<Any?, Any?>
-      return NotificationDataFromLaunch(payload)
-    }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      payload,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other !is NotificationDataFromLaunch) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    return NotificationsPigeonUtils.deepEquals(toList(), other.toList())  }
-
-  override fun hashCode(): Int = toList().hashCode()
-}
 
 /**
  * Generated class from Pigeon that represents data sent in messages.
@@ -203,15 +149,10 @@ private open class NotificationsPigeonCodec : StandardMessageCodec() {
     return when (type) {
       129.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          NotificationDataFromLaunch.fromList(it)
-        }
-      }
-      130.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
           IosNotificationTapEvent.fromList(it)
         }
       }
-      131.toByte() -> {
+      130.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           AndroidNotificationTapEvent.fromList(it)
         }
@@ -221,16 +162,12 @@ private open class NotificationsPigeonCodec : StandardMessageCodec() {
   }
   override fun writeValue(stream: ByteArrayOutputStream, value: Any?)   {
     when (value) {
-      is NotificationDataFromLaunch -> {
+      is IosNotificationTapEvent -> {
         stream.write(129)
         writeValue(stream, value.toList())
       }
-      is IosNotificationTapEvent -> {
-        stream.write(130)
-        writeValue(stream, value.toList())
-      }
       is AndroidNotificationTapEvent -> {
-        stream.write(131)
+        stream.write(130)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -240,46 +177,6 @@ private open class NotificationsPigeonCodec : StandardMessageCodec() {
 
 val NotificationsPigeonMethodCodec = StandardMethodCodec(NotificationsPigeonCodec())
 
-/** Generated interface from Pigeon that represents a handler of messages from Flutter. */
-interface NotificationHostApi {
-  /**
-   * Retrieves notification data if the app was launched by tapping on a notification.
-   *
-   * Returns `launchOptions.remoteNotification`,
-   * which is the raw APNs data dictionary
-   * if the app launch was opened by a notification tap,
-   * else null. See Apple doc:
-   *   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-   */
-  fun getNotificationDataFromLaunch(): NotificationDataFromLaunch?
-
-  companion object {
-    /** The codec used by NotificationHostApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      NotificationsPigeonCodec()
-    }
-    /** Sets up an instance of `NotificationHostApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: NotificationHostApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.NotificationHostApi.getNotificationDataFromLaunch$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              listOf(api.getNotificationDataFromLaunch())
-            } catch (exception: Throwable) {
-              NotificationsPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
-}
 
 private class NotificationsPigeonStreamHandler<T>(
     val wrapper: NotificationsPigeonEventChannelWrapper<T>

--- a/android/app/src/main/kotlin/com/zulip/flutter/notifications/Notifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/notifications/Notifications.g.kt
@@ -14,26 +14,6 @@ import io.flutter.plugin.common.StandardMessageCodec
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 private object NotificationsPigeonUtils {
-
-  fun wrapResult(result: Any?): List<Any?> {
-    return listOf(result)
-  }
-
-  fun wrapError(exception: Throwable): List<Any?> {
-    return if (exception is FlutterError) {
-      listOf(
-        exception.code,
-        exception.message,
-        exception.details
-      )
-    } else {
-      listOf(
-        exception.javaClass.simpleName,
-        exception.toString(),
-        "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception)
-      )
-    }
-  }
   fun doubleEquals(a: Double, b: Double): Boolean {
     // Normalize -0.0 to 0.0 and handle NaN equality.
     return (if (a == 0.0) 0.0 else a) == (if (b == 0.0) 0.0 else b) || (a.isNaN() && b.isNaN())
@@ -192,49 +172,6 @@ class FlutterError (
   val details: Any? = null
 ) : RuntimeException()
 
-/** Generated class from Pigeon that represents data sent in messages. */
-data class NotificationDataFromLaunch (
-  /**
-   * The raw payload that is attached to the notification,
-   * holding the information required to carry out the navigation.
-   *
-   * See [NotificationHostApi.getNotificationDataFromLaunch].
-   */
-  val payload: Map<Any?, Any?>
-)
- {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): NotificationDataFromLaunch {
-      val payload = pigeonVar_list[0] as Map<Any?, Any?>
-      return NotificationDataFromLaunch(payload)
-    }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      payload,
-    )
-  }
-  override fun equals(other: Any?): Boolean {
-    if (other == null || other.javaClass != javaClass) {
-      return false
-    }
-    if (this === other) {
-      return true
-    }
-    val other = other as NotificationDataFromLaunch
-    return NotificationsPigeonUtils.deepEquals(this.payload, other.payload)
-  }
-
-  override fun hashCode(): Int {
-    var result = javaClass.hashCode()
-    result = 31 * result + NotificationsPigeonUtils.deepHash(this.payload)
-    return result
-  }
-  override fun toString(): String {
-    return "NotificationDataFromLaunch(payload=$payload)"
-  }
-}
-
 /**
  * Generated class from Pigeon that represents data sent in messages.
  * This class should not be extended by any user class outside of the generated file.
@@ -344,15 +281,10 @@ private open class NotificationsPigeonCodec : StandardMessageCodec() {
     return when (type) {
       129.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          NotificationDataFromLaunch.fromList(it)
-        }
-      }
-      130.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
           IosNotificationTapEvent.fromList(it)
         }
       }
-      131.toByte() -> {
+      130.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           AndroidNotificationTapEvent.fromList(it)
         }
@@ -362,16 +294,12 @@ private open class NotificationsPigeonCodec : StandardMessageCodec() {
   }
   override fun writeValue(stream: ByteArrayOutputStream, value: Any?)   {
     when (value) {
-      is NotificationDataFromLaunch -> {
+      is IosNotificationTapEvent -> {
         stream.write(129)
         writeValue(stream, value.toList())
       }
-      is IosNotificationTapEvent -> {
-        stream.write(130)
-        writeValue(stream, value.toList())
-      }
       is AndroidNotificationTapEvent -> {
-        stream.write(131)
+        stream.write(130)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -381,46 +309,6 @@ private open class NotificationsPigeonCodec : StandardMessageCodec() {
 
 val NotificationsPigeonMethodCodec = StandardMethodCodec(NotificationsPigeonCodec())
 
-/** Generated interface from Pigeon that represents a handler of messages from Flutter. */
-interface NotificationHostApi {
-  /**
-   * Retrieves notification data if the app was launched by tapping on a notification.
-   *
-   * Returns `launchOptions.remoteNotification`,
-   * which is the raw APNs data dictionary
-   * if the app launch was opened by a notification tap,
-   * else null. See Apple doc:
-   *   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-   */
-  fun getNotificationDataFromLaunch(): NotificationDataFromLaunch?
-
-  companion object {
-    /** The codec used by NotificationHostApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      NotificationsPigeonCodec()
-    }
-    /** Sets up an instance of `NotificationHostApi` to handle messages through the `binaryMessenger`. */
-    @JvmOverloads
-    fun setUp(binaryMessenger: BinaryMessenger, api: NotificationHostApi?, messageChannelSuffix: String = "") {
-      val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.NotificationHostApi.getNotificationDataFromLaunch$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              listOf(api.getNotificationDataFromLaunch())
-            } catch (exception: Throwable) {
-              NotificationsPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-    }
-  }
-}
 
 private class NotificationsPigeonStreamHandler<T>(
     val wrapper: NotificationsPigeonEventChannelWrapper<T>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		B34E9F092D776BEB0009AED2 /* Notifications.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34E9F082D776BEB0009AED2 /* Notifications.g.swift */; };
 		B35E11A62F484E6800DE4085 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		B378A5012F45B08F0031EFA1 /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B378A4FA2F45B08F0031EFA1 /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B3C086B42FA237E1001ACFDD /* NotificationTapEventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C086B32FA237E1001ACFDD /* NotificationTapEventListener.swift */; };
 		B3D425322F6D40C200F9AE69 /* IosNative.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = B340EB372F5B092B007AD309 /* IosNative.g.swift */; };
 		B3D425332F6D40C200F9AE69 /* IosNativeHostApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32717682F6C49E5007682B1 /* IosNativeHostApi.swift */; };
 		F311C174AF9C005CE4AADD72 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EAE3F3F518B95B7BFEB4FE7 /* Pods_Runner.framework */; };
@@ -92,6 +93,7 @@
 		B34E9F082D776BEB0009AED2 /* Notifications.g.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.g.swift; sourceTree = "<group>"; };
 		B378A4FA2F45B08F0031EFA1 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3AF53A72CA20BD10039801D /* Zulip.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Zulip.xcconfig; path = Flutter/Zulip.xcconfig; sourceTree = "<group>"; };
+		B3C086B32FA237E1001ACFDD /* NotificationTapEventListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTapEventListener.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -216,6 +218,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				B3C086B32FA237E1001ACFDD /* NotificationTapEventListener.swift */,
 				B32717682F6C49E5007682B1 /* IosNativeHostApi.swift */,
 				B34E9F082D776BEB0009AED2 /* Notifications.g.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
@@ -575,6 +578,7 @@
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				B340EB382F5B092B007AD309 /* IosNative.g.swift in Sources */,
 				B32717692F6C49E5007682B1 /* IosNativeHostApi.swift in Sources */,
+				B3C086B42FA237E1001ACFDD /* NotificationTapEventListener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -20,18 +20,6 @@ import UIKit
 
     IosNativeHostApiSetup.setUp(binaryMessenger: controller.binaryMessenger, api: IosNativeHostApiImpl())
 
-    // Retrieve the remote notification payload from launch options;
-    // this will be null if the launch wasn't triggered by a notification.
-    let notificationPayload =
-      launchOptions?[.remoteNotification] as? [AnyHashable: Any]
-    let api = NotificationHostApiImpl(
-      notificationPayload.map { NotificationDataFromLaunch(payload: $0) }
-    )
-    NotificationHostApiSetup.setUp(
-      binaryMessenger: controller.binaryMessenger,
-      api: api
-    )
-
     notificationTapEventListener = NotificationTapEventListener()
     NotificationTapEventsStreamHandler.register(
       with: controller.binaryMessenger,
@@ -58,16 +46,3 @@ import UIKit
     completionHandler()
   }
 }
-
-private class NotificationHostApiImpl: NotificationHostApi {
-  private let maybeDataFromLaunch: NotificationDataFromLaunch?
-
-  init(_ maybeDataFromLaunch: NotificationDataFromLaunch?) {
-    self.maybeDataFromLaunch = maybeDataFromLaunch
-  }
-
-  func getNotificationDataFromLaunch() -> NotificationDataFromLaunch? {
-    maybeDataFromLaunch
-  }
-}
-

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -71,19 +71,3 @@ private class NotificationHostApiImpl: NotificationHostApi {
   }
 }
 
-// Adapted from Pigeon's Swift example for @EventChannelApi:
-//   https://github.com/flutter/packages/blob/2dff6213a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift#L49-L74
-class NotificationTapEventListener: NotificationTapEventsStreamHandler {
-  var eventSink: PigeonEventSink<NotificationTapEvent>?
-
-  override func onListen(
-    withArguments arguments: Any?,
-    sink: PigeonEventSink<NotificationTapEvent>
-  ) {
-    eventSink = sink
-  }
-
-  func onNotificationTapEvent(payload: [AnyHashable: Any]) {
-    eventSink?.success(IosNotificationTapEvent(payload: payload))
-  }
-}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -21,18 +21,6 @@ import UIKit
     IosNativeHostApiSetup.setUp(
       binaryMessenger: controller.binaryMessenger, api: IosNativeHostApiImpl())
 
-    // Retrieve the remote notification payload from launch options;
-    // this will be null if the launch wasn't triggered by a notification.
-    let notificationPayload =
-      launchOptions?[.remoteNotification] as? [AnyHashable: Any]
-    let api = NotificationHostApiImpl(
-      notificationPayload.map { NotificationDataFromLaunch(payload: $0) }
-    )
-    NotificationHostApiSetup.setUp(
-      binaryMessenger: controller.binaryMessenger,
-      api: api
-    )
-
     notificationTapEventListener = NotificationTapEventListener()
     NotificationTapEventsStreamHandler.register(
       with: controller.binaryMessenger,
@@ -67,16 +55,3 @@ import UIKit
     }
   }
 }
-
-private class NotificationHostApiImpl: NotificationHostApi {
-  private let maybeDataFromLaunch: NotificationDataFromLaunch?
-
-  init(_ maybeDataFromLaunch: NotificationDataFromLaunch?) {
-    self.maybeDataFromLaunch = maybeDataFromLaunch
-  }
-
-  func getNotificationDataFromLaunch() -> NotificationDataFromLaunch? {
-    maybeDataFromLaunch
-  }
-}
-

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -80,19 +80,3 @@ private class NotificationHostApiImpl: NotificationHostApi {
   }
 }
 
-// Adapted from Pigeon's Swift example for @EventChannelApi:
-//   https://github.com/flutter/packages/blob/2dff6213a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift#L49-L74
-class NotificationTapEventListener: NotificationTapEventsStreamHandler {
-  var eventSink: PigeonEventSink<NotificationTapEvent>?
-
-  override func onListen(
-    withArguments arguments: Any?,
-    sink: PigeonEventSink<NotificationTapEvent>
-  ) {
-    eventSink = sink
-  }
-
-  func onNotificationTapEvent(payload: [AnyHashable: Any]) {
-    eventSink?.success(IosNotificationTapEvent(payload: payload))
-  }
-}

--- a/ios/Runner/NotificationTapEventListener.swift
+++ b/ios/Runner/NotificationTapEventListener.swift
@@ -1,0 +1,19 @@
+import Flutter
+import UIKit
+
+// Adapted from Pigeon's Swift example for @EventChannelApi:
+//   https://github.com/flutter/packages/blob/2dff6213a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift#L49-L74
+class NotificationTapEventListener: NotificationTapEventsStreamHandler {
+  var eventSink: PigeonEventSink<NotificationTapEvent>?
+
+  override func onListen(
+    withArguments arguments: Any?,
+    sink: PigeonEventSink<NotificationTapEvent>
+  ) {
+    eventSink = sink
+  }
+
+  func onNotificationTapEvent(payload: [AnyHashable: Any]) {
+    eventSink?.success(IosNotificationTapEvent(payload: payload))
+  }
+}

--- a/ios/Runner/NotificationTapEventListener.swift
+++ b/ios/Runner/NotificationTapEventListener.swift
@@ -5,15 +5,34 @@ import UIKit
 //   https://github.com/flutter/packages/blob/2dff6213a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift#L49-L74
 class NotificationTapEventListener: NotificationTapEventsStreamHandler {
   var eventSink: PigeonEventSink<NotificationTapEvent>?
+  var buffer: [NotificationTapEvent] = []
 
   override func onListen(
     withArguments arguments: Any?,
     sink: PigeonEventSink<NotificationTapEvent>
   ) {
     eventSink = sink
+    if !buffer.isEmpty {
+      buffer.forEach {
+        sink.success($0)
+      }
+      buffer.removeAll()
+    }
+  }
+
+  override func onCancel(withArguments arguments: Any?) {
+    if let eventSink = self.eventSink {
+      eventSink.endOfStream()
+      self.eventSink = nil
+    }
   }
 
   func onNotificationTapEvent(payload: [AnyHashable: Any]) {
-    eventSink?.success(IosNotificationTapEvent(payload: payload))
+    let event = IosNotificationTapEvent(payload: payload)
+    if let eventSink = self.eventSink {
+      eventSink.success(event)
+    } else {
+      buffer.append(event)
+    }
   }
 }

--- a/ios/Runner/NotificationTapEventListener.swift
+++ b/ios/Runner/NotificationTapEventListener.swift
@@ -4,16 +4,35 @@ import UIKit
 // Adapted from Pigeon's Swift example for @EventChannelApi:
 //   https://github.com/flutter/packages/blob/2dff6213a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift#L49-L74
 class NotificationTapEventListener: NotificationTapEventsStreamHandler {
-  var eventSink: PigeonEventSink<NotificationTapEvent>?
+  private var eventSink: PigeonEventSink<NotificationTapEvent>?
+  private var buffer: [NotificationTapEvent] = []
 
   override func onListen(
     withArguments arguments: Any?,
     sink: PigeonEventSink<NotificationTapEvent>
   ) {
     eventSink = sink
+    if !buffer.isEmpty {
+      buffer.forEach {
+        sink.success($0)
+      }
+      buffer.removeAll()
+    }
+  }
+
+  override func onCancel(withArguments arguments: Any?) {
+    if let eventSink = self.eventSink {
+      eventSink.endOfStream()
+      self.eventSink = nil
+    }
   }
 
   func onNotificationTapEvent(payload: [AnyHashable: Any]) {
-    eventSink?.success(IosNotificationTapEvent(payload: payload))
+    let event = IosNotificationTapEvent(payload: payload)
+    if let eventSink = self.eventSink {
+      eventSink.success(event)
+    } else {
+      buffer.append(event)
+    }
   }
 }

--- a/ios/Runner/Notifications.g.swift
+++ b/ios/Runner/Notifications.g.swift
@@ -29,32 +29,6 @@ final class PigeonError: Error {
   }
 }
 
-private func wrapResult(_ result: Any?) -> [Any?] {
-  return [result]
-}
-
-private func wrapError(_ error: Any) -> [Any?] {
-  if let pigeonError = error as? PigeonError {
-    return [
-      pigeonError.code,
-      pigeonError.message,
-      pigeonError.details,
-    ]
-  }
-  if let flutterError = error as? FlutterError {
-    return [
-      flutterError.code,
-      flutterError.message,
-      flutterError.details,
-    ]
-  }
-  return [
-    "\(error)",
-    "\(type(of: error))",
-    "Stacktrace: \(Thread.callStackSymbols)",
-  ]
-}
-
 private func isNullish(_ value: Any?) -> Bool {
   return value is NSNull || value == nil
 }
@@ -127,35 +101,6 @@ func deepHashNotifications(value: Any?, hasher: inout Hasher) {
 }
 
     
-
-/// Generated class from Pigeon that represents data sent in messages.
-struct NotificationDataFromLaunch: Hashable {
-  /// The raw payload that is attached to the notification,
-  /// holding the information required to carry out the navigation.
-  ///
-  /// See [NotificationHostApi.getNotificationDataFromLaunch].
-  var payload: [AnyHashable?: Any?]
-
-
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ pigeonVar_list: [Any?]) -> NotificationDataFromLaunch? {
-    let payload = pigeonVar_list[0] as! [AnyHashable?: Any?]
-
-    return NotificationDataFromLaunch(
-      payload: payload
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      payload
-    ]
-  }
-  static func == (lhs: NotificationDataFromLaunch, rhs: NotificationDataFromLaunch) -> Bool {
-    return deepEqualsNotifications(lhs.toList(), rhs.toList())  }
-  func hash(into hasher: inout Hasher) {
-    deepHashNotifications(value: toList(), hasher: &hasher)
-  }
-}
 
 /// Generated class from Pigeon that represents data sent in messages.
 /// This protocol should not be extended by any user class outside of the generated file.
@@ -235,10 +180,8 @@ private class NotificationsPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      return NotificationDataFromLaunch.fromList(self.readValue() as! [Any?])
-    case 130:
       return IosNotificationTapEvent.fromList(self.readValue() as! [Any?])
-    case 131:
+    case 130:
       return AndroidNotificationTapEvent.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -248,14 +191,11 @@ private class NotificationsPigeonCodecReader: FlutterStandardReader {
 
 private class NotificationsPigeonCodecWriter: FlutterStandardWriter {
   override func writeValue(_ value: Any) {
-    if let value = value as? NotificationDataFromLaunch {
+    if let value = value as? IosNotificationTapEvent {
       super.writeByte(129)
       super.writeValue(value.toList())
-    } else if let value = value as? IosNotificationTapEvent {
-      super.writeByte(130)
-      super.writeValue(value.toList())
     } else if let value = value as? AndroidNotificationTapEvent {
-      super.writeByte(131)
+      super.writeByte(130)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -279,46 +219,6 @@ class NotificationsPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable
 
 var notificationsPigeonMethodCodec = FlutterStandardMethodCodec(readerWriter: NotificationsPigeonCodecReaderWriter());
 
-/// Generated protocol from Pigeon that represents a handler of messages from Flutter.
-protocol NotificationHostApi {
-  /// Retrieves notification data if the app was launched by tapping on a notification.
-  ///
-  /// Returns `launchOptions.remoteNotification`,
-  /// which is the raw APNs data dictionary
-  /// if the app launch was opened by a notification tap,
-  /// else null. See Apple doc:
-  ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-  func getNotificationDataFromLaunch() throws -> NotificationDataFromLaunch?
-}
-
-/// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class NotificationHostApiSetup {
-  static var codec: FlutterStandardMessageCodec { NotificationsPigeonCodec.shared }
-  /// Sets up an instance of `NotificationHostApi` to handle messages through the `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: NotificationHostApi?, messageChannelSuffix: String = "") {
-    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    /// Retrieves notification data if the app was launched by tapping on a notification.
-    ///
-    /// Returns `launchOptions.remoteNotification`,
-    /// which is the raw APNs data dictionary
-    /// if the app launch was opened by a notification tap,
-    /// else null. See Apple doc:
-    ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-    let getNotificationDataFromLaunchChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.zulip.NotificationHostApi.getNotificationDataFromLaunch\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      getNotificationDataFromLaunchChannel.setMessageHandler { _, reply in
-        do {
-          let result = try api.getNotificationDataFromLaunch()
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
-        }
-      }
-    } else {
-      getNotificationDataFromLaunchChannel.setMessageHandler(nil)
-    }
-  }
-}
 
 private class PigeonStreamHandler<ReturnType>: NSObject, FlutterStreamHandler {
   private let wrapper: PigeonEventChannelWrapper<ReturnType>

--- a/ios/Runner/Notifications.g.swift
+++ b/ios/Runner/Notifications.g.swift
@@ -29,32 +29,6 @@ final class PigeonError: Error {
   }
 }
 
-private func wrapResult(_ result: Any?) -> [Any?] {
-  return [result]
-}
-
-private func wrapError(_ error: Any) -> [Any?] {
-  if let pigeonError = error as? PigeonError {
-    return [
-      pigeonError.code,
-      pigeonError.message,
-      pigeonError.details,
-    ]
-  }
-  if let flutterError = error as? FlutterError {
-    return [
-      flutterError.code,
-      flutterError.message,
-      flutterError.details,
-    ]
-  }
-  return [
-    "\(error)",
-    "\(Swift.type(of: error))",
-    "Stacktrace: \(Thread.callStackSymbols)",
-  ]
-}
-
 enum NotificationsPigeonInternal {
   static func isNullish(_ value: Any?) -> Bool {
     guard let innerValue = value else {
@@ -185,45 +159,6 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
 
 
 /// Generated class from Pigeon that represents data sent in messages.
-struct NotificationDataFromLaunch: Hashable, CustomStringConvertible {
-  /// The raw payload that is attached to the notification,
-  /// holding the information required to carry out the navigation.
-  ///
-  /// See [NotificationHostApi.getNotificationDataFromLaunch].
-  var payload: [AnyHashable?: Any?]
-
-
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ pigeonVar_list: [Any?]) -> NotificationDataFromLaunch? {
-    let payload = pigeonVar_list[0] as! [AnyHashable?: Any?]
-
-    return NotificationDataFromLaunch(
-      payload: payload
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      payload
-    ]
-  }
-  static func == (lhs: NotificationDataFromLaunch, rhs: NotificationDataFromLaunch) -> Bool {
-    if Swift.type(of: lhs) != Swift.type(of: rhs) {
-      return false
-    }
-    return NotificationsPigeonInternal.deepEquals(lhs.payload, rhs.payload)
-  }
-
-  func hash(into hasher: inout Hasher) {
-    hasher.combine("NotificationDataFromLaunch")
-    NotificationsPigeonInternal.deepHash(value: payload, hasher: &hasher)
-  }
-
-  public var description: String {
-    return "NotificationDataFromLaunch(payload: \(String(describing: payload)))"
-  }
-}
-
-/// Generated class from Pigeon that represents data sent in messages.
 /// This protocol should not be extended by any user class outside of the generated file.
 protocol NotificationTapEvent {
 
@@ -321,10 +256,8 @@ private class NotificationsPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      return NotificationDataFromLaunch.fromList(self.readValue() as! [Any?])
-    case 130:
       return IosNotificationTapEvent.fromList(self.readValue() as! [Any?])
-    case 131:
+    case 130:
       return AndroidNotificationTapEvent.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -334,14 +267,11 @@ private class NotificationsPigeonCodecReader: FlutterStandardReader {
 
 private class NotificationsPigeonCodecWriter: FlutterStandardWriter {
   override func writeValue(_ value: Any) {
-    if let value = value as? NotificationDataFromLaunch {
+    if let value = value as? IosNotificationTapEvent {
       super.writeByte(129)
       super.writeValue(value.toList())
-    } else if let value = value as? IosNotificationTapEvent {
-      super.writeByte(130)
-      super.writeValue(value.toList())
     } else if let value = value as? AndroidNotificationTapEvent {
-      super.writeByte(131)
+      super.writeByte(130)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -365,46 +295,6 @@ class NotificationsPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable
 
 var notificationsPigeonMethodCodec = FlutterStandardMethodCodec(readerWriter: NotificationsPigeonCodecReaderWriter());
 
-/// Generated protocol from Pigeon that represents a handler of messages from Flutter.
-protocol NotificationHostApi {
-  /// Retrieves notification data if the app was launched by tapping on a notification.
-  ///
-  /// Returns `launchOptions.remoteNotification`,
-  /// which is the raw APNs data dictionary
-  /// if the app launch was opened by a notification tap,
-  /// else null. See Apple doc:
-  ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-  func getNotificationDataFromLaunch() throws -> NotificationDataFromLaunch?
-}
-
-/// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class NotificationHostApiSetup {
-  static var codec: FlutterStandardMessageCodec { NotificationsPigeonCodec.shared }
-  /// Sets up an instance of `NotificationHostApi` to handle messages through the `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: NotificationHostApi?, messageChannelSuffix: String = "") {
-    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    /// Retrieves notification data if the app was launched by tapping on a notification.
-    ///
-    /// Returns `launchOptions.remoteNotification`,
-    /// which is the raw APNs data dictionary
-    /// if the app launch was opened by a notification tap,
-    /// else null. See Apple doc:
-    ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-    let getNotificationDataFromLaunchChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.zulip.NotificationHostApi.getNotificationDataFromLaunch\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      getNotificationDataFromLaunchChannel.setMessageHandler { _, reply in
-        do {
-          let result = try api.getNotificationDataFromLaunch()
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
-        }
-      }
-    } else {
-      getNotificationDataFromLaunchChannel.setMessageHandler(nil)
-    }
-  }
-}
 
 private class PigeonStreamHandler<ReturnType>: NSObject, FlutterStreamHandler {
   private let wrapper: PigeonEventChannelWrapper<ReturnType>

--- a/lib/host/notifications.g.dart
+++ b/lib/host/notifications.g.dart
@@ -7,32 +7,6 @@ import 'dart:typed_data' show Float64List, Int32List, Int64List, Uint8List;
 
 import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
 import 'package:flutter/services.dart';
-
-Object? _extractReplyValueOrThrow(
-    List<Object?>? replyList,
-    String channelName, {
-    required bool isNullValid,
-}) {
-  if (replyList == null) {
-    throw PlatformException(
-      code: 'channel-error',
-      message: 'Unable to establish connection on channel: "$channelName".',
-    );
-  } else if (replyList.length > 1) {
-    throw PlatformException(
-      code: replyList[0]! as String,
-      message: replyList[1] as String?,
-      details: replyList[2],
-    );
-  } else if (!isNullValid && (replyList.isNotEmpty && replyList[0] == null)) {
-    throw PlatformException(
-      code: 'null-error',
-      message: 'Host platform returned null value for non-null return value.',
-    );
-  }
-  return replyList.firstOrNull;
-}
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
@@ -47,51 +21,6 @@ bool _deepEquals(Object? a, Object? b) {
   return a == b;
 }
 
-
-class NotificationDataFromLaunch {
-  NotificationDataFromLaunch({
-    required this.payload,
-  });
-
-  /// The raw payload that is attached to the notification,
-  /// holding the information required to carry out the navigation.
-  ///
-  /// See [NotificationHostApi.getNotificationDataFromLaunch].
-  Map<Object?, Object?> payload;
-
-  List<Object?> _toList() {
-    return <Object?>[
-      payload,
-    ];
-  }
-
-  Object encode() {
-    return _toList();  }
-
-  static NotificationDataFromLaunch decode(Object result) {
-    result as List<Object?>;
-    return NotificationDataFromLaunch(
-      payload: (result[0] as Map<Object?, Object?>?)!.cast<Object?, Object?>(),
-    );
-  }
-
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(Object other) {
-    if (other is! NotificationDataFromLaunch || other.runtimeType != runtimeType) {
-      return false;
-    }
-    if (identical(this, other)) {
-      return true;
-    }
-    return _deepEquals(encode(), other.encode());
-  }
-
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
-}
 
 sealed class NotificationTapEvent {
 }
@@ -202,14 +131,11 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is NotificationDataFromLaunch) {
+    }    else if (value is IosNotificationTapEvent) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    }    else if (value is IosNotificationTapEvent) {
-      buffer.putUint8(130);
-      writeValue(buffer, value.encode());
     }    else if (value is AndroidNotificationTapEvent) {
-      buffer.putUint8(131);
+      buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -220,10 +146,8 @@ class _PigeonCodec extends StandardMessageCodec {
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
       case 129:
-        return NotificationDataFromLaunch.decode(readValue(buffer)!);
-      case 130:
         return IosNotificationTapEvent.decode(readValue(buffer)!);
-      case 131:
+      case 130:
         return AndroidNotificationTapEvent.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -232,46 +156,6 @@ class _PigeonCodec extends StandardMessageCodec {
 }
 
 const StandardMethodCodec pigeonMethodCodec = StandardMethodCodec(_PigeonCodec());
-
-class NotificationHostApi {
-  /// Constructor for [NotificationHostApi].  The [binaryMessenger] named argument is
-  /// available for dependency injection.  If it is left null, the default
-  /// BinaryMessenger will be used which routes to the host platform.
-  NotificationHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-  final BinaryMessenger? pigeonVar_binaryMessenger;
-
-  static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
-
-  final String pigeonVar_messageChannelSuffix;
-
-  /// Retrieves notification data if the app was launched by tapping on a notification.
-  ///
-  /// Returns `launchOptions.remoteNotification`,
-  /// which is the raw APNs data dictionary
-  /// if the app launch was opened by a notification tap,
-  /// else null. See Apple doc:
-  ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-  Future<NotificationDataFromLaunch?> getNotificationDataFromLaunch() async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.zulip.NotificationHostApi.getNotificationDataFromLaunch$pigeonVar_messageChannelSuffix';
-    final pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
-
-    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
-    return pigeonVar_replyValue as NotificationDataFromLaunch?;
-  }
-}
 
 /// An event stream that emits a notification payload
 /// when a notification is tapped.

--- a/lib/host/notifications.g.dart
+++ b/lib/host/notifications.g.dart
@@ -8,32 +8,6 @@ import 'dart:typed_data' show Float64List, Int32List, Int64List;
 
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
-
-Object? _extractReplyValueOrThrow(
-    List<Object?>? replyList,
-    String channelName, {
-    required bool isNullValid,
-}) {
-  if (replyList == null) {
-    throw PlatformException(
-      code: 'channel-error',
-      message: 'Unable to establish connection on channel: "$channelName".',
-    );
-  } else if (replyList.length > 1) {
-    throw PlatformException(
-      code: replyList[0]! as String,
-      message: replyList[1] as String?,
-      details: replyList[2],
-    );
-  } else if (!isNullValid && (replyList.isNotEmpty && replyList[0] == null)) {
-    throw PlatformException(
-      code: 'null-error',
-      message: 'Host platform returned null value for non-null return value.',
-    );
-  }
-  return replyList.firstOrNull;
-}
-
 bool _deepEquals(Object? a, Object? b) {
   if (identical(a, b)) {
     return true;
@@ -96,55 +70,6 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
-
-class NotificationDataFromLaunch {
-  NotificationDataFromLaunch({
-    required this.payload,
-  });
-
-  /// The raw payload that is attached to the notification,
-  /// holding the information required to carry out the navigation.
-  ///
-  /// See [NotificationHostApi.getNotificationDataFromLaunch].
-  Map<Object?, Object?> payload;
-
-  List<Object?> _toList() {
-    return <Object?>[
-      payload,
-    ];
-  }
-
-  Object encode() {
-    return _toList();  }
-
-  static NotificationDataFromLaunch decode(Object result) {
-    result as List<Object?>;
-    return NotificationDataFromLaunch(
-      payload: result[0]! as Map<Object?, Object?>,
-    );
-  }
-
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(Object other) {
-    if (other is! NotificationDataFromLaunch || other.runtimeType != runtimeType) {
-      return false;
-    }
-    if (identical(this, other)) {
-      return true;
-    }
-    return _deepEquals(payload, other.payload);
-  }
-
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
-
-  @override
-  String toString() {
-    return 'NotificationDataFromLaunch(payload: $payload)';
-  }
-}
 
 sealed class NotificationTapEvent {
 }
@@ -263,14 +188,11 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is NotificationDataFromLaunch) {
+    }    else if (value is IosNotificationTapEvent) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    }    else if (value is IosNotificationTapEvent) {
-      buffer.putUint8(130);
-      writeValue(buffer, value.encode());
     }    else if (value is AndroidNotificationTapEvent) {
-      buffer.putUint8(131);
+      buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -281,10 +203,8 @@ class _PigeonCodec extends StandardMessageCodec {
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
       case 129:
-        return NotificationDataFromLaunch.decode(readValue(buffer)!);
-      case 130:
         return IosNotificationTapEvent.decode(readValue(buffer)!);
-      case 131:
+      case 130:
         return AndroidNotificationTapEvent.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -293,46 +213,6 @@ class _PigeonCodec extends StandardMessageCodec {
 }
 
 const StandardMethodCodec pigeonMethodCodec = StandardMethodCodec(_PigeonCodec());
-
-class NotificationHostApi {
-  /// Constructor for [NotificationHostApi]. The [binaryMessenger] named argument is
-  /// available for dependency injection. If it is left null, the default
-  /// BinaryMessenger will be used which routes to the host platform.
-  NotificationHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-  final BinaryMessenger? pigeonVar_binaryMessenger;
-
-  static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
-
-  final String pigeonVar_messageChannelSuffix;
-
-  /// Retrieves notification data if the app was launched by tapping on a notification.
-  ///
-  /// Returns `launchOptions.remoteNotification`,
-  /// which is the raw APNs data dictionary
-  /// if the app launch was opened by a notification tap,
-  /// else null. See Apple doc:
-  ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-  Future<NotificationDataFromLaunch?> getNotificationDataFromLaunch() async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.zulip.NotificationHostApi.getNotificationDataFromLaunch$pigeonVar_messageChannelSuffix';
-    final pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
-
-    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
-    return pigeonVar_replyValue as NotificationDataFromLaunch?;
-  }
-}
 
 /// An event stream that emits a notification payload
 /// when a notification is tapped.

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -359,11 +359,6 @@ class PackageInfo {
 // in global scope of the generated file. This is a helper class to
 // namespace the notification related Pigeon API under a single class.
 class NotificationPigeonApi {
-  final _hostApi = notif_pigeon.NotificationHostApi();
-
-  Future<notif_pigeon.NotificationDataFromLaunch?> getNotificationDataFromLaunch() =>
-    _hostApi.getNotificationDataFromLaunch();
-
   /// An event stream that emits a notification payload
   /// when a notification is tapped.
   ///

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -199,7 +199,7 @@ abstract class ZulipBinding {
   /// Wraps the [AndroidNotificationHostApi] constructor.
   AndroidNotificationHostApi get androidNotificationHost;
 
-  /// Wraps the [notif_pigeon.NotificationHostApi] class.
+  /// Wraps the [notif_pigeon.notificationTapEvents] function.
   NotificationPigeonApi get notificationPigeonApi;
 
   Stream<android_intents_pigeon.AndroidIntentEvent> get androidIntentEvents;
@@ -374,11 +374,6 @@ class PackageInfo {
 // in global scope of the generated file. This is a helper class to
 // namespace the notification related Pigeon API under a single class.
 class NotificationPigeonApi {
-  final _hostApi = notif_pigeon.NotificationHostApi();
-
-  Future<notif_pigeon.NotificationDataFromLaunch?> getNotificationDataFromLaunch() =>
-    _hostApi.getNotificationDataFromLaunch();
-
   /// An event stream that emits a notification payload
   /// when a notification is tapped.
   ///

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -33,66 +33,20 @@ class NotificationOpenService {
     _instance = null;
   }
 
-  NotificationDataFromLaunch? _notifDataFromLaunch;
+  void start() {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        _notifPigeonApi.notificationTapEventsStream()
+          .listen(_navigateForNotification);
 
-  /// A [Future] that completes to signal that the initialization of
-  /// [NotificationNavigationService] has completed
-  /// (with either success or failure).
-  ///
-  /// Null if [start] hasn't been called.
-  Future<void>? get initialized => _initializedSignal?.future;
-
-  Completer<void>? _initializedSignal;
-
-  Future<void> start() async {
-    assert(_initializedSignal == null);
-    _initializedSignal = Completer<void>();
-    try {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.iOS:
-          // On iOS, the notification tap that causes a launch of the app is
-          // handled a bit differently than on Android where all types of
-          // notification tap events are served via the
-          // `notificationTapEventsStream`.
-          _notifDataFromLaunch = await _notifPigeonApi.getNotificationDataFromLaunch();
-
-          _notifPigeonApi.notificationTapEventsStream()
-            .listen(_navigateForNotification);
-
-        case TargetPlatform.android:
-          _notifPigeonApi.notificationTapEventsStream()
-            .listen(_navigateForNotification);
-
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.macOS:
-        case TargetPlatform.windows:
-          // Do nothing; we don't offer notifications on these platforms.
-          break;
-      }
-    } finally {
-      _initializedSignal!.complete();
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        // Do nothing; we don't offer notifications on these platforms.
+        break;
     }
-  }
-
-  /// Provides the route to open if the app was launched through a tap on
-  /// a notification.
-  ///
-  /// Returns null if app launch wasn't triggered by a notification, or if
-  /// an error occurs while determining the route for the notification.
-  /// In the latter case an error dialog is also shown.
-  ///
-  /// The context argument should be a descendant of the app's main [Navigator].
-  AccountRoute<void>? routeForNotificationFromLaunch({required BuildContext context}) {
-    assert(defaultTargetPlatform == TargetPlatform.iOS);
-    final data = _notifDataFromLaunch;
-    if (data == null) return null;
-    assert(debugLog('opened notif: ${jsonEncode(data.payload)}'));
-
-    final notifNavData = _tryParseIosApnsPayload(context, data.payload);
-    if (notifNavData == null) return null; // TODO(log)
-
-    return routeForNotification(context: context, data: notifNavData);
   }
 
   /// Finds the account associated with the given notification.
@@ -118,25 +72,6 @@ class NotificationOpenService {
       return null;
     }
     return account;
-  }
-
-  /// Provides the route to open by parsing the notification payload.
-  ///
-  /// Returns null and shows an error dialog if the associated account is not
-  /// found in the global store.
-  ///
-  /// The context argument should be a descendant of the app's main [Navigator].
-  static AccountRoute<void>? routeForNotification({
-    required BuildContext context,
-    required NotificationOpenPayload data,
-  }) {
-    final account = _accountForNotification(context: context, data: data);
-    if (account == null) return null;
-
-    return MessageListPage.buildRoute(
-      accountId: account.id,
-      // TODO(#1565): Open at specific message, not just conversation
-      narrow: data.narrow);
   }
 
   /// Navigate appropriately for opening the given notification.

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -34,66 +34,20 @@ class NotificationOpenService {
     _instance = null;
   }
 
-  NotificationDataFromLaunch? _notifDataFromLaunch;
+  void start() {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        _notifPigeonApi.notificationTapEventsStream()
+          .listen(_navigateForNotification);
 
-  /// A [Future] that completes to signal that the initialization of
-  /// [NotificationNavigationService] has completed
-  /// (with either success or failure).
-  ///
-  /// Null if [start] hasn't been called.
-  Future<void>? get initialized => _initializedSignal?.future;
-
-  Completer<void>? _initializedSignal;
-
-  Future<void> start() async {
-    assert(_initializedSignal == null);
-    _initializedSignal = Completer<void>();
-    try {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.iOS:
-          // On iOS, the notification tap that causes a launch of the app is
-          // handled a bit differently than on Android where all types of
-          // notification tap events are served via the
-          // `notificationTapEventsStream`.
-          _notifDataFromLaunch = await _notifPigeonApi.getNotificationDataFromLaunch();
-
-          _notifPigeonApi.notificationTapEventsStream()
-            .listen(_navigateForNotification);
-
-        case TargetPlatform.android:
-          _notifPigeonApi.notificationTapEventsStream()
-            .listen(_navigateForNotification);
-
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.macOS:
-        case TargetPlatform.windows:
-          // Do nothing; we don't offer notifications on these platforms.
-          break;
-      }
-    } finally {
-      _initializedSignal!.complete();
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        // Do nothing; we don't offer notifications on these platforms.
+        break;
     }
-  }
-
-  /// Provides the route to open if the app was launched through a tap on
-  /// a notification.
-  ///
-  /// Returns null if app launch wasn't triggered by a notification, or if
-  /// an error occurs while determining the route for the notification.
-  /// In the latter case an error dialog is also shown.
-  ///
-  /// The context argument should be a descendant of the app's main [Navigator].
-  AccountRoute<void>? routeForNotificationFromLaunch({required BuildContext context}) {
-    assert(defaultTargetPlatform == TargetPlatform.iOS);
-    final data = _notifDataFromLaunch;
-    if (data == null) return null;
-    assert(debugLog('opened notif: ${jsonEncode(data.payload)}'));
-
-    final notifNavData = _tryParseIosApnsPayload(context, data.payload);
-    if (notifNavData == null) return null; // TODO(log)
-
-    return routeForNotification(context: context, data: notifNavData);
   }
 
   /// Finds the account associated with the given notification.
@@ -119,25 +73,6 @@ class NotificationOpenService {
       return null;
     }
     return account;
-  }
-
-  /// Provides the route to open by parsing the notification payload.
-  ///
-  /// Returns null and shows an error dialog if the associated account is not
-  /// found in the global store.
-  ///
-  /// The context argument should be a descendant of the app's main [Navigator].
-  static AccountRoute<void>? routeForNotification({
-    required BuildContext context,
-    required NotificationOpenPayload data,
-  }) {
-    final account = _accountForNotification(context: context, data: data);
-    if (account == null) return null;
-
-    return MessageListPage.buildRoute(
-      accountId: account.id,
-      narrow: data.narrow,
-      initAnchorMessageId: data.messageId);
   }
 
   /// Navigate appropriately for opening the given notification.

--- a/lib/notifications/receive.dart
+++ b/lib/notifications/receive.dart
@@ -64,7 +64,7 @@ class NotificationService {
   }
 
   Future<void> start() async {
-    await NotificationOpenService.instance.start();
+    NotificationOpenService.instance.start();
 
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -9,7 +9,6 @@ import '../log.dart';
 import '../model/actions.dart';
 import '../model/localizations.dart';
 import '../model/store.dart';
-import '../notifications/open.dart';
 import 'about_zulip.dart';
 import 'dialog.dart';
 import 'home.dart';
@@ -183,38 +182,28 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
     super.dispose();
   }
 
-  AccountRoute<void>? _initialRouteIos(BuildContext context) {
-    return NotificationOpenService.instance
-        .routeForNotificationFromLaunch(context: context);
-  }
-
   List<Route<dynamic>> _handleGenerateInitialRoutes(String initialRoute) {
     // The `_ZulipAppState.context` lacks the required ancestors. Instead
     // we use the Navigator which should be available when this callback is
     // called and its context should have the required ancestors.
     final context = ZulipApp.navigatorKey.currentContext!;
 
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      final route = _initialRouteIos(context);
-      if (route != null) {
-        return [
-          HomePage.buildRoute(accountId: route.accountId),
-          route,
-        ];
-      }
-    } else {
-      // On Android, we ignore any notification at this step, and handle
-      // any initial notification by a navigation after the first frame.
-      // See [NotificationOpenService.start], and the buffering in
-      // NotificationTapEventListener.kt when onListen is not yet called.
-      //
-      // The navigation causes a small visible glitch where one loading spinner
-      // gets replaced by another; see recordings:
-      //   https://github.com/zulip/zulip-flutter/pull/2043#discussion_r2794138972
-      // TODO it'd be nice to avoid that glitch by controlling the initial route.
-      //   We accept this glitch as a workaround for an upstream issue:
-      //   https://github.com/flutter/flutter/issues/178305
-    }
+    // We ignore any notification at this step, and handle any initial
+    // notification by a navigation after the first frame.
+    // See [NotificationOpenService.start], and the buffering in
+    // NotificationTapEventListener.kt (on Android) and
+    // NotificationTapEventListener.swift (on iOS) when onListen is not yet
+    // called.
+    //
+    // The navigation causes a small visible glitch where one loading spinner
+    // gets replaced by another.
+    // See recordings for Android (but behaviour is similar on iOS):
+    //   https://github.com/zulip/zulip-flutter/pull/2043#discussion_r2794138972
+    //
+    // TODO(android) consider removing this glitch on Android, either when
+    //   the following upstream issue is fixed:
+    //     https://github.com/flutter/flutter/issues/178305
+    //   or by making a synchronous call to `MainActivity.getIntent` using FFI.
 
     final globalStore = GlobalStoreWidget.of(context);
     final lastVisitedAccountId = globalStore.lastVisitedAccount?.id;
@@ -241,7 +230,6 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     return GlobalStoreWidget(
-      blockingFuture: NotificationOpenService.instance.initialized,
       child: Builder(builder: (context) {
         return MaterialApp(
           onGenerateTitle: (BuildContext context) {

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -9,7 +9,6 @@ import '../log.dart';
 import '../model/actions.dart';
 import '../model/localizations.dart';
 import '../model/store.dart';
-import '../notifications/open.dart';
 import 'about_zulip.dart';
 import 'dialog.dart';
 import 'home.dart';
@@ -183,38 +182,33 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
     super.dispose();
   }
 
-  AccountRoute<void>? _initialRouteIos(BuildContext context) {
-    return NotificationOpenService.instance
-        .routeForNotificationFromLaunch(context: context);
-  }
-
   List<Route<dynamic>> _handleGenerateInitialRoutes(String initialRoute) {
+    // We ignore any notification at this step, and handle any initial
+    // notification by a navigation after the first frame.
+    // See `NotificationOpenService.start`, and the buffering in
+    // NotificationTapEventListener.kt (on Android) and
+    // NotificationTapEventListener.swift (on iOS),
+    // for events that arrive before `onListen` is called.
+    //
+    // That navigation causes a small visible glitch, where one loading
+    // spinner gets replaced by another; and when the notification is for
+    // an account other than the last-visited one, a brief flash of the
+    // latter's home page.
+    // See recordings for Android (the behavior is similar on iOS):
+    //   https://github.com/zulip/zulip-flutter/pull/2043#discussion_r2794138972
+    //
+    // TODO avoid the glitch by controlling the initial route.
+    //   On Android, this may become possible when this upstream issue is fixed:
+    //     https://github.com/flutter/flutter/issues/178305
+    //   Or on both platforms, we could instead have the native side flag whether
+    //   a tap event came from the app's launch, and await the first such event
+    //   (or a report that none is coming) via `GlobalStoreWidget.blockingFuture`
+    //   before generating the initial routes.
+
     // The `_ZulipAppState.context` lacks the required ancestors. Instead
     // we use the Navigator which should be available when this callback is
     // called and its context should have the required ancestors.
     final context = ZulipApp.navigatorKey.currentContext!;
-
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      final route = _initialRouteIos(context);
-      if (route != null) {
-        return [
-          HomePage.buildRoute(accountId: route.accountId),
-          route,
-        ];
-      }
-    } else {
-      // On Android, we ignore any notification at this step, and handle
-      // any initial notification by a navigation after the first frame.
-      // See [NotificationOpenService.start], and the buffering in
-      // NotificationTapEventListener.kt when onListen is not yet called.
-      //
-      // The navigation causes a small visible glitch where one loading spinner
-      // gets replaced by another; see recordings:
-      //   https://github.com/zulip/zulip-flutter/pull/2043#discussion_r2794138972
-      // TODO it'd be nice to avoid that glitch by controlling the initial route.
-      //   We accept this glitch as a workaround for an upstream issue:
-      //   https://github.com/flutter/flutter/issues/178305
-    }
 
     final globalStore = GlobalStoreWidget.of(context);
     final lastVisitedAccountId = globalStore.lastVisitedAccount?.id;
@@ -241,7 +235,6 @@ class _ZulipAppState extends State<ZulipApp> with WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     return GlobalStoreWidget(
-      blockingFuture: NotificationOpenService.instance.initialized,
       child: Builder(builder: (context) {
         return MaterialApp(
           onGenerateTitle: (BuildContext context) {

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -9,16 +9,6 @@ import 'package:pigeon/pigeon.dart';
   kotlinOptions: KotlinOptions(package: 'com.zulip.flutter.notifications'),
 ))
 
-class NotificationDataFromLaunch {
-  const NotificationDataFromLaunch({required this.payload});
-
-  /// The raw payload that is attached to the notification,
-  /// holding the information required to carry out the navigation.
-  ///
-  /// See [NotificationHostApi.getNotificationDataFromLaunch].
-  final Map<Object?, Object?> payload;
-}
-
 sealed class NotificationTapEvent {
   const NotificationTapEvent();
 }
@@ -49,18 +39,6 @@ class AndroidNotificationTapEvent extends NotificationTapEvent {
   ///
   /// See [notificationTapEvents].
   final String dataUrl;
-}
-
-@HostApi()
-abstract class NotificationHostApi {
-  /// Retrieves notification data if the app was launched by tapping on a notification.
-  ///
-  /// Returns `launchOptions.remoteNotification`,
-  /// which is the raw APNs data dictionary
-  /// if the app launch was opened by a notification tap,
-  /// else null. See Apple doc:
-  ///   https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/remotenotification
-  NotificationDataFromLaunch? getNotificationDataFromLaunch();
 }
 
 /// An event stream that emits a notification payload

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -908,18 +908,6 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
 }
 
 class FakeNotificationPigeonApi implements NotificationPigeonApi {
-  NotificationDataFromLaunch? _notificationDataFromLaunch;
-
-  /// Populates the notification data for launch to be returned
-  /// by [getNotificationDataFromLaunch].
-  void setNotificationDataFromLaunch(NotificationDataFromLaunch? data) {
-    _notificationDataFromLaunch = data;
-  }
-
-  @override
-  Future<NotificationDataFromLaunch?> getNotificationDataFromLaunch() async =>
-    _notificationDataFromLaunch;
-
   final _notificationTapEventsStreamController =
     StreamController<NotificationTapEvent>();
 

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -1000,18 +1000,6 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
 }
 
 class FakeNotificationPigeonApi implements NotificationPigeonApi {
-  NotificationDataFromLaunch? _notificationDataFromLaunch;
-
-  /// Populates the notification data for launch to be returned
-  /// by [getNotificationDataFromLaunch].
-  void setNotificationDataFromLaunch(NotificationDataFromLaunch? data) {
-    _notificationDataFromLaunch = data;
-  }
-
-  @override
-  Future<NotificationDataFromLaunch?> getNotificationDataFromLaunch() async =>
-    _notificationDataFromLaunch;
-
   final _notificationTapEventsStreamController =
     StreamController<NotificationTapEvent>();
 

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -172,54 +172,33 @@ void main() {
       }
     }
 
+    void scheduleNotificationTapEvent(
+      WidgetTester tester,
+      Account account,
+      Message message, {
+      bool encrypted = true,
+    }) {
+      final event = switch (defaultTargetPlatform) {
+        TargetPlatform.android => AndroidNotificationTapEvent(
+          dataUrl: notificationUrlForMessage(account, message).toString()),
+        TargetPlatform.iOS => IosNotificationTapEvent(
+          payload: messageApnsPayload(account, message, encrypted: encrypted)),
+        _ => throw UnsupportedError('Unsupported target platform: "$defaultTargetPlatform"'),
+      };
+
+      // Set up an event to be emitted from
+      // `notificationPigeonApi.notificationTapEventsStream`.
+      testBinding.notificationPigeonApi.addNotificationTapEvent(event);
+    }
+
     Future<void> openNotification(
       WidgetTester tester,
       Account account,
       Message message, {
       bool encrypted = true,
     }) async {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-          final intentDataUrl = notificationUrlForMessage(account, message);
-          testBinding.notificationPigeonApi.addNotificationTapEvent(
-            AndroidNotificationTapEvent(dataUrl: intentDataUrl.toString()));
-          await tester.idle(); // let navigateForNotification find navigator
-
-        case TargetPlatform.iOS:
-          final payload = messageApnsPayload(account, message, encrypted: encrypted);
-          testBinding.notificationPigeonApi.addNotificationTapEvent(
-            IosNotificationTapEvent(payload: payload));
-          await tester.idle(); // let navigateForNotification find navigator
-
-        default:
-          throw UnsupportedError('Unsupported target platform: "$defaultTargetPlatform"');
-      }
-    }
-
-    void setupNotificationDataForLaunch(
-      WidgetTester tester,
-      Account account,
-      Message message, {
-      bool encrypted = true,
-    }) {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-          // Set up an event to be emitted from
-          // `notificationPigeonApi.notificationTapEventsStream`.
-          final intentDataUrl = notificationUrlForMessage(account, message);
-          testBinding.notificationPigeonApi.addNotificationTapEvent(
-            AndroidNotificationTapEvent(dataUrl: intentDataUrl.toString()));
-
-        case TargetPlatform.iOS:
-          // Set up a value to return for
-          // `notificationPigeonApi.getNotificationDataFromLaunch`.
-          final payload = messageApnsPayload(account, message, encrypted: encrypted);
-          testBinding.notificationPigeonApi.setNotificationDataFromLaunch(
-            NotificationDataFromLaunch(payload: payload));
-
-        default:
-          throw UnsupportedError('Unsupported target platform: "$defaultTargetPlatform"');
-      }
+      scheduleNotificationTapEvent(tester, account, message, encrypted: encrypted);
+      await tester.idle(); // let navigateForNotification find navigator
     }
 
     void takeHomePageReplacement(int accountId) {
@@ -381,7 +360,7 @@ void main() {
       addTearDown(testBinding.reset);
       final account = eg.selfAccount;
       final message = eg.streamMessage();
-      setupNotificationDataForLaunch(tester, account, message);
+      scheduleNotificationTapEvent(tester, account, message);
 
       // Now start the app.
       await testBinding.globalStore.add(account, eg.initialSnapshot());
@@ -398,7 +377,7 @@ void main() {
       addTearDown(testBinding.reset);
       final account = eg.selfAccount;
       final message = eg.streamMessage();
-      setupNotificationDataForLaunch(tester, account, message, encrypted: false);
+      scheduleNotificationTapEvent(tester, account, message, encrypted: false);
 
       // Now start the app.
       await testBinding.globalStore.add(account, eg.initialSnapshot());
@@ -420,7 +399,7 @@ void main() {
       await testBinding.globalStore.add(accountA, eg.initialSnapshot());
       await testBinding.globalStore.add(accountB, eg.initialSnapshot(
         realmUsers: [eg.otherUser]));
-      setupNotificationDataForLaunch(tester, accountB, message);
+      scheduleNotificationTapEvent(tester, accountB, message);
 
       await prepare(tester, early: true);
       check(pushedRoutes).isEmpty(); // GlobalStore hasn't loaded yet
@@ -558,20 +537,14 @@ void main() {
           accountB, eg.initialSnapshot(realmUsers: [eg.otherUser]),
           markLastVisited: false);
         check(testBinding.globalStore).lastVisitedAccount.equals(accountA);
-        setupNotificationDataForLaunch(tester, accountB, message);
+        scheduleNotificationTapEvent(tester, accountB, message);
 
         await prepare(tester, early: true);
         check(pushedRoutes).isEmpty(); // GlobalStore hasn't loaded yet
 
         await tester.pump();
-        if (defaultTargetPlatform == TargetPlatform.android) {
-          takeHomePageRouteForAccount(accountA.id); // initial account on launch
-          takeHomePageReplacement(accountB.id); // replaced by associated account
-        } else {
-          // On iOS, associated account is determined early while generating
-          // initial routes. See `_ZulipAppState._handleGenerateInitialRoutes`.
-          takeHomePageRouteForAccount(accountB.id);
-        }
+        takeHomePageRouteForAccount(accountA.id); // initial account on launch
+        takeHomePageReplacement(accountB.id); // replaced by associated account
         matchesNavigation(check(pushedRoutes).single, accountB, message);
         check(testBinding.globalStore).lastVisitedAccount.equals(accountB);
       }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -176,54 +176,30 @@ void main() {
       }
     }
 
+    void scheduleNotificationTapEvent(Account account, Message message, {
+      bool encrypted = true,
+    }) {
+      final event = switch (defaultTargetPlatform) {
+        TargetPlatform.android => AndroidNotificationTapEvent(
+          dataUrl: notificationUrlForMessage(account, message).toString()),
+        TargetPlatform.iOS => IosNotificationTapEvent(
+          payload: messageApnsPayload(account, message, encrypted: encrypted)),
+        _ => throw UnsupportedError('Unsupported target platform: "$defaultTargetPlatform"'),
+      };
+
+      // Set up an event to be emitted from
+      // `notificationPigeonApi.notificationTapEventsStream`.
+      testBinding.notificationPigeonApi.addNotificationTapEvent(event);
+    }
+
     Future<void> openNotification(
       WidgetTester tester,
       Account account,
       Message message, {
       bool encrypted = true,
     }) async {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-          final intentDataUrl = notificationUrlForMessage(account, message);
-          testBinding.notificationPigeonApi.addNotificationTapEvent(
-            AndroidNotificationTapEvent(dataUrl: intentDataUrl.toString()));
-          await tester.idle(); // let navigateForNotification find navigator
-
-        case TargetPlatform.iOS:
-          final payload = messageApnsPayload(account, message, encrypted: encrypted);
-          testBinding.notificationPigeonApi.addNotificationTapEvent(
-            IosNotificationTapEvent(payload: payload));
-          await tester.idle(); // let navigateForNotification find navigator
-
-        default:
-          throw UnsupportedError('Unsupported target platform: "$defaultTargetPlatform"');
-      }
-    }
-
-    void setupNotificationDataForLaunch(
-      WidgetTester tester,
-      Account account,
-      Message message, {
-      bool encrypted = true,
-    }) {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-          // Set up an event to be emitted from
-          // `notificationPigeonApi.notificationTapEventsStream`.
-          final intentDataUrl = notificationUrlForMessage(account, message);
-          testBinding.notificationPigeonApi.addNotificationTapEvent(
-            AndroidNotificationTapEvent(dataUrl: intentDataUrl.toString()));
-
-        case TargetPlatform.iOS:
-          // Set up a value to return for
-          // `notificationPigeonApi.getNotificationDataFromLaunch`.
-          final payload = messageApnsPayload(account, message, encrypted: encrypted);
-          testBinding.notificationPigeonApi.setNotificationDataFromLaunch(
-            NotificationDataFromLaunch(payload: payload));
-
-        default:
-          throw UnsupportedError('Unsupported target platform: "$defaultTargetPlatform"');
-      }
+      scheduleNotificationTapEvent(account, message, encrypted: encrypted);
+      await tester.idle(); // let navigateForNotification find navigator
     }
 
     void takeHomePageReplacement(int accountId) {
@@ -388,7 +364,7 @@ void main() {
       addTearDown(testBinding.reset);
       final account = eg.selfAccount;
       final message = eg.streamMessage();
-      setupNotificationDataForLaunch(tester, account, message);
+      scheduleNotificationTapEvent(account, message);
 
       // Now start the app.
       await testBinding.globalStore.add(account, eg.initialSnapshot());
@@ -405,7 +381,7 @@ void main() {
       addTearDown(testBinding.reset);
       final account = eg.selfAccount;
       final message = eg.streamMessage();
-      setupNotificationDataForLaunch(tester, account, message, encrypted: false);
+      scheduleNotificationTapEvent(account, message, encrypted: false);
 
       // Now start the app.
       await testBinding.globalStore.add(account, eg.initialSnapshot());
@@ -418,7 +394,7 @@ void main() {
       matchesNavigation(check(pushedRoutes).single, account, message);
     }, variant: const TargetPlatformVariant({TargetPlatform.iOS}));
 
-    testWidgets('uses associated account as initial account; if initial route', (tester) async {
+    testWidgets('no HomePage replacement when notification is for the last-visited account', (tester) async {
       addTearDown(testBinding.reset);
 
       final accountA = eg.selfAccount;
@@ -427,13 +403,15 @@ void main() {
       await testBinding.globalStore.add(accountA, eg.initialSnapshot());
       await testBinding.globalStore.add(accountB, eg.initialSnapshot(
         realmUsers: [eg.otherUser]));
-      setupNotificationDataForLaunch(tester, accountB, message);
+      check(testBinding.globalStore).lastVisitedAccount.equals(accountB);
+      scheduleNotificationTapEvent(accountB, message);
 
       await prepare(tester, early: true);
       check(pushedRoutes).isEmpty(); // GlobalStore hasn't loaded yet
 
       await tester.pump();
-      takeHomePageRouteForAccount(accountB.id); // because associated account
+      takeHomePageRouteForAccount(accountB.id); // because last-visited account
+      check(lastPoppedRoute).isNull();
       matchesNavigation(check(pushedRoutes).single, accountB, message);
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
@@ -596,20 +574,14 @@ void main() {
           accountB, eg.initialSnapshot(realmUsers: [eg.otherUser]),
           markLastVisited: false);
         check(testBinding.globalStore).lastVisitedAccount.equals(accountA);
-        setupNotificationDataForLaunch(tester, accountB, message);
+        scheduleNotificationTapEvent(accountB, message);
 
         await prepare(tester, early: true);
         check(pushedRoutes).isEmpty(); // GlobalStore hasn't loaded yet
 
         await tester.pump();
-        if (defaultTargetPlatform == TargetPlatform.android) {
-          takeHomePageRouteForAccount(accountA.id); // initial account on launch
-          takeHomePageReplacement(accountB.id); // replaced by associated account
-        } else {
-          // On iOS, associated account is determined early while generating
-          // initial routes. See `_ZulipAppState._handleGenerateInitialRoutes`.
-          takeHomePageRouteForAccount(accountB.id);
-        }
+        takeHomePageRouteForAccount(accountA.id); // initial account on launch
+        takeHomePageReplacement(accountB.id); // replaced by associated account
         matchesNavigation(check(pushedRoutes).single, accountB, message);
         check(testBinding.globalStore).lastVisitedAccount.equals(accountB);
       }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));


### PR DESCRIPTION
It turns out that `userNotificationCenter(_:didReceive:withCompletionHandler:)` does execute when app is terminated and later opened by tapping on a notification, so there is no need to check `launchOptions` in `application(_:didFinishLaunchingWithOptions:)` to handle this case.

But because we currently handle both cases, there is a potential bug where if both are handled, it could cause double navigations for the same notification. This is not observed in practice, probably because we do not buffer events from `userNotificationCenter(_:didReceive:withCompletionHandler:)` currently and those events may be missed until Flutter init is complete and the handler (in NotificationOpenService.init) is setup.

So, remove the unnecessary handlers for `launchOptions`. This also unifies our notification opening implementation between Android and iOS, where we handle all types of notification tap events via the same Pigeon EventChannel API.