### PR TITLE
android: File picker shows all files instead of image gallery UI

### DIFF
--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1172,7 +1172,7 @@ class _AttachMediaButton extends _AttachUploadsButton {
   @override
   Future<Iterable<FileToUpload>> getFiles(BuildContext context) async {
     // TODO(#114): This doesn't give quite the right UI on Android.
-    return _getFilePickerFiles(context, FileType.media);
+    return _getFilePickerFiles(context, FileType.image);
   }
 }
 

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1140,6 +1140,55 @@ void main() {
       await tester.pump();
     }
 
+     group('attach file', () {
+      testWidgets('success', (tester) async {
+        await prepare(tester);
+        checkAppearsLoading(tester, false);
+
+        testBinding.pickFilesResult = FilePickerResult([PlatformFile(
+            readStream: Stream.fromIterable(['asdf'.codeUnits]),
+            path:'/private/var/mobile/Containers/Data/Application/foo/tmp/file.pdf',
+            name: 'file.pdf',
+            size: 12345,
+          ),]);
+        connection.prepare(delay: const Duration(seconds: 1),json:
+        UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/file.pdf',).toJson(),
+        );
+        await tester.tap(find.byIcon(ZulipIcons.attach_file));
+        await tester.pump();
+        final call = testBinding.takePickFilesCalls().single;
+        check(call.allowMultiple).equals(true);
+        check(call.type).equals(FileType.any);
+        checkNoDialog(tester);
+        check(controller!.content.text,)
+         .equals('see image: [Uploading file.pdf…]()\n\n');
+        check(connection.lastRequest!).isA<http.MultipartRequest>()
+          ..method.equals('POST')
+          ..files.single.which(
+            (it) => it
+              ..field.equals('file')
+              ..length.equals(12345)
+              ..filename.equals('file.pdf')
+              ..contentType.asString.equals(
+                'application/pdf',
+              ) // ← different MIME type
+              ..has<Future<List<int>>>(
+                (f) => f.finalize().toBytes(),
+                'contents',
+              ).completes(
+                (it) => it.deepEquals(['asdf'.codeUnits].expand((l) => l)),
+              ),
+          );
+        checkAppearsLoading(tester, true);
+
+        await tester.pump(const Duration(seconds: 1));
+        check(controller!.content.text).equals(
+          'see image: [file.pdf](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/file.pdf)\n\n',
+        );
+        checkAppearsLoading(tester, false);
+      });
+    });
+
     group('attach from media library', () {
       testWidgets('success', (tester) async {
         await prepare(tester);
@@ -1160,7 +1209,7 @@ void main() {
         await tester.pump();
         final call = testBinding.takePickFilesCalls().single;
         check(call.allowMultiple).equals(true);
-        check(call.type).equals(FileType.media);
+        check(call.type).equals(FileType.image);
 
         checkNoDialog(tester);
 


### PR DESCRIPTION
This address the issue #1490 that shows all types of files (PDFs, videos, etc.), not just images.
Discussion :
https://chat.zulip.org/#narrow/channel/48-mobile/topic/Issue.20with.20Gallery.20icon.20behavior

Vide reference given below for the fix 

https://github.com/user-attachments/assets/e2766514-2027-46f3-81ef-a58eb659fd59

Fixes : #1490 