### PR TITLE
events [nfc]: Rename streamId/streamIds on subscription events to channelId/channelIds

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -855,16 +855,16 @@ class SubscriptionRemoveEvent extends SubscriptionEvent {
   @JsonKey(includeToJson: true)
   String get op => 'remove';
 
-  @JsonKey(readValue: _readStreamIds)
-  final List<int> streamIds;
+  @JsonKey(readValue: _readChannelIds)
+  final List<int> channelIds;
 
-  static List<int> _readStreamIds(Map<dynamic, dynamic> json, String key) {
+  static List<int> _readChannelIds(Map<dynamic, dynamic> json, String key) {
     return (json['subscriptions'] as List<dynamic>)
       .map((e) => (e as Map<String, dynamic>)['stream_id'] as int)
       .toList();
   }
 
-  SubscriptionRemoveEvent({required super.id, required this.streamIds});
+  SubscriptionRemoveEvent({required super.id, required this.channelIds});
 
   factory SubscriptionRemoveEvent.fromJson(Map<String, dynamic> json) =>
     _$SubscriptionRemoveEventFromJson(json);
@@ -880,7 +880,8 @@ class SubscriptionUpdateEvent extends SubscriptionEvent {
   @JsonKey(includeToJson: true)
   String get op => 'update';
 
-  final int streamId;
+  @JsonKey(name: 'stream_id')
+  final int channelId;
 
   @JsonKey(unknownEnumValue: SubscriptionProperty.unknown)
   final SubscriptionProperty property;
@@ -917,7 +918,7 @@ class SubscriptionUpdateEvent extends SubscriptionEvent {
 
   SubscriptionUpdateEvent({
     required super.id,
-    required this.streamId,
+    required this.channelId,
     required this.property,
     required this.value,
   });
@@ -936,12 +937,13 @@ class SubscriptionPeerAddEvent extends SubscriptionEvent {
   @JsonKey(includeToJson: true)
   String get op => 'peer_add';
 
-  List<int> streamIds;
+  @JsonKey(name: 'stream_ids')
+  List<int> channelIds;
   List<int> userIds;
 
   SubscriptionPeerAddEvent({
     required super.id,
-    required this.streamIds,
+    required this.channelIds,
     required this.userIds,
   });
 
@@ -959,12 +961,13 @@ class SubscriptionPeerRemoveEvent extends SubscriptionEvent {
   @JsonKey(includeToJson: true)
   String get op => 'peer_remove';
 
-  List<int> streamIds;
+  @JsonKey(name: 'stream_ids')
+  List<int> channelIds;
   List<int> userIds;
 
   SubscriptionPeerRemoveEvent({
     required super.id,
-    required this.streamIds,
+    required this.channelIds,
     required this.userIds,
   });
 

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -589,8 +589,8 @@ SubscriptionRemoveEvent _$SubscriptionRemoveEventFromJson(
   Map<String, dynamic> json,
 ) => SubscriptionRemoveEvent(
   id: (json['id'] as num).toInt(),
-  streamIds:
-      (SubscriptionRemoveEvent._readStreamIds(json, 'stream_ids')
+  channelIds:
+      (SubscriptionRemoveEvent._readChannelIds(json, 'stream_ids')
               as List<dynamic>)
           .map((e) => (e as num).toInt())
           .toList(),
@@ -602,14 +602,14 @@ Map<String, dynamic> _$SubscriptionRemoveEventToJson(
   'id': instance.id,
   'type': instance.type,
   'op': instance.op,
-  'stream_ids': instance.streamIds,
+  'stream_ids': instance.channelIds,
 };
 
 SubscriptionUpdateEvent _$SubscriptionUpdateEventFromJson(
   Map<String, dynamic> json,
 ) => SubscriptionUpdateEvent(
   id: (json['id'] as num).toInt(),
-  streamId: (json['stream_id'] as num).toInt(),
+  channelId: (json['stream_id'] as num).toInt(),
   property: $enumDecode(
     _$SubscriptionPropertyEnumMap,
     json['property'],
@@ -624,7 +624,7 @@ Map<String, dynamic> _$SubscriptionUpdateEventToJson(
   'id': instance.id,
   'type': instance.type,
   'op': instance.op,
-  'stream_id': instance.streamId,
+  'stream_id': instance.channelId,
   'property': instance.property,
   'value': instance.value,
 };
@@ -645,7 +645,7 @@ SubscriptionPeerAddEvent _$SubscriptionPeerAddEventFromJson(
   Map<String, dynamic> json,
 ) => SubscriptionPeerAddEvent(
   id: (json['id'] as num).toInt(),
-  streamIds: (json['stream_ids'] as List<dynamic>)
+  channelIds: (json['stream_ids'] as List<dynamic>)
       .map((e) => (e as num).toInt())
       .toList(),
   userIds: (json['user_ids'] as List<dynamic>)
@@ -659,7 +659,7 @@ Map<String, dynamic> _$SubscriptionPeerAddEventToJson(
   'id': instance.id,
   'type': instance.type,
   'op': instance.op,
-  'stream_ids': instance.streamIds,
+  'stream_ids': instance.channelIds,
   'user_ids': instance.userIds,
 };
 
@@ -667,7 +667,7 @@ SubscriptionPeerRemoveEvent _$SubscriptionPeerRemoveEventFromJson(
   Map<String, dynamic> json,
 ) => SubscriptionPeerRemoveEvent(
   id: (json['id'] as num).toInt(),
-  streamIds: (json['stream_ids'] as List<dynamic>)
+  channelIds: (json['stream_ids'] as List<dynamic>)
       .map((e) => (e as num).toInt())
       .toList(),
   userIds: (json['user_ids'] as List<dynamic>)
@@ -681,7 +681,7 @@ Map<String, dynamic> _$SubscriptionPeerRemoveEventToJson(
   'id': instance.id,
   'type': instance.type,
   'op': instance.op,
-  'stream_ids': instance.streamIds,
+  'stream_ids': instance.channelIds,
   'user_ids': instance.userIds,
 };
 

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -583,7 +583,7 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
         }
 
       case SubscriptionRemoveEvent():
-        for (final streamId in event.streamIds) {
+        for (final streamId in event.channelIds) {
           assert(streams.containsKey(streamId));
           assert(streams[streamId] is Subscription);
           assert(streamsByName.containsKey(streams[streamId]!.name));
@@ -597,9 +597,9 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
         }
 
       case SubscriptionUpdateEvent():
-        final subscription = subscriptions[event.streamId];
+        final subscription = subscriptions[event.channelId];
         if (subscription == null) return; // TODO(log)
-        assert(identical(streams[event.streamId], subscription));
+        assert(identical(streams[event.channelId], subscription));
         assert(identical(streamsByName[subscription.name], subscription));
         switch (event.property) {
           case SubscriptionProperty.color:

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -583,16 +583,16 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
         }
 
       case SubscriptionRemoveEvent():
-        for (final streamId in event.channelIds) {
-          assert(streams.containsKey(streamId));
-          assert(streams[streamId] is Subscription);
-          assert(streamsByName.containsKey(streams[streamId]!.name));
-          assert(streamsByName[streams[streamId]!.name] is Subscription);
-          assert(subscriptions.containsKey(streamId));
-          final subscription = subscriptions.remove(streamId);
+        for (final channelId in event.channelIds) {
+          assert(streams.containsKey(channelId));
+          assert(streams[channelId] is Subscription);
+          assert(streamsByName.containsKey(streams[channelId]!.name));
+          assert(streamsByName[streams[channelId]!.name] is Subscription);
+          assert(subscriptions.containsKey(channelId));
+          final subscription = subscriptions.remove(channelId);
           if (subscription == null) continue; // TODO(log)
           final stream = ZulipStream.fromSubscription(subscription);
-          streams[streamId] = stream;
+          streams[channelId] = stream;
           streamsByName[subscription.name] = stream;
         }
 

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -595,7 +595,7 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
   }
 
   void handleSubscriptionRemoveEvent(SubscriptionRemoveEvent event) {
-    _handleSubscriptionsRemoved(event.streamIds);
+    _handleSubscriptionsRemoved(event.channelIds);
   }
 
   void _handleSubscriptionsRemoved(Iterable<int> channelIds) {

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -37,7 +37,7 @@ extension RealmUserUpdateEventChecks on Subject<RealmUserUpdateEvent> {
 }
 
 extension SubscriptionRemoveEventChecks on Subject<SubscriptionRemoveEvent> {
-  Subject<List<int>> get streamIds => has((e) => e.streamIds, 'streamIds');
+  Subject<List<int>> get channelIds => has((e) => e.channelIds, 'channelIds');
 }
 
 extension SubscriptionUpdateEventChecks on Subject<SubscriptionUpdateEvent> {

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -95,7 +95,7 @@ void main() {
         {'stream_id': 123, 'name': 'name 1'},
         {'stream_id': 456, 'name': 'name 2'},
       ],
-    }) as SubscriptionRemoveEvent).streamIds.jsonEquals([123, 456]);
+    }) as SubscriptionRemoveEvent).channelIds.jsonEquals([123, 456]);
   });
 
   test('subscription/update: convert color correctly', () {

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -83,7 +83,7 @@ void main() {
       checkUnified(store);
 
       await store.handleEvent(SubscriptionRemoveEvent(id: 1,
-        streamIds: [stream.streamId]));
+        channelIds: [stream.streamId]));
       checkUnified(store);
 
       await store.handleEvent(SubscriptionAddEvent(id: 1,
@@ -136,7 +136,7 @@ void main() {
       check(store.subscriptions[stream.streamId]!.color).equals(0xFFFF0000);
 
       await store.handleEvent(SubscriptionUpdateEvent(id: 1,
-        streamId: stream.streamId,
+        channelId: stream.streamId,
         property: SubscriptionProperty.color,
         value: 0xFFFF00FF));
       check(store.subscriptions[stream.streamId]!.color).equals(0xFFFF00FF);
@@ -150,7 +150,7 @@ void main() {
       check(store.subscriptions[stream.streamId]!.isMuted).isFalse();
 
       await store.handleEvent(SubscriptionUpdateEvent(id: 1,
-        streamId: stream.streamId,
+        channelId: stream.streamId,
         property: SubscriptionProperty.isMuted,
         value: true));
       check(store.subscriptions[stream.streamId]!.isMuted).isTrue();

--- a/test/model/test_store.dart
+++ b/test/model/test_store.dart
@@ -390,7 +390,7 @@ extension PerAccountStoreTestExtension on PerAccountStore {
   }
 
   Future<void> removeSubscriptions(List<int> channelIds) async {
-    await handleEvent(SubscriptionRemoveEvent(id: 1, streamIds: channelIds));
+    await handleEvent(SubscriptionRemoveEvent(id: 1, channelIds: channelIds));
   }
 
   Future<void> addChannelFolder(ChannelFolder channelFolder) async {

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -228,7 +228,7 @@ void main() {
       check(model.countInChannelNarrow(stream.streamId)).equals(5);
 
       await store.handleEvent(SubscriptionUpdateEvent(id: 1,
-        streamId: stream.streamId,
+        channelId: stream.streamId,
         property: SubscriptionProperty.isMuted, value: true));
       check(model.countInChannel      (stream.streamId)).equals(2);
       check(model.countInChannelNarrow(stream.streamId)).equals(5);

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -690,7 +690,7 @@ void main() {
             expectCollapsed: false, findSectionContent: findSectionContent);
 
           final newColor = Colors.orange.argbInt;
-          await store.handleEvent(SubscriptionUpdateEvent(id: 1, streamId: 1,
+          await store.handleEvent(SubscriptionUpdateEvent(id: 1, channelId: 1,
             property: SubscriptionProperty.color, value: newColor));
           check(subscription.color).equals(Colors.orange.argbInt);
           await tester.pump();


### PR DESCRIPTION
And downstream from there following data flow from a subscription event.

Here was my prompt to Claude:

> I want to do another round toward issue #631. My PR #2203 was just merged. and I want you to pay close attention to it as an example:
>   1. Stick to the pattern of first renaming a type, or small set of related types (like ChannelNarrow and TopicNarrow), then following the flow of *values of that type, downstream from where the values are constructed*, renaming "stream" references to "channel". In particular I'm not asking you to rename references to data flowing *into* the constructor calls; that's an easy misunderstanding.
>   2. Write commit messages that are clear and accurate about the subsystem(s) involved -- see the examples in the PR -- but brief. They should help orient the reader to the diff and help explain important things that aren't obvious, but not create extra work for us by making lots of boring factual claims for us to verify. We'll assume you're doing a good job with point 1; the commit messages don't need to list long chains of data flow to prove it.
> 
>   It's up to you what type you want to start with, but the choice might need some care. Try to choose something that's likely to produce a tight, clear, coherent PR. Use as many tokens as you need, and make a plan first so I can review.

It then produced the changes in these two commits. I pointed out to Claude what looked like an accidental omission:

> Hmm I see this line in lib/model/channel.dart: "assert(streams.containsKey(channelId));". What might it look like to follow the rename there?

And it said:

> ⏺ That line is where the value channelId flows into ChannelStore.streams — a map of channel ID → ZulipStream. Following the rename there means renaming the streams field (and its sibling streamsByName) on ChannelStore.
> 
>   That's the natural next target, but it's a significantly larger scope than the two commits I just made:
> 
>   - store.streams appears in ~32 call sites across 14 files (widgets, model, tests).
>   - streamsByName and subscriptions are related maps on the same store; you'd likely rename them together (at least streamsByName → channelsByName) for consistency.
>   - Inside channel.dart itself, there are lots of bare streams[...] / streams.containsKey(...) accesses plus the docstrings referring to them.
> 
>   It would fit PR #2203's pattern — "rename a small set of related types, then follow the flow downstream" — with the "type" here being the ChannelStore field declarations. Rough shape:
> 
>   - Commit 1: rename ChannelStore.streams → channels, streamsByName → channelsByName (and all references so each commit compiles)
>   - Then a series of commits by subsystem (widgets, autocomplete, etc.) renaming local variables downstream from those fields, like PR #2203's per-subsystem commits
> 
>   Given the cross-file scope, I'd do that as its own PR rather than expanding this one. Want me to queue it up next, or does the current two-commit PR feel like the right stopping point for now?

I said sure we can defer to a later PR, but let's note the intentional stopping point in the commit message, so it doesn't look like an accident, and Claude did that.