### PR TITLE
api: Enable user_avatar_url_field_optional client capability

### DIFF
--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -36,7 +36,7 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection, {
     'client_capabilities': {
       'notification_settings_null': true,
       'bulk_message_deletion': true,
-      'user_avatar_url_field_optional': false, // TODO(#254): turn on
+      'user_avatar_url_field_optional': true,
       'stream_typing_notifications': true,
       'user_settings_object': true,
       'include_deactivated_groups': true,

--- a/lib/model/avatar_url.dart
+++ b/lib/model/avatar_url.dart
@@ -1,13 +1,28 @@
 /// The size threshold above which is "medium" size for an avatar.
 ///
-/// This is DEFAULT_AVATAR_SIZE in zerver/lib/upload.py.
+/// This is in physical pixels, i.e. image pixels:
+/// the server serves the default avatar size as a 100x100 px image,
+/// so a display size above that in physical pixels
+/// calls for the "medium" 500x500 px variant.
+///
+/// This is DEFAULT_AVATAR_SIZE in zerver/lib/thumbnail.py.
 const defaultUploadSizePx = 100;
 
 abstract class AvatarUrl {
-  factory AvatarUrl.fromUserData({required Uri resolvedUrl}) {
+  /// The right [AvatarUrl] subclass for the given user data.
+  ///
+  /// [resolvedUrl] is the user's `avatar_url` resolved against the realm URL,
+  /// or null if the server omitted the field; see `user_avatar_url_field_optional`
+  /// at https://zulip.com/api/register-queue#parameter-client_capabilities .
+  factory AvatarUrl.fromUserData({
+    required Uri? resolvedUrl,
+    required int userId,
+    required Uri realmUrl,
+  }) {
     // TODO(#255): handle computing gravatars
-    // TODO(#254): handle computing fallback avatar
-    if (resolvedUrl.toString().startsWith(GravatarUrl.origin)) {
+    if (resolvedUrl == null) {
+      return FallbackAvatarUrl(realmUrl: realmUrl, userId: userId);
+    } else if (resolvedUrl.toString().startsWith(GravatarUrl.origin)) {
       return GravatarUrl(resolvedUrl: resolvedUrl);
     } else {
       return UploadedAvatarUrl(resolvedUrl: resolvedUrl);
@@ -30,6 +45,40 @@ class GravatarUrl implements AvatarUrl {
       ...standardUrl.queryParameters,
       's': sizePhysicalPx.toString(),
     });
+  }
+}
+
+/// The fallback avatar URL, `/avatar/{user_id}` on the realm,
+/// for a user whose `avatar_url` field the server omitted.
+///
+/// The server may omit the field at its discretion
+/// when we pass true for `user_avatar_url_field_optional`
+/// in the register request:
+///   https://zulip.com/api/register-queue#parameter-client_capabilities
+/// The fallback endpoint redirects to the user's actual avatar.
+/// Its API documentation is pending, in an unmerged PR
+/// (as of 2026-07-10):
+///   https://github.com/zulip/zulip/pull/32495
+///
+/// Requests to this endpoint require auth,
+/// but the redirect may point off-realm (to Gravatar, or S3-style storage),
+/// where auth headers must not be sent.
+/// Happily `dart:io`'s HttpClient handles that correctly:
+/// it drops sensitive headers, like Authorization,
+/// on cross-origin redirects.
+class FallbackAvatarUrl implements AvatarUrl {
+  FallbackAvatarUrl({required Uri realmUrl, required int userId})
+    : standardUrl = realmUrl.resolve('/avatar/$userId');
+
+  final Uri standardUrl;
+
+  @override
+  Uri get(int sizePhysicalPx) {
+    if (sizePhysicalPx > defaultUploadSizePx) {
+      return standardUrl.replace(path: '${standardUrl.path}/medium');
+    }
+
+    return standardUrl;
   }
 }
 

--- a/lib/widgets/user.dart
+++ b/lib/widgets/user.dart
@@ -73,16 +73,16 @@ class AvatarImage extends StatelessWidget {
       return _AvatarPlaceholder(size: size);
     }
 
-    final resolvedUrl = switch (user.avatarUrl) {
-      null          => null, // TODO(#255): handle computing gravatars
-      var avatarUrl => store.tryResolveUrl(avatarUrl),
-    };
-
-    if (resolvedUrl == null) {
-      return _AvatarPlaceholder(size: size);
+    Uri? resolvedUrl;
+    if (user.avatarUrl != null) {
+      resolvedUrl = store.tryResolveUrl(user.avatarUrl!);
+      if (resolvedUrl == null) { // TODO(log)
+        return _AvatarPlaceholder(size: size);
+      }
     }
 
-    final avatarUrl = AvatarUrl.fromUserData(resolvedUrl: resolvedUrl);
+    final avatarUrl = AvatarUrl.fromUserData(resolvedUrl: resolvedUrl,
+      userId: userId, realmUrl: store.realmUrl);
     final physicalSize = (MediaQuery.devicePixelRatioOf(context) * size).ceil();
 
     return RealmContentNetworkImage(

--- a/test/api/route/events_test.dart
+++ b/test/api/route/events_test.dart
@@ -31,7 +31,7 @@ void main() {
           'client_capabilities': jsonEncode({
             'notification_settings_null': true,
             'bulk_message_deletion': true,
-            'user_avatar_url_field_optional': false,
+            'user_avatar_url_field_optional': true,
             'stream_typing_notifications': true,
             'user_settings_object': true,
             'include_deactivated_groups': true,

--- a/test/model/avatar_url_test.dart
+++ b/test/model/avatar_url_test.dart
@@ -6,26 +6,48 @@ void main() {
   const defaultSize = 30;
   const largeSize = 120;
 
+  const userId = 123;
+  final realmUrl = Uri.parse('https://zulip.example/');
+
+  AvatarUrl fromUserData(Uri? resolvedUrl) => AvatarUrl.fromUserData(
+    resolvedUrl: resolvedUrl, userId: userId, realmUrl: realmUrl);
+
   group('GravatarUrl', () {
     test('gravatar url', () {
       final url = '${GravatarUrl.origin}/avatar/1234';
-      final avatarUrl = AvatarUrl.fromUserData(resolvedUrl: Uri.parse(url));
+      final avatarUrl = fromUserData(Uri.parse(url));
 
       check(avatarUrl.get(defaultSize).toString()).equals('$url?s=30');
+    });
+  });
+
+  group('FallbackAvatarUrl', () {
+    test('standard size', () {
+      final avatarUrl = fromUserData(null);
+
+      check(avatarUrl.get(defaultSize).toString())
+        .equals('https://zulip.example/avatar/$userId');
+    });
+
+    test('larger size', () {
+      final avatarUrl = fromUserData(null);
+
+      check(avatarUrl.get(largeSize).toString())
+        .equals('https://zulip.example/avatar/$userId/medium');
     });
   });
 
   group('UploadedAvatarUrl', () {
     test('png image', () {
       const url = 'https://zulip.example/image.png';
-      final avatarUrl = AvatarUrl.fromUserData(resolvedUrl: Uri.parse(url));
+      final avatarUrl = fromUserData(Uri.parse(url));
 
       check(avatarUrl.get(defaultSize).toString()).equals(url);
     });
 
     test('png image, larger size', () {
       const url = 'https://zulip.example/image.png';
-      final avatarUrl = AvatarUrl.fromUserData(resolvedUrl: Uri.parse(url));
+      final avatarUrl = fromUserData(Uri.parse(url));
       final expectedUrl = url.replaceAll('.png', '-medium.png');
 
       check(avatarUrl.get(largeSize).toString()).equals(expectedUrl);

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -497,10 +497,13 @@ void main() {
       check(find.text('zulip')).findsOne();
 
       // But no emoji image appears.
-      check(find.byWidgetPredicate((widget) => switch(widget) {
-        Image(image: NetworkImage()) => true,
-        _ => false,
-      })).findsNothing();
+      // (The avatar images in the message list don't count.)
+      check(find.descendant(
+        of: find.byType(EmojiAutocompleteItem),
+        matching: find.byWidgetPredicate((widget) => switch(widget) {
+          Image(image: NetworkImage()) => true,
+          _ => false,
+        }))).findsNothing();
 
       debugNetworkImageHttpClientProvider = null;
     });

--- a/test/widgets/image_test.dart
+++ b/test/widgets/image_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -19,9 +21,9 @@ import 'test_app.dart';
 void main() {
   TestZulipBinding.ensureInitialized();
 
-  group('RealmContentNetworkImage', () {
-    final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);
+  final authHeaders = authHeader(email: eg.selfAccount.email, apiKey: eg.selfAccount.apiKey);
 
+  group('RealmContentNetworkImage', () {
     Future<Map<String, List<String>>> actualHeaders(WidgetTester tester, Uri src) async {
       addTearDown(testBinding.reset);
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
@@ -56,6 +58,86 @@ void main() {
       await tester.pumpWidget(
         RealmContentNetworkImage(Uri.parse('https://zulip.invalid/path/to/image.png'), filterQuality: FilterQuality.medium));
       check(tester.takeException()).isA<AssertionError>();
+    });
+  });
+
+  group('dart:io HttpClient auth headers on redirect', () {
+    // These tests exercise no code of ours; they pin dart:io HttpClient
+    // behavior we rely on for security.
+    // An on-realm request carries the user's API key in the
+    // Authorization header (RealmContentNetworkImage tests above),
+    // and the response can be a redirect pointing off-realm:
+    // for example, the /avatar/{user_id} fallback (see [FallbackAvatarUrl])
+    // redirects to Gravatar or S3-style storage.
+    // The API key must not be forwarded there.
+    //
+    // The behavior is deliberate on Dart's part: dropping sensitive
+    // headers on cross-origin redirects was the fix for CVE-2022-0451,
+    // in Dart 2.16:
+    //   https://github.com/dart-lang/sdk/security/advisories/GHSA-c8mh-jj22-xg5h
+    // These tests are a tripwire in case that ever regresses upstream,
+    // which matters because we track Flutter's main channel.
+
+    final authHeaderValue = authHeaders['Authorization']!;
+
+    /// The Authorization header received at the redirect's destination.
+    Future<String?> authHeaderAfterRedirect({required bool sameOrigin}) async {
+      String? result;
+      Future<void> handleDestination(HttpRequest request) async {
+        result = request.headers.value('authorization');
+        await request.response.close();
+      }
+
+      final destServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final redirectServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      Uri urlOf(HttpServer server, String path) => Uri(
+        scheme: 'http',
+        host: server.address.address, port: server.port, path: path);
+
+      destServer.listen(handleDestination);
+      redirectServer.listen((request) async {
+        if (request.uri.path == '/redirect') {
+          // A cross-origin URL differs in port, hence in origin.
+          final destination = urlOf(sameOrigin ? redirectServer : destServer,
+            '/destination');
+          request.response
+            ..statusCode = HttpStatus.found
+            ..headers.set('location', destination.toString());
+          await request.response.close();
+        } else {
+          await handleDestination(request);
+        }
+      });
+
+      // Escape flutter_test's global [HttpOverrides], which stubs out
+      // all HTTP; the [HttpOverrides] base class creates real clients.
+      final client = HttpOverrides.runWithHttpOverrides(
+        () => HttpClient(), _RealHttpOverrides());
+      try {
+        final request = await client.getUrl(urlOf(redirectServer, '/redirect'));
+        request.headers.set('authorization', authHeaderValue);
+        final response = await request.close();
+        await response.drain<void>();
+        // If the client didn't follow the redirect, this would be
+        // the 302 itself; guard against a null `result` meaning
+        // the destination was never contacted at all.
+        check(response.statusCode).equals(HttpStatus.ok);
+      } finally {
+        client.close(force: true);
+        await destServer.close(force: true);
+        await redirectServer.close(force: true);
+      }
+      return result;
+    }
+
+    test('forward auth header on same-origin redirect', () async {
+      check(await authHeaderAfterRedirect(sameOrigin: true))
+        .equals(authHeaderValue);
+    });
+
+    test('no forward auth header on cross-origin redirect', () async {
+      check(await authHeaderAfterRedirect(sameOrigin: false))
+        .isNull();
     });
   });
 
@@ -310,3 +392,6 @@ void main() {
     });
   });
 }
+
+/// Real networking, via the [HttpOverrides] base class's real [HttpClient].
+class _RealHttpOverrides extends HttpOverrides {}

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -2267,16 +2267,14 @@ void main() {
             matching: find.byType(RealmContentNetworkImage))).firstOrNull;
       }
 
-      void checkResultForSender(String? avatarUrl) {
-        if (avatarUrl == null) {
-          check(findAvatarImageWidget(tester)).isNull();
-        } else {
-          check(findAvatarImageWidget(tester)).isNotNull()
-            .src.equals(eg.selfAccount.realmUrl.resolve(avatarUrl));
-        }
-      }
-
       final user = eg.user();
+
+      void checkResultForSender(String? avatarUrl) {
+        final expectedUrl = eg.selfAccount.realmUrl.resolve(
+          avatarUrl ?? '/avatar/${user.userId}');
+        check(findAvatarImageWidget(tester)).isNotNull()
+          .src.equals(expectedUrl);
+      }
 
       Future<void> handleNewAvatarEventAndPump(WidgetTester tester, String avatarUrl) async {
         await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId, avatarUrl: avatarUrl));

--- a/test/widgets/user_test.dart
+++ b/test/widgets/user_test.dart
@@ -4,6 +4,7 @@ import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/api/model/model.dart';
 import 'package:zulip/model/store.dart';
 import 'package:zulip/widgets/icons.dart';
 import 'package:zulip/widgets/image.dart';
@@ -21,17 +22,18 @@ void main() {
 
   group('AvatarImage', () {
     late PerAccountStore store;
+    late User user;
 
     final findPlaceholder = find.descendant(
       of: find.byType(AvatarImage),
       matching: find.byIcon(ZulipIcons.person),
     );
 
-    Future<Uri?> actualUrl(WidgetTester tester, String avatarUrl, [double? size]) async {
+    Future<Uri?> actualUrl(WidgetTester tester, String? avatarUrl, [double? size]) async {
       addTearDown(testBinding.reset);
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
-      final user = eg.user(avatarUrl: avatarUrl);
+      user = eg.user(avatarUrl: avatarUrl);
       await store.addUser(user);
 
       prepareBoringImageHttpClient();
@@ -101,19 +103,19 @@ void main() {
       check(findPlaceholder).findsOne();
     });
 
-    testWidgets('shows placeholder when user avatarUrl is null', (tester) async {
-      addTearDown(testBinding.reset);
-      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+    testWidgets('fallback URL when avatarUrl is missing', (tester) async {
+      check(await actualUrl(tester, null))
+        .equals(store.realmUrl.resolve('/avatar/${user.userId}'));
+      debugNetworkImageHttpClientProvider = null;
+    });
 
-      final userWithNoUrl = eg.user(avatarUrl: null);
-      await store.addUser(userWithNoUrl);
+    testWidgets('fallback URL when avatarUrl is missing, larger size', (tester) async {
+      tester.view.devicePixelRatio = 2.5;
+      addTearDown(tester.view.resetDevicePixelRatio);
 
-      await tester.pumpWidget(
-        TestZulipApp(accountId: eg.selfAccount.id,
-          child: AvatarImage(userId: userWithNoUrl.userId, size: 30)));
-      await tester.pump();
-      check(findPlaceholder).findsOne();
+      check(await actualUrl(tester, null, 50))
+        .equals(store.realmUrl.resolve('/avatar/${user.userId}/medium'));
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('shows placeholder when image fails to load', (tester) async {


### PR DESCRIPTION
Fixes #254.

With this capability, the server may omit `avatar_url` on user objects in the register response, shrinking the payload substantially in organizations with many long-term idle users.

-----

# Profiling data

Here's profiling data for the effect of enabling this capability, collected on chat.zulip.org, 2026-07-10, in a profile build.

**Method.** The instrumentation is a local patch (not part of this PR; included in full at the bottom of this comment). Both datasets below were collected with identical instrumentation: the "before" runs with the patch applied to `main`, the "after" runs with it applied at this branch's tip. Six register requests each, in a profile-mode build.

The phases: `headers` is from sending the request until response headers arrive (network round-trip plus server compute); `body` is until the last body chunk arrives (and its decoded size in bytes) — note our JSON decoding is fused with the download, so this phase includes most of the decode work; `json tail` is decoding that ran after the last chunk; `fromJson` is constructing `InitialSnapshot` from the decoded JSON.

**Before (capability off):**

```
request time registerQueue 5404.3ms total: 3962.0ms headers, 1409.6ms body (19062240 bytes), 0.5ms json tail, 32.1ms fromJson
request time registerQueue 4444.8ms total: 3781.4ms headers, 639.3ms body (19062239 bytes), 0.2ms json tail, 23.8ms fromJson
request time registerQueue 5295.0ms total: 4537.1ms headers, 729.1ms body (19062239 bytes), 0.3ms json tail, 28.6ms fromJson
request time registerQueue 5352.1ms total: 4628.6ms headers, 700.1ms body (19062240 bytes), 0.2ms json tail, 23.2ms fromJson
request time registerQueue 4693.0ms total: 3979.3ms headers, 683.2ms body (19062240 bytes), 0.2ms json tail, 30.3ms fromJson
request time registerQueue 5828.0ms total: 5112.6ms headers, 689.4ms body (19062238 bytes), 0.3ms json tail, 25.8ms fromJson
```

**After (capability on):**

```
request time registerQueue 3942.6ms total: 3433.9ms headers, 482.0ms body (15335213 bytes), 0.3ms json tail, 26.4ms fromJson
request time registerQueue 3652.7ms total: 2926.1ms headers, 701.5ms body (15335230 bytes), 0.1ms json tail, 25.0ms fromJson
request time registerQueue 4004.6ms total: 3400.1ms headers, 577.6ms body (15335230 bytes), 0.1ms json tail, 26.7ms fromJson
request time registerQueue 4245.8ms total: 3508.9ms headers, 710.2ms body (15335227 bytes), 0.4ms json tail, 26.3ms fromJson
request time registerQueue 4270.1ms total: 3707.6ms headers, 540.7ms body (15335237 bytes), 0.2ms json tail, 21.5ms fromJson
request time registerQueue 4095.9ms total: 3382.7ms headers, 689.7ms body (15335357 bytes), 0.2ms json tail, 23.3ms fromJson
```

**Comparison (means of 6 runs):**

| | before | after | delta |
|---|---|---|---|
| decoded body size | 19.06 MB | 15.34 MB | −3.7 MB (−20%) |
| headers (incl. server compute) | ~4330 ms | ~3390 ms | −940 ms (−22%) |
| body (download + decode) | ~810 ms (median 694) | ~620 ms (median 634) | −60–190 ms |
| fromJson | 27 ms | 25 ms | −2 ms |
| **total** | **~5170 ms** | **~4040 ms** | **−1130 ms (−22%)** |

Observations:

- The `headers` improvement is the headline, and the effect is unambiguous: the two distributions don't overlap (every "after" sample, 2926–3708ms, is below every "before" sample, 3781–5113ms). The server isn't just skipping the bytes; it skips computing avatar URLs for every long-term idle user.
- The decoded payload shrinks by 20%. (The first "before" `body` sample, 1410ms, looks like a cold-connection outlier; medians tell the cleaner story there.)
- Deserialization is a non-factor either way: ~25ms out of ~4s, essentially unchanged.

For scale, I counted the affected users (by fetching `realm_user` data with the capability and counting user objects with `avatar_url` omitted): of this org's 37,674 active users, 36,283 (96%) are long-term idle; of its 1,263 deactivated users, just 4 are. So the capability dropped the field for 36,287 of 38,937 user objects (93%) — about 102 bytes of decoded JSON per user, which matches the length of an S3-style avatar URL.

<details>
<summary>The instrumentation patch</summary>

```diff
diff --git lib/api/core.dart lib/api/core.dart
index b7aa01d12..047421847 100644
--- lib/api/core.dart
+++ lib/api/core.dart
@@ -173,6 +173,8 @@ class ApiConnection {
       addUserAgent(request);
     }
 
+    final stopwatch = kProfileMode ? (Stopwatch()..start()) : null;
+
     final http.StreamedResponse response;
     try {
       response = await _client.send(request);
@@ -188,24 +190,52 @@ class ApiConnection {
       }
       throw NetworkException(routeName: routeName, cause: e, message: message);
     }
+    final tHeaders = stopwatch?.elapsed;
 
     final int httpStatus = response.statusCode;
     Map<String, dynamic>? json;
+    Duration? tLastChunk;
+    int bodyLength = 0;
     try {
+      Stream<List<int>> bodyStream = response.stream;
+      if (kProfileMode) {
+        bodyStream = bodyStream.map((chunk) {
+          tLastChunk = stopwatch!.elapsed;
+          bodyLength += chunk.length;
+          return chunk;
+        });
+      }
       // The stream-oriented `bind` method allows decoding to happen in chunks
       // while the response is still being downloaded, improving latency.
-      final jsonStream = jsonUtf8Decoder.bind(response.stream);
+      final jsonStream = jsonUtf8Decoder.bind(bodyStream);
       json = await jsonStream.single as Map<String, dynamic>?;
     } catch (e) {
       // We'll throw something below, seeing `json` is null.
     }
+    final tJson = stopwatch?.elapsed;
 
     if (httpStatus != 200 || json == null) {
       throw _makeApiException(routeName, httpStatus, json);
     }
 
     try {
-      return fromJson(json);
+      final result = fromJson(json);
+      if (kProfileMode) {
+        // Because JSON decoding is interleaved with the download
+        // (see `bind` above), the "body" phase includes most of the
+        // JSON decoding; "json tail" is only the decoding that ran
+        // after the last chunk of the response body arrived.
+        String format(Duration d) =>
+          "${(d.inMicroseconds / 1000.0).toStringAsFixed(1)}ms";
+        final tTotal = stopwatch!.elapsed;
+        final tBody = tLastChunk ?? tHeaders!;
+        profilePrint("request time $routeName ${format(tTotal)} total: "
+          "${format(tHeaders!)} headers, "
+          "${format(tBody - tHeaders)} body ($bodyLength bytes), "
+          "${format(tJson! - tBody)} json tail, "
+          "${format(tTotal - tJson)} fromJson");
+      }
+      return result;
     } catch (exception, stackTrace) { // TODO(log)
       Error.throwWithStackTrace(
         MalformedServerResponseException(
```

</details>
