### PR TITLE
Group consecutive inline images into a gallery

### DIFF
--- a/lib/model/content.dart
+++ b/lib/model/content.dart
@@ -536,6 +536,17 @@ class ImagePreviewNodeList extends BlockContentNode {
   }
 }
 
+class InlineImageNodeList extends InlineContentNode {
+  const InlineImageNodeList(this.inlineImages, {super.debugHtmlNode});
+
+  final List<InlineImageNode> inlineImages;
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return inlineImages.map((node) => node.toDiagnosticsNode()).toList();
+  }
+}
+
 sealed class ImageNode extends ContentNode {
   const ImageNode({
     super.debugHtmlNode,
@@ -2088,6 +2099,70 @@ class _ZulipContentParser {
     }
   }
 
+  /// Group eligible runs of inline images into [InlineImageNodeList] galleries.
+  ///
+  /// A run of one or more consecutive [InlineImageNode]s inside a paragraph is
+  /// collected into a gallery when it is bounded on each side by a
+  /// [LineBreakInlineNode] (or the start/end of the paragraph). Images inside the
+  /// run may be separated from each other by [LineBreakInlineNode]s and/or
+  /// whitespace-only [TextNode]s. Those separators are consumed into the gallery.
+  List<InlineContentNode> _gallerifyInlineImages(List<InlineContentNode> nodes) {
+    final List<InlineContentNode> result = [];
+    List<InlineContentNode> cluster = [];
+    List<InlineImageNode> gallery = [];
+    bool validGalleryStart = true;
+
+    void commitCluster() {
+      gallery.addAll(cluster.whereType<InlineImageNode>());
+      cluster = [];
+    }
+
+    void consumeGalleryAndCluster() {
+      if (gallery.isNotEmpty) {
+        result.add(InlineImageNodeList(gallery));
+      }
+      result.addAll(cluster);
+      gallery = [];
+      cluster = [];
+    }
+
+    for (final node in nodes) {
+      switch (node) {
+        case InlineImageNode():
+          if (validGalleryStart) {
+            cluster.add(node);
+          } else {
+            result.add(node);
+          }
+        case TextNode() when node.text.trim().isEmpty:
+          if (validGalleryStart && cluster.isNotEmpty) {
+            cluster.add(node);
+          } else {
+            result.add(node);
+          }
+        case LineBreakInlineNode():
+          if (validGalleryStart) {
+            // The images up to this point will be put in a gallery as the run is
+            // bounded on both sides.
+            commitCluster();
+            // There is a possibility of more images in the next line that are
+            // eligible to be in the current gallery.
+            cluster.add(node);
+          } else {
+            result.add(node);
+          }
+          validGalleryStart = true;
+        default:
+          consumeGalleryAndCluster();
+          result.add(node);
+          validGalleryStart = false;
+      }
+    }
+    if (validGalleryStart) commitCluster();
+    consumeGalleryAndCluster();
+    return result;
+  }
+
   BlockContentNode parseBlockContent(dom.Node node) {
     final debugHtmlNode = kDebugMode ? node : null;
     if (node is! dom.Element) {
@@ -2109,7 +2184,7 @@ class _ZulipContentParser {
       final parsed = parseBlockInline(element.nodes);
       return ParagraphNode(debugHtmlNode: debugHtmlNode,
         links: parsed.links,
-        nodes: parsed.nodes);
+        nodes: _gallerifyInlineImages(parsed.nodes));
     }
 
     HeadingLevel? headingLevel;
@@ -2217,7 +2292,7 @@ class _ZulipContentParser {
       result.add(ParagraphNode(
         wasImplicit: true,
         links: parsed.links,
-        nodes: parsed.nodes));
+        nodes: _gallerifyInlineImages(parsed.nodes)));
       currentParagraph.clear();
     }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -357,13 +357,13 @@ class BlockContentList extends StatelessWidget {
           SpoilerNode() => Spoiler(node: node),
           CodeBlockNode() => CodeBlock(node: node),
           MathBlockNode() => MathBlock(node: node),
-          ImagePreviewNodeList() => MessageImagePreviewList(node: node),
+          ImagePreviewNodeList() => MessageImageGallery(images: node.imagePreviews),
           ImagePreviewNode() => (){
             assert(false,
               "[ImagePreviewNode] not allowed in [BlockContentList]. "
               "It should be wrapped in [ImagePreviewNodeList]."
             );
-            return MessageImagePreview(node: node);
+            return MessageImageGalleryItem(node: node);
           }(),
           InlineVideoNode() => MessageInlineVideo(node: node),
           EmbedVideoNode() => MessageEmbedVideo(node: node),
@@ -623,24 +623,24 @@ class _SpoilerState extends State<Spoiler> with TickerProviderStateMixin {
   }
 }
 
-class MessageImagePreviewList extends StatelessWidget {
-  const MessageImagePreviewList({super.key, required this.node});
+class MessageImageGallery extends StatelessWidget {
+  const MessageImageGallery({super.key, required this.images});
 
-  final ImagePreviewNodeList node;
+  final List<ImageNode> images;
 
   @override
   Widget build(BuildContext context) {
     return Wrap(
       spacing: 5,
       runSpacing: 5,
-      children: node.imagePreviews.map((node) => MessageImagePreview(node: node)).toList());
+      children: images.map((node) => MessageImageGalleryItem(node: node)).toList());
   }
 }
 
-class MessageImagePreview extends StatelessWidget {
-  const MessageImagePreview({super.key, required this.node});
+class MessageImageGalleryItem extends StatelessWidget {
+  const MessageImageGalleryItem({super.key, required this.node});
 
-  final ImagePreviewNode node;
+  final ImageNode node;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -624,16 +624,23 @@ class _SpoilerState extends State<Spoiler> with TickerProviderStateMixin {
 }
 
 class MessageImageGallery extends StatelessWidget {
-  const MessageImageGallery({super.key, required this.images});
+  const MessageImageGallery({
+    super.key,
+    required this.images,
+    this.padding = EdgeInsets.zero,
+  });
 
   final List<ImageNode> images;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 5,
-      runSpacing: 5,
-      children: images.map((node) => MessageImageGalleryItem(node: node)).toList());
+    return Padding(
+      padding: padding,
+      child: Wrap(
+        spacing: 5,
+        runSpacing: 5,
+        children: images.map((node) => MessageImageGalleryItem(node: node)).toList()));
   }
 }
 
@@ -1160,7 +1167,12 @@ class _InlineContentBuilder {
 
       case InlineImageNodeList():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
-          child: MessageImageGallery(images: node.inlineImages));
+          child: MessageImageGallery(
+            images: node.inlineImages,
+            // Half of [Paragraph]'s vertical spacing, mirroring web, which halves
+            // its inter-element space for the same case; see
+            // `p .message-thumbnail-gallery` in web/styles/rendered_markdown.css.
+            padding: const EdgeInsets.symmetric(vertical: 2)));
 
       case InlineImageNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -631,6 +631,8 @@ class MessageImagePreviewList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wrap(
+      spacing: 5,
+      runSpacing: 5,
       children: node.imagePreviews.map((node) => MessageImagePreview(node: node)).toList());
   }
 }
