### PR TITLE
api: Bump minimum supported Zulip Server to 10.0

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -32,13 +32,13 @@ const kMinAllowedZulipFeatureLevel = 277;
 ///
 /// See also [kMinAllowedZulipVersion], for the version below
 /// which we just refuse to connect.
-const kMinSupportedZulipVersion = '9.2';
+const kMinSupportedZulipVersion = '10.0';
 
 /// The Zulip feature level reserved for the [kMinSupportedZulipVersion] release.
 ///
 /// For this value, see the API changelog:
 ///   https://zulip.com/api/changelog
-const kMinSupportedZulipFeatureLevel = 278;
+const kMinSupportedZulipFeatureLevel = 371;
 
 /// The doc stating our oldest supported server version.
 // TODO: Instead, link to new Help Center doc once we have it:


### PR DESCRIPTION
Stacked atop #2360.

This bumps the "nag banner" threshold so it shows on all 9.x. As noted in the commit message, this won't be ready to merge until 2026-07-16, when all 9.x servers age out of the support window.