### PR TITLE
image: Add RealmIconPlaceholder widget

### DIFF
--- a/lib/widgets/image.dart
+++ b/lib/widgets/image.dart
@@ -5,6 +5,7 @@ import '../api/core.dart';
 import '../api/model/initial_snapshot.dart';
 import '../model/content.dart';
 import 'store.dart';
+import 'theme.dart';
 
 /// Like [Image.network], but includes [authHeader] if [src] is on-realm.
 ///
@@ -211,5 +212,17 @@ extension ImageThumbnailLocatorExtension on ImageThumbnailLocator {
       if (candidate.maxWidth >= width && candidate.maxHeight >= height) break;
     }
     return result;
+  }
+}
+
+// ignore: unused_element
+class RealmIconPlaceholder extends StatelessWidget {
+  const RealmIconPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(color: designVariables.avatarPlaceholderBg));
   }
 }


### PR DESCRIPTION
### Summary

Add a `RealmIconPlaceholder` widget to provide a consistent fallback UI for realm icons when loading fails.

### Context

Currently, realm icons loaded via `Image.network` may be hidden on error or lack a defined fallback. This PR introduces a simple placeholder (a neutral background) to ensure consistent layout and avoid silent failures.

### Notes

* The placeholder is intentionally minimal (no icon), based on discussion in Zulip : [#mobile-dev-help > realm icon placeholder](https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/realm.20icon.20placeholder/with/2408063)
* This is a first step towards standardizing realm icon error handling

Related:

* Fixes Issue #2267 
* PR #2208 
* PR #2209
