### PR TITLE
Use `ZulipIcons.check` icon for resolved topics in the UI (except topic autocomplete)

### DIFF
--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -504,6 +504,7 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
     TextStyle style = TextStyle(
       fontSize: 17,
       height: 20 / 17,
+      color: designVariables.contextMenuItemLabel,
     ).merge(weightVariableTextStyle(context, wght: 500));
 
     final String text;

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -501,20 +501,11 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
 
     final designVariables = DesignVariables.of(context);
 
-    TextStyle style = TextStyle(
+    final style = TextStyle(
       fontSize: 17,
       height: 20 / 17,
       color: designVariables.contextMenuItemLabel,
     ).merge(weightVariableTextStyle(context, wght: 500));
-
-    final String text;
-    if (option.topic.displayName == null) {
-      final store = PerAccountStoreWidget.of(context);
-      text = store.realmEmptyTopicDisplayName;
-      style = style.copyWith(fontStyle: FontStyle.italic);
-    } else {
-      text = option.topic.displayName!;
-    }
 
     return InkWell(
       onTap: () {
@@ -530,10 +521,14 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
           padding: const EdgeInsetsDirectional.fromSTEB(12, 2, 10, 2),
           child: Align(
             alignment: AlignmentDirectional.centerStart,
-            child: Text(
+            child: Text.rich(
+              topicLabelSpan(
+                context: context,
+                topic: option.topic,
+                fontSize: style.fontSize!,
+                color: style.color!),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
-              style: style,
-              text)))));
+              style: style)))));
   }
 }

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -616,16 +616,21 @@ class MessageListAppBarTitle extends StatelessWidget {
   }) {
     final store = PerAccountStoreWidget.of(context);
     final designVariables = DesignVariables.of(context);
+    // (We customize titleTextStyle for Zulip; see zulipThemeData.)
+    final titleTextStyle = Theme.of(context).appBarTheme.titleTextStyle!;
     final icon = stream == null ? null
       : iconDataForTopicVisibilityPolicy(
           store.topicVisibilityPolicy(stream.streamId, topic));
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Flexible(child: Text(topic.displayName ?? store.realmEmptyTopicDisplayName, style: TextStyle(
-          fontSize: 13,
-          fontStyle: topic.displayName == null ? FontStyle.italic : null,
-        ).merge(weightVariableTextStyle(context)))),
+        Flexible(child: Text.rich(
+          topicLabelSpan(
+            context: context,
+            topic: topic,
+            fontSize: 13,
+            color: titleTextStyle.color!),
+          style: TextStyle(fontSize: 13).merge(weightVariableTextStyle(context)))),
         if (icon != null)
           Padding(
             padding: const EdgeInsetsDirectional.only(start: 4),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1918,18 +1918,22 @@ class StreamMessageRecipientHeader extends StatelessWidget {
           ]));
     }
 
