### PR TITLE
Make image previews and standalone inline images consistent with web

### DIFF
--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -631,6 +631,8 @@ class MessageImagePreviewList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wrap(
+      spacing: 5,
+      runSpacing: 5,
       children: node.imagePreviews.map((node) => MessageImagePreview(node: node)).toList());
   }
 }
@@ -642,10 +644,12 @@ class MessageImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The gray background and border are present only for gallery items on web, not
+    // for standalone inline images; see web/styles/rendered_markdown.css.
     return ColoredBox(
       color: ContentTheme.of(context).colorMessageMediaContainerBackground,
       child: Padding(
-        padding: const EdgeInsets.all(1),
+        padding: const EdgeInsets.all(3),
         child: _Image(node: node,
           ambientTextStyle: DefaultTextStyle.of(context).style)));
   }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -642,10 +642,12 @@ class MessageImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Image(node: node, size: MessageMediaContainer.size,
-      buildContainer: (onTap, child) {
-        return MessageMediaContainer(onTap: onTap, child: child);
-      });
+    return ColoredBox(
+      color: ContentTheme.of(context).colorMessageMediaContainerBackground,
+      child: Padding(
+        padding: const EdgeInsets.all(1),
+        child: _Image(node: node,
+          ambientTextStyle: DefaultTextStyle.of(context).style)));
   }
 }
 
@@ -1366,46 +1368,13 @@ class InlineImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
-
-    // Follow web's max-height behavior (10em);
-    // see image_box_em in web/src/postprocess_content.ts.
-    final maxHeight = ambientTextStyle.fontSize! * 10;
-
-    final imageSize = (node.originalWidth != null && node.originalHeight != null)
-      ? Size(node.originalWidth!, node.originalHeight!) / devicePixelRatio
-      // Layout plan when original dimensions are unknown:
-      // a [MessageMediaContainer]-sized and -colored rectangle.
-      : MessageMediaContainer.size;
-
-    // (a) Don't let tall, thin images take up too much vertical space,
-    //     which could be annoying to scroll through. And:
-    // (b) Don't let small images grow to occupy more physical pixels
-    //     than they have data for.
-    //     It looks like web has code for this in web/src/postprocess_content.ts
-    //     but it doesn't account for the device pixel ratio, in 2026-01.
-    //     So in web, small images do get blown up and blurry on modern devices:
-    //       https://chat.zulip.org/#narrow/channel/101-design/topic/Inline.20images.20blown.20up.20and.20blurry/near/2346831
-    final size = BoxConstraints(maxHeight: maxHeight)
-      .constrainSizeAndAttemptToPreserveAspectRatio(imageSize);
-
-    Widget child = _Image(node: node, size: size,
-      buildContainer: (onTap, child) {
-        if (onTap == null) return child;
-        return GestureDetector(onTap: onTap, child: child);
-      });
-
     return Padding(
       // Separate images vertically when they flow onto separate lines.
       // (3px follows web; see web/styles/rendered_markdown.css.)
       padding: const EdgeInsets.only(top: 3),
-      child: ConstrainedBox(
-        constraints: BoxConstraints.loose(size),
-        child: AspectRatio(
-          aspectRatio: size.aspectRatio,
-          child: ColoredBox(
-            color: ContentTheme.of(context).colorMessageMediaContainerBackground,
-            child: child))));
+      child: ColoredBox(
+        color: ContentTheme.of(context).colorMessageMediaContainerBackground,
+        child: _Image(node: node, ambientTextStyle: ambientTextStyle)));
   }
 }
 
@@ -1540,23 +1509,39 @@ class MessageTableCell extends StatelessWidget {
   }
 }
 
