### PR TITLE
check: Split out new `swift_format` suite; run it on macOS/ files too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       run: flutter pub get
 
     - name: Run tools/check
-      run: TERM=dumb tools/check --no-pub --all --output ci --exclude android --exclude ios
+      run: TERM=dumb tools/check --no-pub --all --output ci --exclude android --exclude ios --exclude swift_format
 
   android:
     name: "Android build and lint"
@@ -61,6 +61,10 @@ jobs:
 
     - name: Download our dependencies (flutter pub get)
       run: flutter pub get
+
+    - name: Check Swift formatting
+      # Run before the (multi-minute) iOS build, so CI fails fast on nits.
+      run: TERM=dumb tools/check --no-pub --all --output ci swift_format
 
     - name: Run tools/check
       run: TERM=dumb tools/check --no-pub --all --output ci ios

--- a/tools/check
+++ b/tools/check
@@ -33,7 +33,7 @@ this_dir=${BASH_SOURCE[0]%/*}
 default_suites=(
     analyze test
     flutter_version
-    build_runner l10n drift pigeon icons
+    build_runner l10n drift pigeon icons swift_format
     android ios  # These take multiple minutes in CI, so do them last.
 )
 
@@ -533,28 +533,6 @@ run_ios() {
         ${opt_no_pub:+--no-pub}
     )
 
-    check_no_uncommitted_or_untracked ios/'*'.swift \
-    || return
-
-    if_verbose echo "Checking for style issues in Swift code..."
-
-    # Generated code (*.g.swift) is omitted from this check.
-    # shellcheck disable=SC2207  # filenames in our own tree, assume well-behaved
-    local swift_targets=(
-        $(git ls-files -- ios/'*'.swift :!:ios/'*'.g.swift)
-    )
-
-    # --in-place enables `tools/check --fix ios`; see `check_no_changes`.
-    # TODO: Once we have a dedicated code formatting check,
-    #       move this swift-format check there.
-    xcrun swift-format format --in-place \
-        --configuration ios/.swift-format \
-        "${swift_targets[@]}" \
-    || return
-
-    check_no_changes "changes to Swift files (swift-format)" ios/'*'.swift \
-    || return
-
     check_no_uncommitted_or_untracked ios/ macos/ \
     || return
 
@@ -587,6 +565,38 @@ run_ios() {
     fi
 
     flutter build ipa "${build_opts[@]}"
+}
+
+run_swift_format() {
+    # Omitted from this check:
+    #   pubspec.{yaml,lock} tools/check
+    files_check ios/'*'.swift ios/.swift-format \
+    || return 0
+
+    # swift-format comes from the Swift toolchain via `xcrun`, so needs macOS.
+    if [ "$(uname -s)" != "Darwin" ]; then
+        echo "Skipping swift_format suite (not on macOS)."
+        return 0
+    fi
+
+    check_no_uncommitted_or_untracked ios/'*'.swift \
+    || return
+
+    if_verbose echo "Checking for style issues in Swift code..."
+
+    # Generated code (*.g.swift) is omitted from this check.
+    # shellcheck disable=SC2207  # filenames in our own tree, assume well-behaved
+    local swift_targets=(
+        $(git ls-files -- ios/'*'.swift :!:ios/'*'.g.swift)
+    )
+
+    # --in-place enables `tools/check --fix swift_format`; see `check_no_changes`.
+    xcrun swift-format format --in-place \
+        --configuration ios/.swift-format \
+        "${swift_targets[@]}" \
+    || return
+
+    check_no_changes "changes to Swift files (swift-format)" ios/'*'.swift
 }
 
 run_shellcheck() {
@@ -663,6 +673,7 @@ for suite in "${opt_suites[@]}"; do
         drift)        maybe_time "$suite" run_drift ;;
         pigeon)       maybe_time "$suite" run_pigeon ;;
         icons)        maybe_time "$suite" run_icons ;;
+        swift_format) maybe_time "$suite" run_swift_format ;;
         android)      maybe_time "$suite" run_android ;;
         ios)          maybe_time "$suite" run_ios ;;
         shellcheck)   maybe_time "$suite" run_shellcheck ;;

--- a/tools/check
+++ b/tools/check
@@ -570,7 +570,9 @@ run_ios() {
 run_swift_format() {
     # Omitted from this check:
     #   pubspec.{yaml,lock} tools/check
-    files_check ios/'*'.swift ios/.swift-format \
+    local swift_pathspecs=( ios/'*'.swift macos/'*'.swift )
+
+    files_check "${swift_pathspecs[@]}" ios/.swift-format \
     || return 0
 
     # swift-format comes from the Swift toolchain via `xcrun`, so needs macOS.
@@ -579,15 +581,16 @@ run_swift_format() {
         return 0
     fi
 
-    check_no_uncommitted_or_untracked ios/'*'.swift \
+    check_no_uncommitted_or_untracked "${swift_pathspecs[@]}" \
     || return
 
     if_verbose echo "Checking for style issues in Swift code..."
 
-    # Generated code (*.g.swift) is omitted from this check.
+    # Omit generated code: Pigeon output (*.g.swift) and the plugin registrant.
     # shellcheck disable=SC2207  # filenames in our own tree, assume well-behaved
     local swift_targets=(
-        $(git ls-files -- ios/'*'.swift :!:ios/'*'.g.swift)
+        $(git ls-files -- "${swift_pathspecs[@]}" \
+            ':!:*.g.swift' ':!:*/GeneratedPluginRegistrant.swift')
     )
 
     # --in-place enables `tools/check --fix swift_format`; see `check_no_changes`.
@@ -596,7 +599,8 @@ run_swift_format() {
         "${swift_targets[@]}" \
     || return
 
-    check_no_changes "changes to Swift files (swift-format)" ios/'*'.swift
+    check_no_changes "changes to Swift files (swift-format)" \
+        "${swift_pathspecs[@]}"
 }
 
 run_shellcheck() {


### PR DESCRIPTION
As I mentioned in https://github.com/zulip/zulip-flutter/pull/2307#pullrequestreview-4414763117, here's a followup for a few improvements to the iOS-in-CI checks we landed in #2307.