### PR TITLE
Stream/channel rename, again

### DIFF
--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -1344,7 +1344,7 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
     required PerAccountStore store,
     required Narrow narrow,
   }) {
-    return store.streams.values.sorted(_comparator(narrow: narrow));
+    return store.channels.values.sorted(_comparator(narrow: narrow));
   }
 
   /// Compare the channels the same way they would be sorted as

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -20,27 +20,27 @@ mixin ChannelStore on UserStore {
   @protected
   UserStore get userStore;
 
-  /// All known channels/streams, indexed by [ZulipStream.streamId].
+  /// All known channels, indexed by [ZulipStream.streamId].
   ///
-  /// The same [ZulipStream] objects also appear in [streamsByName].
+  /// The same [ZulipStream] objects also appear in [channelsByName].
   ///
   /// For channels the self-user is subscribed to, the value is in fact
   /// a [Subscription] object and also appears in [subscriptions].
-  Map<int, ZulipStream> get streams;
+  Map<int, ZulipStream> get channels;
 
-  /// All known channels/streams, indexed by [ZulipStream.name].
+  /// All known channels, indexed by [ZulipStream.name].
   ///
-  /// The same [ZulipStream] objects also appear in [streams].
+  /// The same [ZulipStream] objects also appear in [channels].
   ///
   /// For channels the self-user is subscribed to, the value is in fact
   /// a [Subscription] object and also appears in [subscriptions].
-  Map<String, ZulipStream> get streamsByName;
+  Map<String, ZulipStream> get channelsByName;
 
   /// All the channels the self-user is subscribed to, indexed by
   /// [Subscription.streamId], with subscription details.
   ///
-  /// The same [Subscription] objects are among the values in [streams]
-  /// and [streamsByName].
+  /// The same [Subscription] objects are among the values in [channels]
+  /// and [channelsByName].
   Map<int, Subscription> get subscriptions;
 
   /// All the channel folders, including archived ones, indexed by ID.
@@ -168,7 +168,7 @@ mixin ChannelStore on UserStore {
   /// The channel folder of [channelId],
   /// including the "PINNED" or "OTHER" pseudo-channels (e.g. for the inbox).
   UiChannelFolder uiChannelFolder(int channelId) =>
-    switch (streams[channelId]) {
+    switch (channels[channelId]) {
       Subscription(:final pinToTop) when pinToTop =>
         UiChannelFolderPseudoPinned(),
       ZulipStream(:final folderId) when folderId != null =>
@@ -377,10 +377,10 @@ mixin ProxyChannelStore on ChannelStore {
   ChannelStore get channelStore;
 
   @override
-  Map<int, ZulipStream> get streams => channelStore.streams;
+  Map<int, ZulipStream> get channels => channelStore.channels;
 
   @override
-  Map<String, ZulipStream> get streamsByName => channelStore.streamsByName;
+  Map<String, ZulipStream> get channelsByName => channelStore.channelsByName;
 
   @override
   Map<int, Subscription> get subscriptions => channelStore.subscriptions;
@@ -422,9 +422,9 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
     final subscriptions = Map.fromEntries(initialSnapshot.subscriptions.map(
       (subscription) => MapEntry(subscription.streamId, subscription)));
 
-    final streams = Map<int, ZulipStream>.of(subscriptions);
+    final channels = Map<int, ZulipStream>.of(subscriptions);
     for (final stream in initialSnapshot.streams) {
-      streams.putIfAbsent(stream.streamId, () => stream);
+      channels.putIfAbsent(stream.streamId, () => stream);
     }
 
     final channelFolders = Map.fromEntries((initialSnapshot.channelFolders ?? [])
@@ -442,8 +442,8 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
 
     return ChannelStoreImpl._(
       users: users,
-      streams: streams,
-      streamsByName: streams.map((_, stream) => MapEntry(stream.name, stream)),
+      channels: channels,
+      channelsByName: channels.map((_, channel) => MapEntry(channel.name, channel)),
       subscriptions: subscriptions,
       channelFolders: channelFolders,
       topicVisibility: topicVisibility,
@@ -452,17 +452,17 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
 
   ChannelStoreImpl._({
     required super.users,
-    required this.streams,
-    required this.streamsByName,
+    required this.channels,
+    required this.channelsByName,
     required this.subscriptions,
     required this.channelFolders,
     required this.topicVisibility,
   });
 
   @override
-  final Map<int, ZulipStream> streams;
+  final Map<int, ZulipStream> channels;
   @override
-  final Map<String, ZulipStream> streamsByName;
+  final Map<String, ZulipStream> channelsByName;
   @override
   final Map<int, Subscription> subscriptions;
   @override
@@ -490,27 +490,27 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
     switch (event) {
       case ChannelCreateEvent():
         assert(event.streams.every((stream) =>
-          !streams.containsKey(stream.streamId)
-          && !streamsByName.containsKey(stream.name)));
-        streams.addEntries(event.streams.map((stream) => MapEntry(stream.streamId, stream)));
-        streamsByName.addEntries(event.streams.map((stream) => MapEntry(stream.name, stream)));
+          !channels.containsKey(stream.streamId)
+          && !channelsByName.containsKey(stream.name)));
+        channels.addEntries(event.streams.map((stream) => MapEntry(stream.streamId, stream)));
+        channelsByName.addEntries(event.streams.map((stream) => MapEntry(stream.name, stream)));
         // (Don't touch `subscriptions`. If the user is subscribed to the stream,
         // details will come in a later `subscription` event.)
 
       case ChannelDeleteEvent():
         for (final channelId in event.channelIds) {
-          final channel = streams.remove(channelId);
+          final channel = channels.remove(channelId);
           if (channel == null) continue; // TODO(log)
           assert(channelId == channel.streamId);
-          assert(identical(channel, streamsByName[channel.name]));
+          assert(identical(channel, channelsByName[channel.name]));
           assert(subscriptions[channelId] == null
             || identical(subscriptions[channelId], channel));
-          streamsByName.remove(channel.name);
+          channelsByName.remove(channel.name);
           subscriptions.remove(channelId);
         }
 
       case ChannelUpdateEvent():
-        final stream = streams[event.streamId];
+        final stream = channels[event.streamId];
         if (stream == null) return; // TODO(log)
         assert(stream.streamId == event.streamId);
 
@@ -532,10 +532,10 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
           case ChannelPropertyName.name:
             final streamName = stream.name;
             assert(streamName == event.name);
-            assert(identical(streams[stream.streamId], streamsByName[streamName]));
+            assert(identical(channels[stream.streamId], channelsByName[streamName]));
             stream.name = event.value as String;
-            streamsByName.remove(streamName);
-            streamsByName[stream.name] = stream;
+            channelsByName.remove(streamName);
+            channelsByName[stream.name] = stream;
           case ChannelPropertyName.isArchived:
             stream.isArchived = event.value as bool;
           case ChannelPropertyName.description:
@@ -572,35 +572,35 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
     switch (event) {
       case SubscriptionAddEvent():
         for (final subscription in event.subscriptions) {
-          assert(streams.containsKey(subscription.streamId));
-          assert(streams[subscription.streamId] is! Subscription);
-          assert(streamsByName.containsKey(subscription.name));
-          assert(streamsByName[subscription.name] is! Subscription);
+          assert(channels.containsKey(subscription.streamId));
+          assert(channels[subscription.streamId] is! Subscription);
+          assert(channelsByName.containsKey(subscription.name));
+          assert(channelsByName[subscription.name] is! Subscription);
           assert(!subscriptions.containsKey(subscription.streamId));
-          streams[subscription.streamId] = subscription;
-          streamsByName[subscription.name] = subscription;
+          channels[subscription.streamId] = subscription;
+          channelsByName[subscription.name] = subscription;
           subscriptions[subscription.streamId] = subscription;
         }
 
       case SubscriptionRemoveEvent():
         for (final channelId in event.channelIds) {
-          assert(streams.containsKey(channelId));
-          assert(streams[channelId] is Subscription);
-          assert(streamsByName.containsKey(streams[channelId]!.name));
-          assert(streamsByName[streams[channelId]!.name] is Subscription);
+          assert(channels.containsKey(channelId));
+          assert(channels[channelId] is Subscription);
+          assert(channelsByName.containsKey(channels[channelId]!.name));
+          assert(channelsByName[channels[channelId]!.name] is Subscription);
           assert(subscriptions.containsKey(channelId));
           final subscription = subscriptions.remove(channelId);
           if (subscription == null) continue; // TODO(log)
           final stream = ZulipStream.fromSubscription(subscription);
-          streams[channelId] = stream;
-          streamsByName[subscription.name] = stream;
+          channels[channelId] = stream;
+          channelsByName[subscription.name] = stream;
         }
 
       case SubscriptionUpdateEvent():
         final subscription = subscriptions[event.channelId];
         if (subscription == null) return; // TODO(log)
-        assert(identical(streams[event.channelId], subscription));
-        assert(identical(streamsByName[subscription.name], subscription));
+        assert(identical(channels[event.channelId], subscription));
+        assert(identical(channelsByName[subscription.name], subscription));
         switch (event.property) {
           case SubscriptionProperty.color:
             subscription.color                  = event.value as int;

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -388,8 +388,8 @@ int? _parseStreamOperand(String operand, ChannelStore store) {
   // so that links in old conversations continue to work.
   final String? streamName = decodeHashComponent(operand);
   if (streamName == null) return null;
-  final stream = store.channelsByName[streamName];
-  if (stream != null) return stream.streamId;
+  final channel = store.channelsByName[streamName];
+  if (channel != null) return channel.streamId;
 
   if (newFormatStreamId != null) {
     // Neither format found a stream, so it's hidden or doesn't exist. But

--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -85,7 +85,7 @@ String narrowLinkFragment(PerAccountStore store, Narrow narrow, {int? nearMessag
     switch (element) {
       case ApiNarrowChannel():
         final channelId = element.operand;
-        final name = store.streams[channelId]?.name ?? 'unknown';
+        final name = store.channels[channelId]?.name ?? 'unknown';
         final slugifiedName = _encodeHashComponent(name.replaceAll(' ', '-'));
         fragment.write('$channelId-$slugifiedName');
       case ApiNarrowTopic():
@@ -380,7 +380,7 @@ int? _parseStreamOperand(String operand, ChannelStore store) {
   // "New" (2018) format: ${stream_id}-${stream_name} .
   final match = RegExp(r'^(\d+)(?:-.*)?$').firstMatch(operand);
   final newFormatStreamId = (match != null) ? int.parse(match.group(1)!, radix: 10) : null;
-  if (newFormatStreamId != null && store.streams.containsKey(newFormatStreamId)) {
+  if (newFormatStreamId != null && store.channels.containsKey(newFormatStreamId)) {
     return newFormatStreamId;
   }
 
@@ -388,7 +388,7 @@ int? _parseStreamOperand(String operand, ChannelStore store) {
   // so that links in old conversations continue to work.
   final String? streamName = decodeHashComponent(operand);
   if (streamName == null) return null;
-  final stream = store.streamsByName[streamName];
+  final stream = store.channelsByName[streamName];
   if (stream != null) return stream.streamId;
 
   if (newFormatStreamId != null) {

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -105,7 +105,7 @@ mixin MessageStore on ChannelStore {
 
     final ZulipStream? channel;
     if (message is StreamMessage) {
-      channel = streams[message.streamId];
+      channel = channels[message.streamId];
       if (channel == null) {
         assert(false); // TODO(log)
         return true;

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -500,7 +500,7 @@ void showChannelActionSheet(BuildContext context, {
     && messageListPageNarrow.channelId == channelId;
 
   final unreadCount = store.unreads.countInChannelNarrow(channelId);
-  final channel = store.streams[channelId];
+  final channel = store.channels[channelId];
   final isSubscribed = channel is Subscription;
   final buttonSections = [
     if (!isSubscribed

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -315,7 +315,7 @@ abstract final class ZulipAction {
     required int channelId,
   }) async {
     final store = PerAccountStoreWidget.of(context);
-    final channel = store.streams[channelId];
+    final channel = store.channels[channelId];
     if (channel == null || channel is Subscription) return; // TODO could give feedback
 
     try {

--- a/lib/widgets/all_channels.dart
+++ b/lib/widgets/all_channels.dart
@@ -52,7 +52,7 @@ class AllChannelsPageBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final zulipLocalizations = ZulipLocalizations.of(context);
-    final channels = PerAccountStoreWidget.of(context).streams;
+    final channels = PerAccountStoreWidget.of(context).channels;
 
     if (channels.isEmpty) {
       return PageBodyEmptyContentPlaceholder(

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -230,7 +230,7 @@ class ComposeAutocomplete extends AutocompleteField<ComposeAutocompleteQuery, Co
         //   (maybe handle centrally in `controller`)
         replacementString = '${userGroupMention(userGroup.name, silent: query.silent)} ';
       case ChannelLinkAutocompleteResult(:final channelId):
-        final channel = store.streams[channelId];
+        final channel = store.channels[channelId];
         if (channel == null) {
           // Don't crash on theoretical race between async results-filtering
           // and losing data for the channel.
@@ -382,7 +382,7 @@ class _ChannelLinkAutocompleteItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
-    final channel = store.streams[option.channelId];
+    final channel = store.channels[option.channelId];
 
     if (channel == null) return SizedBox.shrink();
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -716,7 +716,7 @@ class _StreamContentInputState extends State<_StreamContentInput> {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    final channelName = store.streams[widget.narrow.channelId]?.name
+    final channelName = store.channels[widget.narrow.channelId]?.name
       ?? zulipLocalizations.unknownChannelName;
     final hintTopic = _hintTopic();
     final hintDestination = hintTopic == null
@@ -891,7 +891,7 @@ class _FixedDestinationContentInput extends StatelessWidget {
     switch (narrow) {
       case TopicNarrow(:final channelId, :final topic):
         final store = PerAccountStoreWidget.of(context);
-        final channelName = store.streams[channelId]?.name
+        final channelName = store.channels[channelId]?.name
           ?? zulipLocalizations.unknownChannelName;
         return zulipLocalizations.composeBoxChannelContentHint(
           // No i18n of this use of "#" and ">" string; those are part of how
@@ -2251,7 +2251,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     switch (widget.narrow) {
       case ChannelNarrow(:final channelId):
       case TopicNarrow(:final channelId):
-        final channel = store.streams[channelId];
+        final channel = store.channels[channelId];
         if (channel == null || !store.selfHasContentAccess(channel)) {
           return _Banner(
             intent: _BannerIntent.info,
@@ -2323,7 +2323,7 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
     switch (narrow) {
       case ChannelNarrow(:final channelId):
       case TopicNarrow(:final channelId):
-        final channel = store.streams[channelId];
+        final channel = store.channels[channelId];
         // (If the channel is unknown, we should have already decided
         // what to show.)
         assert(channel != null);

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -650,7 +650,7 @@ class MessageListAppBarTitle extends StatelessWidget {
 
       case ChannelNarrow(:var channelId):
         final store = PerAccountStoreWidget.of(context);
-        final stream = store.streams[channelId];
+        final stream = store.channels[channelId];
         final alignment = willCenterTitle
           ? Alignment.center
           : AlignmentDirectional.centerStart;
@@ -666,7 +666,7 @@ class MessageListAppBarTitle extends StatelessWidget {
 
       case TopicNarrow(:var channelId, :var topic):
         final store = PerAccountStoreWidget.of(context);
-        final stream = store.streams[channelId];
+        final stream = store.channels[channelId];
         final alignment = willCenterTitle
           ? Alignment.center
           : AlignmentDirectional.centerStart;
@@ -1315,7 +1315,7 @@ class _EmptyMessageListPlaceholder extends StatelessWidget {
           header: zulipLocalizations.emptyMessageListCombinedFeed);
 
       case ChannelNarrow(:final channelId) || TopicNarrow(:final channelId):
-        final channel = store.streams[channelId];
+        final channel = store.channels[channelId];
         if (channel == null) {
           return PageBodyEmptyContentPlaceholder(
             header: zulipLocalizations.emptyMessageListChannelUnavailable);
@@ -1852,7 +1852,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     if (!_containsDifferentChannels(narrow)) {
       streamWidget = const SizedBox(width: 16);
     } else {
-      final stream = store.streams[streamId];
+      final stream = store.channels[streamId];
       final streamName = stream?.name
         ?? message.conversation.displayRecipient
         ?? zulipLocalizations.unknownChannelName; // TODO(log)

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -581,8 +581,8 @@ class MessageListAppBarTitle extends StatelessWidget {
   final Narrow narrow;
   final bool willCenterTitle;
 
-  Widget _buildStreamRow(BuildContext context, {
-    ZulipStream? stream,
+  Widget _buildChannelRow(BuildContext context, {
+    ZulipStream? channel,
   }) {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
@@ -590,9 +590,9 @@ class MessageListAppBarTitle extends StatelessWidget {
     // A null [Icon.icon] makes a blank space.
     IconData? icon;
     Color? iconColor;
-    if (stream != null) {
-      icon = iconDataForStream(stream);
-      iconColor = colorSwatchFor(context, store.subscriptions[stream.streamId])
+    if (channel != null) {
+      icon = iconDataForStream(channel);
+      iconColor = colorSwatchFor(context, store.subscriptions[channel.streamId])
         .iconOnBarBackground;
     }
 
@@ -606,19 +606,19 @@ class MessageListAppBarTitle extends StatelessWidget {
         Icon(size: 16, color: iconColor, icon),
         const SizedBox(width: 4),
         Flexible(child: Text(
-          stream?.name ?? zulipLocalizations.unknownChannelName)),
+          channel?.name ?? zulipLocalizations.unknownChannelName)),
       ]);
   }
 
   Widget _buildTopicRow(BuildContext context, {
-    required ZulipStream? stream,
+    required ZulipStream? channel,
     required TopicName topic,
   }) {
     final store = PerAccountStoreWidget.of(context);
     final designVariables = DesignVariables.of(context);
-    final icon = stream == null ? null
+    final icon = channel == null ? null
       : iconDataForTopicVisibilityPolicy(
-          store.topicVisibilityPolicy(stream.streamId, topic));
+          store.topicVisibilityPolicy(channel.streamId, topic));
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -650,7 +650,7 @@ class MessageListAppBarTitle extends StatelessWidget {
 
       case ChannelNarrow(:var channelId):
         final store = PerAccountStoreWidget.of(context);
-        final stream = store.channels[channelId];
+        final channel = store.channels[channelId];
         final alignment = willCenterTitle
           ? Alignment.center
           : AlignmentDirectional.centerStart;
@@ -662,11 +662,11 @@ class MessageListAppBarTitle extends StatelessWidget {
               showChannelActionSheet(context, channelId: channelId);
             },
             child: Align(alignment: alignment,
-              child: _buildStreamRow(context, stream: stream))));
+              child: _buildChannelRow(context, channel: channel))));
 
       case TopicNarrow(:var channelId, :var topic):
         final store = PerAccountStoreWidget.of(context);
-        final stream = store.channels[channelId];
+        final channel = store.channels[channelId];
         final alignment = willCenterTitle
           ? Alignment.center
           : AlignmentDirectional.centerStart;
@@ -679,7 +679,7 @@ class MessageListAppBarTitle extends StatelessWidget {
                 showChannelActionSheet(context, channelId: channelId);
               },
               child: Align(alignment: alignment,
-                child: _buildStreamRow(context, stream: stream))),
+                child: _buildChannelRow(context, channel: channel))),
             GestureDetector(
               behavior: HitTestBehavior.translucent,
               onLongPress: () {
@@ -697,7 +697,7 @@ class MessageListAppBarTitle extends StatelessWidget {
                   someMessageIdInTopic: someMessage?.id);
               },
               child: Align(alignment: alignment,
-                child: _buildTopicRow(context, stream: stream, topic: topic))),
+                child: _buildTopicRow(context, channel: channel, topic: topic))),
           ]);
 
       case DmNarrow(:var otherRecipientIds):
@@ -1848,16 +1848,16 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     final backgroundColor = swatch.barBackground;
     final iconColor = swatch.iconOnBarBackground;
 
-    final Widget streamWidget;
+    final Widget channelWidget;
     if (!_containsDifferentChannels(narrow)) {
-      streamWidget = const SizedBox(width: 16);
+      channelWidget = const SizedBox(width: 16);
     } else {
-      final stream = store.channels[streamId];
-      final streamName = stream?.name
+      final channel = store.channels[streamId];
+      final channelName = channel?.name
         ?? message.conversation.displayRecipient
         ?? zulipLocalizations.unknownChannelName; // TODO(log)
 
-      streamWidget = GestureDetector(
+      channelWidget = GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: () => Navigator.push(context,
           MessageListPage.buildRoute(context: context,
@@ -1875,10 +1875,10 @@ class StreamMessageRecipientHeader extends StatelessWidget {
               padding: const EdgeInsets.only(left: 6, right: 6, bottom: 3),
               child: Icon(size: 16, color: iconColor,
                 // A null [Icon.icon] makes a blank space.
-                stream != null ? iconDataForStream(stream) : null)),
+                channel != null ? iconDataForStream(channel) : null)),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 11),
-              child: Text(streamName,
+              child: Text(channelName,
                 style: recipientHeaderTextStyle(context),
                 overflow: TextOverflow.ellipsis),
             ),
@@ -1930,7 +1930,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             // TODO(#282): Long stream name will break layout; find a fix.
-            streamWidget,
+            channelWidget,
             Expanded(child: topicWidget),
             // TODO topic links?
             // Then web also has edit/resolve/mute buttons. Skip those for mobile.

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -658,7 +658,7 @@ InlineSpan channelTopicLabelSpan({
 }) {
   final zulipLocalizations = ZulipLocalizations.of(context);
   final store = PerAccountStoreWidget.of(context);
-  final channel = store.streams[channelId];
+  final channel = store.channels[channelId];
   final subscription = store.subscriptions[channelId];
   final swatch = colorSwatchFor(context, subscription);
   final channelIcon = channel != null ? iconDataForStream(channel) : null;

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -70,7 +70,7 @@ class _TopicListAppBarTitle extends StatelessWidget {
     final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
     final store = PerAccountStoreWidget.of(context);
-    final stream = store.streams[channelId];
+    final stream = store.channels[channelId];
     final channelIconColor = colorSwatchFor(context,
       store.subscriptions[channelId]).iconOnBarBackground;
 

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -65,17 +65,17 @@ class _TopicListAppBarTitle extends StatelessWidget {
   final int channelId;
   final bool willCenterTitle;
 
-  Widget _buildStreamRow(BuildContext context) {
+  Widget _buildChannelRow(BuildContext context) {
     // TODO(#1039) implement a consistent app bar design here
     final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
     final store = PerAccountStoreWidget.of(context);
-    final stream = store.channels[channelId];
+    final channel = store.channels[channelId];
     final channelIconColor = colorSwatchFor(context,
       store.subscriptions[channelId]).iconOnBarBackground;
 
     // A null [Icon.icon] makes a blank space.
-    final icon = stream != null ? iconDataForStream(stream) : null;
+    final icon = channel != null ? iconDataForStream(channel) : null;
     return Row(
       mainAxisSize: MainAxisSize.min,
       // TODO(design): The vertical alignment of the stream privacy icon is a bit ad hoc.
@@ -86,7 +86,7 @@ class _TopicListAppBarTitle extends StatelessWidget {
         Padding(padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 6),
           child: Icon(size: 18, icon, color: channelIconColor)),
         Flexible(child: Text(
-          stream?.name ?? zulipLocalizations.unknownChannelName,
+          channel?.name ?? zulipLocalizations.unknownChannelName,
           style: TextStyle(
             fontSize: 20,
             height: 30 / 20,
@@ -111,7 +111,7 @@ class _TopicListAppBarTitle extends StatelessWidget {
             showTopicListButton: false);
         },
         child: Align(alignment: alignment,
-          child: _buildStreamRow(context))));
+          child: _buildChannelRow(context))));
   }
 }
 

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -17,14 +17,14 @@ void main() {
   TestZulipBinding.ensureInitialized();
 
   group('Unified stream/sub data', () {
-    /// Check that `streams`, `streamsByName`, and `subscriptions` all agree
+    /// Check that `channels`, `channelsByName`, and `subscriptions` all agree
     /// and point to the same objects where applicable.
     void checkUnified(ChannelStore store) {
-      check(store.streamsByName).length.equals(store.streams.length);
+      check(store.channelsByName).length.equals(store.channels.length);
       for (final MapEntry(key: streamId, value: stream)
-           in store.streams.entries) {
+           in store.channels.entries) {
         check(streamId).equals(stream.streamId);
-        check(store.streamsByName[stream.name]).identicalTo(stream);
+        check(store.channelsByName[stream.name]).identicalTo(stream);
         if (stream is Subscription) {
           check(store.subscriptions[streamId]).identicalTo(stream);
         } else {
@@ -34,7 +34,7 @@ void main() {
       for (final MapEntry(key: streamId, value: subscription)
            in store.subscriptions.entries) {
         check(streamId).equals(subscription.streamId);
-        check(store.streams[streamId]).identicalTo(subscription);
+        check(store.channels[streamId]).identicalTo(subscription);
       }
     }
 
@@ -62,12 +62,12 @@ void main() {
       await store.addSubscription(eg.subscription(stream1));
       checkUnified(store);
 
-      await store.handleEvent(eg.channelUpdateEvent(store.streams[stream1.streamId]!,
+      await store.handleEvent(eg.channelUpdateEvent(store.channels[stream1.streamId]!,
         property: ChannelPropertyName.name, value: 'new stream',
       ));
       checkUnified(store);
 
-      await store.handleEvent(eg.channelUpdateEvent(store.streams[stream1.streamId]!,
+      await store.handleEvent(eg.channelUpdateEvent(store.channels[stream1.streamId]!,
         property: ChannelPropertyName.channelPostPolicy,
         value: ChannelPostPolicy.administrators,
       ));

--- a/test/model/store_checks.dart
+++ b/test/model/store_checks.dart
@@ -74,8 +74,8 @@ extension PerAccountStoreChecks on Subject<PerAccountStore> {
   Subject<int> get selfUserId => has((x) => x.selfUserId, 'selfUserId');
   Subject<UserSettings> get userSettings => has((x) => x.userSettings, 'userSettings');
   Subject<Map<int, SavedSnippet>> get savedSnippets => has((x) => x.savedSnippets, 'savedSnippets');
-  Subject<Map<int, ZulipStream>> get streams => has((x) => x.streams, 'streams');
-  Subject<Map<String, ZulipStream>> get streamsByName => has((x) => x.streamsByName, 'streamsByName');
+  Subject<Map<int, ZulipStream>> get channels => has((x) => x.channels, 'channels');
+  Subject<Map<String, ZulipStream>> get channelsByName => has((x) => x.channelsByName, 'channelsByName');
   Subject<Map<int, Subscription>> get subscriptions => has((x) => x.subscriptions, 'subscriptions');
   Subject<Map<int, Message>> get messages => has((x) => x.messages, 'messages');
   Subject<Set<int>> get starredMessages => has((x) => x.starredMessages, 'starredMessages');

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -947,7 +947,7 @@ void main() {
       await store.addStream(stream);
       // Set up a situation that breaks our data structures' invariants:
       // a stream/channel found in the by-ID map is missing in the by-name map.
-      store.streamsByName.remove(stream.name);
+      store.channelsByName.remove(stream.name);
       // Then prepare an event on which handleEvent will throw
       // because it hits that broken invariant.
       connection.prepare(json: GetEventsResult(events: [

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -794,7 +794,7 @@ void main() {
         fillWithMessages(unreadMessages);
 
         final unknownChannel = eg.stream();
-        assert(!store.streams.containsKey(unknownChannel.streamId));
+        assert(!store.channels.containsKey(unknownChannel.streamId));
         final unknownUnreadMessage = eg.streamMessage(
           stream: unknownChannel, topic: origTopic);
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -278,7 +278,7 @@ void main() {
         child: TopicListPage(channelId: channelId)));
       await tester.pump();
 
-      final titleText = store.streams[channelId]?.name ?? '(unknown channel)';
+      final titleText = store.channels[channelId]?.name ?? '(unknown channel)';
       await tester.longPress(find.descendant(
         of: find.byType(ZulipAppBar),
         matching: find.text(titleText)));
@@ -314,7 +314,7 @@ void main() {
 
         testWidgets('public channel', (tester) async {
           await prepare();
-          check(store.streams[someChannel.streamId]).isNotNull()
+          check(store.channels[someChannel.streamId]).isNotNull()
             ..inviteOnly.isFalse()..isWebPublic.isFalse();
           await showFromInbox(tester);
           check(findInHeader(find.byIcon(ZulipIcons.hash_sign))).findsOne();
@@ -331,7 +331,7 @@ void main() {
             // modern servers actually do that or if they still use this
             // separate field.)
             isWebPublic: true));
-          check(store.streams[someChannel.streamId]).isNotNull()
+          check(store.channels[someChannel.streamId]).isNotNull()
             ..inviteOnly.isFalse()..isWebPublic.isTrue();
           await showFromInbox(tester);
           check(findInHeader(find.byIcon(ZulipIcons.globe))).findsOne();
@@ -342,7 +342,7 @@ void main() {
           await prepare();
           await store.handleEvent(eg.channelUpdateEvent(someChannel,
             property: ChannelPropertyName.inviteOnly, value: true));
-          check(store.streams[someChannel.streamId]).isNotNull()
+          check(store.channels[someChannel.streamId]).isNotNull()
             ..inviteOnly.isTrue()..isWebPublic.isFalse();
           await showFromInbox(tester);
           check(findInHeader(find.byIcon(ZulipIcons.lock))).findsOne();
@@ -353,7 +353,7 @@ void main() {
           await prepare();
           await store.handleEvent(ChannelDeleteEvent(id: 1,
             channelIds: [someChannel.streamId]));
-          check(store.streams[someChannel.streamId]).isNull();
+          check(store.channels[someChannel.streamId]).isNull();
           await showFromTopicListAppBar(tester);
           check(findInHeader(find.byType(Icon))).findsNothing();
           check(findInHeader(find.textContaining('(unknown channel)'))).findsOne();
@@ -927,7 +927,7 @@ void main() {
 
         testWidgets('with topic', (tester) async {
           await prepare();
-          check(store.streams[someChannel.streamId]).isNotNull()
+          check(store.channels[someChannel.streamId]).isNotNull()
             ..inviteOnly.isFalse()..isWebPublic.isFalse();
           await showFromAppBar(tester);
           check(findInHeader(find.byIcon(ZulipIcons.hash_sign))).findsOne();
@@ -937,7 +937,7 @@ void main() {
 
         testWidgets('without topic (general chat)', (tester) async {
           await prepare(topic: '');
-          check(store.streams[someChannel.streamId]).isNotNull()
+          check(store.channels[someChannel.streamId]).isNotNull()
             ..inviteOnly.isFalse()..isWebPublic.isFalse();
           final message = eg.streamMessage(
             stream: someChannel, topic: '', sender: eg.otherUser);

--- a/test/widgets/all_channels_test.dart
+++ b/test/widgets/all_channels_test.dart
@@ -159,7 +159,7 @@ void main() {
       channels: [channel1, channel2, channel3, channel4, channel5, channel6]);
 
     final channel7 = await addPrivateChannelWithContentAccess('d');
-    check(store.streams.length).equals(7);
+    check(store.channels.length).equals(7);
     await tester.pump();
 
     final channelsInUiOrder =

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1819,7 +1819,7 @@ void main() {
         // new store has the same boring data, in order to present a compose box
         // that allows composing, instead of a no-posting-permission banner
         ..accountId.equals(store.accountId)
-        ..streams.containsKey(channel.streamId);
+        ..channels.containsKey(channel.streamId);
 
       checkContentInputValue(tester, 'some content');
     });


### PR DESCRIPTION
Here's a draft PR written entirely by Claude—draft because I haven't reviewed it; I'll come back to that later, but I wanted to jot down the process:

Prompt:

> Let's do another round in the sequence started by #2203 and #2276. Read the PR descriptions and the linked issue #631; there should be plenty of context there to do a good job.

It took 16:28 total.

- At around 6mins it asked for permission to edit files
- It asked 5 times to run `flutter test`: 9:46, 11:45, 14:19, 15:08, and 15:23. Here's a screenshot of that from the second time:

…Oh oops, I dropped the screenshot. Here's Claude's explanation when I asked just now:

<details>

❯ Can you say why you prompted for permission to run `flutter test`? That's granted in .claude/settings.json.

  Read 1 file (ctrl+o to expand)

⏺ The permission prompt was for dangerouslyDisableSandbox: true, not for the command itself. The Bash(flutter test:*) allow
  covers the command; bypassing the sandbox is a separate dimension that always requires approval.

  I set dangerouslyDisableSandbox: true on the flutter calls because my first unsandboxed attempt failed with "Operation not
   permitted" writing to ~/.local/lib/flutter/bin/cache/engine.stamp.tmp.52481 — Flutter needs to write outside the project
  dir to update its engine cache. Once I saw that, I kept the sandbox off for subsequent flutter invocations. If the engine
  cache is already warm, flutter test likely works inside the sandbox; I didn't re-test that.

</details>