-typedef _ImageContainerBuilder = Widget Function(VoidCallback? onTap, Widget child);
-
 /// A helper widget to deduplicate much of the logic in common
 /// between image previews and inline images.
 class _Image extends StatelessWidget {
-  const _Image({
-    required this.node,
-    required this.size,
-    required this.buildContainer,
-  });
+  const _Image({required this.node, required this.ambientTextStyle});
 
   final ImageNode node;
-  final Size size;
-  final _ImageContainerBuilder buildContainer;
+  final TextStyle ambientTextStyle;
 
   @override
   Widget build(BuildContext context) {
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+
+    // Follow web's max-height behavior (10em);
+    // see image_box_em in web/src/postprocess_content.ts.
+    final maxHeight = ambientTextStyle.fontSize! * 10;
+
+    final imageSize = (node.originalWidth != null && node.originalHeight != null)
+      ? Size(node.originalWidth!, node.originalHeight!) / devicePixelRatio
+      // Layout plan when original dimensions are unknown:
+      // a [MessageMediaContainer]-sized and -colored rectangle.
+      : MessageMediaContainer.size;
+
+    // (a) Don't let tall, thin images take up too much vertical space,
+    //     which could be annoying to scroll through. And:
+    // (b) Don't let small images grow to occupy more physical pixels
+    //     than they have data for.
+    //     It looks like web has code for this in web/src/postprocess_content.ts
+    //     but it doesn't account for the device pixel ratio, in 2026-01.
+    //     So in web, small images do get blown up and blurry on modern devices:
+    //       https://chat.zulip.org/#narrow/channel/101-design/topic/Inline.20images.20blown.20up.20and.20blurry/near/2346831
+    final size = BoxConstraints(maxHeight: maxHeight)
+      .constrainSizeAndAttemptToPreserveAspectRatio(imageSize);
+
     final store = PerAccountStoreWidget.of(context);
     final message = InheritedMessage.of(context);
 
@@ -1598,31 +1583,34 @@ class _Image extends StatelessWidget {
     final lightboxDisplayUrl = (node.loading || node.src is ImageNodeSrcThumbnail)
       ? resolvedOriginalSrc
       : resolvedSrc;
-    if (lightboxDisplayUrl == null) {
-      // TODO(log)
-      return buildContainer(null, child);
-    }
-
-    return buildContainer(
-      () {
-        Navigator.of(context).push(getImageLightboxRoute(
-          context: context,
-          message: message,
+    if (lightboxDisplayUrl != null) { // TODO(log) if null
+      child = GestureDetector(
+        onTap: () {
+          Navigator.of(context).push(getImageLightboxRoute(
+            context: context,
+            message: message,
+            messageImageContext: context,
+            src: lightboxDisplayUrl,
+            thumbnailUrl: node.src is ImageNodeSrcThumbnail
+              ? node.loading
+                // (Image thumbnail is loading; don't show hard-coded spinner image
+                // even if that happens to be a thumbnail URL.)
+                ? null
+                : resolvedSrc
+              : null,
+            originalWidth: node.originalWidth,
+            originalHeight: node.originalHeight));
+        },
+        child: LightboxHero(
           messageImageContext: context,
           src: lightboxDisplayUrl,
-          thumbnailUrl: node.src is ImageNodeSrcThumbnail
-            ? node.loading
-              // (Image thumbnail is loading; don't show hard-coded spinner image
-              // even if that happens to be a thumbnail URL.)
-              ? null
-              : resolvedSrc
-            : null,
-          originalWidth: node.originalWidth,
-          originalHeight: node.originalHeight));
-      },
-      LightboxHero(
-        messageImageContext: context,
-        src: lightboxDisplayUrl,
+          child: child));
+    }
+
+    return ConstrainedBox(
+      constraints: BoxConstraints.loose(size),
+      child: AspectRatio(
+        aspectRatio: size.aspectRatio,
         child: child));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1373,12 +1373,15 @@ class InlineImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      // Separate images vertically when they flow onto separate lines.
-      // (3px follows web; see web/styles/rendered_markdown.css.)
-      padding: const EdgeInsets.only(top: 3),
-      child: ColoredBox(
-        color: ContentTheme.of(context).colorMessageMediaContainerBackground,
-        child: _Image(node: node, ambientTextStyle: ambientTextStyle)));
+      // Separate images vertically when they flow onto separate lines and
+      // horizontally from adjacent elements. Padding values follow web.
+      // The conditional removal of margin when an image opens a paragraph in web is
+      // omitted as the difference is barely noticeable on mobile.
+      // See web/styles/rendered_markdown.css.
+      padding: EdgeInsets.symmetric(
+        vertical: 3,
+        horizontal: ambientTextStyle.fontSize! * 0.125),
+      child: _Image(node: node, ambientTextStyle: ambientTextStyle));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -631,6 +631,8 @@ class MessageImagePreviewList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wrap(
+      spacing: 5,
+      runSpacing: 5,
       children: node.imagePreviews.map((node) => MessageImagePreview(node: node)).toList());
   }
 }
@@ -642,12 +644,15 @@ class MessageImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Image(node: node,
-      sizeDynamically: false,
-      ambientTextStyle: DefaultTextStyle.of(context).style,
-      buildContainer: (onTap, child) {
-        return MessageMediaContainer(onTap: onTap, child: child);
-      });
+    // The gray background and border are present only for gallery items on web,
+    // not for standalone inline images; see web/styles/rendered_markdown.css.
+    return ColoredBox(
+      color: ContentTheme.of(context).colorMessageMediaContainerBackground,
+      child: Padding(
+        padding: const EdgeInsets.all(1),
+        child: _Image(node: node,
+          sizeDynamically: false,
+          ambientTextStyle: DefaultTextStyle.of(context).style)));
   }
 }
 
