### PR TITLE
analyzer: Exclude build/**

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,8 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
+  exclude:
+    - build/**
   language:
     strict-inference: true
     strict-raw-types: true


### PR DESCRIPTION
This saves ~0.8s on my Mac (~2.3s vs ~3.1s) when running `flutter analyze` after running Patrol tests with `patrol test`. I think that's because `patrol test` creates build/ios_integ/, and it's just a lot of files for the analyzer to process.

(To see that Patrol created build/ios_integ/, I ran `flutter clean` to clear out build/, and saw that build/ios_integ did not appear after a normal `flutter run` but it did appear after `patrol test`.)

If I opt back into Flutter's migration to SwiftPM (i.e. change `enable-swift-package-manager: false`, from 4cc3dd67b, to true), then `patrol test` creates build/ios_integ/SourcePackages/ ...in which the analyzer finds 12,259 errors.