### PR TITLE
users: Bring deleted user behaviour to parity with the webapp.

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1705,6 +1705,10 @@
   "@mutedUser": {
     "description": "Text to display in place of a muted user's name."
   },
+  "deletedUser": "Deleted user",
+  "@deletedUser": {
+    "description": "Text to display in place of a deleted user's name."
+  },
   "scrollToBottomTooltip": "Scroll to bottom",
   "@scrollToBottomTooltip": {
     "description": "Tooltip for button to scroll to bottom."

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -600,6 +600,10 @@
   "@successChannelLinkCopied": {
     "description": "Message when link of a channel was copied to the user's system clipboard."
   },
+  "composeBoxBannerLabelDeletedDmRecipient": "You cannot send messages to deleted users.",
+  "@composeBoxBannerLabelDeletedDmRecipient": {
+    "description": "Label text for a banner replacing the compose box when you cannot send messages in the DM conversation because one or more members are deleted."
+  },
   "composeBoxBannerLabelDeactivatedDmRecipient": "You cannot send messages to deactivated users.",
   "@composeBoxBannerLabelDeactivatedDmRecipient": {
     "description": "Label text for a banner replacing the compose box when you cannot send messages in the DM conversation because one or more members are deactivated."

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -501,6 +501,12 @@ class User {
   String? avatarUrl; // TODO(#255) distinguish null from missing, as a `JsonNullable<String>?`
   int avatarVersion;
 
+  // Recent servers omit this when it would be false,
+  // and false captures the behavior on older servers without this feature.
+  // So, `defaultValue: false`, letting consumers skip a null-check.
+  @JsonKey(defaultValue: false) // TODO(server-12) cut mention of older servers
+  bool isDeleted;
+
   // null for bots, which don't have custom profile fields.
   // If null for a non-bot, equivalent to `{}` (null just written for efficiency.)
   // TODO(json_serializable): keys use plain `int.parse`, permitting hexadecimal
@@ -535,6 +541,7 @@ class User {
     required this.timezone,
     required this.avatarUrl,
     required this.avatarVersion,
+    required this.isDeleted,
     required this.profileData,
     required this.isSystemBot,
   });

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -173,6 +173,7 @@ User _$UserFromJson(Map<String, dynamic> json) => User(
   timezone: json['timezone'] as String,
   avatarUrl: json['avatar_url'] as String?,
   avatarVersion: (json['avatar_version'] as num).toInt(),
+  isDeleted: json['is_deleted'] as bool? ?? false,
   profileData:
       (User._readProfileData(json, 'profile_data') as Map<String, dynamic>?)
           ?.map(
@@ -198,6 +199,7 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
   'timezone': instance.timezone,
   'avatar_url': instance.avatarUrl,
   'avatar_version': instance.avatarVersion,
+  'is_deleted': instance.isDeleted,
   'profile_data': instance.profileData?.map(
     (k, e) => MapEntry(k.toString(), e),
   ),

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -972,6 +972,12 @@ abstract class ZulipLocalizations {
   /// **'Channel link copied'**
   String get successChannelLinkCopied;
 
+  /// Label text for a banner replacing the compose box when you cannot send messages in the DM conversation because one or more members are deleted.
+  ///
+  /// In en, this message translates to:
+  /// **'You cannot send messages to deleted users.'**
+  String get composeBoxBannerLabelDeletedDmRecipient;
+
   /// Label text for a banner replacing the compose box when you cannot send messages in the DM conversation because one or more members are deactivated.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -2466,6 +2466,12 @@ abstract class ZulipLocalizations {
   /// **'Muted user'**
   String get mutedUser;
 
+  /// Text to display in place of a deleted user's name.
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted user'**
+  String get deletedUser;
+
   /// Tooltip for button to scroll to bottom.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -1457,6 +1457,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get mutedUser => 'Stummgeschalteter Nutzer';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Nach unten Scrollen';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -524,6 +524,10 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Kanallink kopiert';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Du kannst keine Nachrichten an deaktivierte Nutzer senden.';
 

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -1419,6 +1419,9 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -514,6 +514,10 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Enlace al canal copiado';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'No puedes enviar mensajes a usuarios desactivados.';
 

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -1440,6 +1440,9 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get mutedUser => 'Usuario silenciado';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Deslizar hasta abajo';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -510,6 +510,10 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -1426,6 +1426,9 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -527,6 +527,10 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Lien vers le canal copié';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Vous ne pouvez pas envoyer de messages aux utilisateurs désactivés.';
 

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -1465,6 +1465,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get mutedUser => 'Utilisateur mis en sourdine';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Défiler jusqu\'en bas';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -520,6 +520,10 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Link al canale copiato';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Non è possibile inviare messaggi agli utenti disattivati.';
 

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -1451,6 +1451,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get mutedUser => 'Utente silenziato';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scorri fino in fondo';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -492,6 +492,10 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get successChannelLinkCopied => 'チャンネルのリンクをコピーしました';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       '無効化されたユーザーにはメッセージを送信できません。';
 

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1388,6 +1388,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get mutedUser => 'ミュート中のユーザー';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => '最下部へ移動';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nn.dart
+++ b/lib/generated/l10n/zulip_localizations_nn.dart
@@ -1425,6 +1425,9 @@ class ZulipLocalizationsNn extends ZulipLocalizations {
   String get mutedUser => 'Dempa brukar';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Rull til botna';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nn.dart
+++ b/lib/generated/l10n/zulip_localizations_nn.dart
@@ -504,6 +504,10 @@ class ZulipLocalizationsNn extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Kanallenke kopier';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Du kan ikkje senda ei melding til deaktiverte brukarar.';
 

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -1439,6 +1439,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get mutedUser => 'Wyciszony użytkownik';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Przewiń do dołu';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -514,6 +514,10 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Skopiowano odnośnik do kanału';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Nie można wysyłać wiadomości do dezaktywowanych użytkowników.';
 

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -516,6 +516,10 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Ссылка на канал скопирована';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Нельзя отправить сообщение отключенным пользователям.';
 

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -1451,6 +1451,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get mutedUser => 'Заглушенный пользователь';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Прокрутить вниз';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -1420,6 +1420,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -1459,6 +1459,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get mutedUser => 'Uporabnik je utišan';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Premakni se na konec';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -526,6 +526,10 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Povezava do kanala kopirana';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Deaktiviranim uporabnikom ne morete pošiljati sporočil.';
 

--- a/lib/generated/l10n/zulip_localizations_so.dart
+++ b/lib/generated/l10n/zulip_localizations_so.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsSo extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_so.dart
+++ b/lib/generated/l10n/zulip_localizations_so.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsSo extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -1441,6 +1441,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get mutedUser => 'Заглушений користувач';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Прокрутити вниз';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -516,6 +516,10 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Посилання на канал скопійовано';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'Ви не можете надсилати повідомлення деактивованим користувачам.';
 

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -502,6 +502,10 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get successChannelLinkCopied => 'Channel link copied';
 
   @override
+  String get composeBoxBannerLabelDeletedDmRecipient =>
+      'You cannot send messages to deleted users.';
+
+  @override
   String get composeBoxBannerLabelDeactivatedDmRecipient =>
       'You cannot send messages to deactivated users.';
 

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -1418,6 +1418,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get mutedUser => 'Muted user';
 
   @override
+  String get deletedUser => 'Deleted user';
+
+  @override
   String get scrollToBottomTooltip => 'Scroll to bottom';
 
   @override

--- a/lib/model/compose.dart
+++ b/lib/model/compose.dart
@@ -151,7 +151,8 @@ String userMention(User user, {bool silent = false, UserStore? users}) {
 String userMentionFromMessage(Message message, {bool silent = false, required UserStore users}) =>
   _userMentionImpl(
     silent: silent,
-    fullName: users.senderDisplayName(message, replaceIfMuted: false),
+    fullName: users.senderDisplayName(message,
+      replaceIfMuted: false, replaceIfDeleted: false),
     userId: message.senderId);
 
 String _userMentionImpl({required bool silent, required String fullName, int? userId}) =>

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -58,6 +58,9 @@ mixin UserStore on PerAccountStoreBase, RealmStore {
   /// If the user is muted and [replaceIfMuted] is true (the default),
   /// this is [ZulipLocalizations.mutedUser].
   ///
+  /// Otherwise, if the user is deleted (see [User.isDeleted]),
+  /// this is [ZulipLocalizations.deletedUser].
+  ///
   /// Otherwise this is the user's [User.fullName] if the user is known,
   /// or (if unknown) [ZulipLocalizations.unknownUserName].
   ///
@@ -67,7 +70,11 @@ mixin UserStore on PerAccountStoreBase, RealmStore {
     if (replaceIfMuted && isUserMuted(userId)) {
       return GlobalLocalizations.zulipLocalizations.mutedUser;
     }
-    return getUser(userId)?.fullName
+    final user = getUser(userId);
+    if (user != null && user.isDeleted) {
+      return GlobalLocalizations.zulipLocalizations.deletedUser;
+    }
+    return user?.fullName
       ?? GlobalLocalizations.zulipLocalizations.unknownUserName;
   }
 
@@ -76,19 +83,34 @@ mixin UserStore on PerAccountStoreBase, RealmStore {
   /// If the sender is muted and [replaceIfMuted] is true (the default),
   /// this is [ZulipLocalizations.mutedUser].
   ///
+  /// Otherwise, if the sender is deleted (see [User.isDeleted]) and
+  /// [replaceIfDeleted] is true (the default),
+  /// this is [ZulipLocalizations.deletedUser].
+  ///
   /// Otherwise, if the user is known (see [getUser]),
   /// this is their current [User.fullName].
   /// If unknown, this uses the fallback value conveniently provided on the
   /// [Message] object itself, namely [Message.senderFullName].
   ///
+  /// Pass false for [replaceIfMuted] and [replaceIfDeleted] where the
+  /// sender's actual name is needed, as in @-mention syntax, where the
+  /// server accepts only the user's real name.
+  ///
   /// For a user who isn't the sender of some known message,
   /// see [userDisplayName].
-  String senderDisplayName(Message message, {bool replaceIfMuted = true}) {
+  String senderDisplayName(Message message, {
+    bool replaceIfMuted = true,
+    bool replaceIfDeleted = true,
+  }) {
     final senderId = message.senderId;
     if (replaceIfMuted && isUserMuted(senderId)) {
       return GlobalLocalizations.zulipLocalizations.mutedUser;
     }
-    return getUser(senderId)?.fullName ?? message.senderFullName;
+    final user = getUser(senderId);
+    if (replaceIfDeleted && user != null && user.isDeleted) {
+      return GlobalLocalizations.zulipLocalizations.deletedUser;
+    }
+    return user?.fullName ?? message.senderFullName;
   }
 
   /// Whether the user with [userId] is muted by the self-user.

--- a/lib/widgets/compose_box.dart
+++ b/lib/widgets/compose_box.dart
@@ -2320,6 +2320,13 @@ class _ComposeBoxState extends State<ComposeBox> with PerAccountStoreAwareStateM
         }
 
       case DmNarrow(:final otherRecipientIds):
+        final hasDeletedUser = otherRecipientIds.any((id) =>
+          store.getUser(id)?.isDeleted ?? false);
+        if (hasDeletedUser) {
+          return _Banner(
+            intent: _BannerIntent.info,
+            label: zulipLocalizations.composeBoxBannerLabelDeletedDmRecipient);
+        }
         final hasDeactivatedUser = otherRecipientIds.any((id) =>
           !(store.getUser(id)?.isActive ?? true));
         if (hasDeactivatedUser) {

--- a/lib/widgets/profile.dart
+++ b/lib/widgets/profile.dart
@@ -72,15 +72,23 @@ class ProfilePage extends StatelessWidget {
           // we'll show it by the user's name instead.
           showPresence: false,
           replaceIfMuted: false,
+          // Like presence above, the deactivated indicator goes next to the
+          // name below (where it reads better at this size), not on the avatar.
+          markIfDeactivated: false,
         )),
       const SizedBox(height: 16),
       Text.rich(
         TextSpan(children: [
-          PresenceCircle.asWidgetSpan(
-            userId: userId,
-            fontSize: nameStyle.fontSize!,
-            textScaler: MediaQuery.textScalerOf(context),
-          ),
+          if (!user.isActive)
+            DeactivatedUserIcon.asWidgetSpan(
+              fontSize: nameStyle.fontSize!,
+              textScaler: MediaQuery.textScalerOf(context))
+          else
+            PresenceCircle.asWidgetSpan(
+              userId: userId,
+              fontSize: nameStyle.fontSize!,
+              textScaler: MediaQuery.textScalerOf(context),
+            ),
           // TODO write a test where the user is muted; check this and avatar
           TextSpan(text: store.userDisplayName(userId, replaceIfMuted: false)),
           if (userId != store.selfUserId)

--- a/lib/widgets/recent_dm_conversations.dart
+++ b/lib/widgets/recent_dm_conversations.dart
@@ -334,13 +334,13 @@ class DmConversationAvatar extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
 
     final Widget avatar;
-    int? userIdForPresence;
+    int? userId;
     switch (narrow.otherRecipientIds) {
       case []:
         avatar = AvatarImage(userId: store.selfUserId, size: _avatarSize);
       case [var otherUserId]:
         avatar = AvatarImage(userId: otherUserId, size: _avatarSize);
-        userIdForPresence = otherUserId;
+        userId = otherUserId;
       default:
         final allRecipientsCount = narrow.allRecipientIds.length;
         if (allRecipientsCount < 10) {
@@ -377,8 +377,8 @@ class DmConversationAvatar extends StatelessWidget {
     return AvatarShape(
       size: _avatarSize,
       borderRadius: 3,
-      backgroundColor: userIdForPresence != null ? backgroundColor : null,
-      userIdForPresence: userIdForPresence,
+      backgroundColor: userId != null ? backgroundColor : null,
+      userId: userId,
       child: avatar);
   }
 }

--- a/lib/widgets/user.dart
+++ b/lib/widgets/user.dart
@@ -38,7 +38,8 @@ class Avatar extends StatelessWidget {
       size: size,
       borderRadius: borderRadius,
       backgroundColor: backgroundColor,
-      userIdForPresence: showPresence ? userId : null,
+      userId: userId,
+      showPresence: showPresence,
       child: AvatarImage(userId: userId, size: size, replaceIfMuted: replaceIfMuted));
   }
 }
@@ -122,29 +123,36 @@ class _AvatarPlaceholder extends StatelessWidget {
 
 /// A rounded square shape, to wrap an [AvatarImage] or similar.
 ///
-/// If [userIdForPresence] is provided, this will paint a [PresenceCircle]
-/// on the shape.
+/// If [userId] is provided and [showPresence] is true,
+/// this will paint a [PresenceCircle] on the shape.
 class AvatarShape extends StatelessWidget {
   const AvatarShape({
     super.key,
     required this.size,
     required this.borderRadius,
     this.backgroundColor,
-    this.userIdForPresence,
+    this.userId,
+    this.showPresence = true,
     required this.child,
   });
 
   final double size;
   final double borderRadius;
   final Color? backgroundColor;
-  final int? userIdForPresence;
+  final int? userId;
+
+  /// Defaults to true.  Ignored when [userId] is null.
+  final bool showPresence;
+
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    final userId = this.userId;
+
     // (The backgroundColor is only meaningful if presence will be shown;
     // see [PresenceCircle.backgroundColor].)
-    assert(backgroundColor == null || userIdForPresence != null);
+    assert(backgroundColor == null || (userId != null && showPresence));
 
     Widget result = SizedBox.square(
       dimension: size,
@@ -153,7 +161,7 @@ class AvatarShape extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         child: child));
 
-    if (userIdForPresence != null) {
+    if (userId != null && showPresence) {
       final presenceCircleSize = size / 4; // TODO(design) is this right?
       result = Stack(children: [
         result,
@@ -161,7 +169,7 @@ class AvatarShape extends StatelessWidget {
           end: 0,
           bottom: 0,
           child: PresenceCircle(
-            userId: userIdForPresence!,
+            userId: userId,
             size: presenceCircleSize,
             backgroundColor: backgroundColor)),
       ]);

--- a/lib/widgets/user.dart
+++ b/lib/widgets/user.dart
@@ -20,6 +20,7 @@ class Avatar extends StatelessWidget {
     this.backgroundColor,
     this.showPresence = true,
     this.replaceIfMuted = true,
+    this.markIfDeactivated = true,
   });
 
   final int userId;
@@ -29,18 +30,28 @@ class Avatar extends StatelessWidget {
   final bool showPresence;
   final bool replaceIfMuted;
 
+  /// If true (the default), a deactivated user's avatar is
+  /// dimmed and overlaid with a small badge in the bottom-right corner.
+  /// Callers that show the deactivated indicator separately -- e.g. the
+  /// profile page header, which puts the badge next to the user's name --
+  /// should pass false.
+  final bool markIfDeactivated;
+
   @override
   Widget build(BuildContext context) {
-    // (The backgroundColor is only meaningful if presence will be shown;
-    // see [PresenceCircle.backgroundColor].)
-    assert(backgroundColor == null || showPresence);
+    // (The backgroundColor is only meaningful if an overlay will be shown;
+    // see [PresenceCircle.backgroundColor] and [DeactivatedUserIcon].)
+    assert(backgroundColor == null || showPresence || markIfDeactivated);
     return AvatarShape(
       size: size,
       borderRadius: borderRadius,
       backgroundColor: backgroundColor,
       userId: userId,
       showPresence: showPresence,
-      child: AvatarImage(userId: userId, size: size, replaceIfMuted: replaceIfMuted));
+      markIfDeactivated: markIfDeactivated,
+      child: AvatarImage(userId: userId, size: size,
+        replaceIfMuted: replaceIfMuted,
+        markIfDeactivated: markIfDeactivated));
   }
 }
 
@@ -55,11 +66,22 @@ class AvatarImage extends StatelessWidget {
     required this.userId,
     required this.size,
     this.replaceIfMuted = true,
+    this.markIfDeactivated = true,
   });
 
   final int userId;
   final double size;
   final bool replaceIfMuted;
+
+  /// If true (the default), a deactivated user's avatar is faded
+  /// to [deactivatedOpacity].
+  ///
+  /// For a user who is also muted, the avatar is still replaced by
+  /// the muted placeholder, and the fade applies to the placeholder.
+  final bool markIfDeactivated;
+
+  /// Matches the web client's deactivated-avatar opacity.
+  static const double deactivatedOpacity = 0.5;
 
   @override
   Widget build(BuildContext context) {
@@ -70,10 +92,26 @@ class AvatarImage extends StatelessWidget {
       return _AvatarPlaceholder(size: size);
     }
 
+    final markDeactivated = markIfDeactivated && !user.isActive;
+
+    Widget child;
     if (replaceIfMuted && store.isUserMuted(userId)) {
-      return _AvatarPlaceholder(size: size);
+      // Muting hides the user's identity even when they're deactivated;
+      // the deactivated fade below applies to the placeholder too,
+      // like web's behavior in its message list.
+      child = _AvatarPlaceholder(size: size);
+    } else {
+      child = _buildImageOrPlaceholder(context, user);
     }
 
+    if (markDeactivated) {
+      child = Opacity(opacity: deactivatedOpacity, child: child);
+    }
+    return child;
+  }
+
+  Widget _buildImageOrPlaceholder(BuildContext context, User user) {
+    final store = PerAccountStoreWidget.of(context);
     Uri? resolvedUrl;
     if (user.avatarUrl != null) {
       resolvedUrl = store.tryResolveUrl(user.avatarUrl!);
@@ -125,6 +163,10 @@ class _AvatarPlaceholder extends StatelessWidget {
 ///
 /// If [userId] is provided and [showPresence] is true,
 /// this will paint a [PresenceCircle] on the shape.
+///
+/// If [userId] is provided and [markIfDeactivated] is true,
+/// a deactivated user gets a [DeactivatedUserIcon] badge instead,
+/// painted in the same overlay slot.
 class AvatarShape extends StatelessWidget {
   const AvatarShape({
     super.key,
@@ -133,6 +175,7 @@ class AvatarShape extends StatelessWidget {
     this.backgroundColor,
     this.userId,
     this.showPresence = true,
+    this.markIfDeactivated = true,
     required this.child,
   });
 
@@ -144,15 +187,22 @@ class AvatarShape extends StatelessWidget {
   /// Defaults to true.  Ignored when [userId] is null.
   final bool showPresence;
 
+  /// Whether to mark a deactivated [userId] with a [DeactivatedUserIcon]
+  /// badge, taking priority over the presence circle.
+  ///
+  /// Defaults to true.  Ignored when [userId] is null.
+  final bool markIfDeactivated;
+
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final userId = this.userId;
 
-    // (The backgroundColor is only meaningful if presence will be shown;
-    // see [PresenceCircle.backgroundColor].)
-    assert(backgroundColor == null || (userId != null && showPresence));
+    // (The backgroundColor is only meaningful if an overlay will be shown;
+    // see [PresenceCircle.backgroundColor] and [DeactivatedUserIcon].)
+    assert(backgroundColor == null
+        || (userId != null && (showPresence || markIfDeactivated)));
 
     Widget result = SizedBox.square(
       dimension: size,
@@ -161,17 +211,45 @@ class AvatarShape extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         child: child));
 
-    if (userId != null && showPresence) {
-      final presenceCircleSize = size / 4; // TODO(design) is this right?
+    final markDeactivated = userId != null && markIfDeactivated
+      && !(PerAccountStoreWidget.of(context).getUser(userId)?.isActive ?? true);
+
+    final Widget? overlay;
+    if (markDeactivated) {
+      // The badge takes priority over presence, which is meaningless for a
+      // deactivated user.
+      //
+      // Sized to match web's message list, where the badge is an 0.8em
+      // (11.2px) icon plus 2px of padding on each side, so 15.2px, on a
+      // 2.5em (35px) avatar: 15.2 / 35 ≈ 0.43, nudged up to 0.45 because
+      // [Icons.block] leaves some empty margin inside its own box.  See:
+      //   https://github.com/zulip/zulip/blob/41480799c379715d6248e8282f040b99ebae3f33/web/styles/zulip.css#L2546-L2562
+      // Two details differ from web on purpose:
+      //  * Web's badge sticks 2px past the avatar's corner (as does its
+      //    presence circle, slightly).  Ours sits entirely within the
+      //    avatar, matching where this app puts the presence circle.
+      //  * On web, 2px of padding keeps the icon clear of its circle's
+      //    edge; we add no padding, because the [Icons.block] image
+      //    already has blank space around it.
+      overlay = DeactivatedUserIcon(
+        size: size * 0.45,
+        backgroundColor: backgroundColor);
+    } else if (userId != null && showPresence) {
+      overlay = PresenceCircle(
+        userId: userId,
+        size: size / 4, // TODO(design) is this right?
+        backgroundColor: backgroundColor);
+    } else {
+      overlay = null;
+    }
+
+    if (overlay != null) {
       result = Stack(children: [
         result,
         Positioned.directional(textDirection: Directionality.of(context),
           end: 0,
           bottom: 0,
-          child: PresenceCircle(
-            userId: userId,
-            size: presenceCircleSize,
-            backgroundColor: backgroundColor)),
+          child: overlay),
       ]);
     }
 

--- a/lib/widgets/user.dart
+++ b/lib/widgets/user.dart
@@ -295,6 +295,79 @@ class _PresenceCircleState extends State<PresenceCircle> with PerAccountStoreAwa
   }
 }
 
+/// An [Icons.block] badge marking a deactivated user.
+///
+/// See [DeactivatedUserIconStyle] for the possible presentations.
+class DeactivatedUserIcon extends StatelessWidget {
+  const DeactivatedUserIcon({
+    super.key,
+    required this.size,
+    this.style = DeactivatedUserIconStyle.avatarOverlay,
+    this.backgroundColor,
+  }) : assert(style == DeactivatedUserIconStyle.avatarOverlay
+           || backgroundColor == null);
+
+  final double size;
+  final DeactivatedUserIconStyle style;
+
+  /// The fill color of the circle behind the icon,
+  /// for [DeactivatedUserIconStyle.avatarOverlay].
+  ///
+  /// If not passed, [DesignVariables.mainBackground] is used.
+  final Color? backgroundColor;
+
+  /// Creates a [WidgetSpan] with a [DeactivatedUserIcon] in the
+  /// [DeactivatedUserIconStyle.inlineText] style, for use in rich text
+  /// before a user's name.
+  ///
+  /// Sized larger than [PresenceCircle.asWidgetSpan]: the block glyph has
+  /// internal detail that needs more room to read as clearly as a presence dot.
+  static InlineSpan asWidgetSpan({
+    required double fontSize,
+    required TextScaler textScaler,
+  }) {
+    return WidgetSpan(
+      alignment: PlaceholderAlignment.middle,
+      child: Padding(
+        padding: const EdgeInsetsDirectional.only(end: 4),
+        child: DeactivatedUserIcon(size: textScaler.scale(fontSize),
+          style: DeactivatedUserIconStyle.inlineText)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final designVariables = DesignVariables.of(context);
+    // TODO(design): use a custom Zulip icon instead of Material's,
+    //   as we do for other icons in the app.  [Icons.block] stands in
+    //   for the web app's `fa-ban` in the meantime; see discussion:
+    //     https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/Approach.20towards.20icons/with/2468257
+    final result = Icon(Icons.block, size: size, color: designVariables.icon);
+    switch (style) {
+      case DeactivatedUserIconStyle.avatarOverlay:
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: backgroundColor ?? designVariables.mainBackground,
+            shape: BoxShape.circle),
+          child: result);
+      case DeactivatedUserIconStyle.inlineText:
+        return result;
+    }
+  }
+}
+
+/// How a [DeactivatedUserIcon] is being presented.
+enum DeactivatedUserIconStyle {
+  /// As a badge overlaid on an avatar, in the slot otherwise used by a
+  /// [PresenceCircle] (since presence is meaningless for a deactivated user).
+  ///
+  /// The icon is painted on a filled circle of
+  /// [DeactivatedUserIcon.backgroundColor].
+  avatarOverlay,
+
+  /// Inline in rich text before a user's name: the bare icon, with no circle.
+  inlineText,
+}
+
 /// A user status emoji to be displayed in different parts of the app.
 ///
 /// Use [userId] to show status emoji for that user.

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -41,6 +41,7 @@ extension UserChecks on Subject<User> {
   Subject<String> get timezone => has((x) => x.timezone, 'timezone');
   Subject<String?> get avatarUrl => has((x) => x.avatarUrl, 'avatarUrl');
   Subject<int> get avatarVersion => has((x) => x.avatarVersion, 'avatarVersion');
+  Subject<bool> get isDeleted => has((x) => x.isDeleted, 'isDeleted');
   Subject<Map<int, ProfileFieldUserData>?> get profileData => has((x) => x.profileData, 'profileData');
   Subject<bool> get isSystemBot => has((x) => x.isSystemBot, 'isSystemBot');
 }

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -118,6 +118,12 @@ void main() {
         .equals('name@email.com');
     });
 
+    test('is_deleted', () {
+      // The server only sends is_deleted when true, so absence -> false.
+      check(mkUser({}).isDeleted).isFalse();
+      check(mkUser({'is_deleted': true}).isDeleted).isTrue();
+    });
+
     test('profile_data', () {
       check(mkUser({'profile_data': <String, dynamic>{}}).profileData).isNull();
       check(mkUser({'profile_data': null}).profileData).isNull();

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -295,6 +295,7 @@ User user({
   int? botOwnerId,
   UserRole? role,
   String? avatarUrl,
+  bool? isDeleted,
   Map<int, ProfileFieldUserData>? profileData,
 }) {
   _checkPositive(userId, 'user ID');
@@ -313,6 +314,7 @@ User user({
     timezone: 'UTC',
     avatarUrl: avatarUrl,
     avatarVersion: 0,
+    isDeleted: isDeleted ?? false,
     profileData: profileData,
     isSystemBot: false,
   );
@@ -375,6 +377,7 @@ class _ImmutableUser extends User {
     timezone: user.timezone,
     avatarUrl: user.avatarUrl,
     avatarVersion: user.avatarVersion,
+    isDeleted: user.isDeleted,
     profileData: user.profileData == null ? null : Map.unmodifiable(user.profileData!),
     isSystemBot: user.isSystemBot,
     // When adding a field here, be sure to add the corresponding setter below.
@@ -399,6 +402,7 @@ class _ImmutableUser extends User {
   @override set timezone(_) => throw _error;
   @override set avatarUrl(_) => throw _error;
   @override set avatarVersion(_) => throw _error;
+  @override set isDeleted(_) => throw _error;
   @override set profileData(_) => throw _error;
   // isSystemBot already immutable
 }

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -293,6 +293,18 @@ hello
         check(userMentionFromMessage(message, silent: false, users: store))
           .equals('@**Full Name|123**'); // not replaced with 'Muted user'
       });
+
+      test('userMentionFromMessage, deleted user', () async {
+        // The server accepts only the user's real name in mention syntax,
+        // so the localized 'Deleted user' replacement must not appear here.
+        final user = eg.user(userId: 123, fullName: 'Deleted User 123',
+          isActive: false, isDeleted: true);
+        final message = eg.streamMessage(sender: user);
+        final store = eg.store();
+        await store.addUser(user);
+        check(userMentionFromMessage(message, silent: true, users: store))
+          .equals('@_**Deleted User 123|123**'); // not 'Deleted user'
+      });
     });
 
     test('wildcard', () {

--- a/test/model/user_test.dart
+++ b/test/model/user_test.dart
@@ -29,6 +29,21 @@ void main() {
       final store = eg.store();
       check(store.userDisplayName(eg.user().userId)).equals('(unknown user)');
     });
+
+    test('on a deleted user', () async {
+      final user = eg.user(fullName: 'Deleted User 12', isActive: false, isDeleted: true);
+      final store = eg.store();
+      await store.addUser(user);
+      check(store.userDisplayName(user.userId)).equals('Deleted user');
+    });
+
+    test('muted takes priority over deleted', () async {
+      final user = eg.user(fullName: 'Deleted User 12', isActive: false, isDeleted: true);
+      final store = eg.store();
+      await store.addUser(user);
+      await store.setMutedUsers([user.userId]);
+      check(store.userDisplayName(user.userId)).equals('Muted user');
+    });
   });
 
   group('senderDisplayName', () {
@@ -58,6 +73,17 @@ void main() {
       // ... even though `store.userDisplayName` (with no message available
       // for fallback) only has a generic fallback name.
       check(store.userDisplayName(message.senderId)).equals('(unknown user)');
+    });
+
+    test('on a deleted sender', () async {
+      final user = eg.user(fullName: 'Deleted User 12', isActive: false, isDeleted: true);
+      final store = eg.store();
+      await store.addUser(user);
+      final message = eg.streamMessage(sender: user);
+      await store.addMessage(message);
+      check(store.senderDisplayName(message)).equals('Deleted user');
+      check(store.senderDisplayName(message, replaceIfDeleted: false))
+        .equals('Deleted User 12');
     });
   });
 

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1602,6 +1602,12 @@ void main() {
       checkBannerWithLabel(bannerLabel, isShown: !isShown);
     }
 
+    DmNarrow dmNarrowWith(User otherUser) => DmNarrow.withUser(otherUser.userId,
+      selfUserId: eg.selfUser.userId);
+
+    DmNarrow groupDmNarrowWith(List<User> otherUsers) => DmNarrow.withOtherUsers(
+      otherUsers.map((u) => u.userId), selfUserId: eg.selfUser.userId);
+
     group('in DMs with deactivated users', () {
       void checkComposeBox({required bool isShown}) => checkComposeBoxIsShown(isShown,
         bannerLabel: zulipLocalizations.composeBoxBannerLabelDeactivatedDmRecipient);
@@ -1612,12 +1618,6 @@ void main() {
           userId: user.userId, isActive: isActive));
         await tester.pump();
       }
-
-      DmNarrow dmNarrowWith(User otherUser) => DmNarrow.withUser(otherUser.userId,
-        selfUserId: eg.selfUser.userId);
-
-      DmNarrow groupDmNarrowWith(List<User> otherUsers) => DmNarrow.withOtherUsers(
-        otherUsers.map((u) => u.userId), selfUserId: eg.selfUser.userId);
 
       group('1:1 DMs', () {
         testWidgets('compose box replaced with a banner', (tester) async {
@@ -1682,6 +1682,32 @@ void main() {
           await changeUserStatus(tester, user: deactivatedUsers[1], isActive: true);
           checkComposeBox(isShown: true);
         });
+      });
+    });
+
+    group('in DMs with deleted users', () {
+      void checkComposeBox({required bool isShown}) => checkComposeBoxIsShown(isShown,
+        bannerLabel: zulipLocalizations.composeBoxBannerLabelDeletedDmRecipient);
+
+      testWidgets('1:1 DM with a deleted user: compose box replaced with a banner', (tester) async {
+        final deletedUser = eg.user(isActive: false, isDeleted: true);
+        await prepareComposeBox(tester, narrow: dmNarrowWith(deletedUser),
+          otherUsers: [deletedUser]);
+        checkComposeBox(isShown: false);
+      });
+
+      testWidgets('deleted takes priority over deactivated', (tester) async {
+        // A group DM with one deleted and one merely deactivated recipient
+        // shows the deleted banner, not the deactivated one.
+        final deletedUser = eg.user(isActive: false, isDeleted: true);
+        final deactivatedUser = eg.user(isActive: false);
+        await prepareComposeBox(tester,
+          narrow: groupDmNarrowWith([deletedUser, deactivatedUser]),
+          otherUsers: [deletedUser, deactivatedUser]);
+        checkBannerWithLabel(
+          zulipLocalizations.composeBoxBannerLabelDeletedDmRecipient, isShown: true);
+        checkBannerWithLabel(
+          zulipLocalizations.composeBoxBannerLabelDeactivatedDmRecipient, isShown: false);
       });
     });
 

--- a/test/widgets/profile_test.dart
+++ b/test/widgets/profile_test.dart
@@ -120,6 +120,31 @@ void main() {
     check(find.text(longString).evaluate()).isNotEmpty();
   });
 
+  group('deactivated block icon', () {
+    // The name-row icon and avatar are the only places a block icon could
+    // appear on this page; for deactivated users we expect exactly one (the
+    // name-row icon), with the corner badge on the avatar suppressed via
+    // markIfDeactivated: false.
+    final findBlockIcon = find.byIcon(Icons.block);
+
+    testWidgets('active user: no block icon, presence circle present', (tester) async {
+      final user = eg.user(isActive: true);
+      await setupPage(tester, users: [user], pageUserId: user.userId);
+      check(findBlockIcon).findsNothing();
+      check(find.byType(PresenceCircle)).findsAtLeast(1);
+    });
+
+    testWidgets('deactivated user: block icon in name row, no presence circle', (tester) async {
+      final user = eg.user(isActive: false);
+      await setupPage(tester, users: [user], pageUserId: user.userId);
+      // Exactly one block icon: the name-row indicator.  The Avatar above
+      // has markIfDeactivated: false so it paints no badge of its own.
+      check(findBlockIcon).findsOne();
+      check(find.byType(PresenceCircle)).findsNothing();
+    });
+
+  });
+
   group('_LastActiveTime', () {
     Future<void> update(WidgetTester tester, User user, {
       required int activeSeconds,

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -298,6 +298,18 @@ void main() {
             final narrow = DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId);
             check(findConversationItem(narrow)).findsNothing();
           });
+
+          testWidgets('deactivated user: block badge, no presence circle', (tester) async {
+            final user = eg.user(userId: 1, isActive: false);
+            final message = eg.dmMessage(from: eg.selfUser, to: [user]);
+            await setupPage(tester, users: [user], dmMessages: [message]);
+
+            final itemFinder = find.byType(RecentDmConversationsItem);
+            check(find.descendant(of: itemFinder,
+              matching: find.byIcon(Icons.block))).findsOne();
+            check(find.descendant(of: itemFinder,
+              matching: find.byType(PresenceCircle))).findsNothing();
+          });
         });
 
         testWidgets('no error when user somehow missing from user store', (tester) async {

--- a/test/widgets/user_test.dart
+++ b/test/widgets/user_test.dart
@@ -8,6 +8,7 @@ import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
+import 'package:zulip/widgets/theme.dart';
 import 'package:zulip/widgets/user.dart';
 
 import '../example_data.dart' as eg;
@@ -142,5 +143,57 @@ void main() {
       debugNetworkImageHttpClientProvider = null;
     });
 
+  });
+
+  group('DeactivatedUserIcon', () {
+    Future<void> pumpIcon(WidgetTester tester, {
+      DeactivatedUserIconStyle style = DeactivatedUserIconStyle.avatarOverlay,
+      Color? backgroundColor,
+    }) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          child: DeactivatedUserIcon(size: 16,
+            style: style, backgroundColor: backgroundColor)));
+      await tester.pump();
+    }
+
+    final findBlockIcon = find.descendant(
+      of: find.byType(DeactivatedUserIcon),
+      matching: find.byIcon(Icons.block));
+    final findDecoratedBox = find.descendant(
+      of: find.byType(DeactivatedUserIcon),
+      matching: find.byType(DecoratedBox));
+
+    testWidgets('renders a block icon', (tester) async {
+      await pumpIcon(tester);
+      check(findBlockIcon).findsOne();
+    });
+
+    testWidgets('avatarOverlay: icon on a filled circle of backgroundColor', (tester) async {
+      await pumpIcon(tester, backgroundColor: const Color(0xFF112233));
+      check(findBlockIcon).findsOne();
+      final decoratedBox = tester.widget<DecoratedBox>(findDecoratedBox);
+      final decoration = decoratedBox.decoration as BoxDecoration;
+      check(decoration.color).equals(const Color(0xFF112233));
+      check(decoration.shape).equals(BoxShape.circle);
+    });
+
+    testWidgets('avatarOverlay, no backgroundColor: circle filled with default background', (tester) async {
+      await pumpIcon(tester);
+      final decoratedBox = tester.widget<DecoratedBox>(findDecoratedBox);
+      final decoration = decoratedBox.decoration as BoxDecoration;
+      check(decoration.color).equals(
+        DesignVariables.of(tester.element(findBlockIcon)).mainBackground);
+      check(decoration.shape).equals(BoxShape.circle);
+    });
+
+    testWidgets('inlineText: just the icon, no DecoratedBox', (tester) async {
+      await pumpIcon(tester, style: DeactivatedUserIconStyle.inlineText);
+      check(findBlockIcon).findsOne();
+      check(findDecoratedBox).findsNothing();
+    });
   });
 }

--- a/test/widgets/user_test.dart
+++ b/test/widgets/user_test.dart
@@ -143,6 +143,189 @@ void main() {
       debugNetworkImageHttpClientProvider = null;
     });
 
+    final findOpacity = find.descendant(
+      of: find.byType(AvatarImage),
+      matching: find.byType(Opacity));
+
+    void checkDeactivatedOpacity(WidgetTester tester) {
+      final opacity = tester.widget<Opacity>(findOpacity);
+      check(opacity.opacity).equals(AvatarImage.deactivatedOpacity);
+    }
+
+    Future<void> pumpImage(WidgetTester tester, User user, {
+      bool muted = false,
+      bool markIfDeactivated = true,
+    }) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      await store.addUser(user);
+      if (muted) await store.setMutedUsers([user.userId]);
+
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          child: AvatarImage(userId: user.userId, size: 30,
+            markIfDeactivated: markIfDeactivated)));
+      await tester.pump();
+    }
+
+    testWidgets('deactivated user with placeholder: wrapped in Opacity 0.5', (tester) async {
+      await pumpImage(tester, eg.user(avatarUrl: null, isActive: false));
+      checkDeactivatedOpacity(tester);
+    });
+
+    testWidgets('deactivated user with network image: wrapped in Opacity 0.5', (tester) async {
+      prepareBoringImageHttpClient();
+      await pumpImage(tester,
+        eg.user(avatarUrl: 'https://example/avatar.png', isActive: false));
+      // The network image branch is also wrapped in Opacity.
+      check(find.descendant(
+        of: find.byType(AvatarImage),
+        matching: find.byType(RealmContentNetworkImage))).findsOne();
+      checkDeactivatedOpacity(tester);
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('active user: no Opacity wrapper', (tester) async {
+      await pumpImage(tester, eg.user(avatarUrl: null, isActive: true));
+      check(findOpacity).findsNothing();
+    });
+
+    testWidgets('muted + deactivated user: muted placeholder, faded', (tester) async {
+      await pumpImage(tester,
+        eg.user(avatarUrl: 'https://example/avatar.png', isActive: false),
+        muted: true);
+      // Muting still hides the user's face; the deactivated fade
+      // applies to the muted placeholder.
+      check(find.descendant(
+        of: find.byType(AvatarImage),
+        matching: find.byType(RealmContentNetworkImage))).findsNothing();
+      check(findPlaceholder).findsOne();
+      checkDeactivatedOpacity(tester);
+    });
+
+    testWidgets('markIfDeactivated: false suppresses Opacity on deactivated user', (tester) async {
+      await pumpImage(tester, eg.user(avatarUrl: null, isActive: false),
+        markIfDeactivated: false);
+      check(findOpacity).findsNothing();
+    });
+  });
+
+  group('Avatar deactivated handling', () {
+    final findBlockIcon = find.descendant(
+      of: find.byType(Avatar),
+      matching: find.byIcon(Icons.block));
+    final findOpacity = find.descendant(
+      of: find.byType(Avatar),
+      matching: find.byType(Opacity));
+    final findPresenceCircle = find.descendant(
+      of: find.byType(Avatar),
+      matching: find.byType(PresenceCircle));
+
+    void checkDeactivatedOpacity(WidgetTester tester) {
+      final opacity = tester.widget<Opacity>(findOpacity);
+      check(opacity.opacity).equals(AvatarImage.deactivatedOpacity);
+    }
+
+    Future<void> pumpAvatar(WidgetTester tester, User user, {
+      bool showPresence = true,
+      bool markIfDeactivated = true,
+    }) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      await store.addUser(user);
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          child: Avatar(userId: user.userId, size: 30, borderRadius: 4,
+            showPresence: showPresence,
+            markIfDeactivated: markIfDeactivated)));
+      await tester.pump();
+    }
+
+    testWidgets('active user: no block icon, no Opacity, presence shown', (tester) async {
+      await pumpAvatar(tester, eg.user(isActive: true));
+      check(findBlockIcon).findsNothing();
+      check(findOpacity).findsNothing();
+      check(findPresenceCircle).findsOne();
+    });
+
+    testWidgets('deactivated user: block icon, opacity 0.5, no presence', (tester) async {
+      await pumpAvatar(tester, eg.user(isActive: false));
+      check(findBlockIcon).findsOne();
+      check(findOpacity).findsOne();
+      checkDeactivatedOpacity(tester);
+      check(findPresenceCircle).findsNothing();
+    });
+
+    testWidgets('badge still appears when showPresence: false', (tester) async {
+      // The message list passes showPresence: false; the deactivated badge
+      // and opacity should still appear there.
+      await pumpAvatar(tester, eg.user(isActive: false), showPresence: false);
+      check(findBlockIcon).findsOne();
+      check(findOpacity).findsOne();
+      checkDeactivatedOpacity(tester);
+      check(findPresenceCircle).findsNothing();
+    });
+
+    testWidgets('markIfDeactivated: false suppresses badge and Opacity', (tester) async {
+      // The profile page header passes markIfDeactivated: false because it
+      // shows the indicator next to the user's name instead.
+      await pumpAvatar(tester, eg.user(isActive: false),
+        markIfDeactivated: false);
+      check(findBlockIcon).findsNothing();
+      check(findOpacity).findsNothing();
+    });
+  });
+
+  group('AvatarShape', () {
+    final findBlockIcon = find.descendant(
+      of: find.byType(AvatarShape),
+      matching: find.byIcon(Icons.block));
+
+    Future<void> pumpShape(WidgetTester tester, {
+      User? user,
+      bool showPresence = true,
+      bool markIfDeactivated = true,
+    }) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      if (user != null) await store.addUser(user);
+      await tester.pumpWidget(
+        TestZulipApp(accountId: eg.selfAccount.id,
+          child: AvatarShape(size: 30, borderRadius: 4,
+            userId: user?.userId,
+            showPresence: showPresence,
+            markIfDeactivated: markIfDeactivated,
+            child: const SizedBox.shrink())));
+      await tester.pump();
+    }
+
+    testWidgets('active user: paints presence, no badge', (tester) async {
+      await pumpShape(tester, user: eg.user(isActive: true));
+      check(find.byType(PresenceCircle)).findsOne();
+      check(findBlockIcon).findsNothing();
+    });
+
+    testWidgets('deactivated user: paints badge, suppresses presence', (tester) async {
+      await pumpShape(tester, user: eg.user(isActive: false));
+      check(findBlockIcon).findsOne();
+      check(find.byType(PresenceCircle)).findsNothing();
+    });
+
+    testWidgets('markIfDeactivated: false: no badge for deactivated user', (tester) async {
+      await pumpShape(tester, user: eg.user(isActive: false),
+        markIfDeactivated: false);
+      check(findBlockIcon).findsNothing();
+      check(find.byType(PresenceCircle)).findsOne();
+    });
+
+    testWidgets('no userId: no overlay', (tester) async {
+      await pumpShape(tester);
+      check(find.byType(PresenceCircle)).findsNothing();
+      check(findBlockIcon).findsNothing();
+    });
   });
 
   group('DeactivatedUserIcon', () {


### PR DESCRIPTION
Fixes #2277.

First commit wires up the new `is_deleted` field (feature level 490). Second adds a `UserStore.isUserDeactivated` helper.

Commit 3 introduces the faded avatar and the ban icon similar to the webapp implementation. 

Commit 4 replaces the server-scrubbed `"Deleted User N"` with a localized `Deleted user` string. 

Commit 5 makes sure that when the user cannot send messages to a deleted user, it says `deleted` instead of `deactivated`.


| Surface | Before | After |
|---|---|---|
| Profile page of a deactivated user (block badge next to name) | <img width="1206" height="2622" alt="deactivated-profile-before" src="https://github.com/user-attachments/assets/e126ce3b-6cf1-4331-a774-17955ce667cc" /> | <img width="1206" height="2622" alt="deactivated-profile-after" src="https://github.com/user-attachments/assets/29740232-ccf1-4ce5-b48f-c29ad1025d42" /> |
| Direct-messages list (faded avatar + corner badge, localized "Deleted user" name) | <img width="1206" height="2622" alt="deactivated-dm-list-before" src="https://github.com/user-attachments/assets/2c4b8904-33aa-4a43-9558-dd7bc45b8a2c" /> | <img width="1206" height="2622" alt="deactivated-dm-list-after" src="https://github.com/user-attachments/assets/cac44e8e-bac6-4720-b6d7-ab6c91934375" /> |
| DM thread with a deactivated user (sender avatar in messages) | <img width="1206" height="2622" alt="deactivated-dm-thread-before" src="https://github.com/user-attachments/assets/b2511ec6-133a-42ee-9666-a037b7639dc4" /> | <img width="1206" height="2622" alt="deactivated-dm-thread-after" src="https://github.com/user-attachments/assets/c1dc254e-6137-4bee-9c77-41e66f641782" /> |
| Channel message list with a deactivated sender | <img width="1206" height="2622" alt="deactivated-message-list-before" src="https://github.com/user-attachments/assets/02e55ff4-4fb4-4b57-b396-f675621e9a77" /> | <img width="1206" height="2622" alt="deactivated-message-list-after" src="https://github.com/user-attachments/assets/eacc6091-4386-407b-9a1e-87096dd5ffb8" /> |
| Inbox DM row for a deactivated user | <img width="1206" height="2622" alt="deactivated-inbox-before" src="https://github.com/user-attachments/assets/1ab4b170-7a87-4cf6-821c-f4c0d6f6676b" /> | <img width="1206" height="2622" alt="deactivated-inbox-after" src="https://github.com/user-attachments/assets/e37a72ab-ca22-48c8-a955-ae47cf743452" /> |
| Group DM containing a deleted participant (header recipients + banner) | <img width="1206" height="2622" alt="deleted-group-dm-before" src="https://github.com/user-attachments/assets/264f11a8-d881-44b7-80ff-4105afd1160a" /> | <img width="1206" height="2622" alt="deleted-group-dm-after" src="https://github.com/user-attachments/assets/3ab75d90-f202-459f-9792-7850c497d1ab" /> |
| 1:1 DM with a deleted user ("deleted users" banner) | <img width="1206" height="2622" alt="deleted-dm-1to1-before" src="https://github.com/user-attachments/assets/61bc7780-d7eb-439e-8279-8215163901e0" /> | <img width="1206" height="2622" alt="deleted-dm-1to1-after" src="https://github.com/user-attachments/assets/363bc728-aff7-4c04-8569-51c92233bf22" /> |
| 1:1 DM with a muted + deactivated user (muted placeholder stays; fade + badge apply to it) | <img width="1206" height="2622" alt="muted-deactivated-dm-before" src="https://github.com/user-attachments/assets/23a3b96d-39c7-46e2-afb8-10e7e72cea1c" /> | <img width="1206" height="2622" alt="muted-deactivated-dm-after" src="https://github.com/user-attachments/assets/76628c37-9481-4492-8b62-55403613c128" /> |
| 1:1 DM with a muted + deleted user (muting wins for the name: "Muted user", not "Deleted user") | <img width="1206" height="2622" alt="muted-deleted-dm-before" src="https://github.com/user-attachments/assets/ae6e9688-ff1e-4f5a-85b6-fada85a7e102" /> | <img width="1206" height="2622" alt="muted-deleted-dm-after" src="https://github.com/user-attachments/assets/084589ad-29ba-441e-b16a-0195604207cb" /> |