@@ -1376,11 +1381,7 @@ class InlineImage extends StatelessWidget {
         color: ContentTheme.of(context).colorMessageMediaContainerBackground,
         child: _Image(node: node,
           sizeDynamically: true,
-          ambientTextStyle: ambientTextStyle,
-          buildContainer: (onTap, child) {
-            if (onTap == null) return child;
-            return GestureDetector(onTap: onTap, child: child);
-          })));
+          ambientTextStyle: ambientTextStyle)));
   }
 }
 
@@ -1515,8 +1516,6 @@ class MessageTableCell extends StatelessWidget {
   }
 }
 
-typedef _ImageContainerBuilder = Widget Function(VoidCallback? onTap, Widget child);
-
 /// A helper widget to deduplicate much of the logic in common
 /// between image previews and inline images.
 class _Image extends StatelessWidget {
@@ -1524,7 +1523,6 @@ class _Image extends StatelessWidget {
     required this.node,
     required this.sizeDynamically,
     required this.ambientTextStyle,
-    required this.buildContainer,
   });
 
   final ImageNode node;
@@ -1534,7 +1532,6 @@ class _Image extends StatelessWidget {
   final bool sizeDynamically;
 
   final TextStyle ambientTextStyle;
-  final _ImageContainerBuilder buildContainer;
 
   /// The size to show the image at, based on its original dimensions.
   Size _imageSize(BuildContext context) {
@@ -1608,35 +1605,35 @@ class _Image extends StatelessWidget {
     final lightboxDisplayUrl = (node.loading || node.src is ImageNodeSrcThumbnail)
       ? resolvedOriginalSrc
       : resolvedSrc;
-    VoidCallback? onTap;
     if (lightboxDisplayUrl != null) { // TODO(log) if null
-      onTap = () {
-        Navigator.of(context).push(getImageLightboxRoute(
-          context: context,
-          message: message,
+      child = GestureDetector(
+        onTap: () {
+          Navigator.of(context).push(getImageLightboxRoute(
+            context: context,
+            message: message,
+            messageImageContext: context,
+            src: lightboxDisplayUrl,
+            thumbnailUrl: node.src is ImageNodeSrcThumbnail
+              ? node.loading
+                // (Image thumbnail is loading; don't show hard-coded spinner image
+                // even if that happens to be a thumbnail URL.)
+                ? null
+                : resolvedSrc
+              : null,
+            originalWidth: node.originalWidth,
+            originalHeight: node.originalHeight));
+        },
+        child: LightboxHero(
           messageImageContext: context,
           src: lightboxDisplayUrl,
-          thumbnailUrl: node.src is ImageNodeSrcThumbnail
-            ? node.loading
-              // (Image thumbnail is loading; don't show hard-coded spinner image
-              // even if that happens to be a thumbnail URL.)
-              ? null
-              : resolvedSrc
-            : null,
-          originalWidth: node.originalWidth,
-          originalHeight: node.originalHeight));
-      };
-      child = LightboxHero(
-        messageImageContext: context,
-        src: lightboxDisplayUrl,
-        child: child);
+          child: child));
     }
 
-    return buildContainer(onTap, ConstrainedBox(
+    return ConstrainedBox(
       constraints: BoxConstraints.loose(size),
       child: AspectRatio(
         aspectRatio: size.aspectRatio,
-        child: child)));
+        child: child));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -642,7 +642,9 @@ class MessageImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Image(node: node, size: MessageMediaContainer.size,
+    return _Image(node: node,
+      sizeDynamically: false,
+      ambientTextStyle: DefaultTextStyle.of(context).style,
       buildContainer: (onTap, child) {
         return MessageMediaContainer(onTap: onTap, child: child);
       });
@@ -1366,46 +1368,19 @@ class InlineImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
-
-    // Follow web's max-height behavior (10em);
-    // see image_box_em in web/src/postprocess_content.ts.
-    final maxHeight = ambientTextStyle.fontSize! * 10;
-
-    final imageSize = (node.originalWidth != null && node.originalHeight != null)
-      ? Size(node.originalWidth!, node.originalHeight!) / devicePixelRatio
-      // Layout plan when original dimensions are unknown:
-      // a [MessageMediaContainer]-sized and -colored rectangle.
-      : MessageMediaContainer.size;
-
-    // (a) Don't let tall, thin images take up too much vertical space,
-    //     which could be annoying to scroll through. And:
-    // (b) Don't let small images grow to occupy more physical pixels
-    //     than they have data for.
-    //     It looks like web has code for this in web/src/postprocess_content.ts
-    //     but it doesn't account for the device pixel ratio, in 2026-01.
-    //     So in web, small images do get blown up and blurry on modern devices:
-    //       https://chat.zulip.org/#narrow/channel/101-design/topic/Inline.20images.20blown.20up.20and.20blurry/near/2346831
-    final size = BoxConstraints(maxHeight: maxHeight)
-      .constrainSizeAndAttemptToPreserveAspectRatio(imageSize);
-
-    Widget child = _Image(node: node, size: size,
-      buildContainer: (onTap, child) {
-        if (onTap == null) return child;
-        return GestureDetector(onTap: onTap, child: child);
-      });
-
     return Padding(
       // Separate images vertically when they flow onto separate lines.
       // (3px follows web; see web/styles/rendered_markdown.css.)
       padding: const EdgeInsets.only(top: 3),
-      child: ConstrainedBox(
-        constraints: BoxConstraints.loose(size),
-        child: AspectRatio(
-          aspectRatio: size.aspectRatio,
-          child: ColoredBox(
-            color: ContentTheme.of(context).colorMessageMediaContainerBackground,
-            child: child))));
+      child: ColoredBox(
+        color: ContentTheme.of(context).colorMessageMediaContainerBackground,
+        child: _Image(node: node,
+          sizeDynamically: true,
+          ambientTextStyle: ambientTextStyle,
+          buildContainer: (onTap, child) {
+            if (onTap == null) return child;
+            return GestureDetector(onTap: onTap, child: child);
+          })));
   }
 }
 
