### PR TITLE
actions [nfc]: Move doAddOrRemoveReaction to ZulipAction

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -1375,7 +1375,7 @@ class ReactionButtons extends StatelessWidget {
     Navigator.pop(pageContext);
 
     final zulipLocalizations = ZulipLocalizations.of(pageContext);
-    doAddOrRemoveReaction(
+    ZulipAction.addOrRemoveReaction(
       context: pageContext,
       doRemoveReaction: isSelfVoted,
       messageId: message.id,
@@ -1394,7 +1394,7 @@ class ReactionButtons extends StatelessWidget {
 
     final emoji = await showEmojiPickerSheet(pageContext: pageContext);
     if (emoji == null || !pageContext.mounted) return;
-    unawaited(doAddOrRemoveReaction(
+    unawaited(ZulipAction.addOrRemoveReaction(
       context: pageContext,
       doRemoveReaction: false,
       messageId: message.id,

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -11,6 +11,7 @@ import '../api/route/messages.dart' as messages_api;
 import '../api/route/channels.dart' as channels_api;
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/binding.dart';
+import '../model/emoji.dart';
 import '../model/internal_link.dart';
 import '../model/narrow.dart';
 import '../model/realm.dart';
@@ -273,6 +274,45 @@ abstract final class ZulipAction {
     }
 
     return fetchedMessage?.content;
+  }
+
+  /// Adds or removes a reaction on the message corresponding to
+  /// the [messageId], showing an error dialog on failure.
+  /// Returns a Future resolving to true if operation succeeds.
+  static Future<void> addOrRemoveReaction({
+    required BuildContext context,
+    required bool doRemoveReaction,
+    required int messageId,
+    required EmojiCandidate emoji,
+    required String errorDialogTitle,
+  }) async {
+    final store = PerAccountStoreWidget.of(context);
+    String? errorMessage;
+    try {
+      await (doRemoveReaction ? removeReaction : addReaction).call(
+        store.connection,
+        messageId: messageId,
+        reactionType: emoji.emojiType,
+        emojiCode: emoji.emojiCode,
+        emojiName: emoji.emojiName,
+      );
+    } catch (e) {
+      if (!context.mounted) return;
+
+      switch (e) {
+        case ZulipApiException():
+          errorMessage = e.message;
+          // TODO(#741) specific messages for common errors, like network errors
+          //   (support with reusable code)
+        default:
+          // TODO(log)
+      }
+
+      showErrorDialog(context: context,
+        title: errorDialogTitle,
+        message: errorMessage);
+      return;
+    }
   }
 
   /// Fetch and parse a URL from [messages_api.getFileTemporaryUrl].

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
-import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
 import '../generated/l10n/zulip_localizations.dart';
@@ -12,7 +11,6 @@ import '../model/emoji.dart';
 import '../model/store.dart';
 import 'action_sheet.dart';
 import 'color.dart';
-import 'dialog.dart';
 import 'emoji.dart';
 import 'inset_shadow.dart';
 import 'input.dart';
@@ -357,45 +355,6 @@ class _TextEmoji extends StatelessWidget {
       ).merge(weightVariableTextStyle(context,
           wght: selected ? 600 : null)),
       textEmojiForEmojiName(emojiName));
-  }
-}
-
-/// Adds or removes a reaction on the message corresponding to
-/// the [messageId], showing an error dialog on failure.
-/// Returns a Future resolving to true if operation succeeds.
-Future<void> doAddOrRemoveReaction({
-  required BuildContext context,
-  required bool doRemoveReaction,
-  required int messageId,
-  required EmojiCandidate emoji,
-  required String errorDialogTitle,
-}) async {
-  final store = PerAccountStoreWidget.of(context);
-  String? errorMessage;
-  try {
-    await (doRemoveReaction ? removeReaction : addReaction).call(
-      store.connection,
-      messageId: messageId,
-      reactionType: emoji.emojiType,
-      emojiCode: emoji.emojiCode,
-      emojiName: emoji.emojiName,
-    );
-  } catch (e) {
-    if (!context.mounted) return;
-
-    switch (e) {
-      case ZulipApiException():
-        errorMessage = e.message;
-        // TODO(#741) specific messages for common errors, like network errors
-        //   (support with reusable code)
-      default:
-        // TODO(log)
-    }
-
-    showErrorDialog(context: context,
-      title: errorDialogTitle,
-      message: errorMessage);
-    return;
   }
 }
 


### PR DESCRIPTION
This small PR was made using ["Claude Code on the web"](https://code.claude.com/docs/en/claude-code-on-the-web), which I've spent today experimenting with.

There are some risks with "Claude Code on the web", particularly for maintainers with commit access. I'm hopeful those can be addressed, such that "ask Claude to work asynchronously and open a PR" is a reasonable thing one can do. 🙂 I'm excited to find out and then share what I've learned!