### PR TITLE
inbox: Make channel folders collapsible

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1227,6 +1227,14 @@
   "@inboxEmptyPlaceholderMessage": {
     "description": "Additional centered text on the 'Inbox' page saying that there is no content to show."
   },
+  "pinnedChannelsFolderName": "Pinned channels",
+  "@pinnedChannelsFolderName": {
+    "description": "Label for the channel folder for pinned channels."
+  },
+  "otherChannelsFolderName": "Other channels",
+  "@otherChannelsFolderName": {
+    "description": "Label for the channel folder for other channels."
+  },
   "recentDmConversationsPageTitle": "Direct messages",
   "@recentDmConversationsPageTitle": {
     "description": "Title for the page with a list of DM conversations."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1802,6 +1802,18 @@ abstract class ZulipLocalizations {
   /// **'Use the buttons below to view the combined feed or list of channels.'**
   String get inboxEmptyPlaceholderMessage;
 
+  /// Label for the channel folder for pinned channels.
+  ///
+  /// In en, this message translates to:
+  /// **'Pinned channels'**
+  String get pinnedChannelsFolderName;
+
+  /// Label for the channel folder for other channels.
+  ///
+  /// In en, this message translates to:
+  /// **'Other channels'**
+  String get otherChannelsFolderName;
+
   /// Title for the page with a list of DM conversations.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -1063,6 +1063,12 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'Nutze die Buttons unten, um den kombinierten Feed oder die Liste der Kanäle anzuzeigen.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direktnachrichten';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -1039,6 +1039,12 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -1071,6 +1071,12 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Utilisez les boutons ci-dessous pour voir le fil groupé ou la liste des canaux.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Messages directs';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -1062,6 +1062,12 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
       'Usa i pulsanti qui sotto per visualzzare il feed combinato o la lista dei canali.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Messaggi diretti';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1013,6 +1013,12 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
       '下のボタンを使用して、統合フィードまたはチャンネル一覧を表示します。';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'ダイレクトメッセージ';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -1055,6 +1055,12 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
       'Użyj poniższych przycisków aby skorzystać z widoku mieszanego lub listy kanałów.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Wiadomości bezpośrednie';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -1065,6 +1065,12 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
       'Используйте кнопки внизу для просмотра объединенной ленты или списка каналов.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Личные сообщения';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -1039,6 +1039,12 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Priama správa';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -1072,6 +1072,12 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
       'Uporabite spodnje gumbe za ogled združenega vira ali seznama kanalov.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Neposredna sporočila';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -1056,6 +1056,12 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
       'Скористайтеся кнопками нижче, щоб переглянути об’єднану стрічку або список каналів.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Особисті повідомлення';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -1037,6 +1037,12 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
       'Use the buttons below to view the combined feed or list of channels.';
 
   @override
+  String get pinnedChannelsFolderName => 'Pinned channels';
+
+  @override
+  String get otherChannelsFolderName => 'Other channels';
+
+  @override
   String get recentDmConversationsPageTitle => 'Direct messages';
 
   @override

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import '../api/model/events.dart';
 import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
+import '../generated/l10n/zulip_localizations.dart';
 import 'realm.dart';
 import 'store.dart';
 import 'user.dart';
@@ -62,21 +63,6 @@ mixin ChannelStore on UserStore {
   //    as invalid. See: https://github.com/dart-lang/sdk/issues/61246
   // ignore: valid_regexps
   static final _startsWithEmojiRegex = RegExp(r'^\p{Emoji}', unicode: true);
-
-  /// A compare function for [ChannelFolder]s, using [ChannelFolder.order].
-  ///
-  /// Channels without [ChannelFolder.order] will come first,
-  /// sorted alphabetically.
-  // TODO(server-11) Once [ChannelFolder.order] is required,
-  //   remove alphabetical sorting.
-  static int compareChannelFolders(ChannelFolder a, ChannelFolder b) {
-    return switch ((a.order, b.order)) {
-      (null,   null) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      (null,  int()) => -1,
-      (int(),  null) => 1,
-      (int a, int b) => a.compareTo(b),
-    };
-  }
 
   /// The visibility policy that the self-user has for the given topic.
   ///
@@ -179,6 +165,53 @@ mixin ChannelStore on UserStore {
     }
   }
 
+  /// The channel folder of [channelId],
+  /// including the "PINNED" or "OTHER" pseudo-channels (e.g. for the inbox).
+  UiChannelFolder uiChannelFolder(int channelId) =>
+    switch (streams[channelId]) {
+      Subscription(:final pinToTop) when pinToTop =>
+        UiChannelFolderPseudoPinned(),
+      ZulipStream(:final folderId) when folderId != null =>
+        UiChannelFolderRealmFolder(id: folderId),
+      _ => UiChannelFolderPseudoOther(),
+    };
+
+  /// A compare function for [UiChannelFolder]s,
+  /// using [ChannelFolder.order] for realm channel folders.
+  ///
+  /// Puts "PINNED CHANNELS" first,
+  /// then realm channel folders by [ChannelFolder.order]
+  /// (or alphabetically if that's absent),
+  /// then "OTHER CHANNELS".
+  // TODO(server-11) Once [ChannelFolder.order] is required,
+  //   remove alphabetical sorting and update dartdoc.
+  int compareUiChannelFolders(UiChannelFolder a, UiChannelFolder b) {
+    switch ((a, b)) {
+      case (UiChannelFolderPseudoPinned(), _): return -1;
+      case (_, UiChannelFolderPseudoPinned()): return 1;
+      case (UiChannelFolderPseudoOther(), _): return 1;
+      case (_, UiChannelFolderPseudoOther()): return -1;
+
+      case (
+        UiChannelFolderRealmFolder(id: final idA),
+        UiChannelFolderRealmFolder(id: final idB),
+      ):
+        final folderA = channelFolders[idA];
+        final folderB = channelFolders[idB];
+        if (folderA == null || folderB == null) { // TODO(log)
+          assert(false);
+          return 0;
+        }
+
+        return switch ((folderA.order, folderB.order)) {
+          (null,   null) => folderA.name.toLowerCase().compareTo(folderB.name.toLowerCase()),
+          (null,  int()) => -1,
+          (int(),  null) => 1,
+          (int a, int b) => a.compareTo(b),
+        };
+    }
+  }
+
   bool selfHasContentAccess(ZulipStream channel) {
     // Compare web's stream_data.has_content_access.
     if (channel.isWebPublic) return true;
@@ -270,6 +303,73 @@ enum UserTopicVisibilityEffect {
       _             => UserTopicVisibilityEffect.none,
     };
   }
+}
+
+/// A realm-level channel folder or the "PINNED" or "OTHER" channel folder.
+///
+/// See the Help Center doc:
+///   https://zulip.com/help/channel-folders
+sealed class UiChannelFolder {
+  const UiChannelFolder();
+
+  /// This folder's name, not yet UPPERCASED for the UI.
+  String name({
+    required ChannelStore store,
+    required ZulipLocalizations zulipLocalizations,
+  });
+}
+
+class UiChannelFolderPseudoPinned extends UiChannelFolder {
+  @override
+  String name({required store, required zulipLocalizations}) =>
+    zulipLocalizations.pinnedChannelsFolderName;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! UiChannelFolderPseudoPinned) return false;
+    // Conceptually there's only one value of this type.
+    return true;
+  }
+
+  @override
+  int get hashCode => 'UiChannelFolderPseudoPinned'.hashCode;
+}
+
+class UiChannelFolderPseudoOther extends UiChannelFolder {
+  @override
+  String name({required store, required zulipLocalizations}) =>
+    zulipLocalizations.otherChannelsFolderName;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! UiChannelFolderPseudoOther) return false;
+    // Conceptually there's only one value of this type.
+    return true;
+  }
+
+  @override
+  int get hashCode => 'UiChannelFolderPseudoOther'.hashCode;
+}
+
+class UiChannelFolderRealmFolder extends UiChannelFolder {
+  const UiChannelFolderRealmFolder({required this.id});
+
+  final int id;
+
+  @override
+  String name({required store, required zulipLocalizations}) {
+    final folder = store.channelFolders[id];
+    return folder!.name;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! UiChannelFolderRealmFolder) return false;
+    return id == other.id;
+  }
+
+  @override
+  int get hashCode => Object.hash('UiChannelFolderRealmFolder', id);
 }
 
 mixin ProxyChannelStore on ChannelStore {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -164,7 +164,11 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         return bLastUnreadId.compareTo(aLastUnreadId);
       });
       final section = _InboxListItemChannelSection(
-        streamId, countInStream, streamHasMention, topicItems);
+        streamId: streamId,
+        count: countInStream,
+        hasMention: streamHasMention,
+        items: topicItems,
+      );
       if (sub.pinToTop) {
         pinnedChannelSections.add(section);
       } else {
@@ -234,12 +238,17 @@ class _InboxListItemAllDmsSection extends _InboxListItem {
 }
 
 class _InboxListItemChannelSection extends _InboxListItem {
+  const _InboxListItemChannelSection({
+    required this.streamId,
+    required this.count,
+    required this.hasMention,
+    required this.items,
+  });
+
   final int streamId;
   final int count;
   final bool hasMention;
   final List<InboxChannelSectionTopicData> items;
-
-  const _InboxListItemChannelSection(this.streamId, this.count, this.hasMention, this.items);
 }
 
 @visibleForTesting

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -156,7 +156,6 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         if (!store.isTopicVisible(streamId, topic)) continue;
         final countInTopic = messageIds.length;
         final hasMention = messageIds.any((messageId) => unreadsModel!.mentions.contains(messageId));
-        if (hasMention) streamHasMention = true;
         topicItems.add(InboxChannelSectionTopicData(
           topic: topic,
           count: countInTopic,
@@ -164,6 +163,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
           lastUnreadId: messageIds.last,
         ));
         countInStream += countInTopic;
+        streamHasMention |= hasMention;
       }
       if (countInStream == 0) {
         continue;

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -121,7 +121,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
       dmItems.add((dmNarrow, countInNarrow, hasMention));
       allDmsCount += countInNarrow;
     }
