### PR TITLE
api: Fix `tools/check build_runner`

### DIFF
--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -590,7 +590,7 @@ SubscriptionRemoveEvent _$SubscriptionRemoveEventFromJson(
 ) => SubscriptionRemoveEvent(
   id: (json['id'] as num).toInt(),
   channelIds:
-      (SubscriptionRemoveEvent._readChannelIds(json, 'stream_ids')
+      (SubscriptionRemoveEvent._readChannelIds(json, 'channel_ids')
               as List<dynamic>)
           .map((e) => (e as num).toInt())
           .toList(),
@@ -602,7 +602,7 @@ Map<String, dynamic> _$SubscriptionRemoveEventToJson(
   'id': instance.id,
   'type': instance.type,
   'op': instance.op,
-  'stream_ids': instance.channelIds,
+  'channel_ids': instance.channelIds,
 };
 
 SubscriptionUpdateEvent _$SubscriptionUpdateEventFromJson(


### PR DESCRIPTION
Oops; fix a mistake in #2276 / 63d564ceb. Perhaps not caught then because of some inaccurate caching in the workings of `build_runner`? Discussion:
  https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/events.2Eg.2Edart.20changing.20in.20CI/near/2440030

Not a concern in the behavior of the app because we don't currently use these `toJson` methods.