+    final topicStyle = recipientHeaderTextStyle(context);
     final topicWidget = Padding(
       padding: const EdgeInsets.symmetric(vertical: 11),
       child: Row(
         children: [
           Flexible(
-            child: Text(topic.displayName ?? store.realmEmptyTopicDisplayName,
+            child: Text.rich(
+              topicLabelSpan(
+                context: context,
+                topic: topic,
+                fontSize: topicStyle.fontSize!,
+                color: topicStyle.color!),
               // TODO: Give a way to see the whole topic (maybe a
               //   long-press interaction?)
               overflow: TextOverflow.ellipsis,
-              style: recipientHeaderTextStyle(context,
-                fontStyle: topic.displayName == null ? FontStyle.italic : null,
-              ))),
+              style: topicStyle)),
           const SizedBox(width: 4),
           Icon(size: 14, color: designVariables.title.withFadedAlpha(0.5),
             // A null [Icon.icon] makes a blank space.

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -2031,13 +2031,12 @@ class DmRecipientHeader extends StatelessWidget {
   }
 }
 
-TextStyle recipientHeaderTextStyle(BuildContext context, {FontStyle? fontStyle}) {
+TextStyle recipientHeaderTextStyle(BuildContext context) {
   return TextStyle(
     color: DesignVariables.of(context).title,
     fontSize: 16,
     letterSpacing: proportionalLetterSpacing(context, 0.02, baseFontSize: 16),
     height: (18 / 16),
-    fontStyle: fontStyle,
   ).merge(weightVariableTextStyle(context, wght: 600));
 }
 

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -874,8 +874,15 @@ InlineSpan channelTopicLabelSpan({
         color: color,
         padBefore: true,
         padAfter: true),
-      if (topic.displayName != null)
-        TextSpan(text: topic.displayName)
+      if (topic.isResolved)
+        InlineIcon.asWidgetSpan(
+          icon: ZulipIcons.check,
+          fontSize: fontSize,
+          baselineType: baselineType,
+          color: color,
+          padAfter: true),
+      if (topic.unresolve().displayName != null)
+        TextSpan(text: topic.unresolve().displayName)
       else
         TextSpan(
           style: TextStyle(fontStyle: FontStyle.italic),

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -831,12 +831,51 @@ class InlineIcon extends StatelessWidget {
   }
 }
 
+/// An [InlineSpan] with a [ZulipIcons.check] icon (if resolved) and topic name.
+///
+/// Pass this to [Text.rich], which can be styled arbitrarily.
+/// Pass the [fontSize] and [color] of surrounding text
+/// so that the icon is sized and colored appropriately.
+///
+/// For a span with a channel name/icon and optional topic,
+/// see [channelTopicLabelSpan].
+InlineSpan topicLabelSpan({
+  required BuildContext context,
+  required TopicName topic,
+  required double fontSize,
+  required Color color,
+}) {
+  final store = PerAccountStoreWidget.of(context);
+  final baselineType = localizedTextBaseline(context);
+
+  final unresolved = topic.unresolve();
+
+  return TextSpan(children: [
+    if (topic.isResolved)
+      InlineIcon.asWidgetSpan(
+        icon: ZulipIcons.check,
+        fontSize: fontSize,
+        baselineType: baselineType,
+        color: color,
+        padAfter: true),
+    if (unresolved.displayName != null)
+      TextSpan(text: unresolved.displayName)
+    else
+      TextSpan(
+        style: TextStyle(fontStyle: FontStyle.italic),
+        text: store.realmEmptyTopicDisplayName),
+  ]);
+}
+
 /// An [InlineSpan] with a channel privacy icon, channel name,
 /// and optionally a chevron-right icon plus topic.
 ///
 /// Pass this to [Text.rich], which can be styled arbitrarily.
 /// Pass the [fontSize] and [color] of surrounding text
 /// so that the icons are sized and colored appropriately.
+///
+/// For a span with just the topic (including checkmark icon as applicable)
+/// see [topicLabelSpan].
 InlineSpan channelTopicLabelSpan({
   required BuildContext context,
   required int channelId,
@@ -874,19 +913,11 @@ InlineSpan channelTopicLabelSpan({
         color: color,
         padBefore: true,
         padAfter: true),
-      if (topic.isResolved)
-        InlineIcon.asWidgetSpan(
-          icon: ZulipIcons.check,
-          fontSize: fontSize,
-          baselineType: baselineType,
-          color: color,
-          padAfter: true),
-      if (topic.unresolve().displayName != null)
-        TextSpan(text: topic.unresolve().displayName)
-      else
-        TextSpan(
-          style: TextStyle(fontStyle: FontStyle.italic),
-          text: store.realmEmptyTopicDisplayName),
+      topicLabelSpan(
+        context: context,
+        topic: topic,
+        fontSize: fontSize,
+        color: color),
     ],
   ]);
 }

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -882,8 +882,9 @@ void main() {
 
       final topicRow = find.descendant(
         of: find.byType(ZulipAppBar),
-        matching: find.text(
-          effectiveTopic.displayName ?? eg.defaultRealmEmptyTopicDisplayName));
+        matching: find.textContaining(
+          effectiveTopic.unresolve().displayName ?? eg.defaultRealmEmptyTopicDisplayName,
+          findRichText: true));
       await tester.longPress(topicRow);
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -904,7 +904,9 @@ void main() {
 
       await tester.longPress(find.descendant(
         of: find.byType(RecipientHeader),
-        matching: find.text(effectiveMessage.topic.displayName!)));
+        matching: find.textContaining(
+          effectiveMessage.topic.unresolve().displayName!,
+          findRichText: true)));
       // sheet appears onscreen; default duration of bottom-sheet enter animation
       await tester.pump(const Duration(milliseconds: 250));
     }

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -19,6 +19,7 @@ import 'package:zulip/widgets/compose_box.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/message_list.dart';
+import 'package:zulip/widgets/text.dart';
 import 'package:zulip/widgets/user.dart';
 
 import '../api/fake_api.dart';
@@ -688,6 +689,25 @@ void main() {
       await tester.pumpAndSettle();
 
       check(find.text('general chat')).findsOne();
+    });
+
+    testWidgets('show resolved-topic check icon', (tester) async {
+      final topic = eg.getChannelTopicsEntry(name: '✔ some topic');
+      final topicInputFinder = await setupToTopicInput(tester, topics: [topic]);
+
+      // TODO(#226): Remove this extra edit when this bug is fixed.
+      await tester.enterText(topicInputFinder, 'some');
+      await tester.enterText(topicInputFinder, 'some t');
+      await tester.pumpAndSettle();
+
+      final itemFinder = find.ancestor(
+        of: find.textContaining('some topic', findRichText: true),
+        matching: find.byType(InkWell));
+      check(find.descendant(of: itemFinder,
+        matching: find.byWidgetPredicate(
+          (w) => w is InlineIcon && w.icon == ZulipIcons.check))).findsOne();
+      check(find.descendant(of: itemFinder,
+        matching: find.textContaining('✔', findRichText: true))).findsNothing();
     });
 
     testWidgets('autocomplete to realmEmptyTopicDisplayName sets topic to empty string', (tester) async {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -35,6 +35,7 @@ import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/store.dart';
+import 'package:zulip/widgets/text.dart';
 import 'package:zulip/widgets/channel_colors.dart';
 import 'package:zulip/widgets/theme.dart';
 import 'package:zulip/widgets/topic_list.dart';
@@ -249,6 +250,22 @@ void main() {
         messages: [eg.streamMessage(stream: channel, topic: '')]);
       checkAppBarChannelTopic(
         channel.name, eg.defaultRealmEmptyTopicDisplayName);
+    });
+
+    testWidgets('show resolved-topic check icon in topic narrow', (tester) async {
+      final channel = eg.stream();
+      await setupMessageListPage(tester,
+        narrow: eg.topicNarrow(channel.streamId, '✔ some topic'),
+        subscriptions: [eg.subscription(channel)],
+        messages: [eg.streamMessage(stream: channel, topic: '✔ some topic')]);
+      final appBarFinder = find.byType(MessageListAppBarTitle);
+      check(find.descendant(of: appBarFinder,
+        matching: find.byWidgetPredicate(
+          (w) => w is InlineIcon && w.icon == ZulipIcons.check))).findsOne();
+      check(find.descendant(of: appBarFinder,
+        matching: find.textContaining('some topic', findRichText: true))).findsOne();
+      check(find.descendant(of: appBarFinder,
+        matching: find.textContaining('✔', findRichText: true))).findsNothing();
     });
 
     void testChannelIconInChannelRow(IconData expectedIcon, {

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1820,6 +1820,23 @@ void main() {
         check(findInMessageList(eg.defaultRealmEmptyTopicDisplayName)).single;
       });
 
+      testWidgets('show resolved-topic check icon', (tester) async {
+        final message = eg.streamMessage(
+          stream: stream, topic: '✔ some topic');
+        await setupMessageListPage(tester,
+          narrow: const CombinedFeedNarrow(),
+          messages: [message], subscriptions: [eg.subscription(stream)]);
+        await tester.pump();
+        final headerFinder = find.byType(StreamMessageRecipientHeader);
+        check(find.descendant(of: headerFinder,
+          matching: find.byWidgetPredicate(
+            (w) => w is InlineIcon && w.icon == ZulipIcons.check))).findsOne();
+        check(find.descendant(of: headerFinder,
+          matching: find.textContaining('some topic', findRichText: true))).findsOne();
+        check(find.descendant(of: headerFinder,
+          matching: find.textContaining('✔', findRichText: true))).findsNothing();
+      });
+
       testWidgets('show topic visibility icon when followed', (tester) async {
         await setupMessageListPage(tester,
           narrow: const CombinedFeedNarrow(),

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -3,8 +3,11 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/model/model.dart';
+import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/text.dart';
 
+import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import 'test_app.dart';
@@ -418,6 +421,46 @@ void main() {
 
     // "und" is a special language code meaning undefined; see [Locale]
     testLocalizedTextBaseline(const Locale('und'), TextBaseline.alphabetic);
+  });
+
+  group('channelTopicLabelSpan', () {
+    final channel = eg.stream();
+
+    Future<void> prepareWidget(WidgetTester tester, {
+      required TopicName topic,
+    }) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+        streams: [channel],
+        subscriptions: [eg.subscription(channel)]));
+
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        child: Builder(builder: (context) => Text.rich(
+          channelTopicLabelSpan(
+            context: context,
+            channelId: channel.streamId,
+            topic: topic,
+            fontSize: 17,
+            color: Colors.black)))));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
+    }
+
+    Finder findCheckIcon() => find.byWidgetPredicate(
+      (w) => w is InlineIcon && w.icon == ZulipIcons.check);
+
+    testWidgets('resolved topic shows checkmark and strips prefix', (tester) async {
+      await prepareWidget(tester, topic: eg.t('✔ some topic'));
+      check(findCheckIcon()).findsOne();
+      check(find.textContaining('some topic', findRichText: true)).findsOne();
+      check(find.textContaining('✔', findRichText: true)).findsNothing();
+    });
+
+    testWidgets('unresolved topic shows no checkmark', (tester) async {
+      await prepareWidget(tester, topic: eg.t('some topic'));
+      check(findCheckIcon()).findsNothing();
+      check(find.textContaining('some topic', findRichText: true)).findsOne();
+    });
   });
 
   group('TextWithLink', () {

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -423,6 +423,61 @@ void main() {
     testLocalizedTextBaseline(const Locale('und'), TextBaseline.alphabetic);
   });
 
+  group('topicLabelSpan', () {
+    Future<void> prepareWidget(WidgetTester tester, {
+      required TopicName topic,
+      String? realmEmptyTopicDisplayName,
+    }) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+        realmEmptyTopicDisplayName: realmEmptyTopicDisplayName));
+
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        child: Builder(builder: (context) => Text.rich(
+          topicLabelSpan(
+            context: context,
+            topic: topic,
+            fontSize: 17,
+            color: Colors.black)))));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
+    }
+
+    Finder findCheckIcon() => find.byWidgetPredicate(
+      (w) => w is InlineIcon && w.icon == ZulipIcons.check);
+
+    testWidgets('resolved topic shows checkmark and strips prefix', (tester) async {
+      await prepareWidget(tester, topic: eg.t('✔ some topic'));
+      check(findCheckIcon()).findsOne();
+      check(find.textContaining('some topic', findRichText: true)).findsOne();
+      check(find.textContaining('✔', findRichText: true)).findsNothing();
+    });
+
+    testWidgets('unresolved topic shows no checkmark', (tester) async {
+      await prepareWidget(tester, topic: eg.t('some topic'));
+      check(findCheckIcon()).findsNothing();
+      check(find.textContaining('some topic', findRichText: true)).findsOne();
+    });
+
+    testWidgets('empty topic shows italic placeholder', (tester) async {
+      await prepareWidget(tester, topic: eg.t(''),
+        realmEmptyTopicDisplayName: 'general chat');
+      check(find.textContaining('general chat', findRichText: true)).findsOne();
+
+      FontStyle? italicFontStyle;
+      final richText = tester.widget<RichText>(
+        find.textContaining('general chat', findRichText: true));
+      richText.text.visitChildren((span) {
+        if (span is TextSpan && span.text == 'general chat') {
+          italicFontStyle = span.style?.fontStyle;
+          return false;
+        }
+        return true;
+      });
+      check(italicFontStyle).equals(FontStyle.italic);
+    });
+  });
+
   group('channelTopicLabelSpan', () {
     final channel = eg.stream();
 
@@ -454,12 +509,6 @@ void main() {
       check(findCheckIcon()).findsOne();
       check(find.textContaining('some topic', findRichText: true)).findsOne();
       check(find.textContaining('✔', findRichText: true)).findsNothing();
-    });
-
-    testWidgets('unresolved topic shows no checkmark', (tester) async {
-      await prepareWidget(tester, topic: eg.t('some topic'));
-      check(findCheckIcon()).findsNothing();
-      check(find.textContaining('some topic', findRichText: true)).findsOne();
     });
   });
 


