### PR TITLE
content: Refactor emojis to render with `EmojiWidget` in message content

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1162,10 +1162,18 @@ class UnicodeEmojiNode extends EmojiNode {
 }
 
 class ImageEmojiNode extends EmojiNode {
-  const ImageEmojiNode({super.debugHtmlNode, required this.src, required this.alt });
+  const ImageEmojiNode({
+    super.debugHtmlNode,
+    required this.src,
+    required this.alt,
+    required this.emojiName,
+  });
 
   final String src;
   final String alt;
+
+  /// The emoji's name, as in [Reaction.emojiName].
+  final String emojiName;
 
   @override
   bool operator ==(Object other) {
@@ -1180,6 +1188,7 @@ class ImageEmojiNode extends EmojiNode {
     super.debugFillProperties(properties);
     properties.add(StringProperty('alt', alt));
     properties.add(StringProperty('src', src));
+    properties.add(StringProperty('emojiName', emojiName));
   }
 }
 
@@ -1494,9 +1503,16 @@ class _ZulipInlineContentParser {
       if (className == 'emoji') {
         final alt = element.attributes['alt'];
         if (alt == null) return unimplemented();
+        final emojiName = element.attributes['title'];
+        if (emojiName == null) return unimplemented();
         final src = element.attributes['src'];
         if (src == null) return unimplemented();
-        return ImageEmojiNode(src: src, alt: alt, debugHtmlNode: debugHtmlNode);
+        return ImageEmojiNode(
+          src: src,
+          alt: alt,
+          emojiName: emojiName,
+          debugHtmlNode: debugHtmlNode,
+        );
       }
 
       if (className == 'inline-image') {

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1142,9 +1142,14 @@ sealed class EmojiNode extends InlineContentNode {
 }
 
 class UnicodeEmojiNode extends EmojiNode {
-  const UnicodeEmojiNode({super.debugHtmlNode, required this.emojiUnicode});
+  const UnicodeEmojiNode({
+    super.debugHtmlNode,
+    required this.emojiUnicode,
+    required this.emojiCode,
+  });
 
   final String emojiUnicode;
+  final String emojiCode;
 
   @override
   bool operator ==(Object other) {
@@ -1158,6 +1163,7 @@ class UnicodeEmojiNode extends EmojiNode {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('emojiUnicode', emojiUnicode));
+    properties.add(StringProperty('emojiCode', emojiCode));
   }
 }
 
@@ -1496,7 +1502,11 @@ class _ZulipInlineContentParser {
         .group(1)!;
       final unicode = tryParseEmojiCodeToUnicode(emojiCode);
       if (unicode == null) return unimplemented();
-      return UnicodeEmojiNode(emojiUnicode: unicode, debugHtmlNode: debugHtmlNode);
+      return UnicodeEmojiNode(
+        emojiUnicode: unicode,
+        debugHtmlNode: debugHtmlNode,
+        emojiCode: emojiCode,
+      );
     }
 
     if (localName == 'img') {

--- a/lib/model/emoji.dart
+++ b/lib/model/emoji.dart
@@ -116,6 +116,26 @@ final class EmojiCandidate {
 
 /// The portion of [PerAccountStore] describing what emoji exist.
 mixin EmojiStore {
+  /// An [EmojiDisplay] for an image-emoji node in Zulip message content.
+  ///
+  /// An image-emoji node in Zulip message content doesn't have an "emoji code",
+  /// which we'd normally use for lookups into [allRealmEmoji].
+  /// To work around -- in particular to get [RealmEmojiItem.stillUrl]
+  /// in order to support the device animation settings --
+  /// this function looks for [src]
+  /// in an index of [allRealmEmoji] by [RealmEmojiItem.sourceUrl].
+  ///
+  /// Returns an [ImageEmojiDisplay],
+  /// including [ImageEmojiDisplay.resolvedStillUrl] if one was found,
+  /// and falls back to [TextEmojiDisplay]
+  /// if [src] or the still URL fails parsing.
+  // TODO(server) maybe servers can start including the emoji-code in the HTML?
+  //   Discussion: https://chat.zulip.org/#narrow/channel/378-api-design/topic/Image-emoji.20IDs.20in.20message.20content/near/2431748
+  EmojiDisplay imageEmojiDisplayForContent({
+    required String src,
+    required String emojiName,
+  });
+
   /// An [EmojiDisplay] for the specified emoji.
   ///
   /// Use [EmojiDisplay.resolve] on the result to apply the user's [Emojiset]
@@ -151,6 +171,14 @@ mixin ProxyEmojiStore on EmojiStore {
   EmojiStore get emojiStore;
 
   @override
+  EmojiDisplay imageEmojiDisplayForContent({
+    required String src,
+    required String emojiName,
+  }) {
+    return emojiStore.imageEmojiDisplayForContent(src: src, emojiName: emojiName);
+  }
+
+  @override
   EmojiDisplay emojiDisplayFor({
     required ReactionType emojiType,
     required String emojiCode,
@@ -183,7 +211,8 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
   EmojiStoreImpl({
     required super.core,
     required this.allRealmEmoji,
-  }) : _serverEmojiData = null; // TODO(#974) maybe start from a hard-coded baseline
+  }) : _serverEmojiData = null, // TODO(#974) maybe start from a hard-coded baseline
+       _imageEmojiCodesBySourceUrl = null;
 
   /// The realm's custom emoji, indexed by their [RealmEmojiItem.emojiCode],
   /// including deactivated emoji not available for new uses.
@@ -201,6 +230,25 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
 
   /// The realm-relative URL of the unique "Zulip extra emoji", :zulip:.
   static const kZulipEmojiUrl = '/static/generated/emoji/images/emoji/unicode/zulip.png';
+
+  /// A map from [RealmEmojiItem.sourceUrl] to [RealmEmojiItem.emojiCode].
+  ///
+  /// Computed lazily, and invalidated on [RealmEmojiUpdateEvent].
+  Map<String, String>? _imageEmojiCodesBySourceUrl;
+
+  @override
+  EmojiDisplay imageEmojiDisplayForContent({
+    required String src,
+    required String emojiName,
+  }) {
+    _imageEmojiCodesBySourceUrl
+      ??= allRealmEmoji.map((key, value) => MapEntry(value.sourceUrl, key));
+    final emojiCode = _imageEmojiCodesBySourceUrl![src];
+    final item = emojiCode == null ? null : allRealmEmoji[emojiCode];
+
+    return _tryImageEmojiDisplay(
+      sourceUrl: src, stillUrl: item?.stillUrl, emojiName: emojiName);
+  }
 
   @override
   EmojiDisplay emojiDisplayFor({
@@ -435,6 +483,7 @@ class EmojiStoreImpl extends PerAccountStoreBase with EmojiStore {
   void handleRealmEmojiUpdateEvent(RealmEmojiUpdateEvent event) {
     allRealmEmoji = event.realmEmoji;
     _allEmojiCandidates = null;
+    _imageEmojiCodesBySourceUrl = null;
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -15,6 +15,7 @@ import '../model/internal_link.dart';
 import 'actions.dart';
 import 'code_block.dart';
 import 'dialog.dart';
+import 'emoji.dart';
 import 'icons.dart';
 import 'image.dart';
 import 'inset_shadow.dart';
@@ -1149,8 +1150,19 @@ class _InlineContentBuilder {
           style: ContentTheme.of(_context!).textStyleEmoji);
 
       case ImageEmojiNode():
-        return WidgetSpan(alignment: PlaceholderAlignment.middle,
-          child: MessageImageEmoji(node: node));
+        final store = PerAccountStoreWidget.of(_context!);
+        final resolvedUrl = store.tryResolveUrl(node.src);
+        final imageEmojiDisplay = store.imageEmojiDisplayForContent(
+          src: node.src,
+          emojiName: node.emojiName
+        );
+
+        return resolvedUrl == null //TODO(log)
+          ? WidgetSpan(alignment: PlaceholderAlignment.middle, child: const SizedBox.shrink())
+          : EmojiWidget.asWidgetSpan(
+              emojiDisplay: imageEmojiDisplay.resolve(store.userSettings),
+              fontSize: widget.style.fontSize!,
+              textScaler: MediaQuery.textScalerOf(_context!));
 
       case InlineImageNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
@@ -1322,37 +1334,6 @@ class Mention extends StatelessWidget {
 //     borderRadius: BorderRadius.all(Radius.circular(3))));
 }
 
-class MessageImageEmoji extends StatelessWidget {
-  const MessageImageEmoji({super.key, required this.node});
-
-  final ImageEmojiNode node;
-
-  @override
-  Widget build(BuildContext context) {
-    final store = PerAccountStoreWidget.of(context);
-    final resolvedSrc = store.tryResolveUrl(node.src);
-
-    const size = 20.0;
-
-    return Stack(
-      alignment: Alignment.center,
-      clipBehavior: Clip.none,
-      children: [
-        const SizedBox(width: size, height: kBaseFontSize),
-        Positioned(
-          // Web's css makes this seem like it should be -0.5, but that looks
-          // too low.
-          top: -1.5,
-          child: resolvedSrc == null ? const SizedBox.shrink() // TODO(log)
-            : RealmContentNetworkImage(
-                resolvedSrc,
-                filterQuality: FilterQuality.medium,
-                width: size,
-                height: size,
-              )),
-      ]);
-  }
-}
 
 class InlineImage extends StatelessWidget {
   const InlineImage({

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -11,6 +11,7 @@ import '../api/model/model.dart';
 import '../api/model/permission.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/content.dart';
+import '../model/emoji.dart';
 import '../model/internal_link.dart';
 import 'actions.dart';
 import 'code_block.dart';
@@ -1146,8 +1147,18 @@ class _InlineContentBuilder {
           child: Mention(ambientTextStyle: _resolveStyleStack(), node: node));
 
       case UnicodeEmojiNode():
-        return TextSpan(text: node.emojiUnicode, recognizer: _recognizer,
-          style: ContentTheme.of(_context!).textStyleEmoji);
+        final store = PerAccountStoreWidget.of(_context!);
+        final emojiName = store.getUnicodeEmojiNameByCode(node.emojiCode);
+
+        return emojiName == null
+          ? WidgetSpan(alignment: PlaceholderAlignment.middle, child: const SizedBox.shrink())
+          : EmojiWidget.asWidgetSpan(
+              emojiDisplay: UnicodeEmojiDisplay(
+                emojiName: emojiName,
+                emojiUnicode: node.emojiUnicode,
+              ).resolve(store.userSettings),
+              fontSize: widget.style.fontSize!,
+              textScaler: MediaQuery.textScalerOf(_context!));
 
       case ImageEmojiNode():
         final store = PerAccountStoreWidget.of(_context!);

--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -58,7 +58,12 @@ class EmojiWidget extends StatelessWidget {
     required double fontSize,
     required TextScaler textScaler,
   }) {
-    final size = textScaler.scale(fontSize) * (17 / 14.5);
+    final sizeFactor = 17 / 14.5;
+    final size = switch(emojiDisplay) {
+      UnicodeEmojiDisplay() => textScaler.scale(fontSize) * sizeFactor * sizeFactor,
+      ImageEmojiDisplay() => textScaler.scale(fontSize) * sizeFactor,
+      TextEmojiDisplay() => textScaler.scale(fontSize),
+    };
 
     return WidgetSpan(
       alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -53,6 +53,21 @@ class EmojiWidget extends StatelessWidget {
       ?? Text(textEmojiForEmojiName(emojiDisplay.emojiName));
   }
 
+  static InlineSpan asWidgetSpan({
+    required EmojiDisplay emojiDisplay,
+    required double fontSize,
+    required TextScaler textScaler,
+  }) {
+    final size = textScaler.scale(fontSize) * (17 / 14.5);
+
+    return WidgetSpan(
+      alignment: PlaceholderAlignment.middle,
+      child: EmojiWidget(
+        emojiDisplay: emojiDisplay,
+        squareDimension: size,
+        imagePlaceholderStyle: EmojiImagePlaceholderStyle.text));
+  }
+
   @override
   Widget build(BuildContext context) {
     final emojiDisplay = this.emojiDisplay;

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -257,6 +257,15 @@ class ContentExample {
       alt: ':flutter:',
       emojiName: 'flutter'));
 
+  static final emojiCustomAnimated = ContentExample.inline(
+      'custom animated emoji',
+      ":slackzulip:",
+      '<p><img alt=":slackzulip:" class="emoji" src="/user_avatars/2/emoji/images/2c8d985d.gif" title="slackzulip"></p>',
+      const ImageEmojiNode(
+        src: '/user_avatars/2/emoji/images/2c8d985d.gif',
+        alt: ':slackzulip:',
+        emojiName: 'slackzulip'));
+
   static final emojiCustomInvalidUrl = ContentExample.inline(
     'custom emoji with invalid URL',
     null, // hypothetical, to test for a risk of crashing
@@ -1905,6 +1914,7 @@ void main() async {
   testParseExample(ContentExample.emojiUnicodeMultiCodepoint);
   testParseExample(ContentExample.emojiUnicodeLiteral);
   testParseExample(ContentExample.emojiCustom);
+  testParseExample(ContentExample.emojiCustomAnimated);
   testParseExample(ContentExample.emojiCustomInvalidUrl);
   testParseExample(ContentExample.emojiZulipExtra);
 

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -225,21 +225,21 @@ class ContentExample {
     ":thumbs_up:",
     expectedText: '\u{1f44d}', // "👍"
     '<p><span aria-label="thumbs up" class="emoji emoji-1f44d" role="img" title="thumbs up">:thumbs_up:</span></p>',
-    const UnicodeEmojiNode(emojiUnicode: '\u{1f44d}'));
+    const UnicodeEmojiNode(emojiUnicode: '\u{1f44d}', emojiCode: '1f44d'));
 
   static final emojiUnicodeClassesFlipped = ContentExample.inline(
     'Unicode emoji, encoded in span element, class order reversed',
     null, // ":thumbs_up:" (hypothetical server variation)
     expectedText: '\u{1f44d}', // "👍"
     '<p><span aria-label="thumbs up" class="emoji-1f44d emoji" role="img" title="thumbs up">:thumbs_up:</span></p>',
-    const UnicodeEmojiNode(emojiUnicode: '\u{1f44d}'));
+    const UnicodeEmojiNode(emojiUnicode: '\u{1f44d}', emojiCode: '1f44d'));
 
   static final emojiUnicodeMultiCodepoint = ContentExample.inline(
     'Unicode emoji, encoded in span element, multiple codepoints',
     ":transgender_flag:",
     expectedText: '\u{1f3f3}\u{fe0f}\u{200d}\u{26a7}\u{fe0f}', // "🏳️‍⚧️"
     '<p><span aria-label="transgender flag" class="emoji emoji-1f3f3-fe0f-200d-26a7-fe0f" role="img" title="transgender flag">:transgender_flag:</span></p>',
-    const UnicodeEmojiNode(emojiUnicode: '\u{1f3f3}\u{fe0f}\u{200d}\u{26a7}\u{fe0f}'));
+    const UnicodeEmojiNode(emojiUnicode: '\u{1f3f3}\u{fe0f}\u{200d}\u{26a7}\u{fe0f}', emojiCode: '1f3f3-fe0f-200d-26a7-fe0f'));
 
   static final emojiUnicodeLiteral = ContentExample.inline(
     'Unicode emoji, not encoded in span element',

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -253,21 +253,25 @@ class ContentExample {
     ":flutter:",
     '<p><img alt=":flutter:" class="emoji" src="/user_avatars/2/emoji/images/204.png" title="flutter"></p>',
     const ImageEmojiNode(
-      src: '/user_avatars/2/emoji/images/204.png', alt: ':flutter:'));
+      src: '/user_avatars/2/emoji/images/204.png',
+      alt: ':flutter:',
+      emojiName: 'flutter'));
 
   static final emojiCustomInvalidUrl = ContentExample.inline(
     'custom emoji with invalid URL',
     null, // hypothetical, to test for a risk of crashing
     '<p><img alt=":invalid:" class="emoji" src="::not a URL::" title="invalid"></p>',
     const ImageEmojiNode(
-      src: '::not a URL::', alt: ':invalid:'));
+      src: '::not a URL::', alt: ':invalid:', emojiName: 'invalid'));
 
   static final emojiZulipExtra = ContentExample.inline(
     'Zulip extra emoji',
     ":zulip:",
     '<p><img alt=":zulip:" class="emoji" src="/static/generated/emoji/images/emoji/unicode/zulip.png" title="zulip"></p>',
     const ImageEmojiNode(
-      src: '/static/generated/emoji/images/emoji/unicode/zulip.png', alt: ':zulip:'));
+      src: '/static/generated/emoji/images/emoji/unicode/zulip.png',
+      alt: ':zulip:',
+      emojiName: 'zulip'));
 
   static final inlineImage = ContentExample.inline(
     'inline image',

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -17,6 +17,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/narrow.dart';
 import 'package:zulip/api/route/channels.dart';
 import 'package:zulip/api/route/messages.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/message.dart';
 import 'package:zulip/model/narrow.dart';
@@ -98,6 +99,9 @@ void main() {
     ));
 
     store = await testBinding.globalStore.perAccount(selfAccount.id);
+    store.setServerEmojiData(ServerEmojiData(codeToNames: {
+      '1f44d': ['thumbs_up'],
+    }));
 
     connection = store.connection as FakeApiConnection;
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -10,6 +10,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/messages.dart';
+import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/model/content.dart';
 import 'package:zulip/model/emoji.dart';
 import 'package:zulip/model/narrow.dart';
@@ -137,6 +138,13 @@ Future<void> prepareContent(WidgetTester tester, Widget child, {
       ),
     });
     await testBinding.globalStore.add(eg.selfAccount, initialSnapshot);
+
+    final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+    store.setServerEmojiData(ServerEmojiData(codeToNames: {
+      '2764': ['heart'],
+      '1f44d': ['thumbs_up'],
+      '1f3f3-fe0f-200d-26a7-fe0f': ['transgender_flag'],
+    }));
   } else {
     assert(initialSnapshot == null);
   }
@@ -1495,15 +1503,15 @@ void main() {
   });
 
   group('UnicodeEmoji', () {
-    testContentSmoke(ContentExample.emojiUnicode);
-    testContentSmoke(ContentExample.emojiUnicodeMultiCodepoint);
-    testContentSmoke(ContentExample.emojiUnicodeLiteral);
+    testContentSmoke(ContentExample.emojiUnicode, wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.emojiUnicodeMultiCodepoint, wrapWithPerAccountStoreWidget: true);
+    testContentSmoke(ContentExample.emojiUnicodeLiteral, wrapWithPerAccountStoreWidget: true);
 
     testWidgets('use emoji font', (tester) async {
       // Compare [ContentExample.emojiUnicode].
       const emojiHeartHtml =
         '<p><span aria-label="heart" class="emoji emoji-2764" role="img" title="heart">:heart:</span></p>';
-      await prepareContent(tester, plainContent(emojiHeartHtml));
+      await prepareContent(tester, plainContent(emojiHeartHtml), wrapWithPerAccountStoreWidget: true);
       check(mergedStyleOf(tester, '\u{2764}')).isNotNull()
         .fontFamily.equals(switch (defaultTargetPlatform) {
           TargetPlatform.android => 'Noto Color Emoji',
@@ -1511,14 +1519,6 @@ void main() {
           _ => throw StateError('unexpected platform in test'),
         });
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
-
-    testWidgets('has strike-through line in strike-through', (tester) async {
-      // Regression test for https://github.com/zulip/zulip-flutter/issues/1818
-      await prepareContent(tester,
-        plainContent('<p><del>foo<span aria-label="thumbs up" class="emoji emoji-1f44d" role="img" title="thumbs up">:thumbs_up:</span>bar</del></p>'));
-      final style = mergedStyleOf(tester, '\u{1f44d}');
-      check(style!.decoration).equals(TextDecoration.lineThrough);
-    });
   });
 
   group('inline math', () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -11,10 +11,12 @@ import 'package:zulip/api/model/initial_snapshot.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/content.dart';
+import 'package:zulip/model/emoji.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/settings.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/content.dart';
+import 'package:zulip/widgets/emoji.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/katex.dart';
@@ -126,7 +128,14 @@ Future<void> prepareContent(WidgetTester tester, Widget child, {
   InitialSnapshot? initialSnapshot,
 }) async {
   if (wrapWithPerAccountStoreWidget) {
-    initialSnapshot ??= eg.initialSnapshot();
+    initialSnapshot ??= eg.initialSnapshot(realmEmoji: {
+      '205': eg.realmEmojiItem(
+        emojiCode: '205',
+        emojiName: 'zulipslack',
+        sourceUrl: '/user_avatars/2/emoji/images/2c8d985d.gif',
+        stillUrl: '/user_avatars/2/emoji/images/still/2c8d985d.png',
+      ),
+    });
     await testBinding.globalStore.add(eg.selfAccount, initialSnapshot);
   } else {
     assert(initialSnapshot == null);
@@ -1738,21 +1747,37 @@ void main() {
 
     testWidgets('smoke: custom emoji', (tester) async {
       await prepare(tester, ContentExample.emojiCustom.html);
-      tester.widget(find.byType(MessageImageEmoji));
+      tester.widget(find.byType(EmojiWidget));
       debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('smoke: custom emoji with invalid URL', (tester) async {
       await prepare(tester, ContentExample.emojiCustomInvalidUrl.html);
-      final url = tester.widget<MessageImageEmoji>(find.byType(MessageImageEmoji)).node.src;
-      check(() => Uri.parse(url)).throws<void>();
+      tester.widget(find.byType(BlockContentList));
+      check(find.byType(EmojiWidget)).findsNothing();
+
+      final node = parseContent(ContentExample.emojiCustomInvalidUrl.html)
+          .nodes.first as ParagraphNode;
+      final emojiNode = node.nodes.last as ImageEmojiNode;
+      check(() => Uri.parse(emojiNode.src)).throws<void>();
       debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('smoke: Zulip extra emoji', (tester) async {
       await prepare(tester, ContentExample.emojiZulipExtra.html);
-      tester.widget(find.byType(MessageImageEmoji));
+      tester.widget(find.byType(EmojiWidget));
       debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('animated custom emoji has a corresponding still image', (tester) async {
+      await prepare(tester, ContentExample.emojiCustomAnimated.html);
+
+      final emojiWidget = tester.widget<EmojiWidget>(find.byType(EmojiWidget));
+      final display = emojiWidget.emojiDisplay as ImageEmojiDisplay;
+      check(display.resolvedStillUrl).equals(Uri.parse(
+          'https://chat.example/user_avatars/2/emoji/images/still/2c8d985d.png'));
+      check(display.resolvedUrl).equals(Uri.parse(
+          'https://chat.example/user_avatars/2/emoji/images/2c8d985d.gif'));
     });
   });
 


### PR DESCRIPTION
Fixes #966.
Unblocks #1995 (PR: #2185).

<details>
<summary>Before and After Changes</summary>

<br>

| Before | After |
| --- | --- |
| <img width="498" height="1052" alt="before_heading" src="https://github.com/user-attachments/assets/8079e6be-c36c-4d19-bda7-a45f2b4fe8b4" /> | <img width="498" height="1052" alt="after_heading" src="https://github.com/user-attachments/assets/603103ff-2697-48c5-8b29-dc77ae1c768b" /> |


| Before | After |
| --- | --- |
| <img width="498" height="1052" alt="before_dms" src="https://github.com/user-attachments/assets/6e34b71d-6eb9-4b5d-967b-090230b13000" /> | <img width="498" height="1052" alt="after_dms" src="https://github.com/user-attachments/assets/cb6fe155-de90-44c2-9842-80d18882ba56" /> |

</details>

### Overview

Previously, we rendered Unicode emoji with `TextSpan` and ImageEmoji with `RealmContentNetworkImage` (directly). When rendering emoji as emoji reactions, we have [a couple of nuances](https://github.com/zulip/zulip-flutter/issues/966#:~:text=When%20emoji%20appear,emoji_reaction.dart.) However, we don't show for emojis appearing in message content. We should follow the same by rendering UnicodeEmoji and ImageEmoji using EmojiWidget.

Many Bugs were solved for emojis in message content, some of them which were not included by Greg in the [issue's description](https://github.com/zulip/zulip-flutter/issues/966):
- ImageEmoji now respects heading size.
- ImageEmoji now renders at the correct size of the paragraph, visually inline with text and Unicode emojis.
etc.

Note:
- Unfortunately, due to Uncode, emoji rendering uses `WidgetSpan`. Strike-through line now appears behind the Unicode emoji — similar to what image emoji used to. For more details on this, see [#mobile > ImageEmoji does not strike through as well as not scale](https://chat.zulip.org/#narrow/channel/48-mobile/topic/ImageEmoji.20does.20not.20strike.20through.20as.20well.20as.20not.20scale/with/2430272).