### PR TITLE
api: Don't allow connecting to Zulip Server <9.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,7 +62,7 @@ Uses Pigeon for type-safe platform channels (Android intents, notifications).
 ### Key conventions
 
 - **All API type constructor params are `required`**, even nullable ones — no default values. Use `test/example_data.dart` for test defaults.
-- **Server compatibility**: minimum Zulip Server 7.0 (feature level 185). Use `TODO(server-N)` comments for newer features.
+- **Server compatibility**: the minimum supported server version is `kMinAllowedZulipVersion` in `lib/api/core.dart`. Use `TODO(server-N)` comments for newer features.
 - **Tests use `package:checks`** (not `expect`/`matcher`).
 - **No `dart format`** — follow existing code style manually. Auto-format is disabled in VS Code settings.
 - **Prefer relative imports** within the package.

--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -100,7 +100,7 @@ Check extensions for result types go in `route_checks.dart`.
 - In general, group class fields logically, following the approach of existing items.
 - Where the same list of parameters or fields appears in multiple places, they should have the exact same order as each other.
 - All constructor parameters in API types use `required`, even for nullable fields (see README "Require all parameters in API constructors")
-- Minimum supported server is Zulip Server 7.0 (feature level 185)
+- Minimum supported server: see `kMinAllowedZulipVersion` and `kMinAllowedZulipFeatureLevel` in `lib/api/core.dart`
 - Use `TODO(server-N)` comments for version-gated code paths
 - Generated files (`.g.dart`) must be kept up to date via `build_runner`
 - When interpreting data from the server, prefer checking what's in the data rather than explicit version checks. For example, if a field isn't present that new servers always send, interpret the data accordingly (the server is too old to have that field) rather than checking the server version explicitly. Explicit version checks are very rarely needed on the response-handling side.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ good time to [report them as issues][dart-test-tracker].
 
 #### Server compatibility
 
-We support Zulip Server 7.0 and later.
+We support Zulip Server 9.0 and later.
 
 For API features added in newer versions, use `TODO(server-N)`
 comments (like those you see in the existing code.)

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -15,13 +15,15 @@ import 'exception.dart';
 /// When updating this, also update [kMinAllowedZulipFeatureLevel]
 /// and the README.
 // TODO(#1838) address all TODO(server-7)
-const kMinAllowedZulipVersion = '7.0';
+// TODO(#2362) address all TODO(server-8)
+// TODO(#2363) address all TODO(server-9)
+const kMinAllowedZulipVersion = '9.0';
 
 /// The Zulip feature level reserved for the [kMinAllowedZulipVersion] release.
 ///
 /// For this value, see the API changelog:
 ///   https://zulip.com/api/changelog
-const kMinAllowedZulipFeatureLevel = 185;
+const kMinAllowedZulipFeatureLevel = 277;
 
 /// The oldest Zulip Server version we currently support.
 ///

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -625,25 +625,25 @@ void main() {
       final account = eg.account(user: eg.selfUser,
         realmName: 'Organization A',
         realmIcon: Uri.parse('/image-a.png'),
-        zulipVersion: '6.0+gabcd',
-        zulipMergeBase: '6.0',
-        zulipFeatureLevel: 123,
+        zulipVersion: '9.0+gabcd',
+        zulipMergeBase: '9.0',
+        zulipFeatureLevel: 277,
       );
       await prepareStore(account: account);
       check(globalStore.getAccount(account.id)).isNotNull()
         ..realmName.equals('Organization A')
         ..realmIcon.equals(Uri.parse('/image-a.png'))
-        ..zulipVersion.equals('6.0+gabcd')
-        ..zulipMergeBase.equals('6.0')
-        ..zulipFeatureLevel.equals(123);
+        ..zulipVersion.equals('9.0+gabcd')
+        ..zulipMergeBase.equals('9.0')
+        ..zulipFeatureLevel.equals(277);
 
       globalStore.useCachedApiConnections = true;
       connection.prepare(json: eg.initialSnapshot(
         realmName: 'Organization B',
         realmIconUrl: Uri.parse('/image-b.png'),
-        zulipVersion: '8.0+g9876',
-        zulipMergeBase: '8.0',
-        zulipFeatureLevel: 234,
+        zulipVersion: '10.0+g9876',
+        zulipMergeBase: '10.0',
+        zulipFeatureLevel: 371,
       ).toJson());
       final updateMachine = await UpdateMachine.load(globalStore, account.id);
       updateMachine.debugPauseLoop();
@@ -651,9 +651,9 @@ void main() {
         ..identicalTo(updateMachine.store.account)
         ..realmName.equals('Organization B')
         ..realmIcon.equals(Uri.parse('/image-b.png'))
-        ..zulipVersion.equals('8.0+g9876')
-        ..zulipMergeBase.equals('8.0')
-        ..zulipFeatureLevel.equals(234);
+        ..zulipVersion.equals('10.0+g9876')
+        ..zulipMergeBase.equals('10.0')
+        ..zulipFeatureLevel.equals(371);
     }));
 
     test('retries registerQueue on NetworkError', () => awaitFakeAsync((async) async {


### PR DESCRIPTION
Zulip Server 8.5, the last release in the 8.x series, was released 2024-08-01:
  https://blog.zulip.com/2024/08/01/zulip-server-8-5-bug-fix-release/
So all 8.x releases (and older) have been outside the 18-month support window since 2026-02-01.  As noted when filing issue #1839, that means we can skip past 8.0 and require 9.0.

The versions in the store_test snapshot test were below the new minimum; bump them to 9.0 and 10.0, which are equally arbitrary for that test's purposes.

Fixes: #1839