-    if (allDmsCount > 0) {
+    if (dmItems.isNotEmpty) {
       sections.add(_AllDmsSectionData(allDmsCount, allDmsHasMention, dmItems));
     }
 

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -176,9 +176,11 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
       }
     }
 
-    // TODO add PINNED and OTHER folder headers;
-    //   deduplicate sorting code within PINNED and OTHER
+    // TODO deduplicate sorting code within PINNED and OTHER;
+    //   consider realm-level folders too
     if (pinnedChannelSections.isNotEmpty) {
+      final label = zulipLocalizations.pinnedChannelsFolderName;
+      items.add(_InboxListItemFolderHeader(label: label));
       pinnedChannelSections.sort((a, b) {
         final subA = subscriptions[a.streamId]!;
         final subB = subscriptions[b.streamId]!;
@@ -189,6 +191,8 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
     }
 
     if (otherChannelSections.isNotEmpty) {
+      final label = zulipLocalizations.otherChannelsFolderName;
+      items.add(_InboxListItemFolderHeader(label: label));
       otherChannelSections.sort((a, b) {
         final subA = subscriptions[a.streamId]!;
         final subB = subscriptions[b.streamId]!;
@@ -211,6 +215,8 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         itemBuilder: (context, index) {
           final item = items[index];
           switch (item) {
+            case _InboxListItemFolderHeader():
+              return InboxFolderHeaderItem(label: item.label);
             case _InboxListItemAllDmsSection():
               return _AllDmsSection(
                 data: item,
@@ -227,6 +233,15 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
 
 sealed class _InboxListItem {
   const _InboxListItem();
+}
+
+class _InboxListItemFolderHeader extends _InboxListItem {
+  const _InboxListItemFolderHeader({required this.label});
+
+  /// The label for this folder, not yet uppercased.
+  final String label;
+
+  // TODO count, hasMention
 }
 
 class _InboxListItemAllDmsSection extends _InboxListItem {
@@ -357,6 +372,39 @@ abstract class _HeaderItem extends StatelessWidget {
               kind: CounterBadgeKind.unread,
               channelIdForBackground: channelId,
               count: count)),
+        ])));
+
+    return Semantics(container: true,
+      child: result);
+  }
+}
+
+@visibleForTesting
+class InboxFolderHeaderItem extends StatelessWidget {
+  const InboxFolderHeaderItem({super.key, required this.label});
+
+  /// The label for this folder header, not yet uppercased.
+  ///
+  /// The implementation will call [String.toUpperCase] on this.
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    Widget result = ColoredBox(
+      color: designVariables.background, // TODO(design) check if this is the right variable
+      child: Padding(
+        padding: EdgeInsetsDirectional.fromSTEB(14, 8, 12, 8),
+        child: Row(crossAxisAlignment: CrossAxisAlignment.center, spacing: 8, children: [
+          Expanded(
+            child: Text(
+              style: TextStyle(
+                color: designVariables.folderText,
+                fontSize: 16,
+                height: 20 / 16,
+                letterSpacing: proportionalLetterSpacing(context, 0.02, baseFontSize: 16),
+              ).merge(weightVariableTextStyle(context, wght: 600)),
+              label.toUpperCase())),
         ])));
 
     return Semantics(container: true,

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../api/model/model.dart';
 import '../generated/l10n/zulip_localizations.dart';
+import '../model/channel.dart';
 import '../model/narrow.dart';
 import '../model/recent_dm_conversations.dart';
 import '../model/unreads.dart';
@@ -144,8 +145,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
           return subA.pinToTop ? -1 : 1;
         }
 
-        // TODO(i18n) something like JS's String.prototype.localeCompare
-        return subA.name.toLowerCase().compareTo(subB.name.toLowerCase());
+        return ChannelStore.compareChannelsByName(subA, subB);
       });
 
     for (final MapEntry(key: streamId, value: topics) in sortedUnreadStreams) {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -125,8 +125,8 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
       items.addAll(dmItems);
     }
 
-    final pinnedChannelSections = <_InboxListItemChannelSection>[];
-    final otherChannelSections = <_InboxListItemChannelSection>[];
+    final channelSectionsByFolder = <UiChannelFolder, List<_InboxListItemChannelSection>>{};
+
     for (final MapEntry(key: streamId, value: topics) in unreadsModel!.streams.entries) {
       final sub = subscriptions[streamId];
       // Filter out any straggling unreads in unsubscribed streams.
@@ -162,43 +162,31 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         final bLastUnreadId = b.lastUnreadId;
         return bLastUnreadId.compareTo(aLastUnreadId);
       });
