### PR TITLE
lightbox: Offer to open browser if video player doesn't support a video format

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1026,6 +1026,14 @@
   "@errorVideoPlayerFailed": {
     "description": "Error message when a video fails to play."
   },
+  "errorVideoPlayerFailedTryBrowser": "Try opening it in your browser instead.",
+  "@errorVideoPlayerFailedTryBrowser": {
+    "description": "Body of a dialog suggesting the user open a video in the browser, after the app's video player failed to play it."
+  },
+  "dialogOpenInBrowser": "Open in browser",
+  "@dialogOpenInBrowser": {
+    "description": "Button label to confirm opening a link in the browser."
+  },
   "serverUrlValidationErrorEmpty": "Please enter a URL.",
   "@serverUrlValidationErrorEmpty": {
     "description": "Error message when URL is empty"

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1518,6 +1518,18 @@ abstract class ZulipLocalizations {
   /// **'Unable to play the video.'**
   String get errorVideoPlayerFailed;
 
+  /// Body of a dialog suggesting the user open a video in the browser, after the app's video player failed to play it.
+  ///
+  /// In en, this message translates to:
+  /// **'Try opening it in your browser instead.'**
+  String get errorVideoPlayerFailedTryBrowser;
+
+  /// Button label to confirm opening a link in the browser.
+  ///
+  /// In en, this message translates to:
+  /// **'Open in browser'**
+  String get dialogOpenInBrowser;
+
   /// Error message when URL is empty
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -866,6 +866,13 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
       'Video konnte nicht wiedergegeben werden.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Bitte gib eine URL ein.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -845,6 +845,13 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -858,6 +858,13 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'No se ha podido reproducir el video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Por favor introduce una URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -847,6 +847,13 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -875,6 +875,13 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Échec de la lecture de la vidéo.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty =>
       'Merci de saisir une adresse Internet (URL).';
 

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -864,6 +864,13 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Impossibile riprodurre il video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Inserire un URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -825,6 +825,13 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get errorVideoPlayerFailed => '動画を再生できません。';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'URLを入力してください。';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -859,6 +859,13 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Nie da rady odtworzyć wideo.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Proszę podaj URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -862,6 +862,13 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Не удается воспроизвести видео.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Пожалуйста, введите URL-адрес.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Nepodarilo sa prehrať video';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Vložte adresu.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -869,6 +869,13 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Videa ni mogoče predvajati.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Vnesite URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -860,6 +860,13 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Неможливо відтворити відео.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Будь ласка, введіть URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -844,6 +844,13 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get errorVideoPlayerFailed => 'Unable to play the video.';
 
   @override
+  String get errorVideoPlayerFailedTryBrowser =>
+      'Try opening it in your browser instead.';
+
+  @override
+  String get dialogOpenInBrowser => 'Open in browser';
+
+  @override
   String get serverUrlValidationErrorEmpty => 'Please enter a URL.';
 
   @override

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -275,8 +275,12 @@ abstract final class ZulipAction {
     return fetchedMessage?.content;
   }
 
-  /// Fetch and parse a URL from [messages_api.getFileTemporaryUrl];
-  /// on failure, show an error dialog and return null.
+  /// Fetch and parse a URL from [messages_api.getFileTemporaryUrl].
+  ///
+  /// On failure, shows an error dialog; the returned future resolves when that
+  /// dialog has been dismissed, and the result is null.
+  /// This lets a caller pop a route that it's managing
+  /// without inadvertently popping the error-dialog route instead.
   static Future<Uri?> getFileTemporaryUrl(BuildContext context, UserUploadLink link) async {
     final zulipLocalizations = ZulipLocalizations.of(context);
 
@@ -293,18 +297,20 @@ abstract final class ZulipAction {
         //   (support with reusable code)
         _ => null,
       };
-      showErrorDialog(context: context,
+      final dialogStatus = showErrorDialog(context: context,
         title: zulipLocalizations.errorCouldNotAccessUploadedFileTitle,
         message: errorMessage);
+      await dialogStatus.result;
       return null;
     }
     if (!context.mounted) return null;
 
     final tempUrl = PerAccountStoreWidget.of(context).tryResolveUrl(resultUrl);
     if (tempUrl == null) {
-      showErrorDialog(context: context,
+      final dialogStatus = showErrorDialog(context: context,
         title: zulipLocalizations.errorCouldNotAccessUploadedFileTitle,
         message: zulipLocalizations.errorInvalidResponse);
+      await dialogStatus.result;
       return null;
     }
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -436,7 +436,12 @@ abstract final class PlatformActions {
     }
   }
 
-  /// Opens a URL with [ZulipBinding.launchUrl], with an error dialog on failure.
+  /// Opens a URL with [ZulipBinding.launchUrl].
+  ///
+  /// On failure, shows an error dialog; the returned future resolves when that
+  /// dialog has been dismissed.
+  /// This lets a caller pop a route that it's managing
+  /// without inadvertently popping the error-dialog route instead.
   static Future<void> launchUrl(BuildContext context, Uri url) async {
     final globalSettings = GlobalStoreWidget.settingsOf(context);
 
@@ -452,12 +457,13 @@ abstract final class PlatformActions {
       if (!context.mounted) return;
 
       final zulipLocalizations = ZulipLocalizations.of(context);
-      showErrorDialog(context: context,
+      final dialogStatus = showErrorDialog(context: context,
         title: zulipLocalizations.errorCouldNotOpenLinkTitle,
         message: [
           zulipLocalizations.errorCouldNotOpenLink(url.toString()),
           ?errorMessage,
         ].join("\n\n"));
+      await dialogStatus.result;
     }
   }
 }

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -8,6 +8,7 @@ import '../api/model/model.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../log.dart';
 import '../model/binding.dart';
+import '../model/internal_link.dart';
 import 'actions.dart';
 import 'content.dart';
 import 'dialog.dart';
@@ -517,15 +518,37 @@ class _VideoLightboxPageState extends State<VideoLightboxPage> with PerAccountSt
     } catch (error) { // TODO(log)
       assert(debugLog("VideoPlayerController.initialize failed: $error"));
       if (!mounted) return;
-      final zulipLocalizations = ZulipLocalizations.of(context);
-      final dialog = showErrorDialog(
-        context: context,
-        title: zulipLocalizations.errorDialogTitle,
-        message: zulipLocalizations.errorVideoPlayerFailed);
-      await dialog.result;
+      await _offerOpenInBrowser();
       if (!mounted) return;
       Navigator.pop(context); // Pops the lightbox
     }
+  }
+
+  /// Offer to open the video in a browser, when playing it here has failed.
+  Future<void> _offerOpenInBrowser() async {
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    final dialogStatus = showSuggestedActionDialog(
+      context: context,
+      title: zulipLocalizations.errorVideoPlayerFailed,
+      message: zulipLocalizations.errorVideoPlayerFailedTryBrowser,
+      actionButtonText: zulipLocalizations.dialogOpenInBrowser,
+    );
+    final shouldOpen = await dialogStatus.result;
+    if (!mounted) return;
+    if (shouldOpen != true) return;
+
+    final store = PerAccountStoreWidget.of(context);
+    Uri urlToLaunch = widget.src;
+    // For authenticated on-realm uploads, fetch a temp URL the browser
+    // can open without the user's auth credentials.
+    final internalLink = parseInternalLink(widget.src, store);
+    if (internalLink is UserUploadLink) {
+      final tempUrl = await ZulipAction.getFileTemporaryUrl(context, internalLink);
+      if (!mounted) return;
+      if (tempUrl == null) return;
+      urlToLaunch = tempUrl;
+    }
+    await PlatformActions.launchUrl(context, urlToLaunch);
   }
 
   @override

--- a/test/widgets/lightbox_test.dart
+++ b/test/widgets/lightbox_test.dart
@@ -4,12 +4,15 @@ import 'dart:math';
 import 'package:checks/checks.dart';
 import 'package:clock/clock.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:video_player/video_player.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
+import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
@@ -24,6 +27,7 @@ import '../example_data.dart' as eg;
 import '../model/binding.dart';
 import '../model/content_test.dart';
 import '../model/test_store.dart';
+import '../stdlib_checks.dart';
 import '../test_images.dart';
 import 'dialog_checks.dart';
 import 'test_app.dart';
@@ -31,6 +35,11 @@ import 'test_app.dart';
 const kTestVideoUrl = "https://a/video.mp4";
 const kTestUnsupportedVideoUrl = "https://a/unsupported.mp4";
 const kTestVideoDuration = Duration(seconds: 10);
+
+/// A `/user_uploads/…` URL on [eg.realmUrl], which the fake platform
+/// treats as unsupported (see [FakeVideoPlayerPlatform.createWithOptions]).
+final kTestUnsupportedOnRealmVideoUrl =
+  eg.realmUrl.resolve('/user_uploads/123/ab/unsupported.mp4');
 
 class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   static final FakeVideoPlayerPlatform instance = FakeVideoPlayerPlatform();
@@ -116,7 +125,8 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Future<int?> createWithOptions(VideoCreationOptions options) async  {
     assert(!initialized);
-    if (options.dataSource.uri == kTestUnsupportedVideoUrl) {
+    if (options.dataSource.uri != null
+        && options.dataSource.uri!.contains('unsupported')) {
       _hasError = true;
       _streamController.addError(
         PlatformException(
@@ -494,6 +504,10 @@ void main() {
     FakeVideoPlayerPlatform.registerWith();
     final platform = FakeVideoPlayerPlatform.instance;
 
+    late PerAccountStore store;
+    late FakeApiConnection connection;
+    late TransitionDurationObserver transitionDurationObserver;
+
     /// Find the position shown by the slider, and check the label agrees.
     Duration findSliderPosition(WidgetTester tester) {
       final sliderValue = tester.widget<Slider>(find.byType(Slider)).value;
@@ -538,9 +552,13 @@ void main() {
     }) async {
       addTearDown(testBinding.reset);
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      connection = store.connection as FakeApiConnection;
       addTearDown(platform.reset);
 
+      transitionDurationObserver = TransitionDurationObserver();
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        navigatorObservers: [transitionDurationObserver],
         child: VideoLightboxPage(
           routeEntranceAnimation: kAlwaysCompleteAnimation,
           message: eg.streamMessage(),
@@ -573,12 +591,111 @@ void main() {
       check(platform.isPlaying).isTrue();
     });
 
-    testWidgets('unsupported video shows an error dialog', (tester) async {
-      await setupPage(tester, videoSrc: Uri.parse(kTestUnsupportedVideoUrl));
-      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
-      await tester.tap(find.byWidget(checkErrorDialog(tester,
-        expectedTitle: zulipLocalizations.errorDialogTitle,
-        expectedMessage: zulipLocalizations.errorVideoPlayerFailed)));
+    group('unsupported video offers to open in browser', () {
+      testWidgets('cancel: no launch, no API request', (tester) async {
+        await setupPage(tester, videoSrc: Uri.parse(kTestUnsupportedVideoUrl));
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        final (_, cancelButton) = checkSuggestedActionDialog(tester,
+          expectedTitle: zulipLocalizations.errorVideoPlayerFailed,
+          expectedMessage: zulipLocalizations.errorVideoPlayerFailedTryBrowser,
+          expectedActionButtonText: zulipLocalizations.dialogOpenInBrowser);
+        await tester.tap(find.byWidget(cancelButton));
+        await tester.pump(); // close dialog
+
+        check(connection.takeRequests()).isEmpty();
+        check(testBinding.takeLaunchUrlCalls()).isEmpty();
+      });
+
+      testWidgets('on-realm upload: fetch temp URL then launch', (tester) async {
+        await setupPage(tester, videoSrc: kTestUnsupportedOnRealmVideoUrl);
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        final (actionButton, _) = checkSuggestedActionDialog(tester,
+          expectedTitle: zulipLocalizations.errorVideoPlayerFailed,
+          expectedMessage: zulipLocalizations.errorVideoPlayerFailedTryBrowser,
+          expectedActionButtonText: zulipLocalizations.dialogOpenInBrowser);
+
+        connection.prepare(json: GetFileTemporaryUrlResult(
+          url: '/temp/s3kr1t-auth-token/unsupported.mp4').toJson());
+        await tester.tap(find.byWidget(actionButton));
+        await tester.pump(Duration.zero); // await API request
+        check(connection.lastRequest).isA<http.Request>()
+          ..method.equals('GET')
+          ..url.path.equals('/api/v1/user_uploads/123/ab/unsupported.mp4');
+        await tester.pump(); // launch
+
+        final launchUrlCalls = testBinding.takeLaunchUrlCalls();
+        check(launchUrlCalls).length.equals(1);
+        check(launchUrlCalls.single.url).equals(
+          store.tryResolveUrl('/temp/s3kr1t-auth-token/unsupported.mp4')!);
+        await transitionDurationObserver.pumpPastTransition(tester); // pop lightbox
+        check(find.byType(VideoLightboxPage)).findsNothing();
+      });
+
+      testWidgets('off-realm URL: launch original URL directly', (tester) async {
+        await setupPage(tester, videoSrc: Uri.parse(kTestUnsupportedVideoUrl));
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        final (actionButton, _) = checkSuggestedActionDialog(tester,
+          expectedTitle: zulipLocalizations.errorVideoPlayerFailed,
+          expectedActionButtonText: zulipLocalizations.dialogOpenInBrowser);
+
+        await tester.tap(find.byWidget(actionButton));
+        await tester.pump(); // close dialog, launch
+
+        check(connection.takeRequests()).isEmpty();
+        final launchUrlCalls = testBinding.takeLaunchUrlCalls();
+        check(launchUrlCalls).length.equals(1);
+        check(launchUrlCalls.single.url).equals(Uri.parse(kTestUnsupportedVideoUrl));
+        await transitionDurationObserver.pumpPastTransition(tester); // pop lightbox
+        check(find.byType(VideoLightboxPage)).findsNothing();
+      });
+
+      testWidgets('off-realm URL: launch fails; error dialog shown, lightbox remains until dialog dismissed', (tester) async {
+        // Regression test for:
+        //   https://github.com/zulip/zulip-flutter/pull/2294#discussion_r3140781478
+        await setupPage(tester, videoSrc: Uri.parse(kTestUnsupportedVideoUrl));
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        final (actionButton, _) = checkSuggestedActionDialog(tester,
+          expectedTitle: zulipLocalizations.errorVideoPlayerFailed,
+          expectedActionButtonText: zulipLocalizations.dialogOpenInBrowser);
+
+        testBinding.launchUrlResult = false;
+        await tester.tap(find.byWidget(actionButton));
+        await tester.pump(); // close suggested-action dialog; attempt launch
+        await tester.pump(); // show error dialog
+
+        check(testBinding.takeLaunchUrlCalls()).length.equals(1);
+        final okButton = checkErrorDialog(tester,
+          expectedTitle: zulipLocalizations.errorCouldNotOpenLinkTitle);
+        check(find.byType(VideoLightboxPage)).findsOne();
+
+        await tester.tap(find.byWidget(okButton));
+        await transitionDurationObserver.pumpPastTransition(tester); // close error dialog; pop lightbox
+        check(find.byType(VideoLightboxPage)).findsNothing();
+      });
+
+      testWidgets('on-realm upload: temp URL fetch fails; error dialog shown, lightbox remains until dialog dismissed', (tester) async {
+        // Regression test for:
+        //   https://github.com/zulip/zulip-flutter/pull/2294#discussion_r3140781478
+        await setupPage(tester, videoSrc: kTestUnsupportedOnRealmVideoUrl);
+        final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+        final (actionButton, _) = checkSuggestedActionDialog(tester,
+          expectedTitle: zulipLocalizations.errorVideoPlayerFailed,
+          expectedActionButtonText: zulipLocalizations.dialogOpenInBrowser);
+
+        connection.prepare(httpException: http.ClientException('oops'));
+        await tester.tap(find.byWidget(actionButton));
+        await tester.pump(Duration.zero); // await API request
+        await tester.pump(); // show error dialog
+
+        check(testBinding.takeLaunchUrlCalls()).isEmpty();
+        final okButton = checkErrorDialog(tester,
+          expectedTitle: zulipLocalizations.errorCouldNotAccessUploadedFileTitle);
+        check(find.byType(VideoLightboxPage)).findsOne();
+
+        await tester.tap(find.byWidget(okButton));
+        await transitionDurationObserver.pumpPastTransition(tester); // close error dialog; pop lightbox
+        check(find.byType(VideoLightboxPage)).findsNothing();
+      });
     });
 
     testWidgets('toggles wakelock when playing state changes', (tester) async {


### PR DESCRIPTION
Fixes #1208.

Tested with a video in this message:
  https://chat.zulip.org/#narrow/channel/7-test-here/topic/Chris2/near/2443349
using an iPhone 15 Pro simulator running iOS 17.5. I obtained that video by following a link in the discussion that raised this issue:
  https://chat.zulip.org/#narrow/channel/48-mobile/topic/Unable.20to.20play.20.2Ewebm.20videos/near/2017541
    
<img width="537" height="1017" alt="image" src="https://github.com/user-attachments/assets/d1cdd2e7-8541-4a07-bbe6-503552f2aa8b" />