### PR TITLE
inbox: Use `webInboxShowChannelFolders` for channel folder grouping.

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -197,6 +197,7 @@ class UserSettingsUpdateEvent extends Event {
         return value as bool;
       case UserSettingName.emojiset:
         return Emojiset.fromRawString(value as String);
+      case UserSettingName.webInboxShowChannelFolders:
       case UserSettingName.presenceEnabled:
         return value as bool;
       case null:

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -68,6 +68,7 @@ const _$UserSettingNameEnumMap = {
   UserSettingName.starredMessageCounts: 'starred_message_counts',
   UserSettingName.displayEmojiReactionUsers: 'display_emoji_reaction_users',
   UserSettingName.emojiset: 'emojiset',
+  UserSettingName.webInboxShowChannelFolders: 'web_inbox_show_channel_folders',
   UserSettingName.presenceEnabled: 'presence_enabled',
 };
 

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -378,6 +378,8 @@ class UserSettings {
   bool displayEmojiReactionUsers;
   @JsonKey(unknownEnumValue: Emojiset.unknown)
   Emojiset emojiset;
+  @JsonKey(defaultValue: true)
+  bool webInboxShowChannelFolders; // TODO(server-12) remove default value
   bool presenceEnabled;
 
   // TODO more, as needed. When adding a setting here, please also:
@@ -391,6 +393,7 @@ class UserSettings {
     required this.starredMessageCounts,
     required this.displayEmojiReactionUsers,
     required this.emojiset,
+    required this.webInboxShowChannelFolders,
     required this.presenceEnabled,
   });
 

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -327,6 +327,8 @@ UserSettings _$UserSettingsFromJson(Map<String, dynamic> json) => UserSettings(
     json['emojiset'],
     unknownValue: Emojiset.unknown,
   ),
+  webInboxShowChannelFolders:
+      json['web_inbox_show_channel_folders'] as bool? ?? true,
   presenceEnabled: json['presence_enabled'] as bool,
 );
 
@@ -335,6 +337,7 @@ const _$UserSettingsFieldMap = <String, String>{
   'starredMessageCounts': 'starred_message_counts',
   'displayEmojiReactionUsers': 'display_emoji_reaction_users',
   'emojiset': 'emojiset',
+  'webInboxShowChannelFolders': 'web_inbox_show_channel_folders',
   'presenceEnabled': 'presence_enabled',
 };
 
@@ -346,6 +349,7 @@ Map<String, dynamic> _$UserSettingsToJson(UserSettings instance) =>
       'starred_message_counts': instance.starredMessageCounts,
       'display_emoji_reaction_users': instance.displayEmojiReactionUsers,
       'emojiset': instance.emojiset,