@@ -642,10 +644,12 @@ class MessageImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The gray background and border are present only for gallery items on web, not
+    // for standalone inline images; see web/styles/rendered_markdown.css.
     return ColoredBox(
       color: ContentTheme.of(context).colorMessageMediaContainerBackground,
       child: Padding(
-        padding: const EdgeInsets.all(1),
+        padding: const EdgeInsets.all(3),
         child: _Image(node: node,
           ambientTextStyle: DefaultTextStyle.of(context).style)));
   }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -642,10 +642,12 @@ class MessageImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Image(node: node, size: MessageMediaContainer.size,
-      buildContainer: (onTap, child) {
-        return MessageMediaContainer(onTap: onTap, child: child);
-      });
+    return ColoredBox(
+      color: ContentTheme.of(context).colorMessageMediaContainerBackground,
+      child: Padding(
+        padding: const EdgeInsets.all(1),
+        child: _Image(node: node,
+          ambientTextStyle: DefaultTextStyle.of(context).style)));
   }
 }
 
@@ -1366,46 +1368,13 @@ class InlineImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
-
-    // Follow web's max-height behavior (10em);
-    // see image_box_em in web/src/postprocess_content.ts.
-    final maxHeight = ambientTextStyle.fontSize! * 10;
-
-    final imageSize = (node.originalWidth != null && node.originalHeight != null)
-      ? Size(node.originalWidth!, node.originalHeight!) / devicePixelRatio
-      // Layout plan when original dimensions are unknown:
-      // a [MessageMediaContainer]-sized and -colored rectangle.
-      : MessageMediaContainer.size;
-
-    // (a) Don't let tall, thin images take up too much vertical space,
-    //     which could be annoying to scroll through. And:
-    // (b) Don't let small images grow to occupy more physical pixels
-    //     than they have data for.
-    //     It looks like web has code for this in web/src/postprocess_content.ts
-    //     but it doesn't account for the device pixel ratio, in 2026-01.
-    //     So in web, small images do get blown up and blurry on modern devices:
-    //       https://chat.zulip.org/#narrow/channel/101-design/topic/Inline.20images.20blown.20up.20and.20blurry/near/2346831
-    final size = BoxConstraints(maxHeight: maxHeight)
-      .constrainSizeAndAttemptToPreserveAspectRatio(imageSize);
-
-    Widget child = _Image(node: node, size: size,
-      buildContainer: (onTap, child) {
-        if (onTap == null) return child;
-        return GestureDetector(onTap: onTap, child: child);
-      });
-
     return Padding(
       // Separate images vertically when they flow onto separate lines.
       // (3px follows web; see web/styles/rendered_markdown.css.)
       padding: const EdgeInsets.only(top: 3),
-      child: ConstrainedBox(
-        constraints: BoxConstraints.loose(size),
-        child: AspectRatio(
-          aspectRatio: size.aspectRatio,
-          child: ColoredBox(
-            color: ContentTheme.of(context).colorMessageMediaContainerBackground,
-            child: child))));
+      child: ColoredBox(
+        color: ContentTheme.of(context).colorMessageMediaContainerBackground,
+        child: _Image(node: node, ambientTextStyle: ambientTextStyle)));
   }
 }
 
