### PR TITLE
Use `pickMultipleMedia` from `image_picker` package for picking photos and videos

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -463,6 +463,13 @@
       "num": {"type": "int", "example": "4"}
     }
   },
+  "errorCouldNotReadFile": "Could not read file: {filename}",
+  "@errorCouldNotReadFile": {
+    "description": "Error message when an attached file could not be read.",
+    "placeholders": {
+      "filename": {"type": "String", "example": "foo.txt"}
+    }
+  },
   "errorLoginInvalidInputTitle": "Invalid input",
   "@errorLoginInvalidInputTitle": {
     "description": "Error title for login when input is invalid."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -794,6 +794,12 @@ abstract class ZulipLocalizations {
   /// **'{num, plural, =1{File} other{Files}} too large'**
   String errorFilesTooLargeTitle(int num);
 
+  /// Error message when an attached file could not be read.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not read file: {filename}'**
+  String errorCouldNotReadFile(String filename);
+
   /// Error title for login when input is invalid.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -416,6 +416,11 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Ungültige Eingabe';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -406,6 +406,11 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Entrada inválida';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -404,6 +404,11 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Vigane sisend';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -415,6 +415,11 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Saisie non valide';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'קלט לא תקין';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -410,6 +410,11 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Ingresso non valido';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -389,6 +389,11 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => '入力が正しくありません';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nn.dart
+++ b/lib/generated/l10n/zulip_localizations_nn.dart
@@ -397,6 +397,11 @@ class ZulipLocalizationsNn extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Ugyldige inndata';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -407,6 +407,11 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Błędny wsad';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -408,6 +408,11 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Неверный ввод';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -397,6 +397,11 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Nesprávny vstup';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -417,6 +417,11 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Neveljaven vnos';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_so.dart
+++ b/lib/generated/l10n/zulip_localizations_so.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsSo extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -406,6 +406,11 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Невірний вхід';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -396,6 +396,11 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   }
 
   @override
+  String errorCouldNotReadFile(String filename) {
+    return 'Could not read file: $filename';
+  }
+
+  @override
   String get errorLoginInvalidInputTitle => 'Invalid input';
 
   @override

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -6,6 +6,8 @@ import 'package:firebase_core/firebase_core.dart' as firebase_core;
 import 'package:firebase_messaging/firebase_messaging.dart' as firebase_messaging;
 import 'package:flutter/foundation.dart';
 import 'package:image_picker/image_picker.dart' as image_picker;
+import 'package:image_picker_android/image_picker_android.dart' as image_picker_android;
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart' as image_picker_platform;
 import 'package:package_info_plus/package_info_plus.dart' as package_info_plus;
 import 'package:sodium/sodium.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
@@ -392,6 +394,15 @@ class LiveZulipBinding extends ZulipBinding {
   LiveZulipBinding() {
     _deviceInfo = _prefetchDeviceInfo();
     _packageInfo = _prefetchPackageInfo();
+
+    final imagePickerPlatform = image_picker_platform.ImagePickerPlatform.instance;
+    if (imagePickerPlatform is image_picker_android.ImagePickerAndroid) {
+      // Use Android Photo Picker, so that pickMultipleMedia gives a photo and
+      // video-only gallery instead of a general file browser. The package leaves this
+      // off by default. See:
+      //   https://pub.dev/documentation/image_picker_android/latest/image_picker_android/ImagePickerAndroid/useAndroidPhotoPicker.html
+      imagePickerPlatform.useAndroidPhotoPicker = true;
+    }
   }
 
   /// Initialize the binding if necessary, and ensure it is a [LiveZulipBinding].

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -217,6 +217,14 @@ abstract class ZulipBinding {
     bool requestFullMetadata,
   });
 
+  /// Pick multiple images and/or videos from the media library,
+  /// via package:image_picker.
+  ///
+  /// This wraps [image_picker.ImagePicker.pickMultipleMedia].
+  Future<List<image_picker.XFile>> pickMultipleMedia({
+    bool requestFullMetadata,
+  });
+
   /// Enables or disables keeping the screen on, via package:wakelock_plus.
   ///
   /// This wraps [wakelock_plus.WakelockPlus.toggle].
@@ -555,6 +563,14 @@ class LiveZulipBinding extends ZulipBinding {
   }) async {
     return image_picker.ImagePicker()
       .pickImage(source: source, requestFullMetadata: requestFullMetadata);
+  }
+
+  @override
+  Future<List<image_picker.XFile>> pickMultipleMedia({
+    bool requestFullMetadata = true,
+  }) async {
+    return image_picker.ImagePicker()
+      .pickMultipleMedia(requestFullMetadata: requestFullMetadata);
   }
 
   @override

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -14,8 +14,10 @@ import '../api/exception.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
 import '../generated/l10n/zulip_localizations.dart';
+import '../log.dart';
 import '../model/binding.dart';
 import '../model/compose.dart';
+import '../model/localizations.dart';
 import '../model/message.dart';
 import '../model/narrow.dart';
 import '../model/store.dart';
@@ -1166,8 +1168,19 @@ class _AttachFileButton extends _AttachUploadsButton {
   }
 }
 
