### PR TITLE
Add error haptic feedback to showErrorDialog

### DIFF
--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../generated/l10n/zulip_localizations.dart';
 import '../model/settings.dart';
@@ -146,7 +147,7 @@ class DialogStatus<T> {
 }
 
 /// Displays an [AlertDialog] with a dismiss button
-/// and optional "Learn more" button.
+/// and optional "Learn more" button, and gives haptic feedback.
 ///
 /// The [DialogStatus.result] field of the return value can be used
 /// for waiting for the dialog to be closed.
@@ -165,6 +166,7 @@ DialogStatus<void> showErrorDialog({
   String? message,
   Uri? learnMoreButtonUrl,
 }) {
+  HapticFeedback.errorNotification();
   final zulipLocalizations = ZulipLocalizations.of(context);
   final future = showDialog<void>(
     context: context,

--- a/test/widgets/dialog_test.dart
+++ b/test/widgets/dialog_test.dart
@@ -1,6 +1,7 @@
 import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -36,6 +37,28 @@ void main() {
       showErrorDialog(context: context, title: title, message: message);
       await tester.pump();
       checkErrorDialog(tester, expectedTitle: title, expectedMessage: message);
+    }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
+
+    testWidgets('triggers error haptic feedback', (tester) async {
+      await prepare(tester);
+
+      final calls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (methodCall) async {
+          calls.add(methodCall);
+          return null;
+        });
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform, null);
+      });
+
+      showErrorDialog(context: context, title: title, message: message);
+      await tester.pump();
+
+      check(calls).single.isMethodCall(
+          'HapticFeedback.vibrate', arguments: 'HapticFeedbackType.errorNotification');
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
     testWidgets('user closes error dialog', (tester) async {


### PR DESCRIPTION
Add error haptic feedback when displaying an error dialog.

Currently, `showErrorDialog` provides only visual feedback. This change calls `HapticFeedback.errorNotification()` when showing an error dialog, providing platform-appropriate tactile feedback on Android and iOS.

As requested in the issue, the change is scoped only to `showErrorDialog` and does not affect `showSuggestedActionDialog`.

Fixes #2338

## Testing

* Added test coverage in `test/widgets/dialog_test.dart`.
* Verified that the platform channel receives a `HapticFeedback.vibrate` call with `HapticFeedbackType.errorNotification`.
* Ran:

```text
flutter test test/widgets/dialog_test.dart
flutter test
```
