### PR TITLE
compose: Update file upload placeholder text newlines to match web behaviour

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -274,6 +274,13 @@ class ComposeContentController extends ComposeController<ContentValidationError>
       : TextRange.collapsed(text.length);
   }
 
+  /// Gets the text on the line where [insertionIndex] is located.
+  String _getLineAtInsertion(TextRange insertionIndex) {
+    final beforeCursor = insertionIndex.textBefore(text);
+    final afterCursor = insertionIndex.textAfter(text);
+    return '${beforeCursor.split('\n').last}${afterCursor.split('\n').first}';
+  }
+
   /// Inserts [newText] in [text], setting off with an empty line before and after.
   ///
   /// Assumes [newText] is not empty and consists entirely of complete lines
@@ -301,6 +308,22 @@ class ComposeContentController extends ComposeController<ContentValidationError>
     } else {
       value = value.replaced(i, '$paddingBefore$newText\n');
     }
+  }
+
+  /// Inserts [newText] in [text], placing it on its own line.
+  ///
+  /// Assumes [newText] is not empty and consists entirely of complete lines
+  /// (each line ends with a newline).
+  ///
+  /// Inserts at [insertionIndex]. If insertion is in a non-empty line,
+  /// prepends a newline so the inserted text starts on its own line.
+  void insertAsOwnLine(String newText) {
+    assert(newText.isNotEmpty);
+    assert(newText.endsWith('\n'));
+    final i = insertionIndex();
+    final isCurrentLineEmpty = _getLineAtInsertion(i).trim().isEmpty;
+    final prefixNewline = isCurrentLineEmpty ? '' : '\n';
+    value = value.replaced(i, '$prefixNewline$newText');
   }
 
   /// Tells the controller that a quote-and-reply has started.
@@ -359,7 +382,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
     final placeholder = inlineLink(linkText, '');
     _uploads[tag] = (filename: filename, placeholder: placeholder);
     notifyListeners(); // _uploads change could affect validationErrors
-    value = value.replaced(insertionIndex(), '$placeholder\n\n');
+    insertAsOwnLine('$placeholder\n');
     return tag;
   }
 

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -330,6 +330,89 @@ void main() {
       });
     });
 
