### PR TITLE
Dm you indicator 1320

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -709,6 +709,10 @@
   "@newDmSheetNoUsersFound": {
     "description": "Message shown in the new DM sheet when no users match the search."
   },
+  "you": "you",
+  "@you": {
+    "description": "Label identifying the self-user, shown in places like user lists as '(you)'."
+  },
   "composeBoxDmContentHint": "Message @{user}",
   "@composeBoxDmContentHint": {
     "description": "Hint text for content input when sending a message to one other person.",

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1136,6 +1136,12 @@ abstract class ZulipLocalizations {
   /// **'No users found'**
   String get newDmSheetNoUsersFound;
 
+  /// Label identifying the self-user, shown in places like user lists as '(you)'.
+  ///
+  /// In en, this message translates to:
+  /// **'you'**
+  String get you;
+
   /// Hint text for content input when sending a message to one other person.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -611,6 +611,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Keine Nutzer gefunden';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Nachricht an @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -604,6 +604,9 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No se encontraron usuarios';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Mensaje a @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -596,6 +596,9 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Sõnum kasutajale @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -618,6 +618,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Pas d\'utilisateur trouvé';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message à @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -611,6 +611,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Nessun utente trovato';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Messaggia @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -583,6 +583,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'ユーザーが見つかりません';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return '@$user さんにメッセージ';
   }

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -606,6 +606,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Nie odnaleziono użytkowników';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Napisz do @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -607,6 +607,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Никто не найден';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Сообщение для @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -618,6 +618,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Ni zadetkov med uporabniki';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Sporočilo @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -607,6 +607,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'Користувачі не знайдені';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Повідомлення @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -593,6 +593,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get newDmSheetNoUsersFound => 'No users found';
 
   @override
+  String get you => 'you';
+
+  @override
   String composeBoxDmContentHint(String user) {
     return 'Message @$user';
   }

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -977,9 +977,28 @@ class ViewReactionsUserItem extends StatelessWidget {
       ProfilePage.buildRoute(context: context, userId: userId));
   }
 
+  InlineSpan _displayNameSpan({
+    required BuildContext context,
+    required int userId,
+    required int selfUserId,
+    required String fullName,
+    required String youLabel,
+    required Color color,
+  }) {
+    if (userId != selfUserId) {
+      return TextSpan(text: fullName);
+    }
+    return TextSpan(text: fullName, children: [
+      TextSpan(
+        text: wrapInLocalizedParens(context, youLabel, addSpaceBeforeIfNotCjk: true),
+        style: TextStyle(color: color.withValues(alpha: 0.60))),
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
 
     return InkWell(
@@ -997,7 +1016,7 @@ class ViewReactionsUserItem extends StatelessWidget {
             backgroundColor: designVariables.bgContextMenu,
             userId: userId),
           Flexible(
-            child: Text(
+            child: Text.rich(
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
@@ -1005,7 +1024,13 @@ class ViewReactionsUserItem extends StatelessWidget {
                 height: 17 / 17,
                 color: designVariables.textMessage,
               ).merge(weightVariableTextStyle(context, wght: 500)),
-              store.userDisplayName(userId))),
+              _displayNameSpan(
+                context: context,
+                userId: userId,
+                selfUserId: store.selfUserId,
+                fullName: store.userDisplayName(userId),
+                youLabel: zulipLocalizations.you,
+                color: designVariables.textMessage))),
         ])));
   }
 }