-      final section = _InboxListItemChannelSection(
-        streamId: streamId,
-        count: countInStream,
-        hasMention: streamHasMention,
-        items: topicItems,
-      );
-      if (sub.pinToTop) {
-        pinnedChannelSections.add(section);
-      } else {
-        otherChannelSections.add(section);
-      }
+
+      final uiChannelFolder = store.uiChannelFolder(streamId);
+      (channelSectionsByFolder[uiChannelFolder] ??= [])
+        .add(_InboxListItemChannelSection(
+          streamId: streamId,
+          count: countInStream,
+          hasMention: streamHasMention,
+          items: topicItems,
+        ));
     }
 
-    // TODO deduplicate sorting code within PINNED and OTHER;
-    //   consider realm-level folders too
-    if (pinnedChannelSections.isNotEmpty) {
-      final label = zulipLocalizations.pinnedChannelsFolderName;
-      items.add(_InboxListItemFolderHeader(label: label));
-      pinnedChannelSections.sort((a, b) {
+    final sortedFolders = channelSectionsByFolder.keys.toList()
+      ..sort(store.compareUiChannelFolders);
+
+    for (final folder in sortedFolders) {
+      items.add(_InboxListItemFolderHeader(
+        label: folder.name(store: store, zulipLocalizations: zulipLocalizations)));
+      final channelSections = channelSectionsByFolder[folder]!;
+      channelSections.sort((a, b) {
         final subA = subscriptions[a.streamId]!;
         final subB = subscriptions[b.streamId]!;
 
         return ChannelStore.compareChannelsByName(subA, subB);
       });
-      items.addAll(pinnedChannelSections);
-    }
-
-    if (otherChannelSections.isNotEmpty) {
-      final label = zulipLocalizations.otherChannelsFolderName;
-      items.add(_InboxListItemFolderHeader(label: label));
-      otherChannelSections.sort((a, b) {
-        final subA = subscriptions[a.streamId]!;
-        final subB = subscriptions[b.streamId]!;
-
-        return ChannelStore.compareChannelsByName(subA, subB);
-      });
-      items.addAll(otherChannelSections);
+      items.addAll(channelSections);
     }
 
     if (items.isEmpty) {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -280,104 +280,6 @@ class InboxChannelSectionTopicData {
   });
 }
 
-abstract class _HeaderItem extends StatelessWidget {
-  final bool collapsed;
-  final InboxPageState pageState;
-  final int count;
-  final bool hasMention;
-
-  /// A build context within the [_StreamSection] or [_AllDmsSection].
-  ///
-  /// Used to ensure the [_StreamSection] or [_AllDmsSection] that encloses the
-  /// current [_HeaderItem] is visible after being collapsed through this
-  /// [_HeaderItem].
-  final BuildContext sectionContext;
-
-  const _HeaderItem({
-    super.key,
-    required this.collapsed,
-    required this.pageState,
-    required this.count,
-    required this.hasMention,
-    required this.sectionContext,
-  });
-
-  String title(ZulipLocalizations zulipLocalizations);
-  IconData get icon;
-  Color collapsedIconColor(BuildContext context);
-  Color uncollapsedIconColor(BuildContext context);
-  Color uncollapsedBackgroundColor(BuildContext context);
-
-  /// A channel ID, if this represents a channel, else null.
-  int? get channelId;
-
-  Future<void> onCollapseButtonTap() async {
-    if (!collapsed) {
-      await Scrollable.ensureVisible(
-        sectionContext,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
-      );
-    }
-  }
-
-  Future<void> onRowTap();
-
-  @override
-  Widget build(BuildContext context) {
-    final zulipLocalizations = ZulipLocalizations.of(context);
-    final designVariables = DesignVariables.of(context);
-    Widget result = Material(
-      color: collapsed
-        ? designVariables.background // TODO(design) check if this is the right variable
-        : uncollapsedBackgroundColor(context),
-      child: InkWell(
-        // TODO use onRowTap to handle taps that are not on the collapse button.
-        //   Probably we should give the collapse button a 44px or 48px square
-        //   touch target:
-        //     <https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680973>
-        //   But that's in tension with the Figma, which gives these header rows
-        //   40px min height.
-        onTap: onCollapseButtonTap,
-        onLongPress: this is _LongPressable
-          ? (this as _LongPressable).onLongPress
-          : null,
-        child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
-          Padding(padding: const EdgeInsets.all(10),
-            child: Icon(size: 20, color: designVariables.sectionCollapseIcon,
-              collapsed ? ZulipIcons.arrow_right : ZulipIcons.arrow_down)),
-          Icon(size: 18,
-            color: collapsed
-              ? collapsedIconColor(context)
-              : uncollapsedIconColor(context),
-            icon),
-          const SizedBox(width: 5),
-          Expanded(child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Text(
-              style: TextStyle(
-                fontSize: 17,
-                height: (20 / 17),
-                // TODO(design) check if this is the right variable
-                color: designVariables.labelMenuButton,
-              ).merge(weightVariableTextStyle(context, wght: 600)),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              title(zulipLocalizations)))),
-          const SizedBox(width: 12),
-          if (hasMention) const _IconMarker(icon: ZulipIcons.at_sign),
-          Padding(padding: const EdgeInsetsDirectional.only(end: 16),
-            child: CounterBadge(
-              // TODO(design) use CounterKind.quantity, following Figma
-              kind: CounterBadgeKind.unread,
-              channelIdForBackground: channelId,
-              count: count)),
-        ])));
-
-    return Semantics(container: true,
-      child: result);
-  }
-}
-
 @visibleForTesting
 class InboxFolderHeaderItem extends StatelessWidget {
   const InboxFolderHeaderItem({super.key, required this.label});
@@ -477,50 +379,100 @@ class InboxDmItem extends StatelessWidget {
   }
 }
 
-mixin _LongPressable on _HeaderItem {
-  // TODO(#1272) move to _HeaderItem base class
-  //   when DM headers become long-pressable; remove mixin
-  Future<void> onLongPress();
-}
-
 @visibleForTesting