@@ -1547,16 +1522,51 @@ typedef _ImageContainerBuilder = Widget Function(VoidCallback? onTap, Widget chi
 class _Image extends StatelessWidget {
   const _Image({
     required this.node,
-    required this.size,
+    required this.sizeDynamically,
+    required this.ambientTextStyle,
     required this.buildContainer,
   });
 
   final ImageNode node;
-  final Size size;
+
+  /// Whether to size the image from its original dimensions,
+  /// rather than at a fixed [MessageMediaContainer.size].
+  final bool sizeDynamically;
+
+  final TextStyle ambientTextStyle;
   final _ImageContainerBuilder buildContainer;
+
+  /// The size to show the image at, based on its original dimensions.
+  Size _imageSize(BuildContext context) {
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+
+    // Follow web's max-height behavior (10em);
+    // see image_box_em in web/src/postprocess_content.ts.
+    final maxHeight = ambientTextStyle.fontSize! * 10;
+
+    final imageSize = (node.originalWidth != null && node.originalHeight != null)
+      ? Size(node.originalWidth!, node.originalHeight!) / devicePixelRatio
+      // Layout plan when original dimensions are unknown:
+      // a [MessageMediaContainer]-sized and -colored rectangle.
+      : MessageMediaContainer.size;
+
+    // (a) Don't let tall, thin images take up too much vertical space,
+    //     which could be annoying to scroll through. And:
+    // (b) Don't let small images grow to occupy more physical pixels
+    //     than they have data for.
+    //     It looks like web has code for this in web/src/postprocess_content.ts
+    //     but it doesn't account for the device pixel ratio, in 2026-01.
+    //     So in web, small images do get blown up and blurry on modern devices:
+    //       https://chat.zulip.org/#narrow/channel/101-design/topic/Inline.20images.20blown.20up.20and.20blurry/near/2346831
+    return BoxConstraints(maxHeight: maxHeight)
+      .constrainSizeAndAttemptToPreserveAspectRatio(imageSize);
+  }
 
   @override
   Widget build(BuildContext context) {
+    final size = sizeDynamically
+      ? _imageSize(context) : MessageMediaContainer.size;
+
     final store = PerAccountStoreWidget.of(context);
     final message = InheritedMessage.of(context);
 
@@ -1598,13 +1608,9 @@ class _Image extends StatelessWidget {
     final lightboxDisplayUrl = (node.loading || node.src is ImageNodeSrcThumbnail)
       ? resolvedOriginalSrc
       : resolvedSrc;
-    if (lightboxDisplayUrl == null) {
-      // TODO(log)
-      return buildContainer(null, child);
-    }
-
-    return buildContainer(
-      () {
+    VoidCallback? onTap;
+    if (lightboxDisplayUrl != null) { // TODO(log) if null
+      onTap = () {
         Navigator.of(context).push(getImageLightboxRoute(
           context: context,
           message: message,
@@ -1619,11 +1625,18 @@ class _Image extends StatelessWidget {
             : null,
           originalWidth: node.originalWidth,
           originalHeight: node.originalHeight));
-      },
-      LightboxHero(
+      };
+      child = LightboxHero(
         messageImageContext: context,
         src: lightboxDisplayUrl,
-        child: child));
+        child: child);
+    }
+
+    return buildContainer(onTap, ConstrainedBox(
+      constraints: BoxConstraints.loose(size),
+      child: AspectRatio(
+        aspectRatio: size.aspectRatio,
+        child: child)));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -651,7 +651,6 @@ class MessageImagePreview extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(1),
         child: _Image(node: node,
-          sizeDynamically: false,
           ambientTextStyle: DefaultTextStyle.of(context).style)));
   }
 }
@@ -1379,9 +1378,7 @@ class InlineImage extends StatelessWidget {
       padding: const EdgeInsets.only(top: 3),
       child: ColoredBox(
         color: ContentTheme.of(context).colorMessageMediaContainerBackground,
-        child: _Image(node: node,
-          sizeDynamically: true,
-          ambientTextStyle: ambientTextStyle)));
+        child: _Image(node: node, ambientTextStyle: ambientTextStyle)));
   }
 }
 