### PR DESCRIPTION
This is stacked atop #2262, which has a lot of commits. There are just 5 for review here:

af5a8d95a action_sheet: Use ZulipIcons.check for resolved topic in action sheet header
b9f1009a8 text [nfc]: Extract topicLabelSpan from channelTopicLabelSpan
03e2ed56c message_list: Use ZulipIcons.check for resolved topic in app bar title
840a86769 message_list: Use ZulipIcons.check for resolved topic in recipient header
2487cb3ef message_list [nfc]: Remove unused fontStyle param from recipientHeaderTextStyle

~~This PR leaves one site in the list at #2263 unhandled for now: topic autocomplete, just because #2225 is still in flight and I didn't want to complicate this PR further by cherry-picking that.~~ Done; see screenshots in a separate comment below.

Fixes-partly: #2263

<details>
<summary>Screenshots</summary>

| Before | After |
| --- | --- |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/e88a2b13-2f0b-499e-96eb-4fea66a47131" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/a7e94a74-3d44-4734-980d-31c14925b65e" /> |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/6654f36f-0472-44fe-a633-b2cd46bc76c3" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/bc0b166d-971e-4315-9f5f-6ee9eb0dff48" /> |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/df1ac6f2-ec79-4029-adfd-72441015d2dd" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/1e736dbc-ab94-4df8-be7a-3ad970fd86e4" /> |
| <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/99b96227-b262-4752-b170-eae40b1f132e" /> | <img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/eccaa7a2-9ed8-47c2-a4d8-733360a48f17" /> |

</details>

cc @alya 