-class InboxChannelHeaderItem extends _HeaderItem with _LongPressable {
-  final Subscription subscription;
-
+class InboxChannelHeaderItem extends StatelessWidget {
   const InboxChannelHeaderItem({
     super.key,
     required this.subscription,
-    required super.collapsed,
-    required super.pageState,
-    required super.count,
-    required super.hasMention,
-    required super.sectionContext,
+    required this.collapsed,
+    required this.pageState,
+    required this.count,
+    required this.hasMention,
+    required this.sectionContext,
   });
 
-  @override String title(ZulipLocalizations zulipLocalizations) =>
-    subscription.name;
-  @override IconData get icon => iconDataForStream(subscription);
-  @override Color collapsedIconColor(context) =>
-    colorSwatchFor(context, subscription).iconOnPlainBackground;
-  @override Color uncollapsedIconColor(context) =>
-    colorSwatchFor(context, subscription).iconOnBarBackground;
-  @override Color uncollapsedBackgroundColor(context) =>
-    colorSwatchFor(context, subscription).barBackground;
-  @override int? get channelId => subscription.streamId;
+  final Subscription subscription;
+  final bool collapsed;
+  final InboxPageState pageState;
+  final int count;
+  final bool hasMention;
 
-  @override Future<void> onCollapseButtonTap() async {
-    await super.onCollapseButtonTap();
+  /// A build context within the [_StreamSection] or [_AllDmsSection].
+  ///
+  /// Used to ensure the [_StreamSection] or [_AllDmsSection] that encloses the
+  /// current [InboxFolderHeaderItem] is visible after being collapsed through this
+  /// [InboxFolderHeaderItem].
+  final BuildContext sectionContext;
+
+  void _onCollapseButtonTap() async {
     if (collapsed) {
       pageState.uncollapseStream(subscription.streamId);
     } else {
+      await Scrollable.ensureVisible(
+        sectionContext,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+      );
       pageState.collapseStream(subscription.streamId);
     }
   }
-  @override Future<void> onRowTap() => onCollapseButtonTap(); // TODO open channel narrow
+
+  void _onLongPress() async {
+    showChannelActionSheet(sectionContext, channelId: subscription.streamId);
+  }
 
   @override
-  Future<void> onLongPress() async {
-    showChannelActionSheet(sectionContext, channelId: subscription.streamId);
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+
+    final swatch = colorSwatchFor(context, subscription);
+
+    Widget result = Material(
+      color: collapsed
+        ? designVariables.background // TODO(design) check if this is the right variable
+        : swatch.barBackground,
+      child: InkWell(
+        // TODO use onRowTap to handle taps that are not on the collapse button.
+        //   Probably we should give the collapse button a 44px or 48px square
+        //   touch target:
+        //     <https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/flutter.3A.20Mark-as-read/near/1680973>
+        //   But that's in tension with the Figma, which gives these header rows
+        //   40px min height.
+        onTap: _onCollapseButtonTap,
+        onLongPress: _onLongPress,
+        child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
+          Padding(padding: const EdgeInsets.all(10),
+            child: Icon(size: 20, color: designVariables.sectionCollapseIcon,
+              collapsed ? ZulipIcons.arrow_right : ZulipIcons.arrow_down)),
+          Icon(size: 18,
+            color: collapsed
+              ? swatch.iconOnPlainBackground
+              : swatch.iconOnBarBackground,
+            iconDataForStream(subscription)),
+          const SizedBox(width: 5),
+          Expanded(child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Text(
+              style: TextStyle(
+                fontSize: 17,
+                height: (20 / 17),
+                // TODO(design) check if this is the right variable
+                color: designVariables.labelMenuButton,
+              ).merge(weightVariableTextStyle(context, wght: 600)),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              subscription.name))),
+          const SizedBox(width: 12),
+          if (hasMention) const _IconMarker(icon: ZulipIcons.at_sign),
+          Padding(padding: const EdgeInsetsDirectional.only(end: 16),
+            child: CounterBadge(
+              // TODO(design) use CounterKind.quantity, following Figma
+              kind: CounterBadgeKind.unread,
+              channelIdForBackground: subscription.streamId,
+              count: count)),
+        ])));
+
+    return Semantics(container: true,
+      child: result);
   }
 }
 

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -31,11 +31,15 @@ abstract class InboxPageState extends State<InboxPageBody> {
 
   void collapseStream(int streamId);
   void uncollapseStream(int streamId);
+
+  bool isFolderCollapsed(UiChannelFolder folder);
+  void toggleFolder(UiChannelFolder folder);
 }
 
 class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStateMixin<InboxPageBody> implements InboxPageState{
   Unreads? unreadsModel;
   RecentDmConversationsView? recentDmConversationsModel;
+  final Set<UiChannelFolder> _collapsedFolders = {};
 
   @override
   bool get allDmsCollapsed => _allDmsCollapsed;
@@ -59,6 +63,22 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
   void uncollapseStream(int streamId) {
     setState(() {
       _collapsedStreamIds.remove(streamId);
+    });
+  }
+
+  @override
+  bool isFolderCollapsed(UiChannelFolder folder) {
+    return _collapsedFolders.contains(folder);
+  }
+
+  @override
+  void toggleFolder(UiChannelFolder folder) {
+    setState(() {
+      if (_collapsedFolders.contains(folder)) {
+        _collapsedFolders.remove(folder);
+      } else {
+        _collapsedFolders.add(folder);
+      }
     });
   }
 
@@ -121,7 +141,8 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
     }
     if (dmItems.isNotEmpty) {
       items.add(_InboxListItemFolderHeader(
-        label: zulipLocalizations.recentDmConversationsSectionHeader));
+        label: zulipLocalizations.recentDmConversationsSectionHeader,
+        folder: null));
       items.addAll(dmItems);
     }
 
@@ -178,7 +199,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
 
     for (final folder in sortedFolders) {
       items.add(_InboxListItemFolderHeader(
-        label: folder.name(store: store, zulipLocalizations: zulipLocalizations)));
+        label: folder.name(store: store, zulipLocalizations: zulipLocalizations), folder: folder));
       final channelSections = channelSectionsByFolder[folder]!;
       channelSections.sort((a, b) {
         final subA = subscriptions[a.streamId]!;
@@ -203,10 +224,33 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
           final item = items[index];
           switch (item) {
             case _InboxListItemFolderHeader():
-              return InboxFolderHeaderItem(label: item.label);
+              final isCollapsed = item.folder != null
+                  ? isFolderCollapsed(item.folder!)
+                  : allDmsCollapsed;
+              return InboxFolderHeaderItem(
+                label: item.label,
+                collapsed: isCollapsed,
+                onTap: () {
+                  if (item.folder != null) {
+                    toggleFolder(item.folder!);
+                  } else {
+                    allDmsCollapsed = !allDmsCollapsed;
+                  }
+                },
+
+              );
+            // case _InboxListItemDmConversation(:final narrow, :final count, :final hasMention):
+            //   return InboxDmItem(narrow: narrow, count: count, hasMention: hasMention);
+            // case _InboxListItemChannelSection(:var streamId):
+            //   final collapsed = collapsedStreamIds.contains(streamId);
+            //   return _StreamSection(data: item, collapsed: collapsed, pageState: this);
+
             case _InboxListItemDmConversation(:final narrow, :final count, :final hasMention):
+              if (allDmsCollapsed) return const SizedBox.shrink();
               return InboxDmItem(narrow: narrow, count: count, hasMention: hasMention);
             case _InboxListItemChannelSection(:var streamId):
+              final folder = store.uiChannelFolder(streamId);
+              if (isFolderCollapsed(folder)) return const SizedBox.shrink();
               final collapsed = collapsedStreamIds.contains(streamId);
               return _StreamSection(data: item, collapsed: collapsed, pageState: this);
           }
@@ -219,10 +263,11 @@ sealed class _InboxListItem {
 }
 
 class _InboxListItemFolderHeader extends _InboxListItem {
-  const _InboxListItemFolderHeader({required this.label});
+  const _InboxListItemFolderHeader({required this.label, this.folder});
 
   /// The label for this folder, not yet uppercased.
   final String label;
+  final UiChannelFolder? folder;
 
   // TODO count, hasMention
 }
@@ -268,36 +313,90 @@ class InboxChannelSectionTopicData {
   });
 }
 