+    group('insertAsOwnLine', () {
+      // Like `parseMarkedText` in test/model/autocomplete_test.dart,
+      //   but a bit different -- could maybe deduplicate some.
+      TextEditingValue parseMarkedText(String markedText) {
+        final textBuffer = StringBuffer();
+        int? insertionPoint;
+        int i = 0;
+        for (final char in markedText.codeUnits) {
+          if (char == 94 /* ^ */) {
+            if (insertionPoint != null) {
+              throw Exception('Test error: too many ^ in input');
+            }
+            insertionPoint = i;
+            continue;
+          }
+          textBuffer.writeCharCode(char);
+          i++;
+        }
+        if (insertionPoint == null) {
+          throw Exception('Test error: expected ^ in input');
+        }
+        return TextEditingValue(text: textBuffer.toString(), selection: TextSelection.collapsed(offset: insertionPoint));
+      }
+
+      /// Test the given `insertAsOwnLine` call, in a convenient format.
+      ///
+      /// In valueBefore, represent the insertion point as "^".
+      /// In expectedValue, represent the collapsed selection as "^".
+      void testInsertAsOwnLine(String description, String valueBefore, String textToInsert, String expectedValue) {
+        test(description, () {
+          store = eg.store();
+          final controller = ComposeContentController(store: store);
+          controller.value = parseMarkedText(valueBefore);
+          controller.insertAsOwnLine(textToInsert);
+          check(controller.value).equals(parseMarkedText(expectedValue));
+        });
+      }
+
+      testInsertAsOwnLine('empty; insert one line',
+        '^', 'a\n', 'a\n^');
+      testInsertAsOwnLine('empty; insert two lines',
+        '^', 'a\nb\n', 'a\nb\n^');
+
+      group('insert at end', () {
+        testInsertAsOwnLine('one empty line; insert one line',
+          '\n^', 'a\n', '\na\n^');
+        testInsertAsOwnLine('one line, incomplete; insert one line',
+          'a^', 'b\n', 'a\nb\n^');
+        testInsertAsOwnLine('one line, complete; insert one line',
+          'a\n^', 'b\n', 'a\nb\n^');
+      });
+
+      group('insert at start', () {
+        testInsertAsOwnLine('one line, incomplete; insert one line',
+          '^a', 'b\n', '\nb\n^a');
+        testInsertAsOwnLine('one line, complete; insert one line',
+          '^a\n', 'b\n', '\nb\n^a\n');
+      });
+
+      group('insert in middle', () {
+        testInsertAsOwnLine('middle of line',
+          'a^a\n', 'b\n', 'a\nb\n^a\n');
+        testInsertAsOwnLine('start of non-empty line, after non-empty line',
+          'a\n^b\n', 'c\n', 'a\n\nc\n^b\n');
+      });
+
+      test('expanded selection uses selection end', () {
+        store = eg.store();
+        final controller = ComposeContentController(store: store);
+        controller.value = const TextEditingValue(
+          text: 'abc',
+          selection: TextSelection(baseOffset: 0, extentOffset: 2),
+        );
+
+        controller.insertAsOwnLine('x\n');
+
+        check(controller.value).equals(const TextEditingValue(
+          text: 'ab\nx\nc',
+          selection: TextSelection(baseOffset: 0, extentOffset: 5),
+        ));
+      });
+    });
+
     group('ContentValidationError.empty', () {
       late ComposeContentController controller;
 
@@ -1165,7 +1248,7 @@ void main() {
         checkNoDialog(tester);
 
         check(controller!.content.text)
-          .equals('see image: [Uploading image.jpg…]()\n\n');
+          .equals('see image: \n[Uploading image.jpg…]()\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -1181,7 +1264,7 @@ void main() {
 
         await tester.pump(const Duration(seconds: 1));
         check(controller!.content.text)
-          .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          .equals('see image: \n[image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n');
         checkAppearsLoading(tester, false);
       });
 
@@ -1213,7 +1296,7 @@ void main() {
         checkNoDialog(tester);
 
         check(controller!.content.text)
-          .equals('see image: [Uploading image.jpg…]()\n\n');
+          .equals('see image: \n[Uploading image.jpg…]()\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -1229,7 +1312,7 @@ void main() {
 
         await tester.pump(const Duration(seconds: 1));
         check(controller!.content.text)
-          .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          .equals('see image: \n[image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n');
         checkAppearsLoading(tester, false);
       });
 
@@ -1263,12 +1346,12 @@ void main() {
       await tester.tap(find.byIcon(ZulipIcons.image));
       await tester.pump();
       check(controller!.content.text)
-        .equals('[Uploading 한국어 파일.txt…]()\n\n');
+        .equals('[Uploading 한국어 파일.txt…]()\n');
 
       await tester.pump(Duration.zero);
       check(controller!.content.text)
         .equals('[한국어 파일.txt]('
-          '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/한국어 파일.txt)\n\n');
+          '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/한국어 파일.txt)\n');
     });
 
     group('attach from keyboard', () {
@@ -1314,7 +1397,7 @@ void main() {
 
         await tester.pump();
         check(controller!.content.text)
-          .equals('see image: [Uploading test.gif…]()\n\n');
+          .equals('see image: \n[Uploading test.gif…]()\n');
         // (the request is checked more thoroughly in API tests)
         check(connection.lastRequest!).isA<http.MultipartRequest>()
           ..method.equals('POST')
@@ -1330,7 +1413,7 @@ void main() {
 
         await tester.pump(Duration.zero);
         check(controller!.content.text)
-          .equals('see image: [test.gif]($uploadUrl)\n\n');
+          .equals('see image: \n[test.gif]($uploadUrl)\n');
         checkAppearsLoading(tester, false);
       });
 
@@ -2207,7 +2290,7 @@ void main() {
         connection.prepare(json: UpdateMessageResult().toJson());
         await tester.tap(find.widgetWithText(ZulipWebUiKitButton, 'Save'));
         checkRequest(messageId,
-          prevContent: 'foo', content: 'some new content[file.jpg](/path/file.jpg)');
+          prevContent: 'foo', content: 'some new content\n[file.jpg](/path/file.jpg)');
         await tester.pump(Duration.zero);
         checkNotInEditingMode(tester, narrow: narrow);
 


### PR DESCRIPTION
Fixes #2227 by ensuring consistent newline behavior before and after the file upload placeholder in the compose box, aligning with web behavior. It includes: 
1. Adding a new line before the `![Uploading](...)` if the file upload is happening in line with text.
2. Reduce the number of newlines from `\n\n` to `\n` after the `![Uploading](...)`

Update tests to reflect these changes and tested the behaviour on Android

Here's a demo of the changes made:

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/0b8753e1-ec1a-4f6d-9a22-fa06cb406dd5" controls width="250"/> | <video src="https://github.com/user-attachments/assets/6d9c273d-e8d8-44ea-a3f1-0a8797364cf3" controls width="250"/> |