@@ -1540,23 +1509,39 @@ class MessageTableCell extends StatelessWidget {
   }
 }
 
-typedef _ImageContainerBuilder = Widget Function(VoidCallback? onTap, Widget child);
-
 /// A helper widget to deduplicate much of the logic in common
 /// between image previews and inline images.
 class _Image extends StatelessWidget {
-  const _Image({
-    required this.node,
-    required this.size,
-    required this.buildContainer,
-  });
+  const _Image({required this.node, required this.ambientTextStyle});
 
   final ImageNode node;
-  final Size size;
-  final _ImageContainerBuilder buildContainer;
+  final TextStyle ambientTextStyle;
 
   @override
   Widget build(BuildContext context) {
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+
+    // Follow web's max-height behavior (10em);
+    // see image_box_em in web/src/postprocess_content.ts.
+    final maxHeight = ambientTextStyle.fontSize! * 10;
+
+    final imageSize = (node.originalWidth != null && node.originalHeight != null)
+      ? Size(node.originalWidth!, node.originalHeight!) / devicePixelRatio
+      // Layout plan when original dimensions are unknown:
+      // a [MessageMediaContainer]-sized and -colored rectangle.
+      : MessageMediaContainer.size;
+
+    // (a) Don't let tall, thin images take up too much vertical space,
+    //     which could be annoying to scroll through. And:
+    // (b) Don't let small images grow to occupy more physical pixels
+    //     than they have data for.
+    //     It looks like web has code for this in web/src/postprocess_content.ts
+    //     but it doesn't account for the device pixel ratio, in 2026-01.
+    //     So in web, small images do get blown up and blurry on modern devices:
+    //       https://chat.zulip.org/#narrow/channel/101-design/topic/Inline.20images.20blown.20up.20and.20blurry/near/2346831
+    final size = BoxConstraints(maxHeight: maxHeight)
+      .constrainSizeAndAttemptToPreserveAspectRatio(imageSize);
+
     final store = PerAccountStoreWidget.of(context);
     final message = InheritedMessage.of(context);
 
@@ -1598,31 +1583,34 @@ class _Image extends StatelessWidget {
     final lightboxDisplayUrl = (node.loading || node.src is ImageNodeSrcThumbnail)
       ? resolvedOriginalSrc
       : resolvedSrc;
-    if (lightboxDisplayUrl == null) {
-      // TODO(log)
-      return buildContainer(null, child);
-    }
-
-    return buildContainer(
-      () {
-        Navigator.of(context).push(getImageLightboxRoute(
-          context: context,
-          message: message,
+    if (lightboxDisplayUrl != null) { // TODO(log) if null
+      child = GestureDetector(
+        onTap: () {
+          Navigator.of(context).push(getImageLightboxRoute(
+            context: context,
+            message: message,
+            messageImageContext: context,
+            src: lightboxDisplayUrl,
+            thumbnailUrl: node.src is ImageNodeSrcThumbnail
+              ? node.loading
+                // (Image thumbnail is loading; don't show hard-coded spinner image
+                // even if that happens to be a thumbnail URL.)
+                ? null
+                : resolvedSrc
+              : null,
+            originalWidth: node.originalWidth,
+            originalHeight: node.originalHeight));
+        },
+        child: LightboxHero(
           messageImageContext: context,
           src: lightboxDisplayUrl,
-          thumbnailUrl: node.src is ImageNodeSrcThumbnail
-            ? node.loading
-              // (Image thumbnail is loading; don't show hard-coded spinner image
-              // even if that happens to be a thumbnail URL.)
-              ? null
-              : resolvedSrc
-            : null,
-          originalWidth: node.originalWidth,
-          originalHeight: node.originalHeight));
-      },
-      LightboxHero(
-        messageImageContext: context,
-        src: lightboxDisplayUrl,
+          child: child));
+    }
+
+    return ConstrainedBox(
+      constraints: BoxConstraints.loose(size),
+      child: AspectRatio(
+        aspectRatio: size.aspectRatio,
         child: child));
   }
 }

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1373,12 +1373,15 @@ class InlineImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      // Separate images vertically when they flow onto separate lines.
-      // (3px follows web; see web/styles/rendered_markdown.css.)
-      padding: const EdgeInsets.only(top: 3),
-      child: ColoredBox(
-        color: ContentTheme.of(context).colorMessageMediaContainerBackground,
-        child: _Image(node: node, ambientTextStyle: ambientTextStyle)));
+      // Separate images vertically when they flow onto separate lines and
+      // horizontally from adjacent elements. Padding values follow web.
+      // The conditional removal of margin when an image opens a paragraph in web is
+      // omitted as the difference is barely noticeable on mobile.
+      // See web/styles/rendered_markdown.css.
+      padding: EdgeInsets.symmetric(
+        vertical: 3,
+        horizontal: ambientTextStyle.fontSize! * 0.125),
+      child: _Image(node: node, ambientTextStyle: ambientTextStyle));
   }
 }
 

