### PR TITLE
Use inline syntax on upload for supported images

### DIFF
--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -257,6 +257,34 @@ String inlineLink(String visibleText, String destination) {
   return '[$visibleText]($destination)';
 }
 
+/// https://spec.commonmark.org/0.30/#images
+///
+/// The syntax for images is similar to the syntax defined in [inlineLink], except
+/// that the "link text" is replaced by an "image description", which is made by
+/// enclosing [description] between square brackets, prefixed with "!".
+///
+/// This syntax is suitable for an uploaded image whose MIME type is in
+/// [supportedInlineImageTypes].
+String inlineImage(String description, String destination) {
+  return '![$description]($destination)';
+}
+
+/// Markdown for an uploaded image, with a fallback for old servers.
+///
+/// Produces [inlineImage] if the server supports it, else [inlineLink].
+// TODO(server-12): Remove this helper and call [inlineImage] directly.
+String imageCompat(String description, String destination, {
+  required int zulipFeatureLevel,
+}) {
+  // Zulip's Markdown image syntax was introduced at FL 437 and changed
+  // through FL 467 (server 12.0).
+  // Only generate it for servers that have its final form.  See:
+  //   https://zulip.com/api/message-formatting#changes-to-image-formatting
+  return zulipFeatureLevel >= 467
+    ? inlineImage(description, destination)
+    : inlineLink(description, destination);
+}
+
 /// The image MIME types the server renders inline from Markdown image syntax.
 ///
 /// Should be kept identical to the web app's `SUPPORTED_IMAGE_TYPES` list.  See:

--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -257,6 +257,27 @@ String inlineLink(String visibleText, String destination) {
   return '[$visibleText]($destination)';
 }
 
+/// The image MIME types the server renders inline from Markdown image syntax.
+///
+/// Should be kept identical to the web app's `SUPPORTED_IMAGE_TYPES` list.  See:
+///   https://github.com/zulip/zulip/blob/afb960c04/web/src/upload.ts#L36-L44
+const supportedInlineImageTypes = <String>{
+  'image/avif',
+  'image/gif',
+  'image/heic',
+  'image/jpeg',
+  'image/png',
+  'image/tiff',
+  'image/webp',
+};
+
+/// Whether the server renders a file of this [mimeType] inline from Markdown
+/// image syntax (`![]()`).
+///
+/// See [supportedInlineImageTypes].
+bool isSupportedInlineImage(String? mimeType) =>
+  supportedInlineImageTypes.contains(mimeType);
+
 /// What we show while fetching the target message's raw Markdown.
 ///
 /// Like [quoteAndReply], but the message content is replaced with a placeholder.

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -262,7 +262,7 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   int _nextUploadTag = 0;
 
   final Map<int, ({int messageId, String placeholder})> _quoteAndReplies = {};
-  final Map<int, ({String filename, String placeholder})> _uploads = {};
+  final Map<int, ({String filename, String placeholder, bool isInlineImage})> _uploads = {};
 
   /// A probably-reasonable place to insert Markdown, such as for a file upload.
   ///
@@ -362,12 +362,15 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   ///
   /// Returns an int "tag" that should be passed to registerUploadEnd on the
   /// upload's success or failure.
