### PR TITLE
claude: Commit-message skill and removing direct imports

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,7 +45,7 @@ flutter gen-l10n
 - **`GlobalStore`** (`lib/model/store.dart`) — app-wide state (accounts, global settings). Access via `GlobalStoreWidget.of(context)`.
 - **`PerAccountStore`** (`lib/model/store.dart`) — per-account data (messages, users, channels, unreads, etc.). Uses `ChangeNotifier` for reactivity.
 
-See @./rules/data-store.md for detailed conventions and architecture for writing state logic.
+See ./rules/data-store.md for detailed conventions and architecture for writing state logic.
 
 ### API layer (`lib/api/`)
 
@@ -53,7 +53,7 @@ See @./rules/data-store.md for detailed conventions and architecture for writing
 - **`route/`** — one file per API endpoint group; top-level async functions taking `ApiConnection` as first param
 - **`model/`** — data types with JSON serialization via `json_serializable`; generated `.g.dart` files must be kept up to date
 
-See @./rules/api.md for detailed conventions on writing API bindings.
+See ./rules/api.md for detailed conventions on writing API bindings.
 
 ### Platform layer (`lib/host/`)
 
@@ -76,7 +76,7 @@ Uses Pigeon for type-safe platform channels (Android intents, notifications).
 - External APIs: wrap in `ZulipBinding`, fake in tests
 - Test fixtures: `test/example_data.dart` has builders for all common data types
 
-See @./rules/testing.md for detailed conventions on writing tests.
+See ./rules/testing.md for detailed conventions on writing tests.
 
 ### i18n
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -167,3 +167,7 @@ UI designs come from Figma (linked in issues). Match colors, padding, and font s
   Instead, use `git cherry-pick`
   (with `--no-commit` when modifications are needed)
   to replay commits.
+
+- **Use the `commit-discipline` skill when writing a commit** —
+  invoke it before composing or editing any commit message
+  (writing a new commit, amending, or rewording).

--- a/.claude/skills/commit-discipline/SKILL.md
+++ b/.claude/skills/commit-discipline/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: commit-discipline
+description: "Conventions for commits in this repo — how to split and order them, summary-line format, the [nfc] marker, the Fixes line, and body content. Use whenever writing, structuring, amending, or splitting commits: before running `git commit`, when rewording, or when preparing commits for a PR."
+---
+
+# Writing commits
+
+- **Summary line is `prefix: Sentence`** —
+  the prefix is 1–2 lowercase words naming the part of the codebase
+  (e.g. `compose:`, `api:`, `action_sheet:`), then a complete sentence
+  in the imperative mood ("Add", "Fix", "Rename" — not "Added"/"Fixing"),
+  capitalized, with no period at the end.
+  For a commit that only touches tests, append ` test` to the prefix
+  (e.g. `msglist test:`).
+  Keep the whole line ≤ 72 characters, and leave out self-evident
+  details like "update tests" or "update docs".
+  Never use a generic prefix like `bug:`, `fix:`, or `refactor:`.
+  For recent examples, see `git log`.
+
+- **Mark pure refactors with `[nfc]`** —
+  when a commit is intended to have no effect on how the code behaves
+  (a preparatory refactor, rename, or code move),
+  append ` [nfc]` — "no functional change" — to the prefix, after any
+  ` test` suffix.
+  For example: `compose_box [nfc]: Extract _fileFromXFile helper`, or
+  `msglist test [nfc]: Extract helper` for a test-only refactor.
+  This lets a reviewer see at a glance which commits in a series
+  carry the actual change in behavior.
+
+- **Closing an issue** —
+  make `Fixes #NNNN.` the **first line of the body**, right after the
+  summary's blank line.
+  Never write "Partially fixes #NNNN"; use `Fixes part of #NNNN.` instead.
+
+- **Body explains why and how, not what** —
+  separate it from the summary with a blank line,
+  and line-wrap to about 68 characters (max 70; links may run longer).
+  Give the context and motivation a reviewer needs to verify the change
+  is correct and safe. Don't restate the diff (changed files, "updated
+  tests") or narrate your process ("First I tried X").
+  Many commits need no body at all; omit it when the summary
+  (plus a Fixes line) already tells a reviewer everything they need.
+
+- **Referencing a commit** —
+  use a 9-hex-digit abbreviated hash in commit messages and links;
+  GitHub's 7-digit default risks collisions.
+
+- **Each commit is one minimal coherent idea** —
+  it must pass tests on its own, so test updates ride in the same commit
+  as the change they cover.
+  It shouldn't make the app worse or introduce a regression: each commit
+  should be safe to land on its own (or explain in the body why not), and
+  earlier commits must still work if a later one in the PR is dropped.
+  Split preparatory refactors, renames, and code moves into their own
+  commits *before* the feature commit; don't bundle unrelated changes.
+  A feature needn't split into one commit per subfeature; when in doubt,
+  err toward smaller commits — easy to squash later, not vice versa.
+  Fix a broken commit by amending it, not by stacking a "fix tests" commit.
+
+- **Don't churn within a PR** —
+  don't add content in one commit only to remove or move it in a later
+  one; plan upfront what belongs where.
+  Leave no debugging code, commented-out code, or temporary TODOs behind.
+
+- **Crediting other contributors** — when a commit includes work by
+  someone other than you (e.g. continuing another person's branch),
+  credit them with a `Co-authored-by: Name <email>` trailer after a
+  blank line. (This is separate from the auto-added
+  `Co-Authored-By: Claude …` trailer, whose title-case intentionally
+  differs from the lowercase `Co-authored-by:` used above — it's what
+  the harness emits.) Don't put `@`-mentions in commit messages.


### PR DESCRIPTION
This PR aims to bring two small improvements to CLAUDE.md and related files:
1. Adds a commit-message skill:
Unlike web's CLAUDE.md, this repo's CLAUDE.md did not provide any rules for the format for writing commit messages. This PR adds a commit-message skill so that Claude can lazily read the instructions when actually writing commit messages. Putting the instructions directly in CLAUDE.md instead of a skill results in them being loaded into the context window at session start. It also causes CLAUDE.md to cross 200 lines (the official docs recommend keeping it below 200 lines). See:
  https://code.claude.com/docs/en/memory#write-effective-instructions.
  https://code.claude.com/docs/en/memory#organize-rules-with-claude/rules/
2. Removes the "@" symbol from .claude/rules file references, turning them from direct imports to simple references:
Direct imports are loaded into context at session start unnecessarily, consuming around 10k tokens right away. The rules files are already path-scoped, so Claude will automatically read them when accessing relevant files. See:
  https://code.claude.com/docs/en/memory#import-additional-files
  https://code.claude.com/docs/en/memory#path-specific-rules