### PR TITLE
Add text styling and message background color for self mentions

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -1078,7 +1078,7 @@ sealed class MentionNode extends InlineContainerNode {
     required this.isSilent,
   });
 
-  final bool isSilent; // TODO(#647)
+  final bool isSilent;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -96,9 +96,20 @@ class PollContent implements ZulipMessageContent {
 /// [Stream.renderedDescription], or other text from a Zulip server that comes
 /// in the same Zulip HTML format.
 class ZulipContent extends ContentNode implements ZulipMessageContent {
-  const ZulipContent({super.debugHtmlNode, required this.nodes});
+  const ZulipContent({
+    super.debugHtmlNode,
+    required this.nodes,
+    this.mentionedUserIds = const {},
+  });
 
   final List<BlockContentNode> nodes;
+
+  /// A set of user IDs of all non-silent user mentions in [nodes].
+  ///
+  /// This set carries no information that couldn't be computed from [nodes].
+  /// It exists as an optimization, to allow a widget interpreting this content
+  /// to obtain that set during build without having to walk the [nodes] tree.
+  final Set<int> mentionedUserIds;
 
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
@@ -1326,6 +1337,9 @@ class _ZulipInlineContentParser {
       debugSoftFailReason: kDebugMode ? parsed.softFailReason : null);
   }
 
+  /// The user IDs of all non-silent user mentions found in the current message.
+  final Set<int> _mentionedUserIds = {};
+
   MentionNode? parseMention(dom.Element element) {
     assert(element.localName == 'span');
     final debugHtmlNode = kDebugMode ? element : null;
@@ -1397,6 +1411,9 @@ class _ZulipInlineContentParser {
           debugHtmlNode: debugHtmlNode);
       case ('user-mention', final userIdString):
         final userId = int.tryParse(userIdString ?? '', radix: 10);
+        if (userId != null && !isSilent) {
+          _mentionedUserIds.add(userId);
+        }
         return UserMentionNode(
           nodes: nodes,
           isSilent: isSilent,
@@ -2303,7 +2320,10 @@ class _ZulipContentParser {
   ZulipContent parse(String html) {
     final fragment = HtmlParser(html, parseMeta: false).parseFragment();
     final nodes = parseBlockContentList(fragment.nodes);
-    return ZulipContent(nodes: nodes, debugHtmlNode: kDebugMode ? fragment : null);
+    return ZulipContent(
+      nodes: nodes,
+      debugHtmlNode: kDebugMode ? fragment : null,
+      mentionedUserIds: inlineParser._mentionedUserIds);
   }
 }
 

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -36,7 +36,9 @@ class MessageListRecipientHeaderItem extends MessageListItem {
 class MessageListDateSeparatorItem extends MessageListItem {
   final MessageBase message;
 
-  MessageListDateSeparatorItem(this.message);
+  final ZulipMessageContent? content;
+
+  MessageListDateSeparatorItem(this.message, {this.content});
 }
 
 /// A [MessageBase] to show in the message list.
@@ -439,6 +441,7 @@ mixin _MessageSequence {
   void _addItemsForMessage(MessageBase message, {
     required bool shouldSetMiddleItem,
     required MessageBase? prevMessage,
+    ZulipMessageContent? content,
     required MessageListMessageBaseItem Function(bool canShareSender) buildItem,
   }) {
     final bool canShareSender;
@@ -457,7 +460,7 @@ mixin _MessageSequence {
       prevMessageItem.isLastInBlock = false;
 
       if (!messagesSameDay(prevMessageItem.message, message)) {
-        items.add(MessageListDateSeparatorItem(message));
+        items.add(MessageListDateSeparatorItem(message, content: content));
         canShareSender = false;
       } else if (prevMessageItem.message.senderId == message.senderId) {
         canShareSender = messagesCloseInTime(prevMessage, message);
@@ -488,6 +491,7 @@ mixin _MessageSequence {
     _addItemsForMessage(message,
       shouldSetMiddleItem: index == middleMessage,
       prevMessage: prevMessage,
+      content: content,
       buildItem: (bool canShareSender) => MessageListMessageItem(
         message, content, showSender: !canShareSender, isLastInBlock: true));
   }

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -1290,7 +1290,7 @@ class _MessageActionSheetHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final designVariables = DesignVariables.of(context);
+    final content = parseMessageContent(message);
 
     // TODO this seems to lose the hero animation when opening an image;
     //   investigate.
@@ -1298,9 +1298,8 @@ class _MessageActionSheetHeader extends StatelessWidget {
     //   On popping the pushed narrow route, the sheet is still open.
 
     return Container(
-      // TODO(#647) use different color for highlighted messages
       // TODO(#681) use different color for DM messages
-      color: designVariables.bgMessageRegular,
+      color: messageBackgroundColor(context, message, content),
       padding: EdgeInsets.symmetric(vertical: 4),
       child: Column(
         spacing: 4,
@@ -1311,7 +1310,7 @@ class _MessageActionSheetHeader extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16),
             // TODO(#10) offer text selection; the Figma asks for it here:
             //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=3483-30210&m=dev
-            child: MessageContent(message: message, content: parseMessageContent(message))),
+            child: MessageContent(message: message, content: content)),
         ]));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -44,9 +44,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 0).toColor(),
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.2, 240, 0.7, 0.7).toColor(),
-      colorGroupMentionBackground: const HSLColor.fromAHSL(0.18, 183, 0.6, 0.45).toColor(),
       colorGlobalTimeBackground: const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor(),
       colorGlobalTimeBorder: const HSLColor.fromAHSL(1, 0, 0, 0.8).toColor(),
+      colorGroupMentionBackground: const HSLColor.fromAHSL(0.18, 183, 0.6, 0.45).toColor(),
       colorLink: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor(),
       colorMathBlockBorder: const HSLColor.fromAHSL(0.15, 240, 0.8, 0.5).toColor(),
       colorMessageMediaContainerBackground: const Color.fromRGBO(0, 0, 0, 0.03),
@@ -79,9 +79,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: const HSLColor.fromAHSL(0.04, 0, 0, 1).toColor(),
       colorDirectMentionBackground: const HSLColor.fromAHSL(0.25, 240, 0.52, 0.6).toColor(),
-      colorGroupMentionBackground: const HSLColor.fromAHSL(0.20, 183, 0.52, 0.4).toColor(),
       colorGlobalTimeBackground: const HSLColor.fromAHSL(0.2, 0, 0, 0).toColor(),
       colorGlobalTimeBorder: const HSLColor.fromAHSL(0.4, 0, 0, 0).toColor(),
+      colorGroupMentionBackground: const HSLColor.fromAHSL(0.20, 183, 0.52, 0.4).toColor(),
       colorLink: const HSLColor.fromAHSL(1, 200, 1, 0.4).toColor(), // the same as light in Web
       colorMathBlockBorder: const HSLColor.fromAHSL(1, 240, 0.4, 0.4).toColor(),
       colorMessageMediaContainerBackground: const HSLColor.fromAHSL(0.03, 0, 0, 1).toColor(),
@@ -113,9 +113,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   ContentTheme._({
     required this.colorCodeBlockBackground,
     required this.colorDirectMentionBackground,
-    required this.colorGroupMentionBackground,
     required this.colorGlobalTimeBackground,
     required this.colorGlobalTimeBorder,
+    required this.colorGroupMentionBackground,
     required this.colorLink,
     required this.colorMathBlockBorder,
     required this.colorMessageMediaContainerBackground,
@@ -147,9 +147,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
 
   final Color colorCodeBlockBackground;
   final Color colorDirectMentionBackground;
-  final Color colorGroupMentionBackground;
   final Color colorGlobalTimeBackground;
   final Color colorGlobalTimeBorder;
+  final Color colorGroupMentionBackground;
   final Color colorLink;
   final Color colorMathBlockBorder; // TODO(#46) this won't be needed
   final Color colorMessageMediaContainerBackground;
@@ -209,9 +209,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   ContentTheme copyWith({
     Color? colorCodeBlockBackground,
     Color? colorDirectMentionBackground,
-    Color? colorGroupMentionBackground,
     Color? colorGlobalTimeBackground,
     Color? colorGlobalTimeBorder,
+    Color? colorGroupMentionBackground,
     Color? colorLink,
     Color? colorMathBlockBorder,
     Color? colorMessageMediaContainerBackground,
@@ -233,9 +233,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: colorCodeBlockBackground ?? this.colorCodeBlockBackground,
       colorDirectMentionBackground: colorDirectMentionBackground ?? this.colorDirectMentionBackground,
-      colorGroupMentionBackground: colorGroupMentionBackground ?? this.colorGroupMentionBackground,
       colorGlobalTimeBackground: colorGlobalTimeBackground ?? this.colorGlobalTimeBackground,
       colorGlobalTimeBorder: colorGlobalTimeBorder ?? this.colorGlobalTimeBorder,
+      colorGroupMentionBackground: colorGroupMentionBackground ?? this.colorGroupMentionBackground,
       colorLink: colorLink ?? this.colorLink,
       colorMathBlockBorder: colorMathBlockBorder ?? this.colorMathBlockBorder,
       colorMessageMediaContainerBackground: colorMessageMediaContainerBackground ?? this.colorMessageMediaContainerBackground,
@@ -264,9 +264,9 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     return ContentTheme._(
       colorCodeBlockBackground: Color.lerp(colorCodeBlockBackground, other.colorCodeBlockBackground, t)!,
       colorDirectMentionBackground: Color.lerp(colorDirectMentionBackground, other.colorDirectMentionBackground, t)!,
-      colorGroupMentionBackground: Color.lerp(colorGroupMentionBackground, other.colorGroupMentionBackground, t)!,
       colorGlobalTimeBackground: Color.lerp(colorGlobalTimeBackground, other.colorGlobalTimeBackground, t)!,
       colorGlobalTimeBorder: Color.lerp(colorGlobalTimeBorder, other.colorGlobalTimeBorder, t)!,
+      colorGroupMentionBackground: Color.lerp(colorGroupMentionBackground, other.colorGroupMentionBackground, t)!,
       colorLink: Color.lerp(colorLink, other.colorLink, t)!,
       colorMathBlockBorder: Color.lerp(colorMathBlockBorder, other.colorMathBlockBorder, t)!,
       colorMessageMediaContainerBackground: Color.lerp(colorMessageMediaContainerBackground, other.colorMessageMediaContainerBackground, t)!,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -56,6 +56,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorPollVoteCountText: const HSLColor.fromAHSL(1, 156, 0.41, 0.4).toColor(),
       colorTableCellBorder: const HSLColor.fromAHSL(1, 0, 0, 0.80).toColor(),
       colorTableHeaderBackground: const HSLColor.fromAHSL(1, 0, 0, 0.93).toColor(),
+      colorTextDirectMention: const HSLColor.fromAHSL(1, 240, 0.52, 0.45).toColor(),
+      colorTextGroupOrWildcardMention: const HSLColor.fromAHSL(1, 183, 0.52, 0.26).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor(),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.15).toColor(),
@@ -91,6 +93,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorPollVoteCountText: const HSLColor.fromAHSL(1, 185, 0.35, 0.65).toColor(),
       colorTableCellBorder: const HSLColor.fromAHSL(1, 0, 0, 0.33).toColor(),
       colorTableHeaderBackground: const HSLColor.fromAHSL(0.5, 0, 0, 0).toColor(),
+      colorTextDirectMention: const HSLColor.fromAHSL(1, 240, 1.0, 0.88).toColor(),
+      colorTextGroupOrWildcardMention: const HSLColor.fromAHSL(1, 184, 0.52, 0.63).toColor(),
       colorThematicBreak: const HSLColor.fromAHSL(1, 0, 0, .87).toColor().withValues(alpha: 0.2),
       textStylePlainParagraph: _plainParagraphCommon(context).copyWith(
         color: const HSLColor.fromAHSL(1, 0, 0, 0.85).toColor(),
@@ -125,6 +129,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     required this.colorPollVoteCountText,
     required this.colorTableCellBorder,
     required this.colorTableHeaderBackground,
+    required this.colorTextDirectMention,
+    required this.colorTextGroupOrWildcardMention,
     required this.colorThematicBreak,
     required this.textStylePlainParagraph,
     required this.textStyleEmoji,
@@ -159,6 +165,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
   final Color colorPollVoteCountText;
   final Color colorTableCellBorder;
   final Color colorTableHeaderBackground;
+  final Color colorTextDirectMention;
+  final Color colorTextGroupOrWildcardMention;
   final Color colorThematicBreak;
 
   /// The complete [TextStyle] we use for plain, unstyled paragraphs.
@@ -221,6 +229,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
     Color? colorPollVoteCountText,
     Color? colorTableCellBorder,
     Color? colorTableHeaderBackground,
+    Color? colorTextDirectMention,
+    Color? colorTextGroupOrWildcardMention,
     Color? colorThematicBreak,
     TextStyle? textStylePlainParagraph,
     TextStyle? textStyleEmoji,
@@ -245,6 +255,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorPollVoteCountText: colorPollVoteCountText ?? this.colorPollVoteCountText,
       colorTableCellBorder: colorTableCellBorder ?? this.colorTableCellBorder,
       colorTableHeaderBackground: colorTableHeaderBackground ?? this.colorTableHeaderBackground,
+      colorTextDirectMention: colorTextDirectMention ?? this.colorTextDirectMention,
+      colorTextGroupOrWildcardMention: colorTextGroupOrWildcardMention ?? this.colorTextGroupOrWildcardMention,
       colorThematicBreak: colorThematicBreak ?? this.colorThematicBreak,
       textStylePlainParagraph: textStylePlainParagraph ?? this.textStylePlainParagraph,
       textStyleEmoji: textStyleEmoji ?? this.textStyleEmoji,
@@ -276,6 +288,8 @@ class ContentTheme extends ThemeExtension<ContentTheme> {
       colorPollVoteCountText: Color.lerp(colorPollVoteCountText, other.colorPollVoteCountText, t)!,
       colorTableCellBorder: Color.lerp(colorTableCellBorder, other.colorTableCellBorder, t)!,
       colorTableHeaderBackground: Color.lerp(colorTableHeaderBackground, other.colorTableHeaderBackground, t)!,
+      colorTextDirectMention: Color.lerp(colorTextDirectMention, other.colorTextDirectMention, t)!,
+      colorTextGroupOrWildcardMention: Color.lerp(colorTextGroupOrWildcardMention, other.colorTextGroupOrWildcardMention, t)!,
       colorThematicBreak: Color.lerp(colorThematicBreak, other.colorThematicBreak, t)!,
       textStylePlainParagraph: TextStyle.lerp(textStylePlainParagraph, other.textStylePlainParagraph, t)!,
       textStyleEmoji: TextStyle.lerp(textStyleEmoji, other.textStyleEmoji, t)!,
@@ -1241,11 +1255,14 @@ class Mention extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final contentTheme = ContentTheme.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
+    final message = InheritedMessage.of(context);
 
     var nodes = node.nodes;
+    bool isSelfMention = false;
     switch (node) {
       case UserGroupMentionNode(:final userGroupId):
         final userGroup = store.getGroup(userGroupId);
+        isSelfMention = userGroup?.members.contains(store.selfUserId) ?? false;
         if (userGroup case UserGroup(:final name, :final isSystemGroup)) {
           final String displayName;
           if (isSystemGroup) {
@@ -1258,13 +1275,28 @@ class Mention extends StatelessWidget {
           nodes = [TextNode(node.isSilent ? displayName : '@$displayName')];
         }
       case UserMentionNode(:final userId?):
+        isSelfMention = userId == store.selfUserId;
         final user = store.getUser(userId);
         if (user case User(:final fullName)) {
           nodes = [TextNode(node.isSilent ? fullName : '@$fullName')];
         }
       case UserMentionNode(userId: null):
+        break;
       case WildcardMentionNode():
+        isSelfMention = message.flags.any((flag) =>
+          flag == .topicWildcardMentioned || flag == .streamWildcardMentioned);
     }
+
+    // Following web, the mention text is styled purely on whether the mention is
+    // a self-mention, independent of `isSilent` and channel subscription.
+    //   See `user-mention-me` in zulip:web/src/rendered_markdown.ts.
+    final TextStyle mentionTextStyle = isSelfMention
+      ? ambientTextStyle.copyWith(
+          color: node is UserMentionNode
+            ? contentTheme.colorTextDirectMention
+            : contentTheme.colorTextGroupOrWildcardMention,
+        ).merge(weightVariableTextStyle(context, wght: 600))
+      : ambientTextStyle;
 
     final backgroundPillColor = switch (node) {
       UserMentionNode() => contentTheme.colorDirectMentionBackground,
@@ -1284,8 +1316,7 @@ class Mention extends StatelessWidget {
         // (The parser on creating a MentionNode has a TODO to check that.)
         linkRecognizers: null,
 
-        // TODO(#647) when self-user is mentioned, make bold, and change font color.
-        style: ambientTextStyle,
+        style: mentionTextStyle,
 
         nodes: nodes));
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -318,7 +318,8 @@ class MessageContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final content = this.content;
-    return InheritedMessage(message: message,
+    return InheritedMessageWidget(
+      data: InheritedMessage(message: message, content: content),
       child: DefaultTextStyle(
         style: ContentTheme.of(context).textStylePlainParagraph,
         child: switch (content) {
@@ -328,19 +329,34 @@ class MessageContent extends StatelessWidget {
   }
 }
 
-class InheritedMessage extends InheritedWidget {
-  const InheritedMessage({super.key, required this.message, required super.child});
+/// A [Message] together with its parsed [content], shared down the widget tree by
+/// [InheritedMessageWidget].
+class InheritedMessage {
+  const InheritedMessage({required this.message, required this.content});
 
   final Message message;
+  final ZulipMessageContent content;
+}
+
+/// Provides access to the ambient [InheritedMessage].
+class InheritedMessageWidget extends InheritedWidget {
+  const InheritedMessageWidget({
+    super.key,
+    required this.data,
+    required super.child,
+  });
+
+  final InheritedMessage data;
 
   @override
-  bool updateShouldNotify(covariant InheritedMessage oldWidget) =>
-    !identical(oldWidget.message, message);
+  bool updateShouldNotify(covariant InheritedMessageWidget oldWidget) =>
+    !identical(oldWidget.data.message, data.message)
+      || !identical(oldWidget.data.content, data.content);
 
-  static Message of(BuildContext context) {
-    final widget = context.dependOnInheritedWidgetOfExactType<InheritedMessage>();
-    assert(widget != null, 'No InheritedMessage ancestor');
-    return widget!.message;
+  static InheritedMessage of(BuildContext context) {
+    final widget = context.dependOnInheritedWidgetOfExactType<InheritedMessageWidget>();
+    assert(widget != null, 'No InheritedMessageWidget ancestor');
+    return widget!.data;
   }
 }
 
@@ -670,7 +686,7 @@ class MessageInlineVideo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final message = InheritedMessage.of(context);
+    final message = InheritedMessageWidget.of(context).message;
     final store = PerAccountStoreWidget.of(context);
     final resolvedSrc = store.tryResolveUrl(node.srcUrl);
 
@@ -1255,7 +1271,7 @@ class Mention extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final contentTheme = ContentTheme.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
-    final message = InheritedMessage.of(context);
+    final message = InheritedMessageWidget.of(context).message;
 
     var nodes = node.nodes;
     bool isSelfMention = false;
@@ -1589,7 +1605,7 @@ class _Image extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
-    final message = InheritedMessage.of(context);
+    final message = InheritedMessageWidget.of(context).message;
 
     final resolvedSrc = switch (node.src) {
       ImageNodeSrcThumbnail(:final value) => value.resolve(context,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -26,7 +26,6 @@ import 'profile.dart';
 import 'scrolling.dart';
 import 'store.dart';
 import 'text.dart';
-import 'theme.dart';
 
 /// A central place for styles for Zulip content (rendered Zulip Markdown).
 ///
@@ -851,6 +850,7 @@ class WebsitePreview extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final resolvedImageSrcUrl = store.tryResolveUrl(node.imageSrcUrl);
     final isSmallWidth = MediaQuery.sizeOf(context).width <= 576;
+    final inheritedMessage = InheritedMessageWidget.of(context);
 
     // On Web on larger width viewports, the title and description container's
     // width is constrained using `max-width: calc(100% - 115px)`, we do not
@@ -883,9 +883,9 @@ class WebsitePreview extends StatelessWidget {
       child: InsetShadowBox(
         bottom: 8,
         // TODO(#488) use different color for non-message contexts
-        // TODO(#647) use different color for highlighted messages
         // TODO(#681) use different color for DM messages
-        color: DesignVariables.of(context).bgMessageRegular,
+        color: messageBackgroundColor(
+          context, inheritedMessage.message, inheritedMessage.content),
         child: ClipRect(
           child: ConstrainedBox(
             constraints: BoxConstraints(maxHeight: 80),

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -2367,9 +2367,7 @@ class MessageWithPossibleSender extends StatelessWidget {
         || KeywordSearchNarrow() => true,
     };
 
-    final showAsMuted = store.isUserMuted(message.senderId)
-      && !MessageListPage.maybeRevealedMutedMessagesOf(context)!
-                         .isMutedMessageRevealed(message.id);
+    final showAsMuted = _isMutedMessageHidden(context, message);
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -2433,6 +2431,15 @@ class MessageWithPossibleSender extends StatelessWidget {
             ]),
         ])));
   }
+}
+
+bool _isMutedMessageHidden(BuildContext context, Message message) {
+  final store = PerAccountStoreWidget.of(context);
+  final isRevealed = MessageListPage.maybeRevealedMutedMessagesOf(context)
+    // Fallback is in case message action sheet header calls this function.
+    // Action sheet can only be opened when muted message is revealed.
+    ?.isMutedMessageRevealed(message.id) ?? true;
+  return store.isUserMuted(message.senderId) && !isRevealed;
 }
 
 class _EditMessageStatusRow extends StatelessWidget {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1307,7 +1307,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         final header = RecipientHeader(message: data.message, narrow: widget.narrow);
         return StickyHeaderItem(allowOverflow: true,
           header: header,
-          child: DateSeparator(message: data.message));
+          child: DateSeparator(message: data.message, content: data.content));
       case MessageListMessageItem():
         final header = RecipientHeader(message: data.message, narrow: widget.narrow);
         return MessageItem(
@@ -1714,9 +1714,11 @@ class RecipientHeader extends StatelessWidget {
 }
 
 class DateSeparator extends StatelessWidget {
-  const DateSeparator({super.key, required this.message});
+  const DateSeparator({super.key, required this.message, this.content});
 
   final MessageBase message;
+
+  final ZulipMessageContent? content;
 
   @override
   Widget build(BuildContext context) {
@@ -1728,8 +1730,12 @@ class DateSeparator extends StatelessWidget {
 
     final line = BorderSide(width: 0, color: designVariables.foreground);
 
+    final color = (message is Message && content != null)
+      ? messageBackgroundColor(context, message as Message, content!)
+      : designVariables.bgMessageRegular;
+
     // TODO(#681) use different color for DM messages
-    return ColoredBox(color: designVariables.bgMessageRegular,
+    return ColoredBox(color: color,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 2),
         child: Row(children: [

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart' hide TextDirection;
 import '../api/model/model.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/binding.dart';
+import '../model/content.dart';
 import '../model/database.dart';
 import '../model/message.dart';
 import '../model/message_list.dart';
@@ -1772,8 +1773,13 @@ class MessageItem extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
 
     final item = this.item;
+    final backgroundColor = switch (item) {
+      MessageListMessageItem(:final message, :final content) =>
+        messageBackgroundColor(context, message, content),
+      MessageListOutboxMessageItem() => designVariables.bgMessageRegular,
+    };
     Widget child = ColoredBox(
-      color: designVariables.bgMessageRegular,
+      color: backgroundColor,
       child: Column(children: [
         switch (item) {
           MessageListMessageItem() => MessageWithPossibleSender(
@@ -1797,6 +1803,43 @@ class MessageItem extends StatelessWidget {
       header: header,
       child: child);
   }
+}
+
+/// The background color for a message according to the mentions present.
+///
+/// A non-silent direct self-user mention, in a DM or subscribed channel, returns
+/// [DesignVariables.bgMessageDirectMention]; a group or wildcard mention returns
+/// [DesignVariables.bgMessageGroupOrWildcardMention]. Otherwise,
+/// [DesignVariables.bgMessageRegular] is returned.
+Color messageBackgroundColor(
+  BuildContext context,
+  Message message,
+  ZulipMessageContent content,
+) {
+  final designVariables = DesignVariables.of(context);
+  final hasMention = message.flags.any((flag) => flag.isMentionFlag);
+  if (!hasMention || content is! ZulipContent
+      || _isMutedMessageHidden(context, message)) {
+    return designVariables.bgMessageRegular;
+  }
+
+  final store = PerAccountStoreWidget.of(context);
+
+  // User mentions take precedence; we only color the message as a group/wildcard
+  // mention if there is no self-user mention present.
+  if (!message.flags.contains(MessageFlag.mentioned)
+      || !content.mentionedUserIds.contains(store.selfUserId)) {
+    return designVariables.bgMessageGroupOrWildcardMention;
+  }
+
+  // Following web, highlight the background only in DMs and subscribed channels.
+  //   See `direct_mention` gate in zulip:web/src/message_list_view.ts.
+  return switch (message) {
+    DmMessage() => designVariables.bgMessageDirectMention,
+    StreamMessage(:final streamId) => store.subscriptions.containsKey(streamId)
+      ? designVariables.bgMessageDirectMention
+      : designVariables.bgMessageRegular,
+  };
 }
 
 /// Widget responsible for showing the read status of a message.

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1306,7 +1306,7 @@ class _MessageListState extends State<MessageList> with PerAccountStoreAwareStat
         final header = RecipientHeader(message: data.message, narrow: widget.narrow);
         return StickyHeaderItem(allowOverflow: true,
           header: header,
-          child: DateSeparator(message: data.message));
+          child: DateSeparator(message: data.message, content: data.content));
       case MessageListMessageItem():
         final header = RecipientHeader(message: data.message, narrow: widget.narrow);
         return MessageItem(
@@ -1713,9 +1713,11 @@ class RecipientHeader extends StatelessWidget {
 }
 
 class DateSeparator extends StatelessWidget {
-  const DateSeparator({super.key, required this.message});
+  const DateSeparator({super.key, required this.message, this.content});
 
   final MessageBase message;
+
+  final ZulipMessageContent? content;
 
   @override
   Widget build(BuildContext context) {
@@ -1727,8 +1729,12 @@ class DateSeparator extends StatelessWidget {
 
     final line = BorderSide(width: 0, color: designVariables.foreground);
 
+    final color = (message is Message && content != null)
+      ? messageBackgroundColor(context, message as Message, content!)
+      : designVariables.bgMessageRegular;
+
     // TODO(#681) use different color for DM messages
-    return ColoredBox(color: designVariables.bgMessageRegular,
+    return ColoredBox(color: color,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 2),
         child: Row(children: [

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -2369,9 +2369,7 @@ class MessageWithPossibleSender extends StatelessWidget {
         || KeywordSearchNarrow() => true,
     };
 
-    final showAsMuted = store.isUserMuted(message.senderId)
-      && !MessageListPage.maybeRevealedMutedMessagesOf(context)!
-                         .isMutedMessageRevealed(message.id);
+    final showAsMuted = _isMutedMessageHidden(context, message);
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -2435,6 +2433,15 @@ class MessageWithPossibleSender extends StatelessWidget {
             ]),
         ])));
   }
+}
+
+bool _isMutedMessageHidden(BuildContext context, Message message) {
+  final store = PerAccountStoreWidget.of(context);
+  final isRevealed = MessageListPage.maybeRevealedMutedMessagesOf(context)
+    // Fallback is in case message action sheet header calls this function.
+    // Action sheet can only be opened when muted message is revealed.
+    ?.isMutedMessageRevealed(message.id) ?? true;
+  return store.isUserMuted(message.senderId) && !isRevealed;
 }
 
 class _EditMessageStatusRow extends StatelessWidget {

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart' hide TextDirection;
 import '../api/model/model.dart';
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/binding.dart';
+import '../model/content.dart';
 import '../model/database.dart';
 import '../model/message.dart';
 import '../model/message_list.dart';
@@ -1771,8 +1772,13 @@ class MessageItem extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
 
     final item = this.item;
+    final backgroundColor = switch (item) {
+      MessageListMessageItem(:final message, :final content) =>
+        messageBackgroundColor(context, message, content),
+      MessageListOutboxMessageItem() => designVariables.bgMessageRegular,
+    };
     Widget child = ColoredBox(
-      color: designVariables.bgMessageRegular,
+      color: backgroundColor,
       child: Column(children: [
         switch (item) {
           MessageListMessageItem() => MessageWithPossibleSender(
@@ -1796,6 +1802,43 @@ class MessageItem extends StatelessWidget {
       header: header,
       child: child);
   }
+}
+
+/// The background color for a message according to the mentions present.
+///
+/// A non-silent direct self-user mention, in a DM or subscribed channel, returns
+/// [DesignVariables.bgMessageDirectMention]; a group or wildcard mention returns
+/// [DesignVariables.bgMessageGroupOrWildcardMention]. Otherwise,
+/// [DesignVariables.bgMessageRegular] is returned.
+Color messageBackgroundColor(
+  BuildContext context,
+  Message message,
+  ZulipMessageContent content,
+) {
+  final designVariables = DesignVariables.of(context);
+  final hasMention = message.flags.any((flag) => flag.isMentionFlag);
+  if (!hasMention || content is! ZulipContent
+      || _isMutedMessageHidden(context, message)) {
+    return designVariables.bgMessageRegular;
+  }
+
+  final store = PerAccountStoreWidget.of(context);
+
+  // User mentions take precedence; we only color the message as a group/wildcard
+  // mention if there is no self-user mention present.
+  if (!message.flags.contains(MessageFlag.mentioned)
+      || !content.mentionedUserIds.contains(store.selfUserId)) {
+    return designVariables.bgMessageGroupOrWildcardMention;
+  }
+
+  // Following web, highlight the background only in DMs and subscribed channels.
+  //   See `direct_mention` gate in zulip:web/src/message_list_view.ts.
+  return switch (message) {
+    DmMessage() => designVariables.bgMessageDirectMention,
+    StreamMessage(:final streamId) => store.subscriptions.containsKey(streamId)
+      ? designVariables.bgMessageDirectMention
+      : designVariables.bgMessageRegular,
+  };
 }
 
 /// Widget responsible for showing the read status of a message.

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -151,6 +151,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.15),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.05),
     bgMenuButtonSelected: Colors.white,
+    bgMessageDirectMention: const HSLColor.fromAHSL(1, 240, 0.52, 0.95).toColor(),
+    bgMessageGroupOrWildcardMention: const HSLColor.fromAHSL(1, 180, 0.4, 0.94).toColor(),
     bgMessageRegular: const HSLColor.fromAHSL(1, 0, 0, 1).toColor(),
     bgSearchInput: const Color(0xffe3e3e3),
     bgTopBar: const Color(0xfff5f5f5),
@@ -261,6 +263,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.2),
     bgMenuButtonSelected: Colors.black.withValues(alpha: 0.25),
+    bgMessageDirectMention: const HSLColor.fromAHSL(1, 240, 0.13, 0.16).toColor(),
+    bgMessageGroupOrWildcardMention: const HSLColor.fromAHSL(1, 180, 0.13, 0.14).toColor(),
     bgMessageRegular: const Color(0xff1d1d1d),
     bgSearchInput: const Color(0xff313131),
     bgTopBar: const Color(0xff242424),
@@ -380,6 +384,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.bgCounterUnread,
     required this.bgMenuButtonActive,
     required this.bgMenuButtonSelected,
+    required this.bgMessageDirectMention,
+    required this.bgMessageGroupOrWildcardMention,
     required this.bgMessageRegular,
     required this.bgSearchInput,
     required this.bgTopBar,
@@ -491,6 +497,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color bgCounterUnread;
   final Color bgMenuButtonActive;
   final Color bgMenuButtonSelected;
+  final Color bgMessageDirectMention;
+  final Color bgMessageGroupOrWildcardMention;
   final Color bgMessageRegular;
   final Color bgSearchInput;
   final Color bgTopBar;
@@ -596,6 +604,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? bgCounterUnread,
     Color? bgMenuButtonActive,
     Color? bgMenuButtonSelected,
+    Color? bgMessageDirectMention,
+    Color? bgMessageGroupOrWildcardMention,
     Color? bgMessageRegular,
     Color? bgSearchInput,
     Color? bgTopBar,
@@ -696,6 +706,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       bgCounterUnread: bgCounterUnread ?? this.bgCounterUnread,
       bgMenuButtonActive: bgMenuButtonActive ?? this.bgMenuButtonActive,
       bgMenuButtonSelected: bgMenuButtonSelected ?? this.bgMenuButtonSelected,
+      bgMessageDirectMention: bgMessageDirectMention ?? this.bgMessageDirectMention,
+      bgMessageGroupOrWildcardMention: bgMessageGroupOrWildcardMention ?? this.bgMessageGroupOrWildcardMention,
       bgMessageRegular: bgMessageRegular ?? this.bgMessageRegular,
       bgSearchInput: bgSearchInput ?? this.bgSearchInput,
       bgTopBar: bgTopBar ?? this.bgTopBar,
@@ -803,6 +815,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       bgCounterUnread: Color.lerp(bgCounterUnread, other.bgCounterUnread, t)!,
       bgMenuButtonActive: Color.lerp(bgMenuButtonActive, other.bgMenuButtonActive, t)!,
       bgMenuButtonSelected: Color.lerp(bgMenuButtonSelected, other.bgMenuButtonSelected, t)!,
+      bgMessageDirectMention: Color.lerp(bgMessageDirectMention, other.bgMessageDirectMention, t)!,
+      bgMessageGroupOrWildcardMention: Color.lerp(bgMessageGroupOrWildcardMention, other.bgMessageGroupOrWildcardMention, t)!,
       bgMessageRegular: Color.lerp(bgMessageRegular, other.bgMessageRegular, t)!,
       bgSearchInput: Color.lerp(bgSearchInput, other.bgSearchInput, t)!,
       bgTopBar: Color.lerp(bgTopBar, other.bgTopBar, t)!,

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -151,6 +151,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.15),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.05),
     bgMenuButtonSelected: Colors.white,
+    bgMessageDirectMention: const HSLColor.fromAHSL(1, 240, 0.52, 0.95).toColor(),
+    bgMessageGroupOrWildcardMention: const HSLColor.fromAHSL(1, 180, 0.4, 0.94).toColor(),
     bgMessageRegular: const HSLColor.fromAHSL(1, 0, 0, 1).toColor(),
     bgSearchInput: const Color(0xffe3e3e3),
     bgTopBar: const Color(0xfff5f5f5),
@@ -263,6 +265,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     bgCounterUnread: const Color(0xff666699).withValues(alpha: 0.37),
     bgMenuButtonActive: Colors.black.withValues(alpha: 0.2),
     bgMenuButtonSelected: Colors.black.withValues(alpha: 0.25),
+    bgMessageDirectMention: const HSLColor.fromAHSL(1, 240, 0.13, 0.16).toColor(),
+    bgMessageGroupOrWildcardMention: const HSLColor.fromAHSL(1, 180, 0.13, 0.14).toColor(),
     bgMessageRegular: const Color(0xff1d1d1d),
     bgSearchInput: const Color(0xff313131),
     bgTopBar: const Color(0xff242424),
@@ -384,6 +388,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     required this.bgCounterUnread,
     required this.bgMenuButtonActive,
     required this.bgMenuButtonSelected,
+    required this.bgMessageDirectMention,
+    required this.bgMessageGroupOrWildcardMention,
     required this.bgMessageRegular,
     required this.bgSearchInput,
     required this.bgTopBar,
@@ -497,6 +503,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
   final Color bgCounterUnread;
   final Color bgMenuButtonActive;
   final Color bgMenuButtonSelected;
+  final Color bgMessageDirectMention;
+  final Color bgMessageGroupOrWildcardMention;
   final Color bgMessageRegular;
   final Color bgSearchInput;
   final Color bgTopBar;
@@ -604,6 +612,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
     Color? bgCounterUnread,
     Color? bgMenuButtonActive,
     Color? bgMenuButtonSelected,
+    Color? bgMessageDirectMention,
+    Color? bgMessageGroupOrWildcardMention,
     Color? bgMessageRegular,
     Color? bgSearchInput,
     Color? bgTopBar,
@@ -706,6 +716,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       bgCounterUnread: bgCounterUnread ?? this.bgCounterUnread,
       bgMenuButtonActive: bgMenuButtonActive ?? this.bgMenuButtonActive,
       bgMenuButtonSelected: bgMenuButtonSelected ?? this.bgMenuButtonSelected,
+      bgMessageDirectMention: bgMessageDirectMention ?? this.bgMessageDirectMention,
+      bgMessageGroupOrWildcardMention: bgMessageGroupOrWildcardMention ?? this.bgMessageGroupOrWildcardMention,
       bgMessageRegular: bgMessageRegular ?? this.bgMessageRegular,
       bgSearchInput: bgSearchInput ?? this.bgSearchInput,
       bgTopBar: bgTopBar ?? this.bgTopBar,
@@ -815,6 +827,8 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
       bgCounterUnread: Color.lerp(bgCounterUnread, other.bgCounterUnread, t)!,
       bgMenuButtonActive: Color.lerp(bgMenuButtonActive, other.bgMenuButtonActive, t)!,
       bgMenuButtonSelected: Color.lerp(bgMenuButtonSelected, other.bgMenuButtonSelected, t)!,
+      bgMessageDirectMention: Color.lerp(bgMessageDirectMention, other.bgMessageDirectMention, t)!,
+      bgMessageGroupOrWildcardMention: Color.lerp(bgMessageGroupOrWildcardMention, other.bgMessageGroupOrWildcardMention, t)!,
       bgMessageRegular: Color.lerp(bgMessageRegular, other.bgMessageRegular, t)!,
       bgSearchInput: Color.lerp(bgSearchInput, other.bgSearchInput, t)!,
       bgTopBar: Color.lerp(bgTopBar, other.bgTopBar, t)!,

--- a/test/model/content_checks.dart
+++ b/test/model/content_checks.dart
@@ -22,6 +22,10 @@ extension ContentNodeChecks on Subject<ContentNode> {
   }
 }
 
+extension ZulipContentChecks on Subject<ZulipContent> {
+  Subject<Set<int>> get mentionedUserIds => has((c) => c.mentionedUserIds, 'mentionedUserIds');
+}
+
 Iterable<String>? _compareDiagnosticsNodes(DiagnosticsNode actual, DiagnosticsNode expected) {
   assert(actual is DiagnosticableTreeNode && expected is DiagnosticableTreeNode);
 

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -1896,6 +1896,44 @@ void main() async {
     testParseExample(ContentExample.topicMentionSilentClassOrderReversed);
   });
 
+  group('ZulipContent.mentionedUserIds', () {
+    test('non-silent user mention', () {
+      check(parseContent(ContentExample.userMentionPlain.html))
+        .mentionedUserIds.unorderedEquals({2187});
+    });
+
+    test('multiple non-silent user mentions', () {
+      check(parseContent(
+          '<p><span class="user-mention" data-user-id="11">@Eleven</span> '
+          '<span class="user-mention" data-user-id="12">@Twelve</span></p>'))
+        .mentionedUserIds.unorderedEquals({11, 12});
+    });
+
+    test('silent user mention', () {
+      check(parseContent(ContentExample.userMentionSilent.html))
+        .mentionedUserIds.isEmpty();
+    });
+
+    test('legacy user mention (without user ID)', () {
+      check(parseContent(ContentExample.legacyUserMention.html))
+        .mentionedUserIds.isEmpty();
+    });
+
+    test('group, channel-wildcard, and topic mentions', () {
+      check(parseContent(ContentExample.groupMentionPlain.html))
+        .mentionedUserIds.isEmpty();
+      check(parseContent(ContentExample.channelWildcardMentionPlain.html))
+        .mentionedUserIds.isEmpty();
+      check(parseContent(ContentExample.topicMentionPlain.html))
+        .mentionedUserIds.isEmpty();
+    });
+
+    test('no mentions', () {
+      check(parseContent(ContentExample.strong.html))
+        .mentionedUserIds.isEmpty();
+    });
+  });
+
   testParseExample(ContentExample.emojiUnicode);
   testParseExample(ContentExample.emojiUnicodeClassesFlipped);
   testParseExample(ContentExample.emojiUnicodeMultiCodepoint);

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -35,6 +35,7 @@ import 'package:share_plus_platform_interface/method_channel/method_channel_shar
 import 'package:zulip/widgets/profile.dart';
 import 'package:zulip/widgets/read_receipts.dart';
 import 'package:zulip/widgets/subscription_list.dart';
+import 'package:zulip/widgets/theme.dart';
 import 'package:zulip/widgets/topic_list.dart';
 import 'package:zulip/widgets/user.dart';
 import '../api/fake_api.dart';
@@ -1729,6 +1730,23 @@ void main() {
           of: find.byType(BottomSheet),
           matching: find.byType(Mention))
         ).findsOne();
+      });
+
+      testWidgets('color for self user mention', (tester) async {
+        final message = eg.streamMessage(
+          timestamp: 1671409088,
+          content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+          flags: [MessageFlag.mentioned]);
+        await setupToMessageActionSheet(tester,
+          message: message,
+          narrow: TopicNarrow.ofMessage(message));
+
+        final container = tester.widget<Container>(find.ancestor(
+          of: find.byType(SenderRow),
+          matching: find.byType(Container),
+        ).first);
+        check(container.color).isNotNull()
+          .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
       });
 
       testWidgets('muted sender also shown', (tester) async {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -35,6 +35,7 @@ import 'package:share_plus_platform_interface/method_channel/method_channel_shar
 import 'package:zulip/widgets/profile.dart';
 import 'package:zulip/widgets/read_receipts.dart';
 import 'package:zulip/widgets/subscription_list.dart';
+import 'package:zulip/widgets/theme.dart';
 import 'package:zulip/widgets/topic_list.dart';
 import 'package:zulip/widgets/user.dart';
 import '../api/fake_api.dart';
@@ -1735,6 +1736,23 @@ void main() {
           of: find.byType(BottomSheet),
           matching: find.byType(Mention))
         ).findsOne();
+      });
+
+      testWidgets('color for self user mention', (tester) async {
+        final message = eg.streamMessage(
+          timestamp: 1671409088,
+          content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+          flags: [MessageFlag.mentioned]);
+        await setupToMessageActionSheet(tester,
+          message: message,
+          narrow: TopicNarrow.ofMessage(message));
+
+        final container = tester.widget<Container>(find.ancestor(
+          of: find.byType(SenderRow),
+          matching: find.byType(Container),
+        ).first);
+        check(container.color).isNotNull()
+          .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
       });
 
       testWidgets('muted sender also shown', (tester) async {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -175,7 +175,7 @@ void main() {
   /// and write an appropriate content-has-rendered check directly.
   void testContentSmoke(ContentExample example, {bool wrapWithPerAccountStoreWidget = false}) {
     testWidgets('smoke: ${example.description}', (tester) async {
-      await prepareContent(tester, plainContent(example.html),
+      await prepareContent(tester, messageContent(example.html),
         wrapWithPerAccountStoreWidget: wrapWithPerAccountStoreWidget);
       assert(example.expectedText != null,
         'testContentExample requires expectedText');
@@ -832,7 +832,7 @@ void main() {
     bool wrapWithPerAccountStoreWidget = false,
   }) async {
     await prepareContent(tester, wrapWithPerAccountStoreWidget: wrapWithPerAccountStoreWidget,
-      plainContent(
+      messageContent(
         '<h1>header-plain $targetHtml</h1>\n'
         '<p>paragraph-plain $targetHtml</p>'));
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -17,12 +17,14 @@ import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
+import 'package:zulip/widgets/inset_shadow.dart';
 import 'package:zulip/widgets/katex.dart';
 import 'package:zulip/widgets/lightbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/profile.dart';
 import 'package:zulip/widgets/text.dart';
+import 'package:zulip/widgets/theme.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
@@ -1921,7 +1923,7 @@ void main() {
 
   group('WebsitePreview', () {
     Future<void> prepare(WidgetTester tester, String html) async {
-      await prepareContent(tester, plainContent(html),
+      await prepareContent(tester, messageContent(html),
         wrapWithPerAccountStoreWidget: true);
     }
 
@@ -1979,6 +1981,26 @@ void main() {
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: url, mode: LaunchMode.inAppBrowserView));
       debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('background color for self user mention', (tester) async {
+      final html =
+        '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>'
+        '${ContentExample.websitePreviewSmoke.html}';
+      final stream = eg.stream();
+
+      await prepareContent(tester,
+        wrapWithPerAccountStoreWidget: true,
+        initialSnapshot: eg.initialSnapshot(
+          subscriptions: [eg.subscription(stream)]),
+        MessageContent(
+          message: eg.streamMessage(
+            stream: stream,
+            content: html,
+            flags: [MessageFlag.mentioned]),
+          content: parseContent(html)));
+      check(tester.widget<InsetShadowBox>(find.byType(InsetShadowBox)).color)
+        .equals(DesignVariables.light.bgMessageDirectMention);
     });
   });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1048,40 +1048,156 @@ void main() {
       // Regression test for: https://github.com/zulip/zulip-flutter/issues/1813
       await prepareContent(tester,
         wrapWithPerAccountStoreWidget: true,
-        plainContent('<p><em><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></em></p>'));
+        messageContent('<p><em><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></em></p>'));
       final style = mergedStyleOf(tester, '@Chris Bobbe');
       check(style!.fontStyle).equals(FontStyle.italic);
     });
 
-    testFontWeight('silent or non-self mention in plain paragraph',
+    testFontWeight('non-self mention in plain paragraph',
       expectedWght: 400,
-      // @_**Greg Price**
-      content: plainContent(
-        '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>'),
+      // @**Greg Price**
+      content: messageContent(
+        '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>'),
       wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
-          tester.widget(find.byType(Mention)), 'Greg Price');
+          tester.widget(find.byType(Mention)), '@Greg Price');
       });
 
-    // TODO(#647):
-    //  testFontWeight('non-silent self-user mention in plain paragraph',
-    //    expectedWght: 600, // [etc.]
-
-    testFontWeight('silent or non-self mention in bold context',
+    testFontWeight('self-user mention in plain paragraph',
       expectedWght: 600,
-      // # @_**Chris Bobbe**
-      content: plainContent(
-        '<h1><span class="user-mention silent" data-user-id="13313">Chris Bobbe</span></h1>'),
+      // @**Self User**
+      content: messageContent(
+        '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>'),
       wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
-          tester.widget(find.byType(Mention)), 'Chris Bobbe');
+          tester.widget(find.byType(Mention)), '@${eg.selfUser.fullName}');
       });
 
-    // TODO(#647):
-    //  testFontWeight('non-silent self-user mention in bold context',
-    //    expectedWght: 800, // [etc.]
+    testFontWeight('non-self mention in bold context',
+      expectedWght: 600,
+      // # @**Chris Bobbe**
+      content: messageContent(
+        '<h1><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></h1>'),
+      wrapWithPerAccountStoreWidget: true,
+      styleFinder: (tester) {
+        return textStyleFromWidget(tester,
+          tester.widget(find.byType(Mention)), '@Chris Bobbe');
+      });
+
+    testFontWeight('self-user mention in bold context',
+      expectedWght: 600,
+      // # @**Self User**
+      content: messageContent(
+        '<h1><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></h1>'),
+      wrapWithPerAccountStoreWidget: true,
+      styleFinder: (tester) {
+        return textStyleFromWidget(tester,
+          tester.widget(find.byType(Mention)), '@${eg.selfUser.fullName}');
+      });
+
+    group('font color', () {
+      Future<void> checkFontColor(
+        WidgetTester tester, {
+        required String html,
+        required String mentionText,
+        required Color Function(ContentTheme) expectColor,
+        List<MessageFlag>? flags,
+        List<UserGroup>? userGroups,
+      }) async {
+        await prepareContent(tester,
+          wrapWithPerAccountStoreWidget: true,
+          initialSnapshot: eg.initialSnapshot(realmUserGroups: userGroups),
+          MessageContent(
+            message: eg.streamMessage(content: html, flags: flags ?? []),
+            content: parseContent(html)));
+        final contentTheme = ContentTheme.of(tester.element(find.byType(Mention)));
+        final style = textStyleFromWidget(tester,
+          tester.widget(find.byType(Mention)), mentionText);
+        check(style).color.equals(expectColor(contentTheme));
+      }
+
+      group('non-self', () {
+        testWidgets('user mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.userMentionPlain.html,
+            mentionText: ContentExample.userMentionPlain.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+
+        testWidgets('user group mention', (tester) async {
+          await checkFontColor(tester,
+            html: '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
+            mentionText: '@test-empty',
+            expectColor: (theme) => theme.textStylePlainParagraph.color!,
+            userGroups: [eg.userGroup(id: 186, name: 'test-empty')]);
+        });
+
+        testWidgets('topic wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.topicMentionPlain.html,
+            mentionText: ContentExample.topicMentionPlain.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+
+        testWidgets('channel wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.channelWildcardMentionSilent.html,
+            mentionText: ContentExample.channelWildcardMentionSilent.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+      });
+
+      group('self', () {
+        testWidgets('user mention', (tester) async {
+          await checkFontColor(tester,
+            html: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+            mentionText: '@${eg.selfUser.fullName}',
+            expectColor: (theme) => theme.colorTextDirectMention);
+        });
+
+        testWidgets('user group mention', (tester) async {
+          await checkFontColor(tester,
+            html: '<p><span class="user-group-mention" data-user-group-id="186">@old-name</span></p>',
+            mentionText: '@new-name',
+            expectColor: (theme) => theme.colorTextGroupOrWildcardMention,
+            userGroups: [
+              eg.userGroup(id: 186, name: 'new-name', members: [eg.selfUser.userId]),
+            ]);
+        });
+
+        testWidgets('plain topic wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.topicMentionPlain.html,
+            mentionText: ContentExample.topicMentionPlain.expectedText!,
+            expectColor: (theme) => theme.colorTextGroupOrWildcardMention,
+            flags: [MessageFlag.topicWildcardMentioned]);
+        });
+
+        testWidgets('silent topic wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.topicMentionSilent.html,
+            mentionText: ContentExample.topicMentionSilent.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+
+        testWidgets('plain channel wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.channelWildcardMentionPlain.html,
+            mentionText: ContentExample.channelWildcardMentionPlain.expectedText!,
+            expectColor: (theme) => theme.colorTextGroupOrWildcardMention,
+            flags: [MessageFlag.streamWildcardMentioned]);
+        });
+
+        testWidgets('silent channel wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.channelWildcardMentionSilent.html,
+            mentionText: ContentExample.channelWildcardMentionSilent.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+      });
+    });
 
     group('pill color', () {
       Future<void> checkPillColor(WidgetTester tester, {
@@ -1090,7 +1206,7 @@ void main() {
       }) async {
         await prepareContent(tester,
           wrapWithPerAccountStoreWidget: true,
-          plainContent(html));
+          messageContent(html));
 
         final renderObject = tester.renderObject<RenderBox>(find.byType(Mention));
         final paintBounds = renderObject.paintBounds;
@@ -1131,7 +1247,7 @@ void main() {
         await prepareContent(tester,
           wrapWithPerAccountStoreWidget: true,
           initialSnapshot: initialSnapshot,
-          plainContent(html));
+          messageContent(html));
       }
 
       testWidgets('resolves current user name from store', (tester) async {
@@ -1177,7 +1293,7 @@ void main() {
         await prepareContent(tester,
           wrapWithPerAccountStoreWidget: true,
           initialSnapshot: initialSnapshot,
-          plainContent(html));
+          messageContent(html));
       }
 
       testWidgets('resolves current user group name from store', (tester) async {
@@ -1250,7 +1366,7 @@ void main() {
             ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
 
           await prepareContent(tester,
-            plainContent(html), navObservers: [testNavObserver],
+            messageContent(html), navObservers: [testNavObserver],
             wrapWithPerAccountStoreWidget: true,
             initialSnapshot: eg.initialSnapshot(realmUsers: [
               eg.selfUser,

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -1071,40 +1071,156 @@ void main() {
       // Regression test for: https://github.com/zulip/zulip-flutter/issues/1813
       await prepareContent(tester,
         wrapWithPerAccountStoreWidget: true,
-        plainContent('<p><em><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></em></p>'));
+        messageContent('<p><em><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></em></p>'));
       final style = mergedStyleOf(tester, '@Chris Bobbe');
       check(style!.fontStyle).equals(FontStyle.italic);
     });
 
-    testFontWeight('silent or non-self mention in plain paragraph',
+    testFontWeight('non-self mention in plain paragraph',
       expectedWght: 400,
-      // @_**Greg Price**
-      content: plainContent(
-        '<p><span class="user-mention silent" data-user-id="2187">Greg Price</span></p>'),
+      // @**Greg Price**
+      content: messageContent(
+        '<p><span class="user-mention" data-user-id="2187">@Greg Price</span></p>'),
       wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
-          tester.widget(find.byType(Mention)), 'Greg Price');
+          tester.widget(find.byType(Mention)), '@Greg Price');
       });
 
-    // TODO(#647):
-    //  testFontWeight('non-silent self-user mention in plain paragraph',
-    //    expectedWght: 600, // [etc.]
-
-    testFontWeight('silent or non-self mention in bold context',
+    testFontWeight('self-user mention in plain paragraph',
       expectedWght: 600,
-      // # @_**Chris Bobbe**
-      content: plainContent(
-        '<h1><span class="user-mention silent" data-user-id="13313">Chris Bobbe</span></h1>'),
+      // @**Self User**
+      content: messageContent(
+        '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>'),
       wrapWithPerAccountStoreWidget: true,
       styleFinder: (tester) {
         return textStyleFromWidget(tester,
-          tester.widget(find.byType(Mention)), 'Chris Bobbe');
+          tester.widget(find.byType(Mention)), '@${eg.selfUser.fullName}');
       });
 
-    // TODO(#647):
-    //  testFontWeight('non-silent self-user mention in bold context',
-    //    expectedWght: 800, // [etc.]
+    testFontWeight('non-self mention in bold context',
+      expectedWght: 600,
+      // # @**Chris Bobbe**
+      content: messageContent(
+        '<h1><span class="user-mention" data-user-id="13313">@Chris Bobbe</span></h1>'),
+      wrapWithPerAccountStoreWidget: true,
+      styleFinder: (tester) {
+        return textStyleFromWidget(tester,
+          tester.widget(find.byType(Mention)), '@Chris Bobbe');
+      });
+
+    testFontWeight('self-user mention in bold context',
+      expectedWght: 600,
+      // # @**Self User**
+      content: messageContent(
+        '<h1><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></h1>'),
+      wrapWithPerAccountStoreWidget: true,
+      styleFinder: (tester) {
+        return textStyleFromWidget(tester,
+          tester.widget(find.byType(Mention)), '@${eg.selfUser.fullName}');
+      });
+
+    group('font color', () {
+      Future<void> checkFontColor(
+        WidgetTester tester, {
+        required String html,
+        required String mentionText,
+        required Color Function(ContentTheme) expectColor,
+        List<MessageFlag>? flags,
+        List<UserGroup>? userGroups,
+      }) async {
+        await prepareContent(tester,
+          wrapWithPerAccountStoreWidget: true,
+          initialSnapshot: eg.initialSnapshot(realmUserGroups: userGroups),
+          MessageContent(
+            message: eg.streamMessage(content: html, flags: flags ?? []),
+            content: parseContent(html)));
+        final contentTheme = ContentTheme.of(tester.element(find.byType(Mention)));
+        final style = textStyleFromWidget(tester,
+          tester.widget(find.byType(Mention)), mentionText);
+        check(style).color.equals(expectColor(contentTheme));
+      }
+
+      group('non-self', () {
+        testWidgets('user mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.userMentionPlain.html,
+            mentionText: ContentExample.userMentionPlain.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+
+        testWidgets('user group mention', (tester) async {
+          await checkFontColor(tester,
+            html: '<p><span class="user-group-mention" data-user-group-id="186">@test-empty</span></p>',
+            mentionText: '@test-empty',
+            expectColor: (theme) => theme.textStylePlainParagraph.color!,
+            userGroups: [eg.userGroup(id: 186, name: 'test-empty')]);
+        });
+
+        testWidgets('topic wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.topicMentionPlain.html,
+            mentionText: ContentExample.topicMentionPlain.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+
+        testWidgets('channel wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.channelWildcardMentionSilent.html,
+            mentionText: ContentExample.channelWildcardMentionSilent.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+      });
+
+      group('self', () {
+        testWidgets('user mention', (tester) async {
+          await checkFontColor(tester,
+            html: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+            mentionText: '@${eg.selfUser.fullName}',
+            expectColor: (theme) => theme.colorTextDirectMention);
+        });
+
+        testWidgets('user group mention', (tester) async {
+          await checkFontColor(tester,
+            html: '<p><span class="user-group-mention" data-user-group-id="186">@old-name</span></p>',
+            mentionText: '@new-name',
+            expectColor: (theme) => theme.colorTextGroupOrWildcardMention,
+            userGroups: [
+              eg.userGroup(id: 186, name: 'new-name', members: [eg.selfUser.userId]),
+            ]);
+        });
+
+        testWidgets('plain topic wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.topicMentionPlain.html,
+            mentionText: ContentExample.topicMentionPlain.expectedText!,
+            expectColor: (theme) => theme.colorTextGroupOrWildcardMention,
+            flags: [MessageFlag.topicWildcardMentioned]);
+        });
+
+        testWidgets('silent topic wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.topicMentionSilent.html,
+            mentionText: ContentExample.topicMentionSilent.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+
+        testWidgets('plain channel wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.channelWildcardMentionPlain.html,
+            mentionText: ContentExample.channelWildcardMentionPlain.expectedText!,
+            expectColor: (theme) => theme.colorTextGroupOrWildcardMention,
+            flags: [MessageFlag.streamWildcardMentioned]);
+        });
+
+        testWidgets('silent channel wildcard mention', (tester) async {
+          await checkFontColor(tester,
+            html: ContentExample.channelWildcardMentionSilent.html,
+            mentionText: ContentExample.channelWildcardMentionSilent.expectedText!,
+            expectColor: (theme) => theme.textStylePlainParagraph.color!);
+        });
+      });
+    });
 
     group('pill color', () {
       Future<void> checkPillColor(WidgetTester tester, {
@@ -1113,7 +1229,7 @@ void main() {
       }) async {
         await prepareContent(tester,
           wrapWithPerAccountStoreWidget: true,
-          plainContent(html));
+          messageContent(html));
 
         final renderObject = tester.renderObject<RenderBox>(find.byType(Mention));
         final paintBounds = renderObject.paintBounds;
@@ -1154,7 +1270,7 @@ void main() {
         await prepareContent(tester,
           wrapWithPerAccountStoreWidget: true,
           initialSnapshot: initialSnapshot,
-          plainContent(html));
+          messageContent(html));
       }
 
       testWidgets('resolves current user name from store', (tester) async {
@@ -1200,7 +1316,7 @@ void main() {
         await prepareContent(tester,
           wrapWithPerAccountStoreWidget: true,
           initialSnapshot: initialSnapshot,
-          plainContent(html));
+          messageContent(html));
       }
 
       testWidgets('resolves current user group name from store', (tester) async {
@@ -1273,7 +1389,7 @@ void main() {
             ..onPushed = (route, prevRoute) => pushedRoutes.add(route);
 
           await prepareContent(tester,
-            plainContent(html), navObservers: [testNavObserver],
+            messageContent(html), navObservers: [testNavObserver],
             wrapWithPerAccountStoreWidget: true,
             initialSnapshot: eg.initialSnapshot(realmUsers: [
               eg.selfUser,

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -17,12 +17,14 @@ import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
+import 'package:zulip/widgets/inset_shadow.dart';
 import 'package:zulip/widgets/katex.dart';
 import 'package:zulip/widgets/lightbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/profile.dart';
 import 'package:zulip/widgets/text.dart';
+import 'package:zulip/widgets/theme.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
@@ -1944,7 +1946,7 @@ void main() {
 
   group('WebsitePreview', () {
     Future<void> prepare(WidgetTester tester, String html) async {
-      await prepareContent(tester, plainContent(html),
+      await prepareContent(tester, messageContent(html),
         wrapWithPerAccountStoreWidget: true);
     }
 
@@ -2002,6 +2004,26 @@ void main() {
       check(testBinding.takeLaunchUrlCalls())
         .single.equals((url: url, mode: LaunchMode.inAppBrowserView));
       debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('background color for self user mention', (tester) async {
+      final html =
+        '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>'
+        '${ContentExample.websitePreviewSmoke.html}';
+      final stream = eg.stream();
+
+      await prepareContent(tester,
+        wrapWithPerAccountStoreWidget: true,
+        initialSnapshot: eg.initialSnapshot(
+          subscriptions: [eg.subscription(stream)]),
+        MessageContent(
+          message: eg.streamMessage(
+            stream: stream,
+            content: html,
+            flags: [MessageFlag.mentioned]),
+          content: parseContent(html)));
+      check(tester.widget<InsetShadowBox>(find.byType(InsetShadowBox)).color)
+        .equals(DesignVariables.light.bgMessageDirectMention);
     });
   });
 

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -173,9 +173,14 @@ void main() {
   /// check that the content has actually rendered.  For examples where there's
   /// no suitable value for [ContentExample.expectedText], use [prepareContent]
   /// and write an appropriate content-has-rendered check directly.
-  void testContentSmoke(ContentExample example, {bool wrapWithPerAccountStoreWidget = false}) {
+  void testContentSmoke(ContentExample example, {
+    bool wrapWithMessageContentWidget = false,
+    bool wrapWithPerAccountStoreWidget = false,
+  }) {
     testWidgets('smoke: ${example.description}', (tester) async {
-      await prepareContent(tester, plainContent(example.html),
+      await prepareContent(tester,
+        wrapWithMessageContentWidget
+          ? messageContent(example.html) : plainContent(example.html),
         wrapWithPerAccountStoreWidget: wrapWithPerAccountStoreWidget);
       assert(example.expectedText != null,
         'testContentExample requires expectedText');
@@ -829,12 +834,13 @@ void main() {
   Future<void> checkFontSizeRatio(WidgetTester tester, {
     required String targetHtml,
     required TargetFontSizeFinder targetFontSizeFinder,
+    bool wrapWithMessageContentWidget = false,
     bool wrapWithPerAccountStoreWidget = false,
   }) async {
+    final html = '<h1>header-plain $targetHtml</h1>\n<p>paragraph-plain $targetHtml</p>';
+
     await prepareContent(tester, wrapWithPerAccountStoreWidget: wrapWithPerAccountStoreWidget,
-      plainContent(
-        '<h1>header-plain $targetHtml</h1>\n'
-        '<p>paragraph-plain $targetHtml</p>'));
+      wrapWithMessageContentWidget ? messageContent(html) : plainContent(html));
 
     final headerRootSpan = tester.renderObject<RenderParagraph>(find.textContaining('header')).text;
     final headerPlainStyle = mergedStyleOfSubstring(headerRootSpan, 'header-plain ');
@@ -984,36 +990,52 @@ void main() {
 
   group('Mention', () {
     testContentSmoke(ContentExample.userMentionPlain,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.userMentionSilent,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.userMentionSilentClassOrderReversed,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.legacyUserMention,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.groupMentionPlain,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.groupMentionSilent,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.groupMentionSilentClassOrderReversed,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.channelWildcardMentionPlain,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.channelWildcardMentionSilent,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.channelWildcardMentionSilentClassOrderReversed,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.legacyChannelWildcardMentionPlain,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.legacyChannelWildcardMentionSilent,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.legacyChannelWildcardMentionSilentClassOrderReversed,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.topicMentionPlain,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.topicMentionSilent,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
     testContentSmoke(ContentExample.topicMentionSilentClassOrderReversed,
+      wrapWithMessageContentWidget: true,
       wrapWithPerAccountStoreWidget: true);
 
     Mention? findMentionInSpan(InlineSpan rootSpan) {
@@ -1036,6 +1058,7 @@ void main() {
     testWidgets('maintains font-size ratio with surrounding text', (tester) async {
       await checkFontSizeRatio(tester,
         targetHtml: '<span class="user-mention" data-user-id="13313">@Chris Bobbe</span>',
+        wrapWithMessageContentWidget: true,
         wrapWithPerAccountStoreWidget: true,
         targetFontSizeFinder: (rootSpan) {
           final widget = findMentionInSpan(rootSpan);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -822,6 +822,24 @@ void main() {
     });
   });
 
+  testWidgets('date separator background color for self user mention', (tester) async {
+    final dayOne = DateTime.utc(2026, 1, 1, 12).millisecondsSinceEpoch ~/ 1000;
+    final dayTwo = DateTime.utc(2026, 1, 2, 12).millisecondsSinceEpoch ~/ 1000;
+
+    await setupMessageListPage(tester, messages: [
+      eg.streamMessage(timestamp: dayOne),
+      eg.streamMessage(timestamp: dayTwo,
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+        flags: [MessageFlag.mentioned]),
+    ]);
+    final coloredBox = tester.widget<ColoredBox>(find.descendant(
+      of: find.byType(DateSeparator),
+      matching: find.byType(ColoredBox),
+    ));
+    check(coloredBox.color)
+      .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
+  });
+
   group('fetch initial batch of messages', () {
     // TODO(#1571): test effect of visitFirstUnread setting
     // TODO(#1569): test effect of initAnchorMessageId

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -730,6 +730,98 @@ void main() {
     check(backgroundColor()).isSameColorAs(DesignVariables.dark.bgMessageRegular);
   });
 
+  group('message background color for mentions', () {
+    Color backgroundColor(WidgetTester tester, Message message) {
+      final coloredBoxFinder = find.descendant(
+        of: find.byWidgetPredicate((w) => w is MessageItem && w.item.message.id == message.id),
+        matching: find.byType(ColoredBox),
+      );
+      final widget = tester.widget<ColoredBox>(coloredBoxFinder);
+      return widget.color;
+    }
+
+    testWidgets('non-self user mention', (tester) async {
+      final message = eg.streamMessage(
+        content: ContentExample.userMentionPlain.html,
+        flags: []);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageRegular);
+    });
+
+    testWidgets('self user mention', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+        flags: [MessageFlag.mentioned]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
+    });
+
+    testWidgets('silent self user mention', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-mention silent" data-user-id="${eg.selfUser.userId}">Self User</span></p>',
+        flags: []);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageRegular);
+    });
+
+    testWidgets('self user mention in unsubscribed stream', (tester) async {
+      final stream = eg.stream();
+      final message = eg.streamMessage(stream: stream,
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+        flags: [MessageFlag.mentioned]);
+
+      await setupMessageListPage(tester,
+        narrow: ChannelNarrow(stream.streamId),
+        streams: [stream],
+        subscriptions: [],
+        messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageRegular);
+    });
+
+    testWidgets('user group mention', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-group-mention" data-user-group-id="186">@test-group</span></p>',
+        flags: [MessageFlag.mentioned]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageGroupOrWildcardMention);
+    });
+
+    testWidgets('wildcard mention', (tester) async {
+      final message = eg.streamMessage(
+        content: ContentExample.channelWildcardMentionPlain.html,
+        flags: [MessageFlag.streamWildcardMentioned]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageGroupOrWildcardMention);
+    });
+
+    testWidgets('all three mention types', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span> '
+          '<span class="user-group-mention" data-user-group-id="186">@test-group</span> '
+          '<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span></p>',
+        flags: [
+          MessageFlag.mentioned,
+          MessageFlag.streamWildcardMentioned,
+          MessageFlag.wildcardMentioned,
+        ]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
+    });
+  });
+
   group('fetch initial batch of messages', () {
     // TODO(#1571): test effect of visitFirstUnread setting
     // TODO(#1569): test effect of initAnchorMessageId

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -747,6 +747,98 @@ void main() {
     check(backgroundColor()).isSameColorAs(DesignVariables.dark.bgMessageRegular);
   });
 
+  group('message background color for mentions', () {
+    Color backgroundColor(WidgetTester tester, Message message) {
+      final coloredBoxFinder = find.descendant(
+        of: find.byWidgetPredicate((w) => w is MessageItem && w.item.message.id == message.id),
+        matching: find.byType(ColoredBox),
+      );
+      final widget = tester.widget<ColoredBox>(coloredBoxFinder);
+      return widget.color;
+    }
+
+    testWidgets('non-self user mention', (tester) async {
+      final message = eg.streamMessage(
+        content: ContentExample.userMentionPlain.html,
+        flags: []);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageRegular);
+    });
+
+    testWidgets('self user mention', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+        flags: [MessageFlag.mentioned]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
+    });
+
+    testWidgets('silent self user mention', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-mention silent" data-user-id="${eg.selfUser.userId}">Self User</span></p>',
+        flags: []);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageRegular);
+    });
+
+    testWidgets('self user mention in unsubscribed stream', (tester) async {
+      final stream = eg.stream();
+      final message = eg.streamMessage(stream: stream,
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+        flags: [MessageFlag.mentioned]);
+
+      await setupMessageListPage(tester,
+        narrow: ChannelNarrow(stream.streamId),
+        streams: [stream],
+        subscriptions: [],
+        messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageRegular);
+    });
+
+    testWidgets('user group mention', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-group-mention" data-user-group-id="186">@test-group</span></p>',
+        flags: [MessageFlag.mentioned]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageGroupOrWildcardMention);
+    });
+
+    testWidgets('wildcard mention', (tester) async {
+      final message = eg.streamMessage(
+        content: ContentExample.channelWildcardMentionPlain.html,
+        flags: [MessageFlag.streamWildcardMentioned]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageGroupOrWildcardMention);
+    });
+
+    testWidgets('all three mention types', (tester) async {
+      final message = eg.streamMessage(
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span> '
+          '<span class="user-group-mention" data-user-group-id="186">@test-group</span> '
+          '<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span></p>',
+        flags: [
+          MessageFlag.mentioned,
+          MessageFlag.streamWildcardMentioned,
+          MessageFlag.wildcardMentioned,
+        ]);
+
+      await setupMessageListPage(tester, messages: [message]);
+      check(backgroundColor(tester, message))
+        .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
+    });
+  });
+
   group('fetch initial batch of messages', () {
     // TODO(#1571): test effect of visitFirstUnread setting
     // TODO(#1569): test effect of initAnchorMessageId

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -839,6 +839,24 @@ void main() {
     });
   });
 
+  testWidgets('date separator background color for self user mention', (tester) async {
+    final dayOne = DateTime.utc(2026, 1, 1, 12).millisecondsSinceEpoch ~/ 1000;
+    final dayTwo = DateTime.utc(2026, 1, 2, 12).millisecondsSinceEpoch ~/ 1000;
+
+    await setupMessageListPage(tester, messages: [
+      eg.streamMessage(timestamp: dayOne),
+      eg.streamMessage(timestamp: dayTwo,
+        content: '<p><span class="user-mention" data-user-id="${eg.selfUser.userId}">@Self User</span></p>',
+        flags: [MessageFlag.mentioned]),
+    ]);
+    final coloredBox = tester.widget<ColoredBox>(find.descendant(
+      of: find.byType(DateSeparator),
+      matching: find.byType(ColoredBox),
+    ));
+    check(coloredBox.color)
+      .isSameColorAs(DesignVariables.light.bgMessageDirectMention);
+  });
+
   group('fetch initial batch of messages', () {
     // TODO(#1571): test effect of visitFirstUnread setting
     // TODO(#1569): test effect of initAnchorMessageId


### PR DESCRIPTION
Fixes #647.

<details>
  <summary>Before/After Screenshots</summary>

Self Mentions
|Before|After|
|----|----|
|<img width="1080" height="2400" alt="Screenshot_20260505-020456 Zulip" src="https://github.com/user-attachments/assets/796398ae-1e37-4b06-8d93-981720c7a5db" />|<img width="1080" height="2400" alt="Screenshot_20260505-011355 Zulip" src="https://github.com/user-attachments/assets/0ba21624-d48f-4126-9342-628255db573b" />|
|<img width="1080" height="2400" alt="Screenshot_20260505-020446 Zulip" src="https://github.com/user-attachments/assets/77aad785-b480-4bc1-9125-f8eb629ae0df" />|<img width="1080" height="2400" alt="Screenshot_20260505-011404 Zulip" src="https://github.com/user-attachments/assets/44500ba1-fbbb-4a1b-a3ed-a0282d33031f" />|

Website Preview
|Before|After|
|----|----|
|<img width="1080" height="2400" alt="Screenshot_20260505-020428 Zulip" src="https://github.com/user-attachments/assets/b504f385-9b89-4e53-881e-1714f725d6de" />|<img width="1080" height="2400" alt="Screenshot_20260505-011039 Zulip" src="https://github.com/user-attachments/assets/d0040385-97c6-4d9b-9937-73299a203364" />|
|<img width="1080" height="2400" alt="Screenshot_20260505-020437 Zulip" src="https://github.com/user-attachments/assets/827f2669-2f9f-4ae1-8cde-b7028b9db49e" />|<img width="1080" height="2400" alt="Screenshot_20260505-011017 Zulip" src="https://github.com/user-attachments/assets/9c166c83-4e93-455b-8583-2a70f15c3221" />|

Action Sheet
|Before|After|
|----|----|
|<img width="1080" height="2400" alt="Screenshot_20260505-020505 Zulip" src="https://github.com/user-attachments/assets/242c1be6-dfd5-479f-940b-bae25f3a91ee" />|<img width="1080" height="2400" alt="Screenshot_20260505-030011 Zulip" src="https://github.com/user-attachments/assets/6d9bf5b5-5693-44f7-b17b-c0e3c989f39d" />|
|<img width="1080" height="2400" alt="Screenshot_20260505-020510 Zulip" src="https://github.com/user-attachments/assets/a58ac377-bf7e-4a15-9cae-59f9c54ae0b9" />|<img width="1080" height="2400" alt="Screenshot_20260505-030006 Zulip" src="https://github.com/user-attachments/assets/636f9333-0b97-4713-8b5c-c5c3c5136bdc" />|
|<img width="1080" height="2400" alt="Screenshot_20260505-020520 Zulip" src="https://github.com/user-attachments/assets/42dcdc15-065a-438f-b191-6bad35f2efea" />|<img width="1080" height="2400" alt="Screenshot_20260505-025953 Zulip" src="https://github.com/user-attachments/assets/09d0e0ef-5f53-47c1-902f-8d9c139ad0bf" />|
|<img width="1080" height="2400" alt="Screenshot_20260505-020524 Zulip" src="https://github.com/user-attachments/assets/370a7520-d5fc-4e7a-bcee-c6c5e7f235ee" />|<img width="1080" height="2400" alt="Screenshot_20260505-030000 Zulip" src="https://github.com/user-attachments/assets/a8cccaa0-5d80-4efd-bcaf-7735c68784fb" />|

</details>

With this PR, the mobile app's handling of mentions will be up to date with the web app. This PR adds test styling in case of self mention regardless of whether mention is silent or not (refer discussion: [#design > User group mentions inconsistency @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/User.20group.20mentions.20inconsistency/near/2389405)) and adds message background color in case of non-silent self mentions.

#### Doubts:
1. I was confused regarding what cases I should add for mention font color group tests. Right now, I have only added cases for which the test will produce differences. For example, in case of user mention, expected output is same for both silent and non-silent self mentions, so there is only one case for it. For wildcard mentions, expected output is different because of the bug pointed out here: [#design > User group mentions inconsistency @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/User.20group.20mentions.20inconsistency/near/2443132). Is this approach correct?
2. I have not addressed the bug pointed out above, as it comes from using server flags to decide text styling. Server flags are not sent in case of silent wildcard mentions. This causes the text to be not styled appropriately. Since silent wildcard mentions are not shown in the UI (the user has to go out of their way to send one), it is a very minor bug, as pointed out in the discussion. To address the bug, we will have to move the logic away from server flags and use functions to check topic mute/unmute status, probably. Should I address this bug then or is it fine as it is?
3. Should I refactor the following line into a field `hasMention` on `Message`?: 
```message.flags.any((flag) => flag.isMentionFlag)```
It is being reused multiple times in unreads.dart, narrow.dart, and now in message_list.dart.
4. Right now, website preview calls `parseContent` and passes it to `messageBackgroundColor`, thus ending up repeating functions already called in `MessageItem`. Should I expand `InheritedMessage` to include background color? My main concern was that we would have to pass down background color multiple times just for one widget (website preview), which may decrease readability of the code.