### PR TITLE
notif ios: Fix notifications being silent on iOS

### DIFF
--- a/ios/NotificationService/IosNotifications.g.swift
+++ b/ios/NotificationService/IosNotifications.g.swift
@@ -152,6 +152,16 @@ func deepHashIosNotifications(value: Any?, hasher: inout Hasher) {
 }
 
 
+/// The sound to use for the notification.
+enum IosNotificationSound: Int {
+  /// This corresponds to `UNNotificationSound.default` on iOS,
+  /// i.e. the system's default notification sound.
+  /// See:
+  ///   https://developer.apple.com/documentation/usernotifications/unnotificationsound/default
+  ///   https://developer.apple.com/documentation/usernotifications/unnotificationsound
+  case systemDefault = 0
+}
+
 /// The notification content of the incoming push notification.
 ///
 /// Generated class from Pigeon that represents data sent in messages.
@@ -196,6 +206,8 @@ struct ImprovedNotificationContent: Hashable {
   var subtitle: String
   /// The new body to use for the notification.
   var body: String
+  /// The new sound to use for the notification.
+  var sound: IosNotificationSound
   /// The internal data to attach with the new notification.
   ///
   /// This replaces the raw APNs payload that was initially set from
@@ -208,12 +220,14 @@ struct ImprovedNotificationContent: Hashable {
     let title = pigeonVar_list[0] as! String
     let subtitle = pigeonVar_list[1] as! String
     let body = pigeonVar_list[2] as! String
-    let userInfo = pigeonVar_list[3] as! [String: Any?]
+    let sound = pigeonVar_list[3] as! IosNotificationSound
+    let userInfo = pigeonVar_list[4] as! [String: Any?]
 
     return ImprovedNotificationContent(
       title: title,
       subtitle: subtitle,
       body: body,
+      sound: sound,
       userInfo: userInfo
     )
   }
@@ -222,6 +236,7 @@ struct ImprovedNotificationContent: Hashable {
       title,
       subtitle,
       body,
+      sound,
       userInfo,
     ]
   }
@@ -229,7 +244,7 @@ struct ImprovedNotificationContent: Hashable {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsIosNotifications(lhs.title, rhs.title) && deepEqualsIosNotifications(lhs.subtitle, rhs.subtitle) && deepEqualsIosNotifications(lhs.body, rhs.body) && deepEqualsIosNotifications(lhs.userInfo, rhs.userInfo)
+    return deepEqualsIosNotifications(lhs.title, rhs.title) && deepEqualsIosNotifications(lhs.subtitle, rhs.subtitle) && deepEqualsIosNotifications(lhs.body, rhs.body) && deepEqualsIosNotifications(lhs.sound, rhs.sound) && deepEqualsIosNotifications(lhs.userInfo, rhs.userInfo)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -237,6 +252,7 @@ struct ImprovedNotificationContent: Hashable {
     deepHashIosNotifications(value: title, hasher: &hasher)
     deepHashIosNotifications(value: subtitle, hasher: &hasher)
     deepHashIosNotifications(value: body, hasher: &hasher)
+    deepHashIosNotifications(value: sound, hasher: &hasher)
     deepHashIosNotifications(value: userInfo, hasher: &hasher)
   }
 }
@@ -245,8 +261,14 @@ private class IosNotificationsPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      return NotificationContent.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return IosNotificationSound(rawValue: enumResultAsInt)
+      }
+      return nil
     case 130:
