### PR TITLE
compose: Use `topicsPolicy` and `realmTopicsPolicy` for per-channel topics policy

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -996,7 +996,7 @@
       }
     }
   },
-  "topicValidationErrorMandatoryButEmpty": "Topics are required in this organization.",
+  "topicValidationErrorMandatoryButEmpty": "Topics are required in this channel.",
   "@topicValidationErrorMandatoryButEmpty": {
     "description": "Topic validation error when topic is required but was empty."
   },

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -790,6 +790,8 @@ class ChannelUpdateEvent extends ChannelEvent {
         return value as bool;
       case ChannelPropertyName.messageRetentionDays:
         return value as int?;
+      case ChannelPropertyName.topicsPolicy:
+        return ChannelTopicsPolicy.fromApiValue(value as String);
       case ChannelPropertyName.channelPostPolicy:
         return ChannelPostPolicy.fromApiValue(value as int);
       case ChannelPropertyName.folderId:

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -556,6 +556,7 @@ const _$ChannelPropertyNameEnumMap = {
   ChannelPropertyName.firstMessageId: 'first_message_id',
   ChannelPropertyName.inviteOnly: 'invite_only',
   ChannelPropertyName.messageRetentionDays: 'message_retention_days',
+  ChannelPropertyName.topicsPolicy: 'topics_policy',
   ChannelPropertyName.channelPostPolicy: 'stream_post_policy',
   ChannelPropertyName.folderId: 'folder_id',
   ChannelPropertyName.canAddSubscribersGroup: 'can_add_subscribers_group',

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -99,7 +99,7 @@ class InitialSnapshot {
   @JsonKey(unknownEnumValue: RealmTopicsPolicy.unknown)
   final RealmTopicsPolicy? realmTopicsPolicy; // TODO(server-11)
 
-  final bool realmMandatoryTopics;
+  final bool? realmMandatoryTopics; // TODO(server-11) Remove deprecated setting.
 
   final String realmName;
 

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -96,6 +96,9 @@ class InitialSnapshot {
   /// Search for "realm_wildcard_mention_policy" in https://zulip.com/api/register-queue.
   final RealmWildcardMentionPolicy realmWildcardMentionPolicy;
 
+  @JsonKey(unknownEnumValue: RealmTopicsPolicy.unknown)
+  final RealmTopicsPolicy? realmTopicsPolicy; // TODO(server-11)
+
   final bool realmMandatoryTopics;
 
   final String realmName;
@@ -199,6 +202,7 @@ class InitialSnapshot {
     required this.realmCanDeleteOwnMessageGroup,
     required this.realmDeleteOwnMessagePolicy,
     required this.realmWildcardMentionPolicy,
+    required this.realmTopicsPolicy,
     required this.realmMandatoryTopics,
     required this.realmName,
     required this.realmWaitingPeriodThreshold,
@@ -255,6 +259,17 @@ enum RealmDeleteOwnMessagePolicy {
   final int apiValue;
 
   int toJson() => apiValue;
+}
+
+/// A value of [InitialSnapshot.realmTopicsPolicy].
+///
+/// For docs, search for "realm_topics_policy"
+/// in <https://zulip.com/api/register-queue>.
+@JsonEnum(fieldRename: FieldRename.snake)
+enum RealmTopicsPolicy {
+  allowEmptyTopic,
+  disableEmptyTopic,
+  unknown;
 }
 
 /// An item in `realm_default_external_accounts`.

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -116,7 +116,7 @@ InitialSnapshot _$InitialSnapshotFromJson(
     json['realm_topics_policy'],
     unknownValue: RealmTopicsPolicy.unknown,
   ),
-  realmMandatoryTopics: json['realm_mandatory_topics'] as bool,
+  realmMandatoryTopics: json['realm_mandatory_topics'] as bool?,
   realmName: json['realm_name'] as String,
   realmWaitingPeriodThreshold: (json['realm_waiting_period_threshold'] as num)
       .toInt(),

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -111,6 +111,11 @@ InitialSnapshot _$InitialSnapshotFromJson(
     _$RealmWildcardMentionPolicyEnumMap,
     json['realm_wildcard_mention_policy'],
   ),
+  realmTopicsPolicy: $enumDecodeNullable(
+    _$RealmTopicsPolicyEnumMap,
+    json['realm_topics_policy'],
+    unknownValue: RealmTopicsPolicy.unknown,
+  ),
   realmMandatoryTopics: json['realm_mandatory_topics'] as bool,
   realmName: json['realm_name'] as String,
   realmWaitingPeriodThreshold: (json['realm_waiting_period_threshold'] as num)
@@ -205,6 +210,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(
   'realm_can_delete_own_message_group': instance.realmCanDeleteOwnMessageGroup,
   'realm_delete_own_message_policy': instance.realmDeleteOwnMessagePolicy,
   'realm_wildcard_mention_policy': instance.realmWildcardMentionPolicy,
+  'realm_topics_policy': _$RealmTopicsPolicyEnumMap[instance.realmTopicsPolicy],
   'realm_mandatory_topics': instance.realmMandatoryTopics,
   'realm_name': instance.realmName,
   'realm_waiting_period_threshold': instance.realmWaitingPeriodThreshold,
@@ -244,6 +250,12 @@ const _$RealmWildcardMentionPolicyEnumMap = {
   RealmWildcardMentionPolicy.admins: 5,
   RealmWildcardMentionPolicy.nobody: 6,
   RealmWildcardMentionPolicy.moderators: 7,
+};
+
+const _$RealmTopicsPolicyEnumMap = {
+  RealmTopicsPolicy.allowEmptyTopic: 'allow_empty_topic',
+  RealmTopicsPolicy.disableEmptyTopic: 'disable_empty_topic',
+  RealmTopicsPolicy.unknown: 'unknown',
 };
 
 RealmDefaultExternalAccount _$RealmDefaultExternalAccountFromJson(

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -812,6 +812,14 @@ enum ChannelTopicsPolicy {
   emptyTopicOnly, // TODO(server-11); added in a later FL than the rest
   unknown;
 
+  /// The [ChannelTopicsPolicy] corresponding to the given [RealmTopicsPolicy].
+  static ChannelTopicsPolicy forRealmPolicy(RealmTopicsPolicy realmPolicy) =>
+    switch (realmPolicy) {
+      .allowEmptyTopic   => .allowEmptyTopic,
+      .disableEmptyTopic => .disableEmptyTopic,
+      .unknown           => .unknown,
+    };
+
   static ChannelTopicsPolicy fromApiValue(String value) => _byApiValue[value] ?? unknown;
 
   static final _byApiValue = _$ChannelTopicsPolicyEnumMap

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -809,7 +809,7 @@ enum ChannelTopicsPolicy {
   inherit,
   allowEmptyTopic,
   disableEmptyTopic,
-  emptyTopicOnly, // TODO(server-11); added in a later FL than the rest
+  emptyTopicOnly,
   unknown;
 
   /// The [ChannelTopicsPolicy] corresponding to the given [RealmTopicsPolicy].

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -683,6 +683,10 @@ class ZulipStream {
   bool isWebPublic; // present since 2.1, according to /api/changelog
   bool historyPublicToSubscribers;
   int? messageRetentionDays;
+  // TODO(server-11) remove default value
+  @JsonKey(defaultValue: ChannelTopicsPolicy.inherit,
+    unknownEnumValue: ChannelTopicsPolicy.unknown)
+  ChannelTopicsPolicy topicsPolicy;
   @JsonKey(name: 'stream_post_policy')
   ChannelPostPolicy? channelPostPolicy; // TODO(server-10) remove
   // final bool isAnnouncementOnly; // deprecated for `channelPostPolicy`; ignore
@@ -709,6 +713,7 @@ class ZulipStream {
     required this.isWebPublic,
     required this.historyPublicToSubscribers,
     required this.messageRetentionDays,
+    required this.topicsPolicy,
     required this.channelPostPolicy,
     required this.folderId,
     required this.canAddSubscribersGroup,
@@ -734,6 +739,7 @@ class ZulipStream {
       isWebPublic: subscription.isWebPublic,
       historyPublicToSubscribers: subscription.historyPublicToSubscribers,
       messageRetentionDays: subscription.messageRetentionDays,
+      topicsPolicy: subscription.topicsPolicy,
       channelPostPolicy: subscription.channelPostPolicy,
       folderId: subscription.folderId,
       canAddSubscribersGroup: subscription.canAddSubscribersGroup,
@@ -771,6 +777,7 @@ enum ChannelPropertyName {
   // isWebPublic is updated via its own [ChannelUpdateEvent] field
   // historyPublicToSubscribers is updated via its own [ChannelUpdateEvent] field
   messageRetentionDays,
+  topicsPolicy,
   @JsonValue('stream_post_policy')
   channelPostPolicy,
   folderId,
@@ -790,6 +797,24 @@ enum ChannelPropertyName {
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.snake`
   static final _byRawString = _$ChannelPropertyNameEnumMap
+    .map((key, value) => MapEntry(value, key));
+}
+
+/// A value of [ZulipStream.topicsPolicy].
+///
+/// For docs, search for "topics_policy"
+/// in <https://zulip.com/api/get-stream-by-id>.
+@JsonEnum(fieldRename: FieldRename.snake)
+enum ChannelTopicsPolicy {
+  inherit,
+  allowEmptyTopic,
+  disableEmptyTopic,
+  emptyTopicOnly, // TODO(server-11); added in a later FL than the rest
+  unknown;
+
+  static ChannelTopicsPolicy fromApiValue(String value) => _byApiValue[value] ?? unknown;
+
+  static final _byApiValue = _$ChannelTopicsPolicyEnumMap
     .map((key, value) => MapEntry(value, key));
 }
 
@@ -858,6 +883,7 @@ class Subscription extends ZulipStream {
     required super.isWebPublic,
     required super.historyPublicToSubscribers,
     required super.messageRetentionDays,
+    required super.topicsPolicy,
     required super.channelPostPolicy,
     required super.folderId,
     required super.canAddSubscribersGroup,

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -266,6 +266,13 @@ ZulipStream _$ZulipStreamFromJson(Map<String, dynamic> json) => ZulipStream(
   isWebPublic: json['is_web_public'] as bool,
   historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
   messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
+  topicsPolicy:
+      $enumDecodeNullable(
+        _$ChannelTopicsPolicyEnumMap,
+        json['topics_policy'],
+        unknownValue: ChannelTopicsPolicy.unknown,
+      ) ??
+      ChannelTopicsPolicy.inherit,
   channelPostPolicy: $enumDecodeNullable(
     _$ChannelPostPolicyEnumMap,
     json['stream_post_policy'],
@@ -304,6 +311,7 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'is_web_public': instance.isWebPublic,
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
+      'topics_policy': _$ChannelTopicsPolicyEnumMap[instance.topicsPolicy]!,
       'stream_post_policy': instance.channelPostPolicy,
       'can_add_subscribers_group': instance.canAddSubscribersGroup,
       'can_delete_any_message_group': instance.canDeleteAnyMessageGroup,
@@ -313,6 +321,14 @@ Map<String, dynamic> _$ZulipStreamToJson(ZulipStream instance) =>
       'is_recently_active': instance.isRecentlyActive,
       'stream_weekly_traffic': instance.streamWeeklyTraffic,
     };
+
+const _$ChannelTopicsPolicyEnumMap = {
+  ChannelTopicsPolicy.inherit: 'inherit',
+  ChannelTopicsPolicy.allowEmptyTopic: 'allow_empty_topic',
+  ChannelTopicsPolicy.disableEmptyTopic: 'disable_empty_topic',
+  ChannelTopicsPolicy.emptyTopicOnly: 'empty_topic_only',
+  ChannelTopicsPolicy.unknown: 'unknown',
+};
 
 const _$ChannelPostPolicyEnumMap = {
   ChannelPostPolicy.any: 1,
@@ -334,6 +350,13 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
   isWebPublic: json['is_web_public'] as bool,
   historyPublicToSubscribers: json['history_public_to_subscribers'] as bool,
   messageRetentionDays: (json['message_retention_days'] as num?)?.toInt(),
+  topicsPolicy:
+      $enumDecodeNullable(
+        _$ChannelTopicsPolicyEnumMap,
+        json['topics_policy'],
+        unknownValue: ChannelTopicsPolicy.unknown,
+      ) ??
+      ChannelTopicsPolicy.inherit,
   channelPostPolicy: $enumDecodeNullable(
     _$ChannelPostPolicyEnumMap,
     json['stream_post_policy'],
@@ -380,6 +403,7 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'is_web_public': instance.isWebPublic,
       'history_public_to_subscribers': instance.historyPublicToSubscribers,
       'message_retention_days': instance.messageRetentionDays,
+      'topics_policy': _$ChannelTopicsPolicyEnumMap[instance.topicsPolicy]!,
       'stream_post_policy': instance.channelPostPolicy,
       'can_add_subscribers_group': instance.canAddSubscribersGroup,
       'can_delete_any_message_group': instance.canDeleteAnyMessageGroup,
@@ -568,6 +592,7 @@ const _$ChannelPropertyNameEnumMap = {
   ChannelPropertyName.firstMessageId: 'first_message_id',
   ChannelPropertyName.inviteOnly: 'invite_only',
   ChannelPropertyName.messageRetentionDays: 'message_retention_days',
+  ChannelPropertyName.topicsPolicy: 'topics_policy',
   ChannelPropertyName.channelPostPolicy: 'stream_post_policy',
   ChannelPropertyName.folderId: 'folder_id',
   ChannelPropertyName.canAddSubscribersGroup: 'can_add_subscribers_group',

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1511,7 +1511,7 @@ abstract class ZulipLocalizations {
   /// Topic validation error when topic is required but was empty.
   ///
   /// In en, this message translates to:
-  /// **'Topics are required in this organization.'**
+  /// **'Topics are required in this channel.'**
   String get topicValidationErrorMandatoryButEmpty;
 
   /// Title for error dialog when an attempt to insert rich content failed.

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -827,7 +827,7 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -824,7 +824,7 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
 
   @override
   String get topicValidationErrorMandatoryButEmpty =>
-      'Topics are required in this organization.';
+      'Topics are required in this channel.';
 
   @override
   String get errorContentNotInsertedTitle => 'Content not inserted';

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -546,6 +546,8 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
             stream.inviteOnly = event.value as bool;
           case ChannelPropertyName.messageRetentionDays:
             stream.messageRetentionDays = event.value as int?;
+          case ChannelPropertyName.topicsPolicy:
+            stream.topicsPolicy = event.value as ChannelTopicsPolicy;
           case ChannelPropertyName.channelPostPolicy:
             stream.channelPostPolicy = event.value as ChannelPostPolicy;
           case ChannelPropertyName.folderId:

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -212,6 +212,20 @@ mixin ChannelStore on UserStore {
     }
   }
 
+  ChannelTopicsPolicy effectiveTopicsPolicy(int channelId) {
+    final channelTopicsPolicy = streams[channelId]?.topicsPolicy;
+
+    if (channelTopicsPolicy case .inherit || null) {
+      final realmTopicsPolicy = this.realmTopicsPolicy
+        ?? (realmMandatoryTopics!
+              ? .disableEmptyTopic
+              : .allowEmptyTopic);
+      return ChannelTopicsPolicy.forRealmPolicy(realmTopicsPolicy);
+    }
+
+    return channelTopicsPolicy;
+  }
+
   bool selfHasContentAccess(ZulipStream channel) {
     // Compare web's stream_data.has_content_access.
     if (channel.isWebPublic) return true;

--- a/lib/model/realm.dart
+++ b/lib/model/realm.dart
@@ -59,7 +59,7 @@ mixin RealmStore on PerAccountStoreBase, UserGroupStore {
   GroupSettingValue? get realmCanDeleteOwnMessageGroup; // TODO(server-10)
   bool get realmEnableReadReceipts;
   RealmTopicsPolicy? get realmTopicsPolicy; // TODO(server-11)
-  bool get realmMandatoryTopics;
+  bool? get realmMandatoryTopics; // TODO(server-11) Remove deprecated setting.
   int get maxFileUploadSizeMib;
   int? get realmMessageContentDeleteLimitSeconds;
   Duration? get realmMessageContentEditLimit =>
@@ -200,7 +200,7 @@ mixin ProxyRealmStore on RealmStore {
   @override
   RealmTopicsPolicy? get realmTopicsPolicy => realmStore.realmTopicsPolicy;
   @override
-  bool get realmMandatoryTopics => realmStore.realmMandatoryTopics;
+  bool? get realmMandatoryTopics => realmStore.realmMandatoryTopics;
   @override
   int get maxFileUploadSizeMib => realmStore.maxFileUploadSizeMib;
   @override
@@ -436,7 +436,7 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
   @override
   final RealmTopicsPolicy? realmTopicsPolicy;
   @override
-  final bool realmMandatoryTopics;
+  final bool? realmMandatoryTopics;
   @override
   final int maxFileUploadSizeMib;
   @override

--- a/lib/model/realm.dart
+++ b/lib/model/realm.dart
@@ -58,6 +58,7 @@ mixin RealmStore on PerAccountStoreBase, UserGroupStore {
   GroupSettingValue? get realmCanDeleteAnyMessageGroup; // TODO(server-10)
   GroupSettingValue? get realmCanDeleteOwnMessageGroup; // TODO(server-10)
   bool get realmEnableReadReceipts;
+  RealmTopicsPolicy? get realmTopicsPolicy; // TODO(server-11)
   bool get realmMandatoryTopics;
   int get maxFileUploadSizeMib;
   int? get realmMessageContentDeleteLimitSeconds;
@@ -197,6 +198,8 @@ mixin ProxyRealmStore on RealmStore {
   @override
   bool get realmEnableReadReceipts => realmStore.realmEnableReadReceipts;
   @override
+  RealmTopicsPolicy? get realmTopicsPolicy => realmStore.realmTopicsPolicy;
+  @override
   bool get realmMandatoryTopics => realmStore.realmMandatoryTopics;
   @override
   int get maxFileUploadSizeMib => realmStore.maxFileUploadSizeMib;
@@ -266,6 +269,7 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
     realmAllowMessageEditing = initialSnapshot.realmAllowMessageEditing,
     realmCanDeleteAnyMessageGroup = initialSnapshot.realmCanDeleteAnyMessageGroup,
     realmCanDeleteOwnMessageGroup = initialSnapshot.realmCanDeleteOwnMessageGroup,
+    realmTopicsPolicy = initialSnapshot.realmTopicsPolicy,
     realmMandatoryTopics = initialSnapshot.realmMandatoryTopics,
     maxFileUploadSizeMib = initialSnapshot.maxFileUploadSizeMib,
     realmMessageContentDeleteLimitSeconds = initialSnapshot.realmMessageContentDeleteLimitSeconds,
@@ -429,6 +433,8 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
   final GroupSettingValue? realmCanDeleteOwnMessageGroup;
   @override
   final bool realmEnableReadReceipts;
+  @override
+  final RealmTopicsPolicy? realmTopicsPolicy;
   @override
   final bool realmMandatoryTopics;
   @override

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -160,7 +160,7 @@ class ComposeTopicController extends ComposeController<TopicValidationError> {
   }
 
   // TODO(#668): listen to [PerAccountStore] once we subscribe to this value
-  bool get mandatory => store.realmMandatoryTopics;
+  bool get mandatory => store.realmMandatoryTopics ?? false;
 
   @override int get maxLengthUnicodeCodePoints => store.maxTopicLength;
 
@@ -826,7 +826,7 @@ class _TopicInputState extends State<_TopicInput> {
     TextStyle hintStyle = topicTextStyle.copyWith(
       color: designVariables.textInput.withFadedAlpha(0.5));
 
-    if (store.realmMandatoryTopics) {
+    if (store.realmMandatoryTopics ?? false) {
       // Something short and not distracting.
       hintText = zulipLocalizations.composeBoxTopicHintText;
     } else {

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -155,12 +155,18 @@ enum TopicValidationError {
 }
 
 class ComposeTopicController extends ComposeController<TopicValidationError> {
-  ComposeTopicController({super.text, required super.store}) {
+  ComposeTopicController({
+    super.text,
+    required super.store,
+    required this.channelId,
+  }) {
     _update();
   }
 
-  // TODO(#668): listen to [PerAccountStore] once we subscribe to this value
-  bool get mandatory => store.realmMandatoryTopics ?? false;
+  final int channelId;
+
+  // TODO(#668): listen to [PerAccountStore] once we subscribe to topic policies.
+  bool get mandatory => store.effectiveTopicsPolicy(channelId) == .disableEmptyTopic;
 
   @override int get maxLengthUnicodeCodePoints => store.maxTopicLength;
 
@@ -826,7 +832,7 @@ class _TopicInputState extends State<_TopicInput> {
     TextStyle hintStyle = topicTextStyle.copyWith(
       color: designVariables.textInput.withFadedAlpha(0.5));
 
-    if (store.realmMandatoryTopics ?? false) {
+    if (widget.controller.topic.mandatory) {
       // Something short and not distracting.
       hintText = zulipLocalizations.composeBoxTopicHintText;
     } else {
@@ -1697,8 +1703,8 @@ enum ComposeTopicInteractionStatus {
 }
 
 class StreamComposeBoxController extends ComposeBoxController {
-  StreamComposeBoxController({required super.store})
-    : topic = ComposeTopicController(store: store);
+  StreamComposeBoxController({required super.store, required int channelId})
+    : topic = ComposeTopicController(store: store, channelId: channelId);
 
   final ComposeTopicController topic;
   final topicFocusNode = FocusNode();
@@ -2225,8 +2231,8 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
   void _setNewController(PerAccountStore store) {
     _controller?.dispose(); // `?.` because this might be the first call
     switch (widget.narrow) {
-      case ChannelNarrow():
-        _controller = StreamComposeBoxController(store: store);
+      case ChannelNarrow(:final channelId):
+        _controller = StreamComposeBoxController(store: store, channelId: channelId);
       case TopicNarrow():
       case DmNarrow():
         _controller = FixedDestinationComposeBoxController(store: store);

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1430,6 +1430,7 @@ InitialSnapshot initialSnapshot({
   GroupSettingValue? realmCanDeleteOwnMessageGroup,
   RealmDeleteOwnMessagePolicy? realmDeleteOwnMessagePolicy,
   RealmWildcardMentionPolicy? realmWildcardMentionPolicy,
+  RealmTopicsPolicy? realmTopicsPolicy,
   bool? realmMandatoryTopics,
   String? realmName,
   int? realmWaitingPeriodThreshold,
@@ -1495,6 +1496,8 @@ InitialSnapshot initialSnapshot({
     realmCanDeleteOwnMessageGroup: realmCanDeleteOwnMessageGroup,
     realmDeleteOwnMessagePolicy: realmDeleteOwnMessagePolicy,
     realmWildcardMentionPolicy: realmWildcardMentionPolicy ?? RealmWildcardMentionPolicy.everyone,
+    // no default; allow `null` to simulate servers without this
+    realmTopicsPolicy: realmTopicsPolicy,
     realmMandatoryTopics: realmMandatoryTopics ?? true,
     realmName: realmName ?? 'Example Zulip organization',
     realmWaitingPeriodThreshold: realmWaitingPeriodThreshold ?? 0,

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -515,6 +515,7 @@ ZulipStream stream({
   bool? isWebPublic,
   bool? historyPublicToSubscribers,
   int? messageRetentionDays,
+  ChannelTopicsPolicy? topicsPolicy,
   ChannelPostPolicy? channelPostPolicy,
   int? folderId,
   GroupSettingValue? canAddSubscribersGroup,
@@ -548,6 +549,7 @@ ZulipStream stream({
     isWebPublic: isWebPublic ?? false,
     historyPublicToSubscribers: historyPublicToSubscribers ?? true,
     messageRetentionDays: messageRetentionDays,
+    topicsPolicy: topicsPolicy ?? .inherit,
     channelPostPolicy: channelPostPolicy ?? ChannelPostPolicy.any,
     folderId: folderId,
     canAddSubscribersGroup: canAddSubscribersGroup ?? GroupSettingValueNamed(nobodyGroup.id),
@@ -594,6 +596,7 @@ Subscription subscription(
     isWebPublic: stream.isWebPublic,
     historyPublicToSubscribers: stream.historyPublicToSubscribers,
     messageRetentionDays: stream.messageRetentionDays,
+    topicsPolicy: stream.topicsPolicy,
     channelPostPolicy: stream.channelPostPolicy,
     folderId: stream.folderId,
     canAddSubscribersGroup: stream.canAddSubscribersGroup,
@@ -1333,6 +1336,8 @@ ChannelUpdateEvent channelUpdateEvent(
       assert(value is bool);
     case ChannelPropertyName.messageRetentionDays:
       assert(value is int?);
+    case ChannelPropertyName.topicsPolicy:
+      assert(value is ChannelTopicsPolicy);
     case ChannelPropertyName.channelPostPolicy:
       assert(value is ChannelPostPolicy);
     case ChannelPropertyName.folderId:

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -1317,7 +1317,9 @@ void main() {
       final description = 'topic-input with text: $markedText produces: ${expectedQuery?.raw ?? 'No Query!'}';
       test(description, () {
         final store = eg.store();
-        final controller = ComposeTopicController(store: store);
+        final controller = ComposeTopicController(
+          store: store,
+          channelId: eg.stream().streamId);
         controller.value = parsed.value;
         if (expectedQuery == null) {
           check(controller).autocompleteIntent.isNull();

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -65,7 +65,7 @@ extension PerAccountStoreChecks on Subject<PerAccountStore> {
   Subject<bool> get isRecoveringEventStream => has((x) => x.isRecoveringEventStream, 'isRecoveringEventStream');
   Subject<Uri> get realmUrl => has((x) => x.realmUrl, 'realmUrl');
   Subject<String> get zulipVersion => has((x) => x.zulipVersion, 'zulipVersion');
-  Subject<bool> get realmMandatoryTopics => has((x) => x.realmMandatoryTopics, 'realmMandatoryTopics');
+  Subject<bool?> get realmMandatoryTopics => has((x) => x.realmMandatoryTopics, 'realmMandatoryTopics');
   Subject<int> get maxFileUploadSizeMib => has((x) => x.maxFileUploadSizeMib, 'maxFileUploadSizeMib');
   Subject<Map<String, RealmDefaultExternalAccount>> get realmDefaultExternalAccounts => has((x) => x.realmDefaultExternalAccounts, 'realmDefaultExternalAccounts');
   Subject<List<CustomProfileField>> get customProfileFields => has((x) => x.customProfileFields, 'customProfileFields');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -13,6 +13,7 @@ import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:zulip/api/model/events.dart';
+import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/narrow.dart';
 import 'package:zulip/api/route/channels.dart';
@@ -65,6 +66,7 @@ void main() {
     List<Subscription> subscriptions = const [],
     List<Message>? messages,
     bool? mandatoryTopics,
+    RealmTopicsPolicy? realmTopicsPolicy,
     int? zulipFeatureLevel,
     int? maxTopicLength,
   }) async {
@@ -91,6 +93,7 @@ void main() {
       streams: streams,
       subscriptions: subscriptions,
       zulipFeatureLevel: zulipFeatureLevel,
+      realmTopicsPolicy: realmTopicsPolicy,
       realmMandatoryTopics: mandatoryTopics,
       realmAllowMessageEditing: true,
       realmMessageContentEditLimitSeconds: null,
@@ -468,6 +471,7 @@ void main() {
 
     Future<void> prepare(WidgetTester tester, {
       required Narrow narrow,
+      RealmTopicsPolicy? realmTopicsPolicy,
       bool? mandatoryTopics,
       int? zulipFeatureLevel,
     }) async {
@@ -475,6 +479,7 @@ void main() {
         narrow: narrow,
         otherUsers: [eg.otherUser, eg.thirdUser],
         subscriptions: [eg.subscription(channel)],
+        realmTopicsPolicy: realmTopicsPolicy,
         mandatoryTopics: mandatoryTopics,
         zulipFeatureLevel: zulipFeatureLevel);
     }
@@ -501,7 +506,7 @@ void main() {
       final narrow = ChannelNarrow(channel.streamId);
 
       testWidgets('with empty topic, topic input has focus', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterTopic(tester, narrow: narrow, topic: '');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -521,7 +526,7 @@ void main() {
       });
 
       testWidgets('with non-empty but vacuous topic, topic input has focus', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterTopic(tester, narrow: narrow,
           topic: eg.defaultRealmEmptyTopicDisplayName);
         await tester.pump();
@@ -532,7 +537,7 @@ void main() {
       });
 
       testWidgets('with empty topic, topic input has focus, then content input gains focus', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterTopic(tester, narrow: narrow, topic: '');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -549,7 +554,7 @@ void main() {
       });
 
       testWidgets('with empty topic, topic input has focus, then loses it', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterTopic(tester, narrow: narrow, topic: '');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -565,7 +570,7 @@ void main() {
       });
 
       testWidgets('with empty topic, content input has focus', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterContent(tester, '');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -589,7 +594,7 @@ void main() {
       });
 
       testWidgets('with empty topic, content input has focus, then topic input gains focus', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterContent(tester, '');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -606,7 +611,7 @@ void main() {
       });
 
       testWidgets('with empty topic, content input has focus, then loses it', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterContent(tester, '');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -623,7 +628,7 @@ void main() {
       });
 
       testWidgets('with non-empty topic', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: false);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .allowEmptyTopic);
         await enterTopic(tester, narrow: narrow, topic: 'new topic');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
@@ -637,7 +642,7 @@ void main() {
       final narrow = ChannelNarrow(channel.streamId);
 
       testWidgets('with empty topic', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: true);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .disableEmptyTopic);
         checkComposeBoxHintTexts(tester,
           topicHintText: 'Topic',
           contentHintText: 'Message #${channel.name}');
@@ -653,7 +658,7 @@ void main() {
 
       group('with non-empty but vacuous topics', () {
         testWidgets('realm_empty_topic_display_name', (tester) async {
-          await prepare(tester, narrow: narrow, mandatoryTopics: true);
+          await prepare(tester, narrow: narrow, realmTopicsPolicy: .disableEmptyTopic);
           await enterTopic(tester, narrow: narrow,
             topic: eg.defaultRealmEmptyTopicDisplayName);
           await tester.pump();
@@ -663,7 +668,7 @@ void main() {
         });
 
         testWidgets('"(no topic)"', (tester) async {
-          await prepare(tester, narrow: narrow, mandatoryTopics: true);
+          await prepare(tester, narrow: narrow, realmTopicsPolicy: .disableEmptyTopic);
           await enterTopic(tester, narrow: narrow,
             topic: '(no topic)');
           await tester.pump();
@@ -674,13 +679,83 @@ void main() {
       });
 
       testWidgets('with non-empty topic', (tester) async {
-        await prepare(tester, narrow: narrow, mandatoryTopics: true);
+        await prepare(tester, narrow: narrow, realmTopicsPolicy: .disableEmptyTopic);
         await enterTopic(tester, narrow: narrow, topic: 'new topic');
         await tester.pump();
         checkComposeBoxHintTexts(tester,
           topicHintText: 'Topic',
           contentHintText: 'Message #${channel.name} > new topic');
       });
+    });
+
+    group('to ChannelNarrow, topic policy resolution', () {
+      void doTest(String description, {
+        ChannelTopicsPolicy? channelTopicsPolicy,
+        RealmTopicsPolicy? realmTopicsPolicy,
+        bool? mandatoryTopics,
+        required bool expectAllowsEmpty,
+      }) {
+        assert(
+          (mandatoryTopics == null && channelTopicsPolicy != null && realmTopicsPolicy != null)
+          || (mandatoryTopics != null && channelTopicsPolicy == null && realmTopicsPolicy == null),
+          'Pass either channel and realm policies or mandatoryTopics.');
+
+        testWidgets(description, (tester) async {
+          final channel = eg.stream(topicsPolicy: channelTopicsPolicy);
+          final narrow = ChannelNarrow(channel.streamId);
+          await prepareComposeBox(tester,
+            narrow: narrow,
+            subscriptions: [eg.subscription(channel)],
+            realmTopicsPolicy: realmTopicsPolicy,
+            mandatoryTopics: mandatoryTopics);
+
+          await enterTopic(tester, narrow: narrow, topic: '');
+          await tester.pump();
+          checkComposeBoxHintTexts(tester,
+            topicHintText: expectAllowsEmpty
+              ? 'Enter a topic (skip for “${eg.defaultRealmEmptyTopicDisplayName}”)'
+              : 'Topic',
+            contentHintText: 'Message #${channel.name}');
+        });
+      }
+
+      doTest('channel setting allows empty, realm setting allows empty',
+        channelTopicsPolicy: .allowEmptyTopic,
+        realmTopicsPolicy: .allowEmptyTopic,
+        expectAllowsEmpty: true);
+
+      doTest('channel setting allows empty, realm setting disables empty',
+        channelTopicsPolicy: .allowEmptyTopic,
+        realmTopicsPolicy: .disableEmptyTopic,
+        expectAllowsEmpty: true);
+
+      doTest('channel setting disables empty, realm setting allows empty',
+        channelTopicsPolicy: .disableEmptyTopic,
+        realmTopicsPolicy: .allowEmptyTopic,
+        expectAllowsEmpty: false);
+
+      doTest('channel setting disables empty, realm setting disables empty',
+        channelTopicsPolicy: .disableEmptyTopic,
+        realmTopicsPolicy: .disableEmptyTopic,
+        expectAllowsEmpty: false);
+
+      doTest('channel setting inherits, realm setting allows empty',
+        channelTopicsPolicy: .inherit,
+        realmTopicsPolicy: .allowEmptyTopic,
+        expectAllowsEmpty: true);
+
+      doTest('channel setting inherits, realm setting disables empty',
+        channelTopicsPolicy: .inherit,
+        realmTopicsPolicy: .disableEmptyTopic,
+        expectAllowsEmpty: false);
+
+      doTest('legacy: mandatoryTopics disables empty',
+        mandatoryTopics: true,
+        expectAllowsEmpty: false);
+
+      doTest('legacy: mandatoryTopics allows empty',
+        mandatoryTopics: false,
+        expectAllowsEmpty: true);
     });
 
     group('to TopicNarrow', () {
@@ -1039,7 +1114,9 @@ void main() {
 
     Future<void> setupAndTapSend(WidgetTester tester, {
       required String topicInputText,
-      required bool mandatoryTopics,
+      ChannelTopicsPolicy? channelTopicsPolicy,
+      RealmTopicsPolicy? realmTopicsPolicy,
+      bool? mandatoryTopics,
       int? zulipFeatureLevel,
     }) async {
       TypingNotifier.debugEnable = false;
@@ -1047,11 +1124,12 @@ void main() {
       MessageStoreImpl.debugOutboxEnable = false;
       addTearDown(MessageStoreImpl.debugReset);
 
-      channel = eg.stream();
+      channel = eg.stream(topicsPolicy: channelTopicsPolicy);
       final narrow = ChannelNarrow(channel.streamId);
       await prepareComposeBox(tester,
         narrow: narrow, subscriptions: [eg.subscription(channel)],
         mandatoryTopics: mandatoryTopics,
+        realmTopicsPolicy: realmTopicsPolicy,
         zulipFeatureLevel: zulipFeatureLevel);
 
       await enterTopic(tester, narrow: narrow, topic: topicInputText);
@@ -1064,13 +1142,13 @@ void main() {
       check(connection.takeRequests()).isEmpty();
       checkErrorDialog(tester,
         expectedTitle: 'Message not sent',
-        expectedMessage: 'Topics are required in this organization.');
+        expectedMessage: 'Topics are required in this channel.');
     }
 
     testWidgets('empty topic -> ""', (tester) async {
       await setupAndTapSend(tester,
         topicInputText: '',
-        mandatoryTopics: false);
+        realmTopicsPolicy: .allowEmptyTopic);
       check(connection.lastRequest).isA<http.Request>()
         ..method.equals('POST')
         ..url.path.equals('/api/v1/messages')
@@ -1091,21 +1169,21 @@ void main() {
     testWidgets('if topics are mandatory, reject empty topic', (tester) async {
       await setupAndTapSend(tester,
         topicInputText: '',
-        mandatoryTopics: true);
+        realmTopicsPolicy: .disableEmptyTopic);
       checkMessageNotSent(tester);
     });
 
     testWidgets('if topics are mandatory, reject `realmEmptyTopicDisplayName`', (tester) async {
       await setupAndTapSend(tester,
         topicInputText: eg.defaultRealmEmptyTopicDisplayName,
-        mandatoryTopics: true);
+        realmTopicsPolicy: .disableEmptyTopic);
       checkMessageNotSent(tester);
     });
 
     testWidgets('if topics are mandatory, reject "(no topic)"', (tester) async {
       await setupAndTapSend(tester,
         topicInputText: '(no topic)',
-        mandatoryTopics: true);
+        realmTopicsPolicy: .disableEmptyTopic);
       checkMessageNotSent(tester);
     });
   });


### PR DESCRIPTION
Fixes #1604.
Completes #1956.

First 3 commits are from #1956. This PR specifically addresses the second paragraph of this comment: https://github.com/zulip/zulip-flutter/pull/1956#issuecomment-3639694273
### Changes Made:
1. Added topics policy based handling of topic input in compose box.
2. Updated existing tests to stop using deprecated `realmMandatoryTopics` and replace with `realmTopicsPolicy`.
3. Updated error string for 'mandatory but empty' validation error.

### Doubts:
1. Are TODO comments added for `realmMandatoryTopics` considered unnecessary?
2. I have derived boolean `mandatory` from effective topics policy for code clarity, and because using switch statement on `topicsPolicy` is awkward due to `topicsPolicy.unknown` and `topicsPolicy.inherit`. Is current approach fine?
3. Has the previous author been credited correctly?