--- a/lib/widgets/new_dm_sheet.dart
+++ b/lib/widgets/new_dm_sheet.dart
@@ -349,9 +349,28 @@ class _NewDmUserListItem extends StatelessWidget {
   final bool isSelected;
   final void Function(int userId) onTapped;
 
+  InlineSpan _displayNameSpan({
+    required BuildContext context,
+    required int userId,
+    required int selfUserId,
+    required String fullName,
+    required String youLabel,
+    required Color color,
+  }) {
+    if (userId != selfUserId) {
+      return TextSpan(text: fullName);
+    }
+    return TextSpan(text: fullName, children: [
+      TextSpan(
+        text: wrapInLocalizedParens(context, youLabel, addSpaceBeforeIfNotCjk: true),
+        style: TextStyle(color: color.withValues(alpha: 0.60))),
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
     return Material(
       clipBehavior: Clip.antiAlias,
@@ -379,7 +398,15 @@ class _NewDmUserListItem extends StatelessWidget {
             SizedBox(width: 8),
             Expanded(
               child: Text.rich(
-                TextSpan(text: store.userDisplayName(userId), children: [
+                TextSpan(children: [
+                  _displayNameSpan(
+                    context: context,
+                    userId: userId,
+                    selfUserId: store.selfUserId,
+                    fullName: store.userDisplayName(userId),
+                    youLabel: zulipLocalizations.you,
+                    color: designVariables.textMessage,
+                  ),
                   UserStatusEmoji.asWidgetSpan(userId: userId, fontSize: 17,
                     textScaler: MediaQuery.textScalerOf(context)),
                 ]),

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -168,18 +168,37 @@ class RecentDmConversationsItem extends StatelessWidget {
   final int unreadCount;
   final OnDmSelectCallback onDmSelect;
 
+  InlineSpan _selfNameSpan({
+    required BuildContext context,
+    required String fullName,
+    required int selfUserId,
+    required String youLabel,
+    required Color color,
+  }) {
+    return TextSpan(text: fullName, children: [
+      TextSpan(
+        text: wrapInLocalizedParens(context, youLabel, addSpaceBeforeIfNotCjk: true),
+        style: TextStyle(color: color.withValues(alpha: 0.60))),
+      UserStatusEmoji.asWidgetSpan(userId: selfUserId,
+        fontSize: 17, textScaler: MediaQuery.textScalerOf(context)),
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
 
     final InlineSpan title;
     switch (narrow.otherRecipientIds) { // TODO dedupe with DM items in [InboxPage]
       case []:
-        title = TextSpan(text: store.selfUser.fullName, children: [
-          UserStatusEmoji.asWidgetSpan(userId: store.selfUserId,
-            fontSize: 17, textScaler: MediaQuery.textScalerOf(context)),
-        ]);
+        title = _selfNameSpan(
+          context: context,
+          fullName: store.selfUser.fullName,
+          selfUserId: store.selfUserId,
+          youLabel: zulipLocalizations.you,
+          color: designVariables.labelMenuButton);
       case [var otherUserId]:
         title = TextSpan(text: store.userDisplayName(otherUserId), children: [
           UserStatusEmoji.asWidgetSpan(userId: otherUserId,

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -883,3 +883,20 @@ InlineSpan channelTopicLabelSpan({
     ],
   ]);
 }
+
+/// Wrap [text] in full-width parens for Chinese, Japanese, or Korean;
+/// otherwise use ASCII parens with optional spaces around them.
+String wrapInLocalizedParens(
+  BuildContext context,
+  String text, {
+  bool addSpaceBeforeIfNotCjk = false,
+  bool addSpaceAfterIfNotCjk = false,
+}) {
+  final languageCode = Localizations.localeOf(context).languageCode;
+  return switch (languageCode) {
+    'zh' || 'ja' || 'ko' =>
+      '（$text）',
+    _ =>
+      '${addSpaceBeforeIfNotCjk ? ' ' : ''}($text)${addSpaceAfterIfNotCjk ? ' ' : ''}',
+  };
+}

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -15,12 +15,14 @@ import 'package:legacy_checks/legacy_checks.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/route/realm.dart';
+import 'package:zulip/generated/l10n/zulip_localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/content.dart';
 import 'package:zulip/widgets/emoji_reaction.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/message_list.dart';
+import 'package:zulip/widgets/text.dart';
 
 import '../api/fake_api.dart';
 import '../example_data.dart' as eg;
@@ -705,6 +707,13 @@ void main() {
     }
 
     void checkUserList(WidgetTester tester, String emojiName, List<User> expectUsers) {
+      final context = tester.element(find.byType(ViewReactionsUserListSliver));
+      final zulipLocalizations = ZulipLocalizations.of(context);
+      String userLabel(User user) =>
+        user.userId == eg.selfUser.userId
+          ? '${user.fullName}${wrapInLocalizedParens(context, zulipLocalizations.you, addSpaceBeforeIfNotCjk: true)}'
+          : user.fullName;
+
       final findPanel = find.semantics.byPredicate((node) =>
         node.role == SemanticsRole.tabPanel
         && node.label.contains('Votes for $emojiName'));
@@ -713,10 +722,11 @@ void main() {
       check(panel).containsSemantics(label: 'Votes for $emojiName (${expectUsers.length})');
 
       for (final user in expectUsers) {
+        final label = userLabel(user);
         check(find.semantics.descendant(
           of: findPanel,
-          matching: find.semantics.byLabel(user.fullName)),
-        because: 'expect ${user.fullName}').findsOne();
+          matching: find.semantics.byLabel(label)),
+        because: 'expect $label').findsOne();
       }
     }
 

--- a/test/widgets/new_dm_sheet_test.dart
+++ b/test/widgets/new_dm_sheet_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/basic.dart';
+import 'package:zulip/generated/l10n/zulip_localizations.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/app_bar.dart';
 import 'package:zulip/widgets/compose_box.dart';
@@ -12,6 +13,7 @@ import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/new_dm_sheet.dart';
 import 'package:zulip/widgets/store.dart';
+import 'package:zulip/widgets/text.dart';
 import 'package:zulip/widgets/user.dart';
 
 import '../api/fake_api.dart';
@@ -73,8 +75,17 @@ void main() {
     }
   }
 
-  Finder findUserTile(User user) =>
-    find.ancestor(of: findText(user.fullName, includePlaceholders: false),
+  String selfLabel(WidgetTester tester, String fullName) {
+    final context = tester.element(find.byType(NewDmPicker));
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    return '$fullName${wrapInLocalizedParens(context, zulipLocalizations.you, addSpaceBeforeIfNotCjk: true)}';
+  }
+
+  String displayNameLabel(WidgetTester tester, User user) =>
+    user.userId == store.selfUserId ? selfLabel(tester, user.fullName) : user.fullName;
+
+  Finder findUserTile(WidgetTester tester, User user) =>
+    find.ancestor(of: findText(displayNameLabel(tester, user), includePlaceholders: false),
       matching: find.byType(InkWell)).first;
 
   Finder findUserChip(User user) {
@@ -129,7 +140,7 @@ void main() {
 
     testWidgets('shows full list initially', (tester) async {
       await setupSheet(tester, selfUser: testUsers[0], users: testUsers);
-      check(findText(includePlaceholders: false, 'Alice Anderson')).findsOne();
+      check(findText(includePlaceholders: false, selfLabel(tester, 'Alice Anderson'))).findsOne();
       check(findText(includePlaceholders: false, 'Bob Brown')).findsOne();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsOne();
       check(find.byIcon(ZulipIcons.check_circle_unchecked)).findsExactly(testUsers.length);
@@ -169,7 +180,7 @@ void main() {
         users: [...testUsers, mutedUser], mutedUserIds: [mutedUser.userId]);
       check(findText(includePlaceholders: false, 'Someone Muted')).findsNothing();
       check(findText(includePlaceholders: false, 'Muted user')).findsNothing();
-      check(findText(includePlaceholders: false, 'Alice Anderson')).findsOne();
+      check(findText(includePlaceholders: false, selfLabel(tester, 'Alice Anderson'))).findsOne();
       check(find.byIcon(ZulipIcons.check_circle_unchecked)).findsExactly(testUsers.length);
 
       // … and after a query.  One which matches both the user's actual name and
@@ -178,7 +189,7 @@ void main() {
       await tester.pump();
       check(findText(includePlaceholders: false, 'Someone Muted')).findsNothing();
       check(findText(includePlaceholders: false, 'Muted user')).findsNothing();
-      check(findText(includePlaceholders: false, 'Alice Anderson')).findsOne();
+      check(findText(includePlaceholders: false, selfLabel(tester, 'Alice Anderson'))).findsOne();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsOne();
       check(findText(includePlaceholders: false, 'Édith Piaf')).findsOne();
       check(find.byIcon(ZulipIcons.check_circle_unchecked)).findsExactly(3);
@@ -233,9 +244,16 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Zebra');
       await tester.pump();
       check(findText(includePlaceholders: false, 'No users found')).findsOne();
-      check(findText(includePlaceholders: false, 'Alice Anderson')).findsNothing();
+      check(findText(includePlaceholders: false, selfLabel(tester, 'Alice Anderson'))).findsNothing();
       check(findText(includePlaceholders: false, 'Bob Brown')).findsNothing();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsNothing();
+    });
+
+    testWidgets('searching self shows "(you)" indicator', (tester) async {
+      await setupSheet(tester, selfUser: testUsers[0], users: testUsers);
+      await tester.enterText(find.byType(TextField), 'Alice Anderson');
+      await tester.pump();
+      check(findText(includePlaceholders: false, selfLabel(tester, 'Alice Anderson'))).findsOne();
     });
 
     testWidgets('search text clears when user is selected', (tester) async {
@@ -247,30 +265,30 @@ void main() {
       final textField = tester.widget<TextField>(find.byType(TextField));
       check(textField.controller!.text).equals('Test');
 
-      await tester.tap(findUserTile(user));
+      await tester.tap(findUserTile(tester, user));
       await tester.pump();
       check(textField.controller!.text).isEmpty();
     });
   });
 
   group('user selection', () {
-    Finder findInUserTile(User user, Finder finder) => find.descendant(
-      of: findUserTile(user),
+    Finder findInUserTile(WidgetTester tester, User user, Finder finder) => find.descendant(
+      of: findUserTile(tester, user),
       matching: finder,
     );
 
     void checkUserSelected(WidgetTester tester, User user, bool expected) {
       if (expected) {
         check(findUserChip(user)).findsOne();
-        check(findInUserTile(user, find.byIcon(ZulipIcons.check_circle_checked)))
+        check(findInUserTile(tester, user, find.byIcon(ZulipIcons.check_circle_checked)))
           .findsOne();
-        check(findInUserTile(user, find.byIcon(ZulipIcons.check_circle_unchecked)))
+        check(findInUserTile(tester, user, find.byIcon(ZulipIcons.check_circle_unchecked)))
           .findsNothing();
       } else {
         check(findUserChip(user)).findsNothing();
-        check(findInUserTile(user, find.byIcon(ZulipIcons.check_circle_unchecked)))
+        check(findInUserTile(tester, user, find.byIcon(ZulipIcons.check_circle_unchecked)))
           .findsOne();
-        check(findInUserTile(user, find.byIcon(ZulipIcons.check_circle_checked)))
+        check(findInUserTile(tester, user, find.byIcon(ZulipIcons.check_circle_checked)))
           .findsNothing();
       }
     }
@@ -278,7 +296,7 @@ void main() {
     testWidgets('tapping user chip deselects the user', (tester) async {
       await setupSheet(tester, users: [eg.otherUser, eg.thirdUser]);
 
-      await tester.tap(findUserTile(eg.otherUser));
+      await tester.tap(findUserTile(tester, eg.otherUser));
       await tester.pump();
       checkUserSelected(tester, eg.otherUser, true);
       await tester.tap(findUserChip(eg.otherUser));
@@ -294,12 +312,12 @@ void main() {
       checkUserSelected(tester, eg.selfUser, false);
       checkComposeButtonEnabled(tester, false);
 
-      await tester.tap(findUserTile(user));
+      await tester.tap(findUserTile(tester, user));
       await tester.pump();
       checkUserSelected(tester, user, true);
       checkComposeButtonEnabled(tester, true);
 
-      await tester.tap(findUserTile(user));
+      await tester.tap(findUserTile(tester, user));
       await tester.pump();
       checkUserSelected(tester, user, false);
       checkComposeButtonEnabled(tester, false);
@@ -309,26 +327,27 @@ void main() {
       final otherUser = eg.user(fullName: 'Other User');
       await setupSheet(tester, users: [otherUser]);
 
-      await tester.tap(findUserTile(eg.selfUser));
+      await tester.tap(findUserTile(tester, eg.selfUser));
       await tester.pump();
       checkUserSelected(tester, eg.selfUser, true);
-      check(findText(includePlaceholders: false, eg.selfUser.fullName)).findsExactly(2);
+      check(findText(includePlaceholders: false, selfLabel(tester, eg.selfUser.fullName))).findsOne();
+      check(findText(includePlaceholders: false, eg.selfUser.fullName)).findsOne();
 
-      await tester.tap(findUserTile(otherUser));
+      await tester.tap(findUserTile(tester, otherUser));
       await tester.pump();
       checkUserSelected(tester, otherUser, true);
-      check(find.text(eg.selfUser.fullName)).findsNothing();
+      check(find.text(selfLabel(tester, eg.selfUser.fullName))).findsNothing();
     });
 
     testWidgets('other user selection hides self user', (tester) async {
       final otherUser = eg.user(fullName: 'Other User');
       await setupSheet(tester, users: [otherUser]);
 
-      check(findText(includePlaceholders: false, eg.selfUser.fullName)).findsOne();
+      check(findText(includePlaceholders: false, selfLabel(tester, eg.selfUser.fullName))).findsOne();
 
-      await tester.tap(findUserTile(otherUser));
+      await tester.tap(findUserTile(tester, otherUser));
       await tester.pump();
-      check(find.text(eg.selfUser.fullName)).findsNothing();
+      check(find.text(selfLabel(tester, eg.selfUser.fullName))).findsNothing();
     });
 
     testWidgets('can select multiple users', (tester) async {
@@ -336,9 +355,9 @@ void main() {
       final user2 = eg.user(fullName: 'Test User 2');
       await setupSheet(tester, users: [user1, user2]);
 
-      await tester.tap(findUserTile(user1));
+      await tester.tap(findUserTile(tester, user1));
       await tester.pump();
-      await tester.tap(findUserTile(user2));
+      await tester.tap(findUserTile(tester, user2));
       await tester.pump();
       checkUserSelected(tester, user1, true);
       checkUserSelected(tester, user2, true);
@@ -349,7 +368,7 @@ void main() {
     void checkFindsTileStatusEmoji(WidgetTester tester, User user, Finder emojiFinder) {
       final statusEmojiFinder = find.ancestor(of: emojiFinder,
         matching: find.byType(UserStatusEmoji));
-      final tileStatusEmojiFinder = find.descendant(of: findUserTile(user),
+      final tileStatusEmojiFinder = find.descendant(of: findUserTile(tester, user),
         matching: statusEmojiFinder);
       check(tester.widget<UserStatusEmoji>(tileStatusEmojiFinder)
         .animationMode).equals(ImageAnimationMode.animateNever);
@@ -379,7 +398,7 @@ void main() {
       check(findUserChip(user)).findsNothing();
       check(find.textContaining('Busy')).findsNothing();
 
-      await tester.tap(findUserTile(user));
+      await tester.tap(findUserTile(tester, user));
       await tester.pump();
 
       checkFindsTileStatusEmoji(tester, user, find.text('\u{1f6e0}'));
@@ -395,14 +414,14 @@ void main() {
         text: OptionSome('Busy'), emoji: OptionNone()));
       await tester.pump();
 
-      check(findUserTile(user)).findsOne();
+      check(findUserTile(tester, user)).findsOne();
       check(findUserChip(user)).findsNothing();
       check(find.textContaining('Busy')).findsNothing();
 
-      await tester.tap(findUserTile(user));
+      await tester.tap(findUserTile(tester, user));
       await tester.pump();
 
-      check(findUserTile(user)).findsOne();
+      check(findUserTile(tester, user)).findsOne();
       check(findUserChip(user)).findsOne();
       check(find.textContaining('Busy')).findsNothing();
     });
@@ -422,7 +441,7 @@ void main() {
       connection.prepare(
         json: eg.newestGetMessagesResult(foundOldest: true, messages: []).toJson());
       for (final user in users) {
-        await tester.tap(findUserTile(user));
+        await tester.tap(findUserTile(tester, user));
         await tester.pump();
       }
       await tester.tap(findComposeButton);

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/events.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/basic.dart';
+import 'package:zulip/generated/l10n/zulip_localizations.dart';
 import 'package:zulip/model/narrow.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/home.dart';
@@ -15,6 +16,7 @@ import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/new_dm_sheet.dart';
 import 'package:zulip/widgets/page.dart';
 import 'package:zulip/widgets/recent_dm_conversations.dart';
+import 'package:zulip/widgets/text.dart';
 import 'package:zulip/widgets/user.dart';
 
 import '../example_data.dart' as eg;
@@ -66,6 +68,12 @@ Future<void> setupPage(WidgetTester tester, {
 
 void main() {
   TestZulipBinding.ensureInitialized();
+
+  String selfLabel(WidgetTester tester, String fullName) {
+    final context = tester.element(find.byType(RecentDmConversationsItem));
+    final zulipLocalizations = ZulipLocalizations.of(context);
+    return '$fullName${wrapInLocalizedParens(context, zulipLocalizations.you, addSpaceBeforeIfNotCjk: true)}';
+  }
 
   Finder findConversationItem(Narrow narrow) => find.byWidgetPredicate(
     (widget) => widget is RecentDmConversationsItem && widget.narrow == narrow,
@@ -222,7 +230,7 @@ void main() {
           await setupPage(tester, users: [], dmMessages: [message]);
 
           checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
-          checkTitle(tester, eg.selfUser.fullName);
+          checkTitle(tester, selfLabel(tester, eg.selfUser.fullName));
         });
 
         testWidgets('short name takes one line', (tester) async {
@@ -230,7 +238,7 @@ void main() {
           final selfUser = eg.user(fullName: name);
           await setupPage(tester, selfUser: selfUser, users: [],
             dmMessages: [eg.dmMessage(from: selfUser, to: [])]);
-          checkTitle(tester, name, 1);
+          checkTitle(tester, selfLabel(tester, name), 1);
         });
 
         testWidgets('very long name takes two lines (must be ellipsized)', (tester) async {
@@ -238,7 +246,7 @@ void main() {
           final selfUser = eg.user(fullName: name);
           await setupPage(tester, selfUser: selfUser, users: [],
             dmMessages: [eg.dmMessage(from: selfUser, to: [])]);
-          checkTitle(tester, name, 2);
+          checkTitle(tester, selfLabel(tester, name), 2);
         });
 
         group('User status', () {


### PR DESCRIPTION
Fixes #1320

This PR adds a "(you)" indicator for the self-user in DM-related user lists, with localization support and CJK-aware parentheses formatting.

## What changed

- Added a translatable `"you"` string in l10n resources.
- Added `wrapInLocalizedParens(...)` helper in `lib/widgets/text.dart`:
  - Uses full-width parens for `zh`, `ja`, `ko`
  - Uses ASCII parens (with optional spacing) for other locales
- Updated UI to show the localized indicator for self-user in:
  - recent DM conversations list
  - new DM sheet user list
  - view-reactions user list

## Tests

Updated widget tests to validate localized self-user labels instead of hardcoded `"(you)"`:

- `test/widgets/recent_dm_conversations_test.dart`
- `test/widgets/new_dm_sheet_test.dart`
- `test/widgets/emoji_reaction_test.dart`

Ran:

- `flutter test test/widgets/emoji_reaction_test.dart test/widgets/new_dm_sheet_test.dart test/widgets/recent_dm_conversations_test.dart`

All passed.

## Notes

### Direct messages "you" indicator

| Before | After |
| --- | --- |
| ![before-dm-you-indicator](https://github.com/user-attachments/assets/f5096288-c098-4fd9-a977-1312dde04b49) | ![after-dm-you-indicator](https://github.com/user-attachments/assets/cffa9a7f-29b7-4b2a-a5e0-237946a506cf) |