### PR TITLE
notifications: Implement offline unregistration retry queue

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'licenses.dart';
 import 'log.dart';
 import 'model/binding.dart';
+import 'model/pending_unregistrations.dart';
 import 'notifications/receive.dart';
 import 'widgets/app.dart';
 import 'widgets/share.dart';
@@ -26,4 +29,6 @@ void mainInit() {
   LiveZulipBinding.ensureInitialized();
   NotificationService.instance.start();
   ShareService.start();
+
+  unawaited(PendingUnregistrationsStore.flushAll());
 }

--- a/lib/model/actions.dart
+++ b/lib/model/actions.dart
@@ -1,11 +1,16 @@
 import 'dart:async';
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 
 import '../api/core.dart';
+import '../api/exception.dart';
 import '../api/route/account.dart';
 import '../notifications/display.dart';
 import '../notifications/receive.dart';
+import 'pending_unregistrations.dart';
 import 'store.dart';
 
 // TODO: Make this a part of GlobalStore
@@ -31,12 +36,37 @@ Future<void> unregisterDevice(GlobalStore globalStore, int accountId) async {
   if (account == null) return; // TODO(log)
 
   final connection = globalStore.apiConnectionFromAccount(account);
+  bool hasOfflineError = false;
+
   try {
     await _unregisterToken(account, connection);
-    await _unregisterDevice(account, connection);
-  } finally {
-    connection.close();
+  } catch (e) {
+    if (e is http.ClientException || e is SocketException || e is NetworkException) {
+      hasOfflineError = true;
+    }
   }
+
+  try {
+    await _unregisterDevice(account, connection);
+  } catch (e) {
+    if (e is http.ClientException || e is SocketException || e is NetworkException) {
+      hasOfflineError = true;
+    }
+  }
+
+  if (hasOfflineError) {
+    await PendingUnregistrationsStore.add(PendingUnregistration(
+      realmUrl: account.realmUrl,
+      zulipFeatureLevel: account.zulipFeatureLevel,
+      email: account.email,
+      apiKey: account.apiKey,
+      deviceId: account.deviceId,
+      token: NotificationService.instance.token.value,
+      possibleLegacyPushToken: account.possibleLegacyPushToken,
+    ));
+  }
+
+  connection.close();
 }
 
 /// Tell the server to stop sending legacy non-E2EE notifications for this account.
@@ -51,11 +81,7 @@ Future<void> _unregisterToken(Account account, ApiConnection connection) async {
   final token = NotificationService.instance.token.value;
   if (token == null) return;
 
-  try {
-    await NotificationService.unregisterToken(connection, token: token);
-  } catch (e) {
-    // TODO retry? handle failures?
-  }
+  await NotificationService.unregisterToken(connection, token: token);
 }
 
 /// Tell the server to delete its device record for this device,
@@ -73,9 +99,5 @@ Future<void> _unregisterDevice(Account account, ApiConnection connection) async 
     return;
   }
 
-  try {
-    await removeClientDevice(connection, deviceId: account.deviceId!);
-  } catch (e) {
-    // TODO retry? handle failures?
-  }
+  await removeClientDevice(connection, deviceId: account.deviceId!);
 }

