### PR TITLE
Request longer-lived event queue from server

### DIFF
--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -7,6 +7,13 @@ import '../model/initial_snapshot.dart';
 part 'events.g.dart';
 
 /// https://zulip.com/api/register-queue
+///
+/// Unlike in most of our API bindings, this function hard-codes
+/// the values of many parameters rather than expose them to the caller.
+/// That's because those parameters control the shape of the data
+/// that the server returns, mostly in enabling modern rather than legacy APIs.
+/// The types in [InitialSnapshot] and the [Event] subclasses, and their
+/// deserialization logic, are written for the settings chosen here.
 Future<InitialSnapshot> registerQueue(ApiConnection connection) {
   return connection.post('registerQueue', InitialSnapshot.fromJson, 'register', {
     'apply_markdown': true,

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -16,9 +16,19 @@ part 'events.g.dart';
 /// deserialization logic, are written for the settings chosen here.
 Future<InitialSnapshot> registerQueue(ApiConnection connection) {
   return connection.post('registerQueue', InitialSnapshot.fromJson, 'register', {
+    // Parameters that change the scope of the data we get,
+    // and in principle could be exposed to the caller:
+    //   event_types and fetch_event_types omitted; get all events and all data
+    //   all_public_streams
+    //   narrow
+
+    // Parameters that don't make sense to expose to the caller,
+    // for the reasons in the dartdoc above.
+    // (We might change these; we'll just need to update types to match.)
     'apply_markdown': true,
-    'slim_presence': true,
     'client_gravatar': false, // TODO(#255): turn on
+    // 'include_subscribers': false, // the default
+    'slim_presence': true,
     'client_capabilities': {
       'notification_settings_null': true,
       'bulk_message_deletion': true,

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -14,8 +14,12 @@ part 'events.g.dart';
 /// that the server returns, mostly in enabling modern rather than legacy APIs.
 /// The types in [InitialSnapshot] and the [Event] subclasses, and their
 /// deserialization logic, are written for the settings chosen here.
-Future<InitialSnapshot> registerQueue(ApiConnection connection) {
+Future<InitialSnapshot> registerQueue(ApiConnection connection, {
+  IdleQueueTimeout? idleQueueTimeout,
+}) {
   return connection.post('registerQueue', InitialSnapshot.fromJson, 'register', {
+    'idle_queue_timeout': ?idleQueueTimeout,
+
     // Parameters that change the scope of the data we get,
     // and in principle could be exposed to the caller:
     //   event_types and fetch_event_types omitted; get all events and all data
@@ -39,6 +43,29 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection) {
       'empty_topic_name': true,
     },
   });
+}
+
+/// A value for `idleQueueTimeout` on [registerQueue].
+///
+/// https://zulip.com/api/register-queue#parameter-idle_queue_timeout
+class IdleQueueTimeout {
+  const IdleQueueTimeout.numeric(this._numeric) : _enum = null;
+
+  static const IdleQueueTimeout mobile = IdleQueueTimeout._(.mobile);
+
+  const IdleQueueTimeout._(this._enum) : _numeric = null;
+
+  final int? _numeric;
+  final _IdleQueueTimeout? _enum;
+
+  Object toJson() {
+    assert((_numeric != null) ^ (_enum != null));
+    return _numeric ?? _enum!.name;
+  }
+}
+
+enum _IdleQueueTimeout {
+  mobile;
 }
 
 /// https://zulip.com/api/get-events

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1483,7 +1483,7 @@ class UpdateMachine {
     while (true) {
       InitialSnapshot? result;
       try {
-        result = await registerQueue(connection);
+        result = await registerQueue(connection, idleQueueTimeout: .mobile);
       } catch (e, stackTrace) {
         stopAndThrowIfNoAccount();
         // TODO(#890): tell user if initial-fetch errors persist, or look non-transient

--- a/test/api/route/events_test.dart
+++ b/test/api/route/events_test.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:checks/checks.dart';
+import 'package:http/http.dart' as http;
+import 'package:test_api/scaffolding.dart';
+import 'package:zulip/api/model/initial_snapshot.dart';
+import 'package:zulip/api/route/events.dart';
+
+import '../../example_data.dart' as eg;
+import '../../stdlib_checks.dart';
+import '../fake_api.dart';
+
+void main() {
+  group('registerQueue', () {
+    Future<InitialSnapshot> checkRegisterQueue(FakeApiConnection connection, {
+      IdleQueueTimeout? idleQueueTimeout,
+    }) async {
+      final result = await registerQueue(connection,
+        idleQueueTimeout: idleQueueTimeout);
+      check(connection.lastRequest).isA<http.Request>()
+        ..method.equals('POST')
+        ..url.path.equals('/api/v1/register')
+        ..bodyFields.which((it) =>
+            idleQueueTimeout == null
+              ? it.not((it) => it.containsKey('idle_queue_timeout'))
+              : it['idle_queue_timeout'].equals(jsonEncode(idleQueueTimeout)));
+      return result;
+    }
+
+    test('idleQueueTimeout absent', () => FakeApiConnection.with_((connection) async {
+      connection.prepare(json: eg.initialSnapshot().toJson());
+      await checkRegisterQueue(connection, idleQueueTimeout: null);
+    }));
+
+    test('idleQueueTimeout numeric', () => FakeApiConnection.with_((connection) async {
+      connection.prepare(json: eg.initialSnapshot().toJson());
+      await checkRegisterQueue(connection, idleQueueTimeout: .numeric(3600));
+    }));
+
+    test('idleQueueTimeout mobile', () => FakeApiConnection.with_((connection) async {
+      connection.prepare(json: eg.initialSnapshot().toJson());
+      await checkRegisterQueue(connection, idleQueueTimeout: .mobile);
+    }));
+  });
+}

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:checks/checks.dart';
@@ -596,7 +597,8 @@ void main() {
     void checkLastRequest() {
       check(connection.takeRequests()).single.isA<http.Request>()
         ..method.equals('POST')
-        ..url.path.equals('/api/v1/register');
+        ..url.path.equals('/api/v1/register')
+        ..bodyFields['idle_queue_timeout'].equals(jsonEncode('mobile'));
     }
 
     test('smoke', () => awaitFakeAsync((async) async {


### PR DESCRIPTION
Fixes #1934.

This will cause the server to keep around the event queue for longer
periods of not hearing from the app: 12 hours, rather than 10 minutes.
That means if you open the app at several different times in the day,
it'll typically be immediately ready to go.


### Selected commit messages

c167cadf5 api [nfc]: Explain why registerQueue hard-codes many parameters



d09c0582c api [nfc]: Fill in registerQueue parameters we hard-code not passing

This doesn't cover parameters that were added in recent Zulip Server
versions; just those that in principle would have been mentioned
since early versions of this endpoint binding.

(The newer parameters will naturally be added separately when we
periodically sweep through the API changelog.)



7acb59c36 api: Add idleQueueTimeout parameter to registerQueue route

This is a bit overkill -- we'd have been fine just hard-coding to
the value "mobile".  But I figured I'd experiment with a new way
to express this sort of "int or enum" type.  This seems potentially
a bit cleaner, for the app code that consumes it, than the pattern
we have in places like Anchor (with AnchorCode and NumericAnchor).

(This bit of API is also a bit different from that one, in that
the "enum" values are in proper JSON.  But that's orthogonal to the
difference in the code-facing API here.)