+// @visibleForTesting
+// class InboxFolderHeaderItem extends StatelessWidget {
+//   const InboxFolderHeaderItem({super.key, required this.label});
+//
+//   /// The label for this folder header, not yet uppercased.
+//   ///
+//   /// The implementation will call [String.toUpperCase] on this.
+//   final String label;
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     final designVariables = DesignVariables.of(context);
+//     Widget result = ColoredBox(
+//       color: designVariables.background, // TODO(design) check if this is the right variable
+//       child: Padding(
+//         padding: EdgeInsetsDirectional.fromSTEB(14, 8, 12, 8),
+//         child: Row(crossAxisAlignment: CrossAxisAlignment.center, spacing: 8, children: [
+//           Expanded(
+//             child: Text(
+//               style: TextStyle(
+//                 color: designVariables.folderText,
+//                 fontSize: 16,
+//                 height: 20 / 16,
+//                 letterSpacing: proportionalLetterSpacing(context, 0.02, baseFontSize: 16),
+//               ).merge(weightVariableTextStyle(context, wght: 600)),
+//               label.toUpperCase())),
+//         ])));
+//
+//     return Semantics(container: true,
+//       child: result);
+//   }
+// }
+
 @visibleForTesting
 class InboxFolderHeaderItem extends StatelessWidget {
-  const InboxFolderHeaderItem({super.key, required this.label});
+  const InboxFolderHeaderItem({
+    super.key,
+    required this.label,
+    required this.collapsed,
+    required this.onTap,
 
-  /// The label for this folder header, not yet uppercased.
-  ///
-  /// The implementation will call [String.toUpperCase] on this.
+  });
+
   final String label;
+  final bool collapsed;
+  final VoidCallback onTap;
+
 
   @override
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
-    Widget result = ColoredBox(
-      color: designVariables.background, // TODO(design) check if this is the right variable
-      child: Padding(
-        padding: EdgeInsetsDirectional.fromSTEB(14, 8, 12, 8),
-        child: Row(crossAxisAlignment: CrossAxisAlignment.center, spacing: 8, children: [
-          Expanded(
-            child: Text(
-              style: TextStyle(
-                color: designVariables.folderText,
-                fontSize: 16,
-                height: 20 / 16,
-                letterSpacing: proportionalLetterSpacing(context, 0.02, baseFontSize: 16),
-              ).merge(weightVariableTextStyle(context, wght: 600)),
-              label.toUpperCase())),
-        ])));
+    Widget result = Material(
+      color: designVariables.background,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: EdgeInsetsDirectional.fromSTEB(14, 8, 12, 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            spacing: 4,
+            children: [
+              Text(
+                style: TextStyle(
+                  color: designVariables.folderText,
+                  fontSize: 16,
+                  height: 20 / 16,
+                  letterSpacing: proportionalLetterSpacing(
+                      context, 0.02, baseFontSize: 16),
+                ).merge(weightVariableTextStyle(context, wght: 600)),
+                label.toUpperCase(),
+              ),
+              Icon(
+                size: 20,
+                color: designVariables.sectionCollapseIcon,
+                collapsed ? ZulipIcons.arrow_right : ZulipIcons.arrow_down,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
 
-    return Semantics(container: true,
-      child: result);
+    return Semantics(container: true, child: result);
   }
 }
 
@@ -428,28 +527,42 @@ class InboxChannelHeaderItem extends StatelessWidget {
         onTap: _onCollapseButtonTap,
         onLongPress: _onLongPress,
         child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
-          Padding(padding: const EdgeInsets.all(10),
-            child: Icon(size: 20, color: designVariables.sectionCollapseIcon,
-              collapsed ? ZulipIcons.arrow_right : ZulipIcons.arrow_down)),
-          Icon(size: 18,
-            color: collapsed
-              ? swatch.iconOnPlainBackground
-              : swatch.iconOnBarBackground,
-            iconDataForStream(subscription)),
-          const SizedBox(width: 5),
+          Padding(
+            padding: const EdgeInsets.only(left: 10.0, top: 10.0, bottom: 10.0),
+            child: Icon(size: 18,
+              color: collapsed
+                ? swatch.iconOnPlainBackground
+                : swatch.iconOnBarBackground,
+              iconDataForStream(subscription)),
+          ),
+          const SizedBox(width: 8),
           Expanded(child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Text(
-              style: TextStyle(
-                fontSize: 17,
-                height: (20 / 17),
-                // TODO(design) check if this is the right variable
-                color: designVariables.labelMenuButton,
-              ).merge(weightVariableTextStyle(context, wght: 600)),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              subscription.name))),
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 4,
+                children: [
+                  Flexible(child: Text(
+                      style: TextStyle(
+                        fontSize: 17,
+                        height: (20 / 17),
+                        color: designVariables.labelMenuButton,
+                      ).merge(weightVariableTextStyle(context, wght: 600)),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      subscription.name)),
+                  Icon(
+                    size: 18,
+                    color: collapsed
+                        ? swatch.iconOnPlainBackground
+                        : swatch.iconOnBarBackground,
+                    collapsed ? ZulipIcons.arrow_right : ZulipIcons.arrow_down,
+                  ),
+                ],
+              ))
+          ),
           const SizedBox(width: 12),
