### PR TITLE
login: Show password form if LDAP is enabled

### DIFF
--- a/lib/api/route/realm.dart
+++ b/lib/api/route/realm.dart
@@ -23,14 +23,7 @@ Future<GetServerSettingsResult> getServerSettings(ApiConnection connection) {
 
 @JsonSerializable(fieldRename: FieldRename.snake)
 class GetServerSettingsResult {
-  // This is marked as deprecated, but we still need it to answer some
-  // questions:
-  // - Do we offer dev login? (Yes if it has `dev: true`.)
-  // - Do we offer password login? (Yes if it has `password: true` or `ldap: true`.)
-  // - Do we offer a "Log in with SSO" button? (Yes if it has `remoteuser: true`.)
-  //
-  // Discussion: https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60authentication_methods.60.20in.20server.20settings/near/1722986
-  final Map<String, bool> authenticationMethods;
+  final AuthenticationMethods authenticationMethods;
 
   final List<ExternalAuthenticationMethod> externalAuthenticationMethods;
 
@@ -73,6 +66,40 @@ class GetServerSettingsResult {
     _$GetServerSettingsResultFromJson(json);
 
   Map<String, dynamic> toJson() => _$GetServerSettingsResultToJson(this);
+}
+
+// This is marked as deprecated, but we still need it to answer some
+// questions:
+// - Do we offer dev login? (Yes if it has `dev: true`.)
+// - Do we offer password login? (Yes if it has `password: true` or `ldap: true`.)
+// - Do we offer a "Log in with SSO" button? (Yes if it has `remoteuser: true`.)
+//
+// Discussion: https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60authentication_methods.60.20in.20server.20settings/near/1722986
+@JsonSerializable(fieldRename: FieldRename.snake)
+class AuthenticationMethods {
+  // final bool password; // deprecated; ignore
+  // final bool dev; // deprecated; ignore
+  // final bool email; // deprecated; ignore
+  final bool ldap;
+  // final bool remoteuser; // deprecated; ignore
+  // final bool github; // deprecated; ignore
+  // final bool azuread; // deprecated; ignore
+  // final bool gitlab; // deprecated; ignore
+  // final bool apple; // deprecated; ignore
+  // final bool google; // deprecated; ignore
+  // final bool saml; // deprecated; ignore
+
+  // @JsonKey(name: 'openid connect')
+  // final bool openidConnect; // deprecated; ignore
+
+  AuthenticationMethods({
+    required this.ldap,
+  });
+
+  factory AuthenticationMethods.fromJson(Map<String, dynamic> json) =>
+    _$AuthenticationMethodsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AuthenticationMethodsToJson(this);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/api/route/realm.g.dart
+++ b/lib/api/route/realm.g.dart
@@ -11,8 +11,8 @@ part of 'realm.dart';
 GetServerSettingsResult _$GetServerSettingsResultFromJson(
   Map<String, dynamic> json,
 ) => GetServerSettingsResult(
-  authenticationMethods: Map<String, bool>.from(
-    json['authentication_methods'] as Map,
+  authenticationMethods: AuthenticationMethods.fromJson(
+    json['authentication_methods'] as Map<String, dynamic>,
   ),
   externalAuthenticationMethods:
       (json['external_authentication_methods'] as List<dynamic>)
@@ -54,6 +54,14 @@ Map<String, dynamic> _$GetServerSettingsResultToJson(
   'realm_description': instance.realmDescription,
   'realm_web_public_access_enabled': instance.realmWebPublicAccessEnabled,
 };
+
+AuthenticationMethods _$AuthenticationMethodsFromJson(
+  Map<String, dynamic> json,
+) => AuthenticationMethods(ldap: json['ldap'] as bool);
+
+Map<String, dynamic> _$AuthenticationMethodsToJson(
+  AuthenticationMethods instance,
+) => <String, dynamic>{'ldap': instance.ldap};
 
 ExternalAuthenticationMethod _$ExternalAuthenticationMethodFromJson(
   Map<String, dynamic> json,

--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -454,12 +454,14 @@ class _LoginPageState extends State<LoginPage> {
 
     final externalAuthenticationMethods = widget.serverSettings.externalAuthenticationMethods;
     final emailAuthEnabled = widget.serverSettings.emailAuthEnabled;
+    final ldapEnabled = widget.serverSettings.authenticationMethods.ldap;
+    final showPasswordForm = emailAuthEnabled || ldapEnabled;
 
     final loginContent = Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-      if (emailAuthEnabled)
+      if (showPasswordForm)
         _UsernamePasswordForm(loginPageState: this),
       if (externalAuthenticationMethods.isNotEmpty) ...[
-        if (emailAuthEnabled)
+        if (showPasswordForm)
           _AlternativeAuthDivider(),
         ...externalAuthenticationMethods.map((method) {
           final icon = method.displayIcon;

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -102,8 +102,16 @@ const int recentZulipFeatureLevel = 476;
 const int futureZulipFeatureLevel = 9999;
 const int ancientZulipFeatureLevel = kMinSupportedZulipFeatureLevel - 1;
 
+AuthenticationMethods authMethods({
+  bool ldap = false,
+}) {
+  return AuthenticationMethods(
+    ldap: ldap,
+  );
+}
+
 GetServerSettingsResult serverSettings({
-  Map<String, bool>? authenticationMethods,
+  AuthenticationMethods? authenticationMethods,
   List<ExternalAuthenticationMethod>? externalAuthenticationMethods,
   int? zulipFeatureLevel,
   String? zulipVersion,
@@ -119,7 +127,7 @@ GetServerSettingsResult serverSettings({
   bool? realmWebPublicAccessEnabled,
 }) {
   return GetServerSettingsResult(
-    authenticationMethods: authenticationMethods ?? {},
+    authenticationMethods: authenticationMethods ?? authMethods(),
     externalAuthenticationMethods: externalAuthenticationMethods ?? [],
     zulipFeatureLevel: zulipFeatureLevel ?? recentZulipFeatureLevel,
     zulipVersion: zulipVersion ?? recentZulipVersion,

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -375,19 +375,33 @@ void main() {
       // TODO test _inProgress logic
     });
 
-    group('email auth visibility', () { // another name for username/password auth
+    group('password auth visibility', () {
       testWidgets('hides username/password fields and login button', (tester) async {
-        final serverSettings = eg.serverSettings(emailAuthEnabled: false);
+        final serverSettings = eg.serverSettings(
+          emailAuthEnabled: false,
+          authenticationMethods: eg.authMethods(ldap: false));
         await prepare(tester, serverSettings);
         check(findUsernameInput).findsNothing();
         check(findPasswordInput).findsNothing();
         check(findSubmitButton).findsNothing();
       });
 
+      testWidgets('shows fields when email auth disabled but LDAP enabled', (tester) async {
+        final serverSettings = eg.serverSettings(
+          emailAuthEnabled: false,
+          authenticationMethods: eg.authMethods(ldap: true),
+        );
+        await prepare(tester, serverSettings);
+        check(findUsernameInput).findsOne();
+        check(findPasswordInput).findsOne();
+        check(findSubmitButton).findsOne();
+      });
+
       testWidgets('shows external auth methods without divider', (tester) async {
         prepareBoringImageHttpClient(); // icon on social-auth button
         final serverSettings = eg.serverSettings(
           emailAuthEnabled: false,
+          authenticationMethods: eg.authMethods(ldap: false),
           externalAuthenticationMethods: [googleAuthMethod]);
         await prepare(tester, serverSettings);
         check(find.textContaining('Google')).findsOne();


### PR DESCRIPTION
PR #2167  (addressing #745 ) hid the username/password form when `email_auth_enabled` was false. However, this form is also required for LDAP authentication.

Fix this by showing the form if either `email_auth_enabled` or the `ldap` method in `authentication_methods` is true.

Related
[#mobile > non-email password auth](https://chat.zulip.org/#narrow/channel/48-mobile/topic/non-email.20password.20auth/with/2433982)
[#api design > &#96;authentication_methods&#96; in server settings](https://chat.zulip.org/#narrow/channel/378-api-design/topic/.60authentication_methods.60.20in.20server.20settings/with/1763753)

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/d3c58856-0f18-472a-a132-059ee0329ccc" alt="LTR" width="300"/>
      <p align="center"><strong>Both email_auth_enabled and ldap false</strong></p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/66fd97e9-5db9-47c1-9fff-749c21e7fab0" alt="RTL" width="300"/>
      <p align="center"><strong>Atleast one is true</strong></p>
    </td>
  </tr>
</table>