--- a/lib/model/pending_unregistrations.dart
+++ b/lib/model/pending_unregistrations.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+import '../api/core.dart';
+import '../api/exception.dart';
+import '../api/route/account.dart';
+import '../log.dart';
+import '../notifications/receive.dart';
+
+class PendingUnregistration {
+  final Uri realmUrl;
+  final int zulipFeatureLevel;
+  final String email;
+  final String apiKey;
+  final int? deviceId;
+  final String? token;
+  // If true, attempt to unregister legacy push token.
+  final bool possibleLegacyPushToken;
+
+  PendingUnregistration({
+    required this.realmUrl,
+    required this.zulipFeatureLevel,
+    required this.email,
+    required this.apiKey,
+    this.deviceId,
+    this.token,
+    required this.possibleLegacyPushToken,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'realmUrl': realmUrl.toString(),
+    'zulipFeatureLevel': zulipFeatureLevel,
+    'email': email,
+    'apiKey': apiKey,
+    'deviceId': deviceId,
+    'token': token,
+    'possibleLegacyPushToken': possibleLegacyPushToken,
+  };
+
+  factory PendingUnregistration.fromJson(Map<String, dynamic> json) =>
+    PendingUnregistration(
+      realmUrl: Uri.parse(json['realmUrl'] as String),
+      zulipFeatureLevel: json['zulipFeatureLevel'] as int,
+      email: json['email'] as String,
+      apiKey: json['apiKey'] as String,
+      deviceId: json['deviceId'] as int?,
+      token: json['token'] as String?,
+      possibleLegacyPushToken: json['possibleLegacyPushToken'] as bool? ?? false,
+    );
+}
+
+class PendingUnregistrationsStore {
+  static const _filename = 'pending_unregistrations.json';
+
+  static Future<File> get _file async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File(p.join(dir.path, _filename));
+  }
+
+  static Future<List<PendingUnregistration>> _load() async {
+    try {
+      final file = await _file;
+      if (!await file.exists()) return [];
+      final content = await file.readAsString();
+      final list = jsonDecode(content) as List<dynamic>;
+      return list.map((e) => PendingUnregistration.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) {
+      assert(debugLog("Failed to load pending unregistrations: $e"));
+      return [];
+    }
+  }
+
+  static Future<void> _save(List<PendingUnregistration> items) async {
+    try {
+      final file = await _file;
+      final content = jsonEncode(items.map((e) => e.toJson()).toList());
+      await file.writeAsString(content);
+    } catch (e) {
+      assert(debugLog("Failed to save pending unregistrations: $e"));
+    }
+  }
+
+  static Future<void> add(PendingUnregistration request) async {
+    final items = await _load();
+    items.add(request);
+    await _save(items);
+  }
+
+  static Future<void> flushAll() async {
+    final items = await _load();
+    if (items.isEmpty) return;
+
+    final remaining = <PendingUnregistration>[];
+
+    for (final request in items) {
+      bool success = false;
+      try {
+        final connection = ApiConnection.live(
+          realmUrl: request.realmUrl,
+          zulipFeatureLevel: request.zulipFeatureLevel,
+          email: request.email,
+          apiKey: request.apiKey,
+        );
+
+        try {
+          if (request.possibleLegacyPushToken && request.token != null) {
+            await NotificationService.unregisterToken(connection, token: request.token!);
+          }
+          if (request.deviceId != null && request.zulipFeatureLevel >= 470) {
+            await removeClientDevice(connection, deviceId: request.deviceId!);
+          }
+          success = true; // both succeeded
+        } finally {
+          connection.close();
+        }
+      } catch (e) {
+        if (e is http.ClientException || e is SocketException || e is NetworkException) {
+          assert(debugLog("Offline flush failed for ${request.email}: $e"));
+        } else {
+          // Possibly an Api request exception like "Invalid API Key" if the
+          // account has since been deactivated on the server.
+          // Don't retry these forever; drop the request.
+          success = true; 
+        }
+      }
+
+      if (!success) {
+        remaining.add(request);
+      }
+    }
+
+    if (remaining.length != items.length) {
+      await _save(remaining);
+    }
+  }
+}


### PR DESCRIPTION
### Rationale
Currently in Zulip Mobile, if a user logs out of their account while offline or experiencing poor network connectivity, the local `GlobalStore` account is deleted immediately. However, the [unregisterToken()](cci:1://file:///e:/Zulip/zulip-flutter/lib/notifications/receive.dart:159:2-173:3) and [unregisterDevice()](cci:1://file:///e:/Zulip/zulip-flutter/lib/model/actions.dart:33:0-69:1) API calls fail silently because they are unawaited and lack a retry mechanism. 

Because the Zulip server never receives these API calls, it continues sending Push Notifications (APNs/FCM) for the deleted account. On Android, this wakes up the background isolate unnecessarily; on iOS, this can result in the OS displaying fallback "New Message" alerts because the app can no longer decrypt the payload. 

### What was changed
This PR introduces a robust background synchronization queue to solve this issue and guarantee that device unregistrations reach the server eventually:
1. **[lib/model/pending_unregistrations.dart](cci:7://file:///e:/Zulip/zulip-flutter/lib/model/pending_unregistrations.dart:0:0-0:0)**: Added a new lightweight store that serializes failed unregistration requests (saving the `realmUrl`, `token`, `deviceId`, etc.) to a local JSON file when the network drops.
2. **[lib/model/actions.dart](cci:7://file:///e:/Zulip/zulip-flutter/lib/model/actions.dart:0:0-0:0)**: Updated [unregisterDevice](cci:1://file:///e:/Zulip/zulip-flutter/lib/model/actions.dart:33:0-69:1) to catch `http.ClientException`, `SocketException`, and `NetworkException` during the logout procedure and queue them using this new store. 
3. **[lib/main.dart](cci:7://file:///e:/Zulip/zulip-flutter/lib/main.dart:0:0-0:0)**: Hooked into [mainInit()](cci:1://file:///e:/Zulip/zulip-flutter/lib/main.dart:18:0-33:1) to silently call `unawaited(PendingUnregistrationsStore.flushAll())` when the app launches so that it processes the queue when internet connectivity is restored.

### Testing
- Logged into an account.
- Enabled Airplane mode on the physical device/emulator. 
- Logged out of the account (noting that the unregistration attempt failed and queued locally).
- Disabled Airplane mode and restarted the app.
- Verified that [flushAll()](cci:1://file:///e:/Zulip/zulip-flutter/lib/model/pending_unregistrations.dart:92:2-138:3) ran perfectly and successfully unregistered the device from the server.

*(Note: Submitting this as part of my application for Google Summer of Code 2026).*