--- a/lib/widgets/content.dart
+++ b/lib/widgets/content.dart
@@ -1158,6 +1158,10 @@ class _InlineContentBuilder {
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
           child: MessageImageEmoji(node: node));
 
+      case InlineImageNodeList():
+        return WidgetSpan(alignment: PlaceholderAlignment.middle,
+          child: MessageImageGallery(images: node.inlineImages));
+
       case InlineImageNode():
         return WidgetSpan(alignment: PlaceholderAlignment.middle,
           child: InlineImage(node: node, ambientTextStyle: widget.style));

--- a/lib/widgets/lightbox.dart
+++ b/lib/widgets/lightbox.dart
@@ -35,7 +35,7 @@ class _LightboxHeroTag {
     required this.src,
   });
 
-  /// The [BuildContext] for the [MessageImagePreview] being expanded into the lightbox.
+  /// The [BuildContext] for the [MessageImageGalleryItem] being expanded into the lightbox.
   ///
   /// In particular this prevents hero animations between
   /// different message lists that happen to have the same message.
@@ -48,7 +48,7 @@ class _LightboxHeroTag {
   ///
   /// This ensures the animation only occurs between matching images, even if
   /// the message was edited before navigating back to the message list
-  /// so that the original [MessageImagePreview] has been replaced in the tree
+  /// so that the original [MessageImageGalleryItem] has been replaced in the tree
   /// by a different image.
   final Uri src;
 

--- a/test/model/content_test.dart
+++ b/test/model/content_test.dart
@@ -269,77 +269,542 @@ class ContentExample {
     const ImageEmojiNode(
       src: '/static/generated/emoji/images/emoji/unicode/zulip.png', alt: ':zulip:'));
 
-  static final inlineImage = ContentExample.inline(
+  static final inlineImage = ContentExample(
     'inline image',
-    '![image.png](/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png)',
+    'text ![image.png](/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png)',
     // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Chris/near/2346984
-    '<p><img alt="image.png" class="inline-image" '
+    // Text before the image is not in the reference. It is included so the image
+    // stays as an individual InlineImageNode, rather than being put in a gallery.
+    '<p>'
+      'text '
+      '<img alt="image.png" class="inline-image" '
       'data-original-content-type="image/png" '
       'data-original-dimensions="186x142" '
       'data-original-src="/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png" '
-      'src="/user_uploads/thumbnail/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png/840x560.webp"></p>',
-    InlineImageNode(
-      loading: false,
-      src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
-        defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png/840x560.webp'))),
-      alt: 'image.png',
-      originalSrc: '/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png',
-      originalWidth: 186,
-      originalHeight: 142));
+      'src="/user_uploads/thumbnail/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png/840x560.webp"></p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('text '),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png/840x560.webp'))),
+        alt: 'image.png',
+        originalSrc: '/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png',
+        originalWidth: 186,
+        originalHeight: 142),
+    ]),
+  ]);
 