+      'web_inbox_show_channel_folders': instance.webInboxShowChannelFolders,
       'presence_enabled': instance.presenceEnabled,
     };
 

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -340,6 +340,7 @@ enum UserSettingName {
   starredMessageCounts,
   displayEmojiReactionUsers,
   emojiset,
+  webInboxShowChannelFolders,
   presenceEnabled,
   ;
 

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -569,6 +569,7 @@ const _$UserSettingNameEnumMap = {
   UserSettingName.starredMessageCounts: 'starred_message_counts',
   UserSettingName.displayEmojiReactionUsers: 'display_emoji_reaction_users',
   UserSettingName.emojiset: 'emojiset',
+  UserSettingName.webInboxShowChannelFolders: 'web_inbox_show_channel_folders',
   UserSettingName.presenceEnabled: 'presence_enabled',
 };
 

--- a/lib/api/route/settings.dart
+++ b/lib/api/route/settings.dart
@@ -21,6 +21,7 @@ Future<void> updateSettings(ApiConnection connection, {
         value = valueRaw as bool;
       case UserSettingName.emojiset:
         value = RawParameter((valueRaw as Emojiset).toJson());
+      case UserSettingName.webInboxShowChannelFolders:
       case UserSettingName.presenceEnabled:
         value = valueRaw as bool;
     }

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -166,7 +166,7 @@ mixin ChannelStore on UserStore {
   }
 
   /// The channel folder of [channelId],
-  /// including the "PINNED" or "OTHER" pseudo-channels (e.g. for the inbox).
+  /// including the "PINNED" or "OTHER" pseudo-channel-folders (e.g. for the inbox).
   UiChannelFolder uiChannelFolder(int channelId) =>
     switch (streams[channelId]) {
       Subscription(:final pinToTop) when pinToTop =>

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -167,11 +167,15 @@ mixin ChannelStore on UserStore {
 
   /// The channel folder of [channelId],
   /// including the "PINNED" or "OTHER" pseudo-channel-folders (e.g. for the inbox).
-  UiChannelFolder uiChannelFolder(int channelId) =>
+  ///
+  /// When [useRealmFolders] is false, realm channel folders are ignored, so a
+  /// channel falls into only the "PINNED" or "OTHER" pseudo-channel-folders.
+  /// This is to implement [UserSettings.webInboxShowChannelFolders].
+  UiChannelFolder uiChannelFolder(int channelId, {required bool useRealmFolders}) =>
     switch (streams[channelId]) {
       Subscription(:final pinToTop) when pinToTop =>
         UiChannelFolderPseudoPinned(),
-      ZulipStream(:final folderId) when folderId != null =>
+      ZulipStream(:final folderId) when useRealmFolders && folderId != null =>
         UiChannelFolderRealmFolder(id: folderId),
       _ => UiChannelFolderPseudoOther(),
     };

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -910,15 +910,17 @@ class PerAccountStore extends PerAccountStoreBase with
         }
         switch (event.property!) {
           case UserSettingName.twentyFourHourTime:
-            userSettings.twentyFourHourTime        = event.value as TwentyFourHourTimeMode;
+            userSettings.twentyFourHourTime         = event.value as TwentyFourHourTimeMode;
           case UserSettingName.starredMessageCounts:
-            userSettings.starredMessageCounts      = event.value as bool;
+            userSettings.starredMessageCounts       = event.value as bool;
           case UserSettingName.displayEmojiReactionUsers:
-            userSettings.displayEmojiReactionUsers = event.value as bool;
+            userSettings.displayEmojiReactionUsers  = event.value as bool;
           case UserSettingName.emojiset:
-            userSettings.emojiset                  = event.value as Emojiset;
+            userSettings.emojiset                   = event.value as Emojiset;
+          case UserSettingName.webInboxShowChannelFolders:
+            userSettings.webInboxShowChannelFolders = event.value as bool;
           case UserSettingName.presenceEnabled:
-            userSettings.presenceEnabled           = event.value as bool;
+            userSettings.presenceEnabled            = event.value as bool;
         }
         notifyListeners();
 

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -127,6 +127,7 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
       items.addAll(dmItems);
     }
 
+    final useRealmFolders = store.userSettings.webInboxShowChannelFolders;
     final channelSectionsByFolder = <UiChannelFolder, List<_InboxListItemChannelSection>>{};
 
     for (final MapEntry(key: streamId, value: topics) in unreadsModel!.streams.entries) {
@@ -165,7 +166,8 @@ class _InboxPageState extends State<InboxPageBody> with PerAccountStoreAwareStat
         return bLastUnreadId.compareTo(aLastUnreadId);
       });
 
-      final uiChannelFolder = store.uiChannelFolder(streamId);
+      final uiChannelFolder = store.uiChannelFolder(streamId,
+        useRealmFolders: useRealmFolders);
       (channelSectionsByFolder[uiChannelFolder] ??= [])
         .add(_InboxListItemChannelSection(
           streamId: streamId,

--- a/test/api/route/settings_test.dart
+++ b/test/api/route/settings_test.dart
@@ -28,6 +28,9 @@ void main() {
           case UserSettingName.emojiset:
             newSettings[name] = Emojiset.googleBlob;
             expectedBodyFields['emojiset'] = 'google-blob';
+          case UserSettingName.webInboxShowChannelFolders:
+            newSettings[name] = false;
+            expectedBodyFields['web_inbox_show_channel_folders'] = 'false';
           case UserSettingName.presenceEnabled:
             newSettings[name] = true;
             expectedBodyFields['presence_enabled'] = 'true';

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1389,6 +1389,7 @@ UserSettings userSettings({
   TwentyFourHourTimeMode? twentyFourHourTime,
   bool? displayEmojiReactionUsers,
   Emojiset? emojiset,
+  bool? webInboxShowChannelFolders,
   bool? presenceEnabled,
 }) {
   return UserSettings(
@@ -1396,6 +1397,7 @@ UserSettings userSettings({
     starredMessageCounts: true,
     displayEmojiReactionUsers: displayEmojiReactionUsers ?? true,
     emojiset: emojiset ?? Emojiset.google,
+    webInboxShowChannelFolders: webInboxShowChannelFolders ?? true,
     presenceEnabled: presenceEnabled ?? true,
   );
 }

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -66,12 +66,15 @@ void main() {
     List<Subscription>? subscriptions,
     List<ChannelFolder>? channelFolders,
     List<User>? users,
+    bool webInboxShowChannelFolders = true,
     required List<Message> unreadMessages,
     List<Message>? otherMessages,
     NavigatorObserver? navigatorObserver,
   }) async {
     addTearDown(testBinding.reset);
-    await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+    await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+      userSettings: eg.userSettings(
+        webInboxShowChannelFolders: webInboxShowChannelFolders)));
     store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
 
     await store.addChannelFolders(channelFolders ?? []);
@@ -430,6 +433,27 @@ void main() {
           'Alpha',
           'Other channels',
         ]);
+      });
+
+      testWidgets('respect webInboxShowChannelFolders', (tester) async {
+        final folder = eg.channelFolder(name: 'Engineering');
+        final pinned = eg.stream();
+        final inFolder = eg.stream(folderId: folder.id);
+        await setupPage(tester,
+          webInboxShowChannelFolders: false,
+          streams: [pinned, inFolder],
+          subscriptions: [
+            eg.subscription(pinned, pinToTop: true),
+            eg.subscription(inFolder),
+          ],
+          channelFolders: [folder],
+          unreadMessages: [
+            eg.streamMessage(stream: pinned),
+            eg.streamMessage(stream: inFolder),
+          ]);
+        checkFolderHeader('Pinned channels');
+        checkNoFolderHeader('Engineering');
+        checkFolderHeader('Other channels');
       });
     });
 


### PR DESCRIPTION
Fixes #2271.

#### Screenshots

|Before|After|
|----|----|
|<img width="1080" height="2400" alt="Before" src="https://github.com/user-attachments/assets/8a11ea87-9332-4b5c-a020-f5a720f579fd" />|<img width="1080" height="2400" alt="After" src="https://github.com/user-attachments/assets/301e32ee-5ae6-490d-afd4-aeb310106768" />|

This PR makes mobile follow the `webInboxShowChannelFolders` setting for showing channel folders. If the setting is off, show only "Pinned" and "Other Channels" folders. Otherwise, show realm channel folders.