-  int registerUploadStart(String filename, ZulipLocalizations zulipLocalizations) {
+  int registerUploadStart(String filename, ZulipLocalizations zulipLocalizations, {
+    required bool isInlineImage,
+  }) {
     final tag = _nextUploadTag;
     _nextUploadTag += 1;
     final linkText = zulipLocalizations.composeBoxUploadingFilename(filename);
     final placeholder = inlineLink(linkText, '');
-    _uploads[tag] = (filename: filename, placeholder: placeholder);
+    _uploads[tag] = (filename: filename, placeholder: placeholder,
+      isInlineImage: isInlineImage);
     notifyListeners(); // _uploads change could affect validationErrors
     value = value.replaced(insertionIndex(), '$placeholder\n\n');
     return tag;
@@ -380,15 +383,21 @@ class ComposeContentController extends ComposeController<ContentValidationError>
   void registerUploadEnd(int tag, String? url) {
     final val = _uploads[tag];
     assert(val != null, 'registerUploadEnd called twice for same tag');
-    final (:filename, :placeholder) = val!;
+    final (:filename, :placeholder, :isInlineImage) = val!;
     final int startIndex = text.indexOf(placeholder);
     final replacementRange = startIndex >= 0
       ? TextRange(start: startIndex, end: startIndex + placeholder.length)
       : insertionIndex();
+    final String replacement;
+    if (url == null) {
+      replacement = '';
+    } else if (isInlineImage) {
+      replacement = imageCompat(filename, url, zulipFeatureLevel: store.zulipFeatureLevel);
+    } else {
+      replacement = inlineLink(filename, url);
+    }
 
-    value = value.replaced(
-      replacementRange,
-      url == null ? '' : inlineLink(filename, url));
+    value = value.replaced(replacementRange, replacement);
     _uploads.remove(tag);
     notifyListeners(); // _uploads change could affect validationErrors
   }
@@ -1016,7 +1025,8 @@ Future<void> _uploadFiles({
   final List<(int, FileToUpload)> uploadsInProgress = [];
   for (final file in rightSizeFiles) {
     final tag = contentController.registerUploadStart(file.filename,
-      zulipLocalizations);
+      zulipLocalizations,
+      isInlineImage: isSupportedInlineImage(file.mimeType));
     uploadsInProgress.add((tag, file));
   }
   if (shouldRequestFocus && !contentFocusNode.hasFocus) {

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -382,7 +382,21 @@ hello
   test('inlineLink', () {
     check(inlineLink('CZO', 'https://chat.zulip.org/')).equals('[CZO](https://chat.zulip.org/)');
     check(inlineLink('Uploading file.txt…', '')).equals('[Uploading file.txt…]()');
-    check(inlineLink('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png'))
+  });
+
+  test('inlineImage', () {
+    check(inlineImage('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png'))
+      .equals('![IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
+    check(inlineImage('Uploading IMG_2488.png…', ''))
+      .equals('![Uploading IMG_2488.png…]()');
+  });
+
+  test('imageCompat', () {
+    check(imageCompat('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png',
+        zulipFeatureLevel: 467))
+      .equals('![IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
+    check(imageCompat('IMG_2488.png', '/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png',
+        zulipFeatureLevel: 466))
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
   });
 

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -386,6 +386,14 @@ hello
       .equals('[IMG_2488.png](/user_uploads/2/a3/ucEMyjxk90mcNF0y9rmW5XKO/IMG_2488.png)');
   });
 
+  test('isSupportedInlineImage', () {
+    check(isSupportedInlineImage('image/png')).isTrue();
+    check(isSupportedInlineImage('image/jpeg')).isTrue();
+    check(isSupportedInlineImage('image/svg+xml')).isFalse();
+    check(isSupportedInlineImage('audio/mpeg')).isFalse();
+    check(isSupportedInlineImage(null)).isFalse();
+  });
+
   test('quoteAndReply / quoteAndReplyPlaceholder', () async {
     final sender = eg.user(userId: 123, fullName: 'Full Name');
     final stream = eg.stream(streamId: 1, name: 'test here');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1260,7 +1260,7 @@ void main() {
 
           await tester.pump(const Duration(seconds: 1));
           check(controller!.content.text)
-            .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+            .equals('see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
           checkAppearsLoading(tester, false);
         }, variant: const TargetPlatformVariant({TargetPlatform.android}));
 
@@ -1300,12 +1300,12 @@ void main() {
 
           await tester.pump(const Duration(seconds: 1));
           check(controller!.content.text).equals(
-            'see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n[Uploading test.gif…]()\n\n');
+            'see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n[Uploading test.gif…]()\n\n');
           checkAppearsLoading(tester, true);
 
           await tester.pump(const Duration(seconds: 1));
           check(controller!.content.text).equals(
-            'see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n[test.gif](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/test.gif)\n\n');
+            'see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n![test.gif](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/test.gif)\n\n');
           checkAppearsLoading(tester, false);
         }, variant: const TargetPlatformVariant({TargetPlatform.android}));
 
@@ -1337,7 +1337,7 @@ void main() {
 
           await tester.pump(const Duration(seconds: 1));
           check(controller!.content.text)
-            .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+            .equals('see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         }, variant: const TargetPlatformVariant({TargetPlatform.android}));
       },
       // These tests fail on Windows because [XFile.name] splits on
@@ -1387,7 +1387,7 @@ void main() {
 
         await tester.pump(const Duration(seconds: 1));
         check(controller!.content.text)
-          .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          .equals('see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         checkAppearsLoading(tester, false);
       }, variant: const TargetPlatformVariant({TargetPlatform.iOS}));
 
@@ -1435,7 +1435,7 @@ void main() {
 
         await tester.pump(const Duration(seconds: 1));
         check(controller!.content.text)
-          .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          .equals('see image: ![image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         checkAppearsLoading(tester, false);
       });
 
@@ -1532,7 +1532,7 @@ void main() {
 
         await tester.pump(Duration.zero);
         check(controller!.content.text)
-          .equals('see image: [test.gif]($uploadUrl)\n\n');
+          .equals('see image: ![test.gif]($uploadUrl)\n\n');
         checkAppearsLoading(tester, false);
       });
 


### PR DESCRIPTION
Fixes #2178.
Completes part of #2188 (Abandoned PR).

<details>
<summary>Screenshots</summary>

|Before|After|
|----|----|
|<img width="1080" height="2400" alt="Screenshot_20260525-160604_Zulip" src="https://github.com/user-attachments/assets/86a30913-f287-426e-a757-c0cd0a55412d" />|<img width="1080" height="2400" alt="Screenshot_20260525-160926_Zulip" src="https://github.com/user-attachments/assets/4b23aeca-e5aa-484c-86d2-79f714759851" />|
|<img width="1080" height="2400" alt="Screenshot_20260525-160622_Zulip" src="https://github.com/user-attachments/assets/a2700917-3587-44de-aef8-66954b4c14bd" />|<img width="1080" height="2400" alt="Screenshot_20260525-160935_Zulip" src="https://github.com/user-attachments/assets/3c2fd3b6-0db3-46fb-8c9b-2c84b4ee248d" />|

</details>

This PR introduces [Markdown image syntax](https://spec.commonmark.org/0.30/#image-description) for uploaded images belonging to supported image types. Now images will be rendered using `InlineImage` instead of `MessageImagePreview`. This means that the src of uploaded images will not be visible after sending the message.

This PR is derived from #2188, focusing only on the part regarding inline images. The original PR tried to solve both inline image and inline audio issues simultaneously (#2178 and #2179). There is a complication regarding supported audio types due to an upstream bug (https://github.com/zulip/zulip-flutter/pull/2188#issuecomment-4260794126), so it makes sense to merge the image part separately.