-  static final inlineImageLoading = ContentExample.inline(
+  static final inlineImageLoading = ContentExample(
     'inline image, loading',
-    '![image.png](/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png)',
+    'text ![image.png](/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png)',
     // HTML constructed from the API doc in the pull request for this feature:
     //   https://github.com/zulip/zulip/pull/36226
-    '<p><img alt="example image" class="inline-image image-loading-placeholder" '
+    // Text before the image keeps it as an individual InlineImageNode.
+    '<p>'
+      'text '
+      '<img alt="example image" class="inline-image image-loading-placeholder" '
       'data-original-content-type="image/png" '
       'data-original-dimensions="1050x700" '
       'data-original-src="/user_uploads/path/to/example.png" '
-      'src="/path/to/spinner.png"></p>',
-    InlineImageNode(
-      loading: true,
-      src: ImageNodeSrcOther('/path/to/spinner.png'),
-      alt: 'example image',
-      originalSrc: '/user_uploads/path/to/example.png',
-      originalWidth: 1050,
-      originalHeight: 700));
+      'src="/path/to/spinner.png"></p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('text '),
+      InlineImageNode(
+        loading: true,
+        src: ImageNodeSrcOther('/path/to/spinner.png'),
+        alt: 'example image',
+        originalSrc: '/user_uploads/path/to/example.png',
+        originalWidth: 1050,
+        originalHeight: 700),
+    ]),
+  ]);
 
-  static final inlineImageLoadingClassOrderReversed = ContentExample.inline(
+  static final inlineImageLoadingClassOrderReversed = ContentExample(
     'inline image, loading, class order reversed',
-    '![image.png](/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png)',
+    'text ![image.png](/user_uploads/2/15/nO8mls-ZGl6LBC9bRNVL2jAG/image.png)',
     // Hypothetical server variation on inlineImageLoading.
-    '<p><img alt="example image" class="image-loading-placeholder inline-image" '
+    // Text before the image keeps it as an individual InlineImageNode.
+    '<p>'
+      'text '
+      '<img alt="example image" class="image-loading-placeholder inline-image" '
       'data-original-content-type="image/png" '
       'data-original-dimensions="1050x700" '
       'data-original-src="/user_uploads/path/to/example.png" '
-      'src="/path/to/spinner.png"></p>',
-    InlineImageNode(
-      loading: true,
-      src: ImageNodeSrcOther('/path/to/spinner.png'),
-      alt: 'example image',
-      originalSrc: '/user_uploads/path/to/example.png',
-      originalWidth: 1050,
-      originalHeight: 700));
+      'src="/path/to/spinner.png"></p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('text '),
+      InlineImageNode(
+        loading: true,
+        src: ImageNodeSrcOther('/path/to/spinner.png'),
+        alt: 'example image',
+        originalSrc: '/user_uploads/path/to/example.png',
+        originalWidth: 1050,
+        originalHeight: 700),
+    ]),
+  ]);
 