+      return NotificationContent.fromList(self.readValue() as! [Any?])
+    case 131:
       return ImprovedNotificationContent.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -256,11 +278,14 @@ private class IosNotificationsPigeonCodecReader: FlutterStandardReader {
 
 private class IosNotificationsPigeonCodecWriter: FlutterStandardWriter {
   override func writeValue(_ value: Any) {
-    if let value = value as? NotificationContent {
+    if let value = value as? IosNotificationSound {
       super.writeByte(129)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? NotificationContent {
+      super.writeByte(130)
       super.writeValue(value.toList())
     } else if let value = value as? ImprovedNotificationContent {
-      super.writeByte(130)
+      super.writeByte(131)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -65,6 +65,10 @@ class NotificationService: UNNotificationServiceExtension {
         bestAttemptContent.title = improvedNotificationContent.title
         bestAttemptContent.subtitle = improvedNotificationContent.subtitle
         bestAttemptContent.body = improvedNotificationContent.body
+        switch improvedNotificationContent.sound {
+        case .systemDefault:
+          bestAttemptContent.sound = UNNotificationSound.default
+        }
         bestAttemptContent.userInfo = improvedNotificationContent.userInfo as [AnyHashable: Any]
         contentHandler(bestAttemptContent)
 

--- a/lib/host/ios_notifications.g.dart
+++ b/lib/host/ios_notifications.g.dart
@@ -81,6 +81,16 @@ int _deepHash(Object? value) {
 }
 
 
+/// The sound to use for the notification.
+enum IosNotificationSound {
+  /// This corresponds to `UNNotificationSound.default` on iOS,
+  /// i.e. the system's default notification sound.
+  /// See:
+  ///   https://developer.apple.com/documentation/usernotifications/unnotificationsound/default
+  ///   https://developer.apple.com/documentation/usernotifications/unnotificationsound
+  systemDefault,
+}
+
 /// The notification content of the incoming push notification.
 class NotificationContent {
   NotificationContent({
@@ -129,6 +139,7 @@ class ImprovedNotificationContent {
     required this.title,
     required this.subtitle,
     required this.body,
+    required this.sound,
     required this.userInfo,
   });
 
@@ -141,6 +152,9 @@ class ImprovedNotificationContent {
   /// The new body to use for the notification.
   String body;
 
+  /// The new sound to use for the notification.
+  IosNotificationSound sound;
+
   /// The internal data to attach with the new notification.
   ///
   /// This replaces the raw APNs payload that was initially set from
@@ -152,6 +166,7 @@ class ImprovedNotificationContent {
       title,
       subtitle,
       body,
+      sound,
       userInfo,
     ];
   }
@@ -165,7 +180,8 @@ class ImprovedNotificationContent {
       title: result[0]! as String,
       subtitle: result[1]! as String,
       body: result[2]! as String,
-      userInfo: (result[3]! as Map<Object?, Object?>).cast<String, Object?>(),
+      sound: result[3]! as IosNotificationSound,
+      userInfo: (result[4]! as Map<Object?, Object?>).cast<String, Object?>(),
     );
   }
 
@@ -178,7 +194,7 @@ class ImprovedNotificationContent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(title, other.title) && _deepEquals(subtitle, other.subtitle) && _deepEquals(body, other.body) && _deepEquals(userInfo, other.userInfo);
+    return _deepEquals(title, other.title) && _deepEquals(subtitle, other.subtitle) && _deepEquals(body, other.body) && _deepEquals(sound, other.sound) && _deepEquals(userInfo, other.userInfo);
   }
 
   @override
@@ -194,11 +210,14 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is NotificationContent) {
+    }    else if (value is IosNotificationSound) {
       buffer.putUint8(129);
+      writeValue(buffer, value.index);
+    }    else if (value is NotificationContent) {
+      buffer.putUint8(130);
       writeValue(buffer, value.encode());
     }    else if (value is ImprovedNotificationContent) {
-      buffer.putUint8(130);
+      buffer.putUint8(131);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -209,8 +228,11 @@ class _PigeonCodec extends StandardMessageCodec {
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
       case 129:
-        return NotificationContent.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : IosNotificationSound.values[value];
       case 130:
+        return NotificationContent.decode(readValue(buffer)!);
+      case 131:
         return ImprovedNotificationContent.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/lib/notifications/ios_service.dart
+++ b/lib/notifications/ios_service.dart
@@ -101,6 +101,7 @@ class _IosNotifFlutterApiImpl extends IosNotifFlutterApi {
       title: title,
       subtitle: subtitle,
       body: data.content,
+      sound: IosNotificationSound.systemDefault,
       userInfo: {
         // Pass the notification URL to this custom data map, so when a
         // notification is opened we can read this custom map to decide

--- a/pigeon/ios_notifications.dart
+++ b/pigeon/ios_notifications.dart
@@ -17,12 +17,23 @@ class NotificationContent {
   final Map<Object?, Object?> payload;
 }
 
+/// The sound to use for the notification.
+enum IosNotificationSound {
+  /// This corresponds to `UNNotificationSound.default` on iOS,
+  /// i.e. the system's default notification sound.
+  /// See:
+  ///   https://developer.apple.com/documentation/usernotifications/unnotificationsound/default
+  ///   https://developer.apple.com/documentation/usernotifications/unnotificationsound
+  systemDefault
+}
+
 /// The improved notification content that will be displayed to the user.
 class ImprovedNotificationContent {
   const ImprovedNotificationContent({
     required this.title,
     required this.subtitle,
     required this.body,
+    required this.sound,
     required this.userInfo,
   });
 
@@ -34,6 +45,9 @@ class ImprovedNotificationContent {
 
   /// The new body to use for the notification.
   final String body;
+
+  /// The new sound to use for the notification.
+  final IosNotificationSound sound;
 
   /// The internal data to attach with the new notification.
   ///

--- a/test/notifications/ios_service_test.dart
+++ b/test/notifications/ios_service_test.dart
@@ -81,6 +81,7 @@ void main() {
       ..title.equals(expectedTitle)
       ..subtitle.equals(expectedSubtitle)
       ..body.equals(data.content)
+      ..sound.equals(IosNotificationSound.systemDefault)
       ..userInfo.deepEquals({
         NotificationOpenPayload.kIosNotificationUrlKey: expectedNotificationUrl.toString(),
       });
@@ -126,5 +127,6 @@ extension on Subject<ImprovedNotificationContent> {
   Subject<String> get title => has((x) => x.title, 'title');
   Subject<String> get subtitle => has((x) => x.subtitle, 'subtitle');
   Subject<String> get body => has((x) => x.body, 'body');
+  Subject<IosNotificationSound> get sound => has((x) => x.sound, 'sound');
   Subject<Map<Object?, Object?>> get userInfo => has((x) => x.userInfo, 'userInfo');
 }


### PR DESCRIPTION
Discussion: https://chat.zulip.org/#narrow/channel/48-mobile/topic/iOS.20notifications.20silent/with/2444979

Unlike the legacy non-E2EE APNs payloads, the newer E2EE payloads
do not set the `"sound": "default"` pair currently.
Which is required for indicating iOS to play a sound
(specifically default system sound) with the notification.

So fix that in NotificationService extension by unconditionally
playing the default system sound when any "alert" notification is
received and processed, in both the success and the failure cases
(which just displays "New notification").

(NotificationService extension will only trigger when the incoming
notification is an "alert" notification, see:
    https://developer.apple.com/documentation/usernotifications/modifying-content-in-newly-delivered-notifications#Configure-the-payload-for-the-remote-notification )