+
           if (hasMention) const _IconMarker(icon: ZulipIcons.at_sign),
           Padding(padding: const EdgeInsetsDirectional.only(end: 16),
             child: CounterBadge(
@@ -457,7 +570,8 @@ class InboxChannelHeaderItem extends StatelessWidget {
               kind: CounterBadgeKind.unread,
               channelIdForBackground: subscription.streamId,
               count: count)),
-        ])));
+        ])
+      ));
 
     return Semantics(container: true,
       child: result);

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -346,6 +346,7 @@ class InboxChannelSectionTopicData {
 //   }
 // }
 
+
 @visibleForTesting
 class InboxFolderHeaderItem extends StatelessWidget {
   const InboxFolderHeaderItem({

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -92,19 +92,37 @@ void main() {
     });
   });
 
-  group('channelFolderComparator', () {
-    final folder1 = eg.channelFolder(id: 1, order: null, name: 'M');
-    final folder2 = eg.channelFolder(id: 2, order: null, name: 'n');
-    final folder3 = eg.channelFolder(id: 3, order: 2, name: 'a');
-    final folder4 = eg.channelFolder(id: 4, order: 0, name: 'b');
-    final folder5 = eg.channelFolder(id: 5, order: 1, name: 'c');
+  test('compareUiChannelFolders', () async {
+    final store = eg.store();
 
-    final store = eg.store(initialSnapshot: eg.initialSnapshot(
-      channelFolders: [folder1, folder2, folder3, folder4, folder5]));
+    final folder1 = eg.channelFolder(order: null, name: 'M');
+    final folder2 = eg.channelFolder(order: null, name: 'n');
+    final folder3 = eg.channelFolder(order: 2,    name: 'a');
+    final folder4 = eg.channelFolder(order: 0,    name: 'b');
+    final folder5 = eg.channelFolder(order: 1,    name: 'c');
 
-    final sorted = store.channelFolders.values.toList()
-      .sorted(ChannelStore.compareChannelFolders);
-    check(sorted).deepEquals([folder1, folder2, folder4, folder5, folder3]);
+    await store.addChannelFolders([folder1, folder2, folder3, folder4, folder5]);
+
+    final unsorted = <UiChannelFolder>[
+      UiChannelFolderRealmFolder(id: folder1.id),
+      UiChannelFolderRealmFolder(id: folder2.id),
+      UiChannelFolderRealmFolder(id: folder3.id),
+      UiChannelFolderRealmFolder(id: folder4.id),
+      UiChannelFolderRealmFolder(id: folder5.id),
+      UiChannelFolderPseudoOther(),
+      UiChannelFolderPseudoPinned(),
+    ];
+
+    final sorted = unsorted.toList().sorted(store.compareUiChannelFolders);
+    check(sorted).deepEquals([
+      UiChannelFolderPseudoPinned(),
+      UiChannelFolderRealmFolder(id: folder1.id),
+      UiChannelFolderRealmFolder(id: folder2.id),
+      UiChannelFolderRealmFolder(id: folder4.id),
+      UiChannelFolderRealmFolder(id: folder5.id),
+      UiChannelFolderRealmFolder(id: folder3.id),
+      UiChannelFolderPseudoOther(),
+    ]);
   });
 
   group('SubscriptionEvent', () {

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -397,6 +397,12 @@ extension PerAccountStoreTestExtension on PerAccountStore {
     await handleEvent(ChannelFolderAddEvent(id: 1, channelFolder: channelFolder));
   }
 
+  Future<void> addChannelFolders(Iterable<ChannelFolder> channelFolders) async {
+    for (final channelFolder in channelFolders) {
+      await addChannelFolder(channelFolder);
+    }
+  }
+
   Future<void> setUserTopic(ZulipStream stream, String topic, UserTopicVisibilityPolicy visibilityPolicy) async {
     await handleEvent(eg.userTopicEvent(stream.streamId, topic, visibilityPolicy));
   }

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -136,54 +136,6 @@ void main() {
       .findsNothing();
   }
 
-  // TODO instead of .first, could look for both the row in the list *and*
-  //   in the sticky-header position, or at least target one or the other
-  //   intentionally.
-  final findAllDmsHeader = find.byType(InboxAllDmsHeaderItem).first;
-
-  /// Check details of the "Direct messages" header.
-  ///
-  /// For [findSectionContent], optionally pass a [Finder]
-  /// that will find some of the section's content if it is uncollapsed.
-  /// It will be expected to find something or nothing,
-  /// depending on [expectCollapsed].
-  void checkAllDmsHeader(WidgetTester tester, {
-    Color? expectedBackgroundColor,
-    bool? expectAtSignIcon,
-    bool? expectCollapsed,
-    Finder? findSectionContent,
-  }) {
-    check(findAllDmsHeader).findsOne();
-
-    if (expectAtSignIcon != null) {
-      check(find.descendant(of: findAllDmsHeader, matching: find.byIcon(ZulipIcons.at_sign)))
-        .findsExactly(expectAtSignIcon ? 1 : 0);
-    }
-
-    if (expectCollapsed != null) {
-      check(find.descendant(
-        of: findAllDmsHeader,
-        matching: find.byIcon(
-          expectCollapsed ? ZulipIcons.arrow_right : ZulipIcons.arrow_down))).findsOne();
-
-      final renderObject = tester.renderObject<RenderBox>(findAllDmsHeader);
-      final paintBounds = renderObject.paintBounds;
-
-      // `paints` isn't a [Matcher] so we wrap it with `equals`;
-      // awkward but it works
-      check(renderObject).legacyMatcher(equals(paints..rrect(
-        rrect: RRect.fromRectAndRadius(paintBounds, Radius.zero),
-        style: .fill,
-        color: expectCollapsed
-          ? Colors.white
-          : const HSLColor.fromAHSL(1, 46, 0.35, 0.93).toColor())));
-
-      if (findSectionContent != null) {
-        check(findSectionContent).findsExactly(expectCollapsed ? 0 : 1);
-      }
-    }
-  }
-
   void checkDm(Pattern expectLabelContains, {
     bool expectAtSignIcon = false,
     String? expectCounterBadgeText,
@@ -340,6 +292,13 @@ void main() {
     });
 
     group('folder headers', () {
+      testWidgets('DMs header', (tester) async {
+        await setupPage(tester,
+          users: [eg.selfUser, eg.otherUser],
+          unreadMessages: [eg.dmMessage(from: eg.otherUser, to: [eg.selfUser])]);
+        checkFolderHeader('Direct messages');
+      });
+
       testWidgets('only pinned channels: shows pinned header, no other header', (tester) async {
         final channel = eg.stream();
         await setupPage(tester,
@@ -484,7 +443,7 @@ void main() {
           unreadMessages: [eg.dmMessage(from: eg.otherUser, to: [eg.selfUser],
             flags: [MessageFlag.mentioned])]);
 
-        checkAllDmsHeader(tester, expectAtSignIcon: true);
+        checkFolderHeader('Direct messages');
         checkDm(eg.otherUser.fullName, expectAtSignIcon: true);
       });
 
@@ -494,7 +453,7 @@ void main() {
           unreadMessages: [eg.dmMessage(from: eg.otherUser, to: [eg.selfUser],
             flags: [])]);
 
-        checkAllDmsHeader(tester, expectAtSignIcon: false);
+        checkFolderHeader('Direct messages');
         checkDm(eg.otherUser.fullName, expectAtSignIcon: false);
       });
     });
@@ -574,64 +533,6 @@ void main() {
     });
 
     group('collapsing', () {
-      group('all-DMs section', () {
-        Future<void> tapCollapseIcon(WidgetTester tester) async {
-          checkAllDmsHeader(tester);
-          await tester.tap(find.descendant(
-            of: findAllDmsHeader,
-            matching: find.byWidgetPredicate((widget) =>
-              widget is Icon
-              && (widget.icon == ZulipIcons.arrow_down
-                  || widget.icon == ZulipIcons.arrow_right))));
-          await tester.pump();
-        }
-
-        testWidgets('appearance', (tester) async {
-          await setupVarious(tester);
-
-          final findSectionContent = find.text(eg.otherUser.fullName);
-
-          checkAllDmsHeader(tester,
-            expectCollapsed: false, findSectionContent: findSectionContent);
-          await tapCollapseIcon(tester);
-          checkAllDmsHeader(tester,
-            expectCollapsed: true, findSectionContent: findSectionContent);
-          await tapCollapseIcon(tester);
-          checkAllDmsHeader(tester,
-            expectCollapsed: false, findSectionContent: findSectionContent);
-        });
-
-        testWidgets('collapse all-DMs section when partially offscreen: '
-          'header remains sticky at top', (tester) async {
-          await setupVarious(tester);
-
-          final listFinder = find.byType(Scrollable);
-          final dmFinder = find.text(eg.otherUser.fullName).hitTestable();
-
-          // Scroll part of [_AllDmsSection] offscreen.
-          await dragUntilInvisible(
-            tester, dmFinder, listFinder, const Offset(0, -50));
-
-          // Check that the header is present (which must therefore
-          // be as a sticky header).
-          checkAllDmsHeader(tester, expectCollapsed: false);
-
-          await tapCollapseIcon(tester);
-
-          // Check that the header is still visible even after
-          // collapsing the section.
-          checkAllDmsHeader(tester, expectCollapsed: true);
-        });
-
-        // TODO check it remains collapsed even if you scroll far away and back
-
-        // TODO check that it's always uncollapsed when it appears after being
-        //   absent, even if it was collapsed the last time it was present.
-        //   (Could test multiple triggers for its reappearance: it could
-        //   reappear because a new unread arrived, but with #296 it could also
-        //   reappear because of a change in muted-users state.)
-      });
-
       group('stream section', () {
         Future<void> tapCollapseIcon(WidgetTester tester, Subscription subscription) async {
           checkChannelHeader(tester, subscription);

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -290,9 +290,43 @@ void main() {
       check(find.textContaining('There are no unread messages in your inbox.')).findsOne();
     });
 
-    // TODO more checks: ordering, etc.
     testWidgets('page builds; not empty', (tester) async {
       await setupVarious(tester);
+    });
+
+    group('channel sorting', () {
+      testWidgets('channels with names starting with an emoji sort before others', (tester) async {
+        final channelBeta   = eg.stream(name: 'Beta Stream');
+        final channelRocket = eg.stream(name: '🚀 Rocket Stream');
+        final channelAlpha  = eg.stream(name: 'Alpha Stream');
+        await setupPage(tester,
+          users: [eg.selfUser, eg.otherUser],
+          streams: [channelBeta, channelRocket, channelAlpha],
+          subscriptions: [
+            eg.subscription(channelBeta),
+            eg.subscription(channelRocket),
+            eg.subscription(channelAlpha),
+          ],
+          unreadMessages: [
+            // Add an unread DM to shift the channel headers downward,
+            // preventing a channel header being duplicated in the widget tree
+            // as a sticky header.
+            eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
+
+            eg.streamMessage(stream: channelBeta),
+            eg.streamMessage(stream: channelRocket),
+            eg.streamMessage(stream: channelAlpha),
+          ]);
+
+        final listedChannelIds =
+          tester.widgetList<InboxChannelHeaderItem>(find.byType(InboxChannelHeaderItem))
+            .map((item) => item.subscription.streamId).toList();
+        check(listedChannelIds).deepEquals([
+          channelRocket.streamId,
+          channelAlpha.streamId,
+          channelBeta.streamId,
+        ]);
+      });
     });
 
     testWidgets('UnreadCountBadge text color for a channel', (tester) async {

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -65,6 +65,7 @@ void main() {
   Future<void> setupPage(WidgetTester tester, {
     List<ZulipStream>? streams,
     List<Subscription>? subscriptions,
+    List<ChannelFolder>? channelFolders,
     List<User>? users,
     required List<Message> unreadMessages,
     List<Message>? otherMessages,
@@ -76,6 +77,7 @@ void main() {
 
     await store.addStreams(streams ?? []);
     await store.addSubscriptions(subscriptions ?? []);
+    await store.addChannelFolders(channelFolders ?? []);
     await store.addUsers(users ?? [eg.selfUser]);
 
     for (final message in unreadMessages) {
@@ -299,22 +301,30 @@ void main() {
         checkFolderHeader('Direct messages');
       });
 
-      testWidgets('only pinned channels: shows pinned header, no other header', (tester) async {
-        final channel = eg.stream();
+      testWidgets('unreads only in pinned channels: shows pinned header, no other header', (tester) async {
+        final pinnedChannel = eg.stream();
+        final unpinnedChannel = eg.stream();
         await setupPage(tester,
-          streams: [channel],
-          subscriptions: [eg.subscription(channel, pinToTop: true)],
-          unreadMessages: [eg.streamMessage(stream: channel)]);
+          streams: [pinnedChannel, unpinnedChannel],
+          subscriptions: [
+            eg.subscription(pinnedChannel, pinToTop: true),
+            eg.subscription(unpinnedChannel, pinToTop: false),
+          ],
+          unreadMessages: [eg.streamMessage(stream: pinnedChannel)]);
         checkFolderHeader('Pinned channels');
         checkNoFolderHeader('Other channels');
       });
 
-      testWidgets('only unpinned channels: shows other header, no pinned header', (tester) async {
-        final channel = eg.stream();
+      testWidgets('unreads only in unpinned channels: shows other header, no pinned header', (tester) async {
+        final pinnedChannel = eg.stream();
+        final unpinnedChannel = eg.stream();
         await setupPage(tester,
-          streams: [channel],
-          subscriptions: [eg.subscription(channel, pinToTop: false)],
-          unreadMessages: [eg.streamMessage(stream: channel)]);
+          streams: [pinnedChannel, unpinnedChannel],
+          subscriptions: [
+            eg.subscription(pinnedChannel, pinToTop: true),
+            eg.subscription(unpinnedChannel, pinToTop: false),
+          ],
+          unreadMessages: [eg.streamMessage(stream: unpinnedChannel)]);
         checkNoFolderHeader('Pinned channels');
         checkFolderHeader('Other channels');
       });
@@ -334,6 +344,110 @@ void main() {
           ]);
         checkFolderHeader('Pinned channels');
         checkFolderHeader('Other channels');
+      });
+
+      testWidgets('channel in a realm folder: shows folder name as header', (tester) async {
+        final folder = eg.channelFolder(name: 'Engineering');
+        final channel = eg.stream(folderId: folder.id);
+        await setupPage(tester,
+          streams: [channel],
+          subscriptions: [eg.subscription(channel)],
+          channelFolders: [folder],
+          unreadMessages: [eg.streamMessage(stream: channel)]);
+        checkFolderHeader('Engineering');
+        checkNoFolderHeader('Pinned channels');
+        checkNoFolderHeader('Other channels');
+      });
+
+      testWidgets('channels in different realm folders: each gets its own header', (tester) async {
+        final folder1 = eg.channelFolder(name: 'Engineering', order: 0);
+        final folder2 = eg.channelFolder(name: 'Marketing', order: 1);
+        final channel1 = eg.stream(folderId: folder1.id);
+        final channel2 = eg.stream(folderId: folder2.id);
+        await setupPage(tester,
+          streams: [channel1, channel2],
+          subscriptions: [
+            eg.subscription(channel1),
+            eg.subscription(channel2),
+          ],
+          channelFolders: [folder1, folder2],
+          unreadMessages: [
+            eg.streamMessage(stream: channel1),
+            eg.streamMessage(stream: channel2),
+          ]);
+        checkFolderHeader('Engineering');
+        checkFolderHeader('Marketing');
+      });
+
+      testWidgets('mix of pinned, realm folder, and other channels', (tester) async {
+        final folder = eg.channelFolder(name: 'Design');
+        final pinned = eg.stream();
+        final inFolder = eg.stream(folderId: folder.id);
+        final other = eg.stream();
+        await setupPage(tester,
+          streams: [pinned, inFolder, other],
+          subscriptions: [
+            eg.subscription(pinned, pinToTop: true),
+            eg.subscription(inFolder),
+            eg.subscription(other),
+          ],
+          channelFolders: [folder],
+          unreadMessages: [
+            eg.streamMessage(stream: pinned),
+            eg.streamMessage(stream: inFolder),
+            eg.streamMessage(stream: other),
+          ]);
+        checkFolderHeader('Pinned channels');
+        checkFolderHeader('Design');
+        checkFolderHeader('Other channels');
+      });
+
+      testWidgets('pinned channel in a realm folder: goes under pinned, not the folder', (tester) async {
+        final folder = eg.channelFolder(name: 'Engineering');
+        final channel = eg.stream(folderId: folder.id);
+        await setupPage(tester,
+          streams: [channel],
+          subscriptions: [eg.subscription(channel, pinToTop: true)],
+          channelFolders: [folder],
+          unreadMessages: [eg.streamMessage(stream: channel)]);
+        checkFolderHeader('Pinned channels');
+        checkNoFolderHeader('Engineering');
+      });
+
+      testWidgets('DMs, pinned, realm folders in order, other', (tester) async {
+        final folder1 = eg.channelFolder(name: 'Zebra', order: 1);
+        final folder2 = eg.channelFolder(name: 'Alpha', order: 0);
+        final pinned = eg.stream();
+        final inFolder1 = eg.stream(folderId: folder1.id);
+        final inFolder2 = eg.stream(folderId: folder2.id);
+        final other = eg.stream();
+        await setupPage(tester,
+          users: [eg.selfUser, eg.otherUser],
+          streams: [pinned, inFolder1, inFolder2, other],
+          subscriptions: [
+            eg.subscription(pinned, pinToTop: true),
+            eg.subscription(inFolder1),
+            eg.subscription(inFolder2),
+            eg.subscription(other),
+          ],
+          channelFolders: [folder1, folder2],
+          unreadMessages: [
+            eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]),
+            eg.streamMessage(stream: pinned),
+            eg.streamMessage(stream: inFolder1),
+            eg.streamMessage(stream: inFolder2),
+            eg.streamMessage(stream: other),
+          ]);
+
+        final headers = tester.widgetList<InboxFolderHeaderItem>(
+          find.byType(InboxFolderHeaderItem)).toList();
+        check(headers.map((h) => h.label)).deepEquals([
+          'Direct messages',
+          'Pinned channels',
+          'Alpha',
+          'Zebra',
+          'Other channels',
+        ]);
       });
     });
 

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -126,6 +126,16 @@ void main() {
       ]);
   }
 
+  void checkFolderHeader(String label) {
+    check(find.widgetWithText(InboxFolderHeaderItem, label.toUpperCase()))
+      .findsOne();
+  }
+
+  void checkNoFolderHeader(String label) {
+    check(find.widgetWithText(InboxFolderHeaderItem, label.toUpperCase()))
+      .findsNothing();
+  }
+
   // TODO instead of .first, could look for both the row in the list *and*
   //   in the sticky-header position, or at least target one or the other
   //   intentionally.
@@ -326,6 +336,45 @@ void main() {
           channelAlpha.streamId,
           channelBeta.streamId,
         ]);
+      });
+    });
+
+    group('folder headers', () {
+      testWidgets('only pinned channels: shows pinned header, no other header', (tester) async {
+        final channel = eg.stream();
+        await setupPage(tester,
+          streams: [channel],
+          subscriptions: [eg.subscription(channel, pinToTop: true)],
+          unreadMessages: [eg.streamMessage(stream: channel)]);
+        checkFolderHeader('Pinned channels');
+        checkNoFolderHeader('Other channels');
+      });
+
+      testWidgets('only unpinned channels: shows other header, no pinned header', (tester) async {
+        final channel = eg.stream();
+        await setupPage(tester,
+          streams: [channel],
+          subscriptions: [eg.subscription(channel, pinToTop: false)],
+          unreadMessages: [eg.streamMessage(stream: channel)]);
+        checkNoFolderHeader('Pinned channels');
+        checkFolderHeader('Other channels');
+      });
+
+      testWidgets('both pinned and unpinned channels: shows both headers', (tester) async {
+        final pinned = eg.stream();
+        final unpinned = eg.stream();
+        await setupPage(tester,
+          streams: [pinned, unpinned],
+          subscriptions: [
+            eg.subscription(pinned, pinToTop: true),
+            eg.subscription(unpinned, pinToTop: false),
+          ],
+          unreadMessages: [
+            eg.streamMessage(stream: pinned),
+            eg.streamMessage(stream: unpinned),
+          ]);
+        checkFolderHeader('Pinned channels');
+        checkFolderHeader('Other channels');
       });
     });
 

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -160,7 +160,7 @@ void main() {
   //   in the sticky-header position, or at least target one or the other
   //   intentionally.
   Finder findChannelHeader(int channelId) => find.byWidgetPredicate((widget) =>
-    widget is InboxChannelHeaderItem && widget.channelId == channelId).first;
+    widget is InboxChannelHeaderItem && widget.subscription.streamId == channelId).first;
 
   /// Check details of a channel header.
   ///


### PR DESCRIPTION
Fixes #2220

Makes the channel folder headers in the inbox collapsible/expandable.
Tapping a folder header will collapse or expand all channels under it.

This builds on top of #2186, which introduces folder headers in the inbox.

Screenshots:

Expanded — all folders showing channels:
![WhatsApp Image 2026-03-20 at 5 59 50 PM (2)](https://github.com/user-attachments/assets/b06d76e7-ad45-4074-b4f6-64929019b1de)

Collapsed —  2 folders, channels hidden:
![WhatsApp Image 2026-03-20 at 5 59 50 PM (1)](https://github.com/user-attachments/assets/0bf74860-15b7-4060-bf11-5dc53e993630)