-Future<FileToUpload> _fileFromXFile(XFile xFile) async {
-  final length = await xFile.length();
+/// Make a [FileToUpload] from an [XFile],
+/// or null (with a brief error message shown to the user)
+/// if the file can't be read, e.g. because it's gone missing.
+Future<FileToUpload?> _fileFromXFile(XFile xFile) async {
+  final int length;
+  try {
+    length = await xFile.length();
+  } catch (e) {
+    // TODO(log)
+    reportErrorToUserBriefly(GlobalLocalizations.zulipLocalizations
+      .errorCouldNotReadFile(xFile.name));
+    return null;
+  }
 
   List<int>? headerBytes;
   try {
@@ -1222,7 +1235,7 @@ class _AttachMediaButton extends _AttachUploadsButton {
         message: e.toString());
       return [];
     }
-    return Future.wait(results.map(_fileFromXFile));
+    return (await Future.wait(results.map(_fileFromXFile))).nonNulls;
   }
 }
 
@@ -1272,7 +1285,7 @@ class _AttachFromCameraButton extends _AttachUploadsButton {
     if (result == null) {
       return []; // User cancelled; do nothing
     }
-    return [await _fileFromXFile(result)];
+    return [?await _fileFromXFile(result)];
   }
 }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1165,6 +1165,31 @@ class _AttachFileButton extends _AttachUploadsButton {
   }
 }
 
+Future<FileToUpload> _fileFromXFile(XFile xFile) async {
+  final length = await xFile.length();
+
+  List<int>? headerBytes;
+  try {
+    headerBytes = await xFile.openRead(
+      0,
+      // Despite its dartdoc, [XFile.openRead] can throw if `end` is greater
+      // than the file's length. We can *probably* trust our `length` to be
+      // accurate, but it's nontrivial to verify. If it's inaccurate, we'd
+      // rather sacrifice this part of the MIME lookup than throw the whole
+      // upload. So, the try/catch.
+      min(defaultMagicNumbersMaxLength, length),
+    ).expand((l) => l).toList();
+  } catch (e) {
+    // TODO(log)
+  }
+  return FileToUpload(
+    content: xFile.openRead(),
+    length: length,
+    filename: xFile.name,
+    mimeType: xFile.mimeType
+      ?? lookupMimeType(xFile.path, headerBytes: headerBytes));
+}
+
 class _AttachMediaButton extends _AttachUploadsButton {
   const _AttachMediaButton({required super.controller, required super.enabled});
 
@@ -1228,29 +1253,7 @@ class _AttachFromCameraButton extends _AttachUploadsButton {
     if (result == null) {
       return []; // User cancelled; do nothing
     }
-    final length = await result.length();
-
-    List<int>? headerBytes;
-    try {
-      headerBytes = await result.openRead(
-        0,
-        // Despite its dartdoc, [XFile.openRead] can throw if `end` is greater
-        // than the file's length. We can *probably* trust our `length` to be
-        // accurate, but it's nontrivial to verify. If it's inaccurate, we'd
-        // rather sacrifice this part of the MIME lookup than throw the whole
-        // upload. So, the try/catch.
-        min(defaultMagicNumbersMaxLength, length)
-      ).expand((l) => l).toList();
-    } catch (e) {
-      // TODO(log)
-    }
-    return [FileToUpload(
-      content: result.openRead(),
-      length: length,
-      filename: result.name,
-      mimeType: result.mimeType
-        ?? lookupMimeType(result.path, headerBytes: headerBytes),
-    )];
+    return [await _fileFromXFile(result)];
   }
 }
 

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -1211,7 +1211,6 @@ class _AttachMediaButton extends _AttachUploadsButton {
       return _getFilePickerFiles(context, FileType.media);
     }
 