@@ -1519,18 +1516,9 @@ class MessageTableCell extends StatelessWidget {
 /// A helper widget to deduplicate much of the logic in common
 /// between image previews and inline images.
 class _Image extends StatelessWidget {
-  const _Image({
-    required this.node,
-    required this.sizeDynamically,
-    required this.ambientTextStyle,
-  });
+  const _Image({required this.node, required this.ambientTextStyle});
 
   final ImageNode node;
-
-  /// Whether to size the image from its original dimensions,
-  /// rather than at a fixed [MessageMediaContainer.size].
-  final bool sizeDynamically;
-
   final TextStyle ambientTextStyle;
 
   /// The size to show the image at, based on its original dimensions.
@@ -1561,8 +1549,7 @@ class _Image extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final size = sizeDynamically
-      ? _imageSize(context) : MessageMediaContainer.size;
+    final size = _imageSize(context);
 
     final store = PerAccountStoreWidget.of(context);
     final message = InheritedMessage.of(context);

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -649,7 +649,7 @@ class MessageImagePreview extends StatelessWidget {
     return ColoredBox(
       color: ContentTheme.of(context).colorMessageMediaContainerBackground,
       child: Padding(
-        padding: const EdgeInsets.all(1),
+        padding: const EdgeInsets.all(3),
         child: _Image(node: node,
           ambientTextStyle: DefaultTextStyle.of(context).style)));
   }


### PR DESCRIPTION
Fixes #2344.

<details>
<summary> Screenshots of Inline Images </summary>

|Before|After|
|---|---|
|<img width="1080" height="2400" alt="Old_II_light" src="https://github.com/user-attachments/assets/98064401-93ab-42a5-afce-5f5c312199ca" />|<img width="1080" height="2400" alt="New_II_light" src="https://github.com/user-attachments/assets/d0a7949d-29a3-47de-8642-157e5290bace" />|
|<img width="1080" height="2400" alt="Old_II_dark" src="https://github.com/user-attachments/assets/233e97ad-1c7c-4ba2-97c3-3ac5dd6f41d3" />|<img width="1080" height="2400" alt="New_II_dark" src="https://github.com/user-attachments/assets/4146b8fa-32c4-467a-bcac-306cd2b5142e" />|

</details>
<details>

<summary> Screenshots of Image Previews </summary>

|Before|After|
|---|---|
|<img width="1080" height="2400" alt="Old_IP_light" src="https://github.com/user-attachments/assets/b3825868-4563-4d71-bd33-f34517d2172a" />|<img width="1080" height="2400" alt="New_IP_light" src="https://github.com/user-attachments/assets/ccd48a6e-48b2-431e-b50f-0bc216f6b47e" />|
|<img width="1080" height="2400" alt="Old_IP_dark" src="https://github.com/user-attachments/assets/486ed018-0cd5-441e-95c7-b6e140a189f6" />|<img width="1080" height="2400" alt="New_IP_dark" src="https://github.com/user-attachments/assets/d36e983a-d5d3-42e9-bb6e-95f7d7da552c" />|


</details>

This PR brings image previews and standalone inline images up-to-date with web. Here is a list of effective changes made in this PR:
1. Use dynamic aspect ratio-based sizing for image previews (previously used for inline images only).
2. Remove the gray background from standalone inline images.
3. Update border for image previews from 1px to 3px.
4. Update image preview gallery to use Wrap for spacing and run spacing.
5. For inline images, change vertical padding from top to symmetric and add horizontal padding.

#### Note:

Currently, web's conditional removal of margin if inline image starts paragraph is omitted from this PR. See:
  https://github.com/zulip/zulip/blob/338f47245a1856cb1259e2a098713a09097af04d/web/styles/rendered_markdown.css#L543-L547
  [#mobile-design > Inline Image padding if it opens paragraph](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/Inline.20Image.20padding.20if.20it.20opens.20paragraph/with/2490486)