-  static final inlineImageAnimated = ContentExample.inline(
+  static final inlineImageAnimated = ContentExample(
     'inline image, animated',
-    '![2451eb2d.gif](/user_uploads/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif)',
+    'text ![2451eb2d.gif](/user_uploads/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif)',
     // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Chris/near/2346992
-    '<p><img alt="2451eb2d.gif" class="inline-image" '
+    // Text before the image keeps it as an individual InlineImageNode.
+    '<p>'
+      'text '
+      '<img alt="2451eb2d.gif" class="inline-image" '
       'data-animated="true" '
       'data-original-content-type="image/gif" '
       'data-original-dimensions="64x64" '
       'data-original-src="/user_uploads/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif" '
-      'src="/user_uploads/thumbnail/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif/840x560-anim.webp"></p>',
-    InlineImageNode(
-      loading: false,
-      src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: true,
-        defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif/840x560-anim.webp'))),
-      alt: '2451eb2d.gif',
-      originalSrc: '/user_uploads/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif',
-      originalWidth: 64,
-      originalHeight: 64));
+      'src="/user_uploads/thumbnail/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif/840x560-anim.webp"></p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('text '),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: true,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif/840x560-anim.webp'))),
+        alt: '2451eb2d.gif',
+        originalSrc: '/user_uploads/2/1a/igMNAkwVOP7NLJy-Hye6WiKP/2451eb2d.gif',
+        originalWidth: 64,
+        originalHeight: 64),
+    ]),
+  ]);
+
+  static final inlineImageGallerySingle = ContentExample.inline(
+    'inline image gallery, single image',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460790
+    '<p><img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp"></p>',
+    InlineImageNodeList([
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]));
+
+  static final inlineImageGalleryTwoAdjacent = ContentExample.inline(
+    'inline image gallery, two adjacent images',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460791
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp"></p>',
+    InlineImageNodeList([
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+        alt: 'number-2.png',
+        originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]));
+
+  static final inlineImageGallerySpaceSeparated = ContentExample.inline(
+    'inline image gallery, space-separated images',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png) ![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460792
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      ' '
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp"></p>',
+    InlineImageNodeList([
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+        alt: 'number-2.png',
+        originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]));
+
+  static final inlineImageGalleryBrSeparated = ContentExample.inline(
+    'inline image gallery, br-separated images',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)\n![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460793
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<br>\n'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp"></p>',
+    InlineImageNodeList([
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+        alt: 'number-2.png',
+        originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]));
+
+  static final inlineImageGalleryAdjacentAndBr = ContentExample.inline(
+    'inline image gallery, adjacent and br-separated images in one gallery',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)\n![number-3.png](/user_uploads/2/39/YyOdS37_MX2OtZohjKrbfuyC/number-3.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460794
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp">'
+      '<br>\n'
+      '<img alt="number-3.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/39/YyOdS37_MX2OtZohjKrbfuyC/number-3.png" '
+      'src="/user_uploads/thumbnail/2/39/YyOdS37_MX2OtZohjKrbfuyC/number-3.png/840x560.webp"></p>',
+    InlineImageNodeList([
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+        alt: 'number-2.png',
+        originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/39/YyOdS37_MX2OtZohjKrbfuyC/number-3.png/840x560.webp'))),
+        alt: 'number-3.png',
+        originalSrc: '/user_uploads/2/39/YyOdS37_MX2OtZohjKrbfuyC/number-3.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]));
+
+  static final inlineImageGalleryTextSeparated = ContentExample(
+    'inline image gallery, text-separated images each in their own gallery',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)\nsome text\n![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460795
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<br>\n'
+      'some text'
+      '<br>\n'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp"></p>', [
+    ParagraphNode(links: null, nodes: [
+      InlineImageNodeList([
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+          alt: 'number-1.png',
+          originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+          originalWidth: 512,
+          originalHeight: 512),
+      ]),
+      LineBreakInlineNode(),
+      TextNode('\nsome text'),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      InlineImageNodeList([
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+          alt: 'number-2.png',
+          originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+          originalWidth: 512,
+          originalHeight: 512),
+      ]),
+    ]),
+  ]);
+
+  static final inlineImageFirstInlineSecondGallery = ContentExample(
+    'inline image gallery, first image inline (bounded by text), second in gallery',
+    'some text ![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)\n![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460796
+    '<p>'
+      'some text '
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<br>\n'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp"></p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('some text '),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      InlineImageNodeList([
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+          alt: 'number-2.png',
+          originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+          originalWidth: 512,
+          originalHeight: 512),
+      ]),
+    ]),
+  ]);
+
+  static final inlineImageFirstGallerySecondInline = ContentExample(
+    'inline image gallery, first image in gallery, second inline (bounded by text)',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)\n![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png) some text',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2460797
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<br>\n'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp">'
+      ' some text</p>', [
+    ParagraphNode(links: null, nodes: [
+      InlineImageNodeList([
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+          alt: 'number-1.png',
+          originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+          originalWidth: 512,
+          originalHeight: 512),
+      ]),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+        alt: 'number-2.png',
+        originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      TextNode(' some text'),
+    ]),
+  ]);
+
+  static final inlineImagesTextBetween = ContentExample(
+    'inline images with text between, not gallerified',
+    '![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png) or ![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)',
+    // Adapted from web test corpus (web/tests/postprocess_content.test.cjs). See:
+    //   https://github.com/zulip/zulip/pull/38324
+    '<p>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      ' or '
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp">'
+      '</p>', [
+    ParagraphNode(links: null, nodes: [
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+      TextNode(' or '),
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+        alt: 'number-2.png',
+        originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]),
+  ]);
+
+  static final inlineImageGalleryWithSurroundingText = ContentExample(
+    'inline image gallery, with text before and after in paragraph',
+    'some text\n![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)\n![number-2.png](/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png)\nmore text',
+    // Adapted from web test corpus (web/tests/postprocess_content.test.cjs). See:
+    //   https://github.com/zulip/zulip/pull/38324
+    '<p>'
+      'some text<br>\n'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '<br>\n'
+      '<img alt="number-2.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png" '
+      'src="/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp">'
+      '<br>\n'
+      'more text</p>', [
+    ParagraphNode(links: null, nodes: [
+      TextNode('some text'),
+      LineBreakInlineNode(),
+      TextNode('\n'),
+      InlineImageNodeList([
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+          alt: 'number-1.png',
+          originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+          originalWidth: 512,
+          originalHeight: 512),
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png/840x560.webp'))),
+          alt: 'number-2.png',
+          originalSrc: '/user_uploads/2/af/g-nEd33W43G-8Iy5cGgPs3jC/number-2.png',
+          originalWidth: 512,
+          originalHeight: 512),
+      ]),
+      LineBreakInlineNode(),
+      TextNode('\nmore text'),
+    ]),
+  ]);
+
+  static final inlineImageInStrong = ContentExample(
+    'inline image inside strong, not gallerified',
+    '**![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)**',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2466691
+    '<p><strong>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '</strong></p>', [
+    ParagraphNode(links: null, nodes: [
+      StrongNode(nodes: [
+        InlineImageNode(
+          loading: false,
+          src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+            defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+          alt: 'number-1.png',
+          originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+          originalWidth: 512,
+          originalHeight: 512),
+      ]),
+    ]),
+  ]);
+
+  static final inlineImageInHeading = ContentExample(
+    'inline image inside heading, not gallerified',
+    '# ![number-1.png](/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png)',
+    // https://chat.zulip.org/#narrow/channel/7-test-here/topic/Ruhaan/near/2466692
+    '<h1>'
+      '<img alt="number-1.png" class="inline-image" '
+      'data-original-content-type="image/png" '
+      'data-original-dimensions="512x512" '
+      'data-original-src="/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png" '
+      'src="/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp">'
+      '</h1>', [
+    HeadingNode(level: HeadingLevel.h1, links: null, nodes: [
+      InlineImageNode(
+        loading: false,
+        src: ImageNodeSrcThumbnail(ImageThumbnailLocator(animated: false,
+          defaultFormatSrc: Uri.parse('/user_uploads/thumbnail/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png/840x560.webp'))),
+        alt: 'number-1.png',
+        originalSrc: '/user_uploads/2/54/MMM7YsKMLJvcVXRmGkd5x4h7/number-1.png',
+        originalWidth: 512,
+        originalHeight: 512),
+    ]),
+  ]);
 
   static final globalTime = ContentExample.inline(
     'global time',
@@ -1908,6 +2373,18 @@ void main() async {
   testParseExample(ContentExample.inlineImageLoading);
   testParseExample(ContentExample.inlineImageLoadingClassOrderReversed);
   testParseExample(ContentExample.inlineImageAnimated);
+  testParseExample(ContentExample.inlineImageGallerySingle);
+  testParseExample(ContentExample.inlineImageGalleryTwoAdjacent);
+  testParseExample(ContentExample.inlineImageGallerySpaceSeparated);
+  testParseExample(ContentExample.inlineImageGalleryBrSeparated);
+  testParseExample(ContentExample.inlineImageGalleryAdjacentAndBr);
+  testParseExample(ContentExample.inlineImageGalleryTextSeparated);
+  testParseExample(ContentExample.inlineImageFirstInlineSecondGallery);
+  testParseExample(ContentExample.inlineImageFirstGallerySecondInline);
+  testParseExample(ContentExample.inlineImagesTextBetween);
+  testParseExample(ContentExample.inlineImageGalleryWithSurroundingText);
+  testParseExample(ContentExample.inlineImageInStrong);
+  testParseExample(ContentExample.inlineImageInHeading);
   testParseExample(ContentExample.tableWithInlineImage);
 
   testParseExample(ContentExample.mathInline);

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -702,6 +702,45 @@ void main() {
       check(images.map((i) => i.src).toList())
         .deepEquals(expectedImages.map((n) => otherSrc(n.src)));
     });
+
+    group('inline image gallery', () {
+      testWidgets('renders images in order', (tester) async {
+        final example = ContentExample.inlineImageGalleryAdjacentAndBr;
+        await prepare(tester, example.html);
+        final paragraph = example.expectedNodes[0] as ParagraphNode;
+        final expectedImages = (paragraph.nodes[0] as InlineImageNodeList).inlineImages;
+        final images = tester.widgetList<RealmContentNetworkImage>(
+          find.byType(RealmContentNetworkImage));
+        check(images.map((i) => i.src).toList())
+          .deepEquals(expectedImages.map((n) => thumbnailSrc(n.src)));
+      });
+
+      testWidgets('text-separated images', (tester) async {
+        final example = ContentExample.inlineImageGalleryTextSeparated;
+        await prepare(tester, example.html);
+        final paragraph = example.expectedNodes[0] as ParagraphNode;
+        final expectedImages = (paragraph.nodes[0] as InlineImageNodeList).inlineImages
+          + (paragraph.nodes[5] as InlineImageNodeList).inlineImages;
+        final images = tester.widgetList<RealmContentNetworkImage>(
+          find.byType(RealmContentNetworkImage));
+        check(images.map((i) => i.src).toList())
+          .deepEquals(expectedImages.map((n) => thumbnailSrc(n.src)));
+      });
+
+      testWidgets('first inline second gallery', (tester) async {
+        final example = ContentExample.inlineImageFirstInlineSecondGallery;
+        await prepare(tester, example.html);
+        final paragraph = example.expectedNodes[0] as ParagraphNode;
+        final expectedImages = <InlineImageNode>[
+          paragraph.nodes[1] as InlineImageNode,
+          ...(paragraph.nodes[4] as InlineImageNodeList).inlineImages,
+        ];
+        final images = tester.widgetList<RealmContentNetworkImage>(
+          find.byType(RealmContentNetworkImage));
+        check(images.map((i) => i.src).toList())
+          .deepEquals(expectedImages.map((n) => thumbnailSrc(n.src)));
+      });
+    });
   });
 
   group("MessageInlineVideo", () {

--- a/test/widgets/content_test.dart
+++ b/test/widgets/content_test.dart
@@ -364,7 +364,7 @@ void main() {
 
   testContentSmoke(ContentExample.quotation);
 
-  group('MessageImagePreview, MessageImagePreviewList', () {
+  group('MessageImageGallery, MessageImageGalleryItem', () {
     Future<void> prepare(WidgetTester tester, String html, {
       List<NavigatorObserver> navObservers = const [],
     }) async {
@@ -406,7 +406,7 @@ void main() {
           ..contains('href="$rawHref"')
           ..contains('src="$rawSrc"');
 
-        final findImagePreview = find.byType(MessageImagePreview);
+        final findImagePreview = find.byType(MessageImageGalleryItem);
         final findLoadingIndicator = find.descendant(
           of: findImagePreview, matching: find.byType(CupertinoActivityIndicator));
 


### PR DESCRIPTION
Fixes #2206.

Rebased on top of #2355.

#### Screenshots

|Before|After|
|---|---|
|<img width="1080" height="2400" alt="Old_light" src="https://github.com/user-attachments/assets/abeae581-0424-4cb8-bc05-7c0429a3e754" />|<img width="1080" height="2400" alt="New_light" src="https://github.com/user-attachments/assets/009da053-5978-4744-a2d5-06e73f016ccf" />|
|<img width="1080" height="2400" alt="Old_dark" src="https://github.com/user-attachments/assets/68dcbe8a-76ae-49c6-a0b9-65d00a7b92eb" />|<img width="1080" height="2400" alt="New_dark" src="https://github.com/user-attachments/assets/21f63732-720a-481d-ac35-609a639abcaf" />|

This PR introduces "gallerifying" of inline images. The bugs and edge cases found in web [#issues > 🎯 images not galleryifying @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20images.20not.20galleryifying/near/2413539) are addressed by using a different approach from the one used in web (https://github.com/zulip/zulip/pull/38324) for creating galleries.