-    // TODO(#114): This doesn't give quite the right UI on Android.
     final List<XFile> results;
     try {
       results = await ZulipBinding.instance.pickMultipleMedia(

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:app_settings/app_settings.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -1202,8 +1203,27 @@ class _AttachMediaButton extends _AttachUploadsButton {
 
   @override
   Future<Iterable<FileToUpload>> getFiles(BuildContext context) async {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      // On iOS, this gives the native media picker. Switching to
+      // `image_picker` would be a regression: it re-encodes picked images
+      // to JPEG instead of giving the original files. See:
+      //   https://github.com/zulip/zulip-flutter/pull/2331#pullrequestreview-4604793479
+      return _getFilePickerFiles(context, FileType.media);
+    }
+
     // TODO(#114): This doesn't give quite the right UI on Android.
-    return _getFilePickerFiles(context, FileType.media);
+    final List<XFile> results;
+    try {
+      results = await ZulipBinding.instance.pickMultipleMedia(
+        requestFullMetadata: false);
+    } catch (e) {
+      if (!context.mounted) return [];
+      showErrorDialog(context: context,
+        title: ZulipLocalizations.of(context).errorDialogTitle,
+        message: e.toString());
+      return [];
+    }
+    return Future.wait(results.map(_fileFromXFile));
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -570,7 +570,7 @@ packages:
     source: hosted
     version: "1.2.3"
   image_picker_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_android
       sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
@@ -610,7 +610,7 @@ packages:
     source: hosted
     version: "0.2.2+1"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_platform_interface
       sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,8 @@ dependencies:
   http: ^1.0.0
   http_parser: ^4.0.2
   image_picker: ^1.0.0
+  image_picker_android: ^0.8.13+14
+  image_picker_platform_interface: ^2.11.1
   json_annotation: ^4.9.0
   mime: ^2.0.0
   package_info_plus: ^9.0.0

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -83,6 +83,7 @@ class TestZulipBinding extends ZulipBinding {
     _resetNotifications();
     _resetPickFiles();
     _resetPickImage();
+    _resetPickMultipleMedia();
     _resetWakelock();
   }
 
@@ -424,6 +425,42 @@ class TestZulipBinding extends ZulipBinding {
   }) async {
     (_pickImageCalls ??= []).add((source: source, requestFullMetadata: requestFullMetadata));
     return pickImageResult;
+  }
+
+  /// The value that `ZulipBinding.instance.pickMultipleMedia()` should return.
+  ///
+  /// See also [takePickMultipleMediaCalls].
+  List<XFile> pickMultipleMediaResult = const [];
+
+  void _resetPickMultipleMedia() {
+    pickMultipleMediaResult = const [];
+    _pickMultipleMediaCalls = null;
+  }
+
+  /// Consume the log of calls made to `ZulipBinding.instance.pickMultipleMedia()`.
+  ///
+  /// This returns a list of the arguments to all calls made
+  /// to `ZulipBinding.instance.pickMultipleMedia()` since the last call to
+  /// either this method or [reset].
+  ///
+  /// See also [pickMultipleMediaResult].
+  List<({
+    bool requestFullMetadata,
+  })> takePickMultipleMediaCalls() {
+    final result = _pickMultipleMediaCalls;
+    _pickMultipleMediaCalls = null;
+    return result ?? [];
+  }
+  List<({
+    bool requestFullMetadata,
+  })>? _pickMultipleMediaCalls;
+
+  @override
+  Future<List<XFile>> pickMultipleMedia({
+    bool requestFullMetadata = true,
+  }) async {
+    (_pickMultipleMediaCalls ??= []).add((requestFullMetadata: requestFullMetadata));
+    return pickMultipleMediaResult;
   }
 
   /// Returns the current status of wakelock, which can be

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1219,7 +1219,103 @@ void main() {
     }
 
     group('attach from media library', () {
-      testWidgets('success', (tester) async {
+      group('Android (uses image_picker)', () {
+        testWidgets('success', (tester) async {
+          await prepare(tester);
+          checkAppearsLoading(tester, false);
+
+          testBinding.pickMultipleMediaResult = [XFile.fromData(
+            // TODO test inference of MIME type when it's missing here
+            mimeType: 'image/jpeg',
+            utf8.encode('asdf'),
+            name: 'image.jpg',
+            length: 12345,
+            path: '/data/user/0/com.zulipmobile/cache/image.jpg',
+          )];
+          connection.prepare(delay: const Duration(seconds: 1), json:
+            UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
+
+          await tester.tap(find.byIcon(ZulipIcons.image));
+          await tester.pump();
+          final call = testBinding.takePickMultipleMediaCalls().single;
+          check(call.requestFullMetadata).equals(false);
+
+          checkNoDialog(tester);
+
+          check(controller!.content.text)
+            .equals('see image: [Uploading image.jpg…]()\n\n');
+          // (the request is checked more thoroughly in API tests)
+          check(connection.lastRequest!).isA<http.MultipartRequest>()
+            ..method.equals('POST')
+            ..files.single.which((it) => it
+              ..field.equals('file')
+              ..length.equals(12345)
+              ..filename.equals('image.jpg')
+              ..contentType.asString.equals('image/jpeg')
+              ..has<Future<List<int>>>((f) => f.finalize().toBytes(), 'contents')
+                .completes((it) => it.deepEquals(['asdf'.codeUnits].expand((l) => l)))
+            );
+          checkAppearsLoading(tester, true);
+
+          await tester.pump(const Duration(seconds: 1));
+          check(controller!.content.text)
+            .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
+          checkAppearsLoading(tester, false);
+        }, variant: const TargetPlatformVariant({TargetPlatform.android}));
+
+        testWidgets('multiple files', (tester) async {
+          await prepare(tester);
+          checkAppearsLoading(tester, false);
+
+          testBinding.pickMultipleMediaResult = [
+            XFile.fromData(
+              mimeType: 'image/jpeg',
+              utf8.encode('asdf'),
+              name: 'image.jpg',
+              length: 12345,
+              path: '/data/user/0/com.zulipmobile/cache/image.jpg'),
+            XFile.fromData(
+              mimeType: 'image/gif',
+              utf8.encode('asdf'),
+              name: 'test.gif',
+              length: 12345,
+              path: '/data/user/0/com.zulipmobile/cache/test.gif'),
+          ];
+          connection.prepare(delay: const Duration(seconds: 1), json:
+            UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
+          connection.prepare(delay: const Duration(seconds: 1), json:
+            UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/test.gif').toJson());
+
+          await tester.tap(find.byIcon(ZulipIcons.image));
+          await tester.pump();
+          final call = testBinding.takePickMultipleMediaCalls().single;
+          check(call.requestFullMetadata).equals(false);
+
+          checkNoDialog(tester);
+
+          check(controller!.content.text).equals(
+            'see image: [Uploading image.jpg…]()\n\n[Uploading test.gif…]()\n\n');
+          checkAppearsLoading(tester, true);
+
+          await tester.pump(const Duration(seconds: 1));
+          check(controller!.content.text).equals(
+            'see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n[Uploading test.gif…]()\n\n');
+          checkAppearsLoading(tester, true);
+
+          await tester.pump(const Duration(seconds: 1));
+          check(controller!.content.text).equals(
+            'see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n[test.gif](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/test.gif)\n\n');
+          checkAppearsLoading(tester, false);
+        }, variant: const TargetPlatformVariant({TargetPlatform.android}));
+      },
+      // These tests fail on Windows because [XFile.name] splits on
+      // [Platform.pathSeparator], corresponding to the actual host platform
+      // the test is running on, instead of the path separator for the
+      // target platform the test is simulating.
+      // TODO(upstream): unskip after fix to https://github.com/flutter/flutter/issues/161073
+      skip: Platform.isWindows);
+
+      testWidgets('iOS (uses file_picker): success', (tester) async {
         await prepare(tester);
         checkAppearsLoading(tester, false);
 
@@ -1261,7 +1357,7 @@ void main() {
         check(controller!.content.text)
           .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         checkAppearsLoading(tester, false);
-      });
+      }, variant: const TargetPlatformVariant({TargetPlatform.iOS}));
 
       // TODO test what happens when selecting/uploading fails
     });
@@ -1313,10 +1409,6 @@ void main() {
 
       // TODO test what happens when capturing/uploading fails
     },
-    // This test fails on Windows because [XFile.name] splits on
-    // [Platform.pathSeparator], corresponding to the actual host platform
-    // the test is running on, instead of the path separator for the
-    // target platform the test is simulating.
     // TODO(upstream): unskip after fix to https://github.com/flutter/flutter/issues/161073
     skip: Platform.isWindows);
 
@@ -1338,7 +1430,7 @@ void main() {
       )]);
       connection.prepare(json: UploadFileResult(url:
         '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/한국어 파일.txt').toJson());
-      await tester.tap(find.byIcon(ZulipIcons.image));
+      await tester.tap(find.byIcon(ZulipIcons.attach_file));
       await tester.pump();
       check(controller!.content.text)
         .equals('[Uploading 한국어 파일.txt…]()\n\n');

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -18,6 +18,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/model/narrow.dart';
 import 'package:zulip/api/route/channels.dart';
 import 'package:zulip/api/route/messages.dart';
+import 'package:zulip/log.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/message.dart';
 import 'package:zulip/model/narrow.dart';
@@ -1306,6 +1307,37 @@ void main() {
           check(controller!.content.text).equals(
             'see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n[test.gif](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/test.gif)\n\n');
           checkAppearsLoading(tester, false);
+        }, variant: const TargetPlatformVariant({TargetPlatform.android}));
+
+        testWidgets('unreadable file skipped with message; other file uploads', (tester) async {
+          await prepare(tester);
+
+          final reportedErrors = <String?>[];
+          reportErrorToUserBriefly = (message, {details}) => reportedErrors.add(message);
+          addTearDown(() => reportErrorToUserBriefly = defaultReportErrorToUserBriefly);
+
+          testBinding.pickMultipleMediaResult = [
+            XFile.fromData(
+              mimeType: 'image/jpeg',
+              utf8.encode('asdf'),
+              name: 'image.jpg',
+              length: 12345,
+              path: '/data/user/0/com.zulipmobile/cache/image.jpg'),
+            _UnreadableXFile('/data/user/0/com.zulipmobile/cache/missing.jpg'),
+          ];
+          connection.prepare(json:
+            UploadFileResult(url: '/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg').toJson());
+
+          await tester.tap(find.byIcon(ZulipIcons.image));
+          await tester.pump();
+          check(reportedErrors).single.equals('Could not read file: missing.jpg');
+
+          check(controller!.content.text)
+            .equals('see image: [Uploading image.jpg…]()\n\n');
+
+          await tester.pump(const Duration(seconds: 1));
+          check(controller!.content.text)
+            .equals('see image: [image.jpg](/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/image.jpg)\n\n');
         }, variant: const TargetPlatformVariant({TargetPlatform.android}));
       },
       // These tests fail on Windows because [XFile.name] splits on
@@ -2714,4 +2746,14 @@ enum _EditInteractionStart {
       _EditInteractionStart.restoreFailedEdit => 'from restoring a failed edit',
     };
   }
+}
+
+/// An [XFile] whose contents can't be read, as when the underlying file
+/// has gone missing from the filesystem.
+class _UnreadableXFile extends XFile {
+  _UnreadableXFile(super.path);
+
+  @override
+  Future<int> length() async =>
+    throw PathNotFoundException(path, const OSError());
 }


### PR DESCRIPTION
Fixes part of #855.
Fixes #1490.
Fixes #1510.

#1490 states only images should be shown after clicking `_AttachMediaButton`, which is not what we want: https://chat.zulip.org/#narrow/channel/48-mobile/topic/Issue.20with.20Gallery.20icon.20behavior/near/2466391.
Instead, both photos and videos should be available in a gallery-style UI. To get this UI, we need to opt in to use Android Photo Picker. For this, we need to include the platform interface and Android-specific packages of `image_picker` in direct dependencies. Since these were already present in the codebase as transitive dependencies, I used the same versions as before to avoid bugs or regressions.

The default in `image_picker` library is not to use the Photo Picker. However, an upstream PR is open which will make Photo Picker mandatory for Android 16+: https://github.com/flutter/packages/pull/11320.

The Android photo picker is available on Android 11+. Older versions can get a backported version of the Photo Picker. See: https://developer.android.com/training/data-storage/shared/photo-picker#device-availability
If Photo Picker is not available on a device, it will fallback to the old code path, thus, avoiding any regressions. I have manually verified this using Android emulators.

#### Note:
* I could not reproduce the bug mentioned in #1510. Still, now that we are using `image_picker` package, this issue can be considered resolved.
* I do not have any way to manually test on Apple devices. Manual verification by reviewers will be required to ensure #1308 is resolved through this PR.
* I have not included screenshots since there is no UI change within the Zulip app, changes are external, dependent on device.

Edit: Adding screenshots after feedback. Screenshots were taken on Android 16.

|Before|After|
|-----|-----|
|<img width="1080" height="2400" alt="Before" src="https://github.com/user-attachments/assets/5f57f9fb-e616-4921-ba56-677cac4b7471" />|<img width="1080" height="2400" alt="After" src="https://github.com/user-attachments/assets/39331a7d-e14c-4634-a880-2991cfb68ab3" />|





