### PR TITLE
home: Show organization icon in app bar

### DIFF
--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -16,6 +16,7 @@ class ZulipAppBar extends AppBar {
   // TODO(upstream) send a PR to replace our `willCenterTitle` code
   ZulipAppBar({
     super.key,
+    super.leading,
     super.titleSpacing,
     Widget? title,
     Widget Function(bool willCenterTitle)? buildTitle,

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -154,9 +154,13 @@ class _OrgIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final store = PerAccountStoreWidget.of(context);
     return Center(
-      child: Tooltip(
-        message: store.realmName,
-        child: AvatarShape(
+      child: IconButton(
+        tooltip: store.realmName,
+        onPressed: () {
+          Navigator.push(context,
+            MaterialWidgetRoute(page: const ChooseAccountPage()));
+        },
+        icon: AvatarShape(
           size: 28,
           borderRadius: 4,
           child: RealmContentNetworkImage(

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -121,7 +121,8 @@ class _HomePageState extends State<HomePage> {
     ];
 
     return Scaffold(
-      appBar: ZulipAppBar(titleSpacing: 16,
+      appBar: ZulipAppBar(
+        leading: const _OrgIcon(),
         title: Semantics(
           identifier: HomePage.titleSemanticsIdentifier,
           namesRoute: true,
@@ -143,6 +144,25 @@ class _HomePageState extends State<HomePage> {
                 ]))),
         ]),
       bottomNavigationBar: _BottomNavBar(tabNotifier: _tab));
+  }
+}
+
+class _OrgIcon extends StatelessWidget {
+  const _OrgIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    final store = PerAccountStoreWidget.of(context);
+    return Center(
+      child: Tooltip(
+        message: store.realmName,
+        child: AvatarShape(
+          size: 28,
+          borderRadius: 4,
+          child: RealmContentNetworkImage(
+            store.resolvedRealmIcon,
+            filterQuality: FilterQuality.medium,
+            fit: BoxFit.cover))));
   }
 }
 

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -28,6 +28,7 @@ import '../model/narrow_checks.dart';
 import '../model/store_checks.dart';
 import '../model/test_store.dart';
 import '../stdlib_checks.dart';
+import '../test_images.dart';
 import '../test_navigation.dart';
 import '../widgets/checks.dart';
 import '../widgets/dialog_checks.dart';
@@ -315,6 +316,7 @@ void main() {
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
     testWidgets('mismatching account', (tester) async {
+      prepareBoringImageHttpClient();
       addTearDown(testBinding.reset);
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       await prepare(tester);
@@ -324,6 +326,7 @@ void main() {
       await tester.tap(find.byWidget(checkErrorDialog(tester,
         expectedTitle: zulipLocalizations.errorNotificationOpenTitle,
         expectedMessage: zulipLocalizations.errorNotificationOpenAccountNotFound)));
+      debugNetworkImageHttpClientProvider = null;
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
     testWidgets('find account among several', (tester) async {

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -321,12 +321,14 @@ void main() {
           find.descendant(of: findHeader, matching: finder);
 
         testWidgets('public channel', (tester) async {
+          prepareBoringImageHttpClient();
           await prepare();
           check(store.streams[someChannel.streamId]).isNotNull()
             ..inviteOnly.isFalse()..isWebPublic.isFalse();
           await showFromInbox(tester);
           check(findInHeader(find.byIcon(ZulipIcons.hash_sign))).findsOne();
           check(findInHeader(find.textContaining(someChannel.name))).findsOne();
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('web-public channel', (tester) async {

--- a/test/widgets/all_channels_test.dart
+++ b/test/widgets/all_channels_test.dart
@@ -24,6 +24,7 @@ import '../model/binding.dart';
 import '../example_data.dart' as eg;
 import '../model/test_store.dart';
 import '../stdlib_checks.dart';
+import '../test_images.dart';
 import 'checks.dart';
 import 'dialog_checks.dart';
 import 'test_app.dart';
@@ -75,6 +76,7 @@ void main() {
   }
 
   testWidgets('navigate to page', (tester) async {
+    prepareBoringImageHttpClient();
     addTearDown(testBinding.reset);
 
     final channel = eg.stream();
@@ -108,6 +110,7 @@ void main() {
 
     check(find.byType(AllChannelsPageBody)).findsOne();
     check(find.widgetWithText(ZulipAppBar, 'All channels')).findsOne();
+    debugNetworkImageHttpClientProvider = null;
   });
 
   testWidgets('navigate to page from empty subscription list', (tester) async {

--- a/test/widgets/app_test.dart
+++ b/test/widgets/app_test.dart
@@ -15,6 +15,7 @@ import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/store_checks.dart';
 import '../model/test_store.dart';
+import '../test_images.dart';
 import '../test_navigation.dart';
 import 'dialog_checks.dart';
 import 'checks.dart';
@@ -304,6 +305,7 @@ void main() {
     });
 
     testWidgets('choosing an account clears the navigator stack', (tester) async {
+      prepareBoringImageHttpClient();
       addTearDown(testBinding.reset);
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
       await testBinding.globalStore.add(
@@ -343,6 +345,7 @@ void main() {
       check(pushedRoutes).single.isA<MaterialAccountWidgetRoute>()
         ..accountId.equals(eg.otherAccount.id)
         ..page.isA<HomePage>();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('choosing an account changes the last visited account', (tester) async {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -43,6 +43,7 @@ import '../model/store_checks.dart';
 import '../model/test_store.dart';
 import '../model/typing_status_test.dart';
 import '../stdlib_checks.dart';
+import '../test_images.dart';
 import 'checks.dart';
 import 'dialog_checks.dart';
 import 'test_app.dart';
@@ -933,6 +934,7 @@ void main() {
     }
 
     testWidgets('navigating away sends a "typing stopped" notice', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareComposeBoxWithNavigation(tester);
 
       await checkStartTyping(tester, narrow);
@@ -941,6 +943,7 @@ void main() {
       (await ZulipApp.navigator).pop();
       await tester.pump(Duration.zero);
       checkTypingRequest(TypingOp.stop, narrow);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('for content input, unfocusing sends a "typing stopped" notice', (tester) async {

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -42,6 +42,7 @@ import '../model/store_checks.dart';
 import '../model/test_store.dart';
 import '../model/typing_status_test.dart';
 import '../stdlib_checks.dart';
+import '../test_images.dart';
 import 'checks.dart';
 import 'dialog_checks.dart';
 import 'test_app.dart';
@@ -933,6 +934,7 @@ void main() {
     }
 
     testWidgets('navigating away sends a "typing stopped" notice', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareComposeBoxWithNavigation(tester);
 
       await checkStartTyping(tester, narrow);
@@ -941,6 +943,7 @@ void main() {
       (await ZulipApp.navigator).pop();
       await tester.pump(Duration.zero);
       checkTypingRequest(TypingOp.stop, narrow);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('for content input, unfocusing sends a "typing stopped" notice', (tester) async {

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -18,6 +18,7 @@ import 'package:zulip/widgets/app_bar.dart';
 import 'package:zulip/widgets/banner.dart';
 import 'package:zulip/widgets/home.dart';
 import 'package:zulip/widgets/icons.dart';
+import 'package:zulip/widgets/image.dart';
 import 'package:zulip/widgets/inbox.dart';
 import 'package:zulip/widgets/message_list.dart';
 import 'package:zulip/widgets/page.dart';
@@ -107,7 +108,7 @@ void main () {
       // sticky-header position (via [StickyHeaderItem]).
       // We arrange that by also preparing an unread DM, which
       // shifts the channel header down so it's not at the top of the viewport.
-
+      prepareBoringImageHttpClient();
       await prepare(tester);
       await store.addUser(eg.otherUser);
       await store.addMessage(
@@ -138,6 +139,7 @@ void main () {
       await tester.tap(find.byIcon(ZulipIcons.inbox));
       await tester.pump();
       check(findChevron).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('update app bar title and actions when switching between views', (tester) async {
@@ -165,6 +167,19 @@ void main () {
         of: find.byType(ZulipAppBar),
         matching: find.text('Direct messages'))).findsOne();
       check(findSearchButton).findsNothing();
+    });
+
+    testWidgets('organization icon in app bar shows the realm icon', (tester) async {
+      prepareBoringImageHttpClient();
+      await prepare(tester);
+
+      final iconFinder = find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.byType(RealmContentNetworkImage));
+      check(iconFinder).findsOne();
+      check(tester.widget<RealmContentNetworkImage>(iconFinder).src)
+        .equals(store.resolvedRealmIcon);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets("view switches when labels are tapped", (tester) async {
@@ -535,6 +550,7 @@ void main () {
     });
 
     testWidgets('while loading, choose a different account', (tester) async {
+      prepareBoringImageHttpClient();
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       await prepare(tester);
       await tester.pump(kTryAnotherAccountWaitPeriod);
@@ -550,6 +566,7 @@ void main () {
       await tester.pump(loadPerAccountDuration);
       // The second loadPerAccount finished.
       checkOnHomePage(tester, expectedAccount: eg.otherAccount);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('while loading, choosing an account disallows going back', (tester) async {
@@ -571,6 +588,7 @@ void main () {
     });
 
     testWidgets('while loading, go to nested levels of ChooseAccountPage', (tester) async {
+      prepareBoringImageHttpClient();
       testBinding.globalStore.loadPerAccountDuration = loadPerAccountDuration;
       final thirdAccount = eg.account(user: eg.thirdUser);
       await testBinding.globalStore.add(thirdAccount, eg.initialSnapshot(
@@ -601,6 +619,7 @@ void main () {
 
       await tester.pump(loadPerAccountDuration); // wait for loadPerAccount
       checkOnHomePage(tester, expectedAccount: thirdAccount);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('after finishing loading, go back from ChooseAccountPage', (tester) async {
@@ -750,39 +769,48 @@ void main () {
     final unsupportedVersion = '3.0';
 
     testWidgets('not shown when server is at supported feature level', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareBanner(tester,
         zulipFeatureLevel: kMinSupportedZulipFeatureLevel,
         zulipVersion: kMinSupportedZulipVersion);
       check(find.byType(ZulipBanner)).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('shown for administrator when server is below supported feature level', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareBanner(tester,
         zulipFeatureLevel: unsupportedFeatureLevel,
         zulipVersion: unsupportedVersion,
         selfUser: eg.user(role: UserRole.administrator));
       check(find.text(zulipLocalizations.serverCompatBannerAdminMessage(
         sampleRealmUrl, unsupportedVersion))).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('shown for owner when server is below supported feature level', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareBanner(tester,
         zulipFeatureLevel: unsupportedFeatureLevel,
         zulipVersion: unsupportedVersion,
         selfUser: eg.user(role: UserRole.owner));
       check(find.text(zulipLocalizations.serverCompatBannerAdminMessage(
         sampleRealmUrl, unsupportedVersion))).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('shown for member when server is below supported feature level', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareBanner(tester,
         zulipFeatureLevel: unsupportedFeatureLevel,
         zulipVersion: unsupportedVersion);
       check(find.text(zulipLocalizations.serverCompatBannerUserMessage(
         sampleRealmUrl, unsupportedVersion))).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('banner has alert semantics role', (tester) async {
+      prepareBoringImageHttpClient();
       final findBannerSemantics = find.byWidgetPredicate((widget) =>
         widget is Semantics && widget.properties.role == SemanticsRole.alert);
       await prepareBanner(tester,
@@ -792,6 +820,7 @@ void main () {
         of: find.byType(ZulipBanner),
         matching: findBannerSemantics)
       ).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('banner dismiss state persists when switching account away and back', (tester) async {
@@ -834,12 +863,14 @@ void main () {
     });
 
     testWidgets('learn more opens kServerSupportDocUrl', (tester) async {
+      prepareBoringImageHttpClient();
       await prepareBanner(tester,
         zulipFeatureLevel: unsupportedFeatureLevel,
         zulipVersion: unsupportedVersion);
       await tester.tap(find.text(zulipLocalizations.serverCompatBannerLearnMoreLabel));
       check(testBinding.takeLaunchUrlCalls()).single
         .equals((url: kServerSupportDocUrl, mode: LaunchMode.inAppBrowserView));
+      debugNetworkImageHttpClientProvider = null;
     });
   });
 }

--- a/test/widgets/home_test.dart
+++ b/test/widgets/home_test.dart
@@ -44,6 +44,7 @@ void main () {
   late PerAccountStore store;
   late FakeApiConnection connection;
 
+  late TransitionDurationObserver transitionDurationObserver;
   late Route<dynamic>? topRoute;
   late Route<dynamic>? previousTopRoute;
   late List<Route<dynamic>> pushedRoutes;
@@ -63,6 +64,7 @@ void main () {
     previousTopRoute = null;
     pushedRoutes = [];
     lastPoppedRoute = null;
+    transitionDurationObserver = TransitionDurationObserver();
     await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
     store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
     connection = store.connection as FakeApiConnection;
@@ -70,7 +72,7 @@ void main () {
 
     await tester.pumpWidget(TestZulipApp(
       accountId: eg.selfAccount.id,
-      navigatorObservers: [testNavObserver],
+      navigatorObservers: [testNavObserver, transitionDurationObserver],
       child: const HomePage()));
     await tester.pump();
   }
@@ -179,6 +181,19 @@ void main () {
       check(iconFinder).findsOne();
       check(tester.widget<RealmContentNetworkImage>(iconFinder).src)
         .equals(store.resolvedRealmIcon);
+      debugNetworkImageHttpClientProvider = null;
+    });
+
+    testWidgets('tapping organization icon opens the account list', (tester) async {
+      prepareBoringImageHttpClient();
+      await prepare(tester);
+
+      await tester.tap(find.descendant(
+        of: find.byType(ZulipAppBar),
+        matching: find.byType(RealmContentNetworkImage)));
+      await tester.pump();
+      await transitionDurationObserver.pumpPastTransition(tester);
+      check(find.byType(ChooseAccountPage)).findsOne();
       debugNetworkImageHttpClientProvider = null;
     });
 

--- a/test/widgets/inbox_test.dart
+++ b/test/widgets/inbox_test.dart
@@ -20,6 +20,7 @@ import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/test_store.dart';
+import '../test_images.dart';
 import '../test_navigation.dart';
 import 'checks.dart';
 import 'test_app.dart';
@@ -235,8 +236,10 @@ void main() {
 
   group('InboxPage', () {
     testWidgets('page builds; empty', (tester) async {
+      prepareBoringImageHttpClient();
       await setupPage(tester, unreadMessages: []);
       check(find.textContaining('There are no unread messages in your inbox.')).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('page builds; not empty', (tester) async {

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -294,6 +294,7 @@ void main() {
       });
 
       testWidgets('logging into a second account', (tester) async {
+        prepareBoringImageHttpClient();
         await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
         final serverSettings = eg.serverSettings();
         await prepare(tester, serverSettings);
@@ -310,6 +311,7 @@ void main() {
         checkMatchesAccount(newAccount, eg.otherAccount);
         check(poppedRoutes).length.equals(2);
         check(pushedRoutes).single.isA<WidgetRoute>().page.isA<HomePage>();
+        debugNetworkImageHttpClientProvider = null;
       });
 
       testWidgets('trims whitespace on username', (tester) async {

--- a/test/widgets/new_dm_sheet_test.dart
+++ b/test/widgets/new_dm_sheet_test.dart
@@ -19,6 +19,7 @@ import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/test_store.dart';
+import '../test_images.dart';
 import '../test_navigation.dart';
 import 'finders.dart';
 import 'test_app.dart';
@@ -87,6 +88,7 @@ void main() {
   }
 
   testWidgets('shows header with correct buttons', (tester) async {
+    prepareBoringImageHttpClient();
     await setupSheet(tester, users: []);
 
     check(find.descendant(
@@ -96,9 +98,11 @@ void main() {
     check(findComposeButton).findsOne();
 
     checkComposeButtonEnabled(tester, false);
+    debugNetworkImageHttpClientProvider = null;
   });
 
   testWidgets('search field has focus when sheet opens', (tester) async {
+    prepareBoringImageHttpClient();
     await setupSheet(tester, users: []);
 
     void checkHasFocus() {
@@ -117,6 +121,7 @@ void main() {
     checkHasFocus(); // It's focused initially.
     await tester.pump(Duration(seconds: 1));
     checkHasFocus(); // Something else doesn't come along and steal the focus.
+    debugNetworkImageHttpClientProvider = null;
   });
 
   group('user filtering', () {
@@ -128,24 +133,29 @@ void main() {
     ];
 
     testWidgets('shows full list initially', (tester) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, selfUser: testUsers[0], users: testUsers);
       check(findText(includePlaceholders: false, 'Alice Anderson')).findsOne();
       check(findText(includePlaceholders: false, 'Bob Brown')).findsOne();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsOne();
       check(find.byIcon(ZulipIcons.check_circle_unchecked)).findsExactly(testUsers.length);
       check(find.byIcon(ZulipIcons.check_circle_checked)).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('shows filtered users based on search', (tester) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, users: testUsers);
       await tester.enterText(find.byType(TextField), 'Alice');
       await tester.pump();
       check(findText(includePlaceholders: false, 'Alice Anderson')).findsOne();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsNothing();
       check(findText(includePlaceholders: false, 'Bob Brown')).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('deactivated users excluded', (tester) async {
+      prepareBoringImageHttpClient();
       // Omit a deactivated user both before there's a query…
       final deactivatedUser = eg.user(fullName: 'Impostor Charlie', isActive: false);
       await setupSheet(tester, selfUser: testUsers[0],
@@ -160,9 +170,11 @@ void main() {
       check(findText(includePlaceholders: false, 'Impostor Charlie')).findsNothing();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsOne();
       check(find.byIcon(ZulipIcons.check_circle_unchecked)).findsExactly(1);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('muted users excluded', (tester) async {
+      prepareBoringImageHttpClient();
       // Omit muted users both before there's a query…
       final mutedUser = eg.user(fullName: 'Someone Muted');
       await setupSheet(tester, selfUser: testUsers[0],
@@ -182,12 +194,14 @@ void main() {
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsOne();
       check(findText(includePlaceholders: false, 'Édith Piaf')).findsOne();
       check(find.byIcon(ZulipIcons.check_circle_unchecked)).findsExactly(3);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     // TODO test sorting by recent-DMs
     // TODO test that scroll position resets on query change
 
     testWidgets('search is case- and diacritics-insensitive', (tester) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, users: testUsers);
       await tester.enterText(find.byType(TextField), 'alice');
       await tester.pump();
@@ -204,9 +218,11 @@ void main() {
       await tester.enterText(find.byType(TextField), 'edith');
       await tester.pump();
       check(findText(includePlaceholders: false, 'Édith Piaf')).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('partial name and last name search handling', (tester) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, users: testUsers);
 
       await tester.enterText(find.byType(TextField), 'Ali');
@@ -226,9 +242,11 @@ void main() {
       check(findText(includePlaceholders: false, 'Alice Anderson')).findsOne();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsNothing();
       check(findText(includePlaceholders: false, 'Bob Brown')).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('shows empty state when no users match', (tester) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, users: testUsers);
       await tester.enterText(find.byType(TextField), 'Zebra');
       await tester.pump();
@@ -236,9 +254,11 @@ void main() {
       check(findText(includePlaceholders: false, 'Alice Anderson')).findsNothing();
       check(findText(includePlaceholders: false, 'Bob Brown')).findsNothing();
       check(findText(includePlaceholders: false, 'Charlie Carter')).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('search text clears when user is selected', (tester) async {
+      prepareBoringImageHttpClient();
       final user = eg.user(fullName: 'Test User');
       await setupSheet(tester, users: [user]);
 
@@ -250,6 +270,7 @@ void main() {
       await tester.tap(findUserTile(user));
       await tester.pump();
       check(textField.controller!.text).isEmpty();
+      debugNetworkImageHttpClientProvider = null;
     });
   });
 
@@ -276,6 +297,7 @@ void main() {
     }
 
     testWidgets('tapping user chip deselects the user', (tester) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, users: [eg.otherUser, eg.thirdUser]);
 
       await tester.tap(findUserTile(eg.otherUser));
@@ -284,9 +306,11 @@ void main() {
       await tester.tap(findUserChip(eg.otherUser));
       await tester.pump();
       checkUserSelected(tester, eg.otherUser, false);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('selecting and deselecting a user', (tester) async {
+      prepareBoringImageHttpClient();
       final user = eg.user(fullName: 'Test User');
       await setupSheet(tester, users: [user]);
 
@@ -303,9 +327,11 @@ void main() {
       await tester.pump();
       checkUserSelected(tester, user, false);
       checkComposeButtonEnabled(tester, false);
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('other user selection deselects self user', (tester) async {
+      prepareBoringImageHttpClient();
       final otherUser = eg.user(fullName: 'Other User');
       await setupSheet(tester, users: [otherUser]);
 
@@ -318,9 +344,11 @@ void main() {
       await tester.pump();
       checkUserSelected(tester, otherUser, true);
       check(find.text(eg.selfUser.fullName)).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('other user selection hides self user', (tester) async {
+      prepareBoringImageHttpClient();
       final otherUser = eg.user(fullName: 'Other User');
       await setupSheet(tester, users: [otherUser]);
 
@@ -329,9 +357,11 @@ void main() {
       await tester.tap(findUserTile(otherUser));
       await tester.pump();
       check(find.text(eg.selfUser.fullName)).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('can select multiple users', (tester) async {
+      prepareBoringImageHttpClient();
       final user1 = eg.user(fullName: 'Test User 1');
       final user2 = eg.user(fullName: 'Test User 2');
       await setupSheet(tester, users: [user1, user2]);
@@ -342,6 +372,7 @@ void main() {
       await tester.pump();
       checkUserSelected(tester, user1, true);
       checkUserSelected(tester, user2, true);
+      debugNetworkImageHttpClientProvider = null;
     });
   });
 
@@ -367,6 +398,7 @@ void main() {
     }
 
     testWidgets('emoji & text are set -> emoji is displayed, text is not', (tester) async {
+      prepareBoringImageHttpClient();
       final user = eg.user();
       await setupSheet(tester, users: [user]);
       await store.changeUserStatus(user.userId, UserStatusChange(
@@ -386,9 +418,11 @@ void main() {
       check(findUserChip(user)).findsOne();
       checkFindsChipStatusEmoji(tester, user, find.text('\u{1f6e0}'));
       check(find.textContaining('Busy')).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('emoji is not set, text is set -> text is not displayed', (tester) async {
+      prepareBoringImageHttpClient();
       final user = eg.user();
       await setupSheet(tester, users: [user]);
       await store.changeUserStatus(user.userId, UserStatusChange(
@@ -405,6 +439,7 @@ void main() {
       check(findUserTile(user)).findsOne();
       check(findUserChip(user)).findsOne();
       check(find.textContaining('Busy')).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
   });
 
@@ -413,6 +448,7 @@ void main() {
       required List<User> users,
       required String expectedAppBarTitle,
     }) async {
+      prepareBoringImageHttpClient();
       await setupSheet(tester, users: users);
 
       final context = tester.element(find.byType(NewDmPicker));
@@ -430,6 +466,7 @@ void main() {
       check(find.widgetWithText(ZulipAppBar, expectedAppBarTitle)).findsOne();
 
       check(find.byType(ComposeBox)).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     }
 
     testWidgets('navigates to self DM', (tester) async {

--- a/test/widgets/recent_dm_conversations_test.dart
+++ b/test/widgets/recent_dm_conversations_test.dart
@@ -21,6 +21,7 @@ import '../example_data.dart' as eg;
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../model/test_store.dart';
+import '../test_images.dart';
 import '../test_navigation.dart';
 import 'checks.dart';
 import 'finders.dart';
@@ -73,12 +74,15 @@ void main() {
 
   group('RecentDmConversationsPage', () {
     testWidgets('appearance when empty', (tester) async {
+      prepareBoringImageHttpClient();
       await setupPage(tester, users: [], dmMessages: []);
       check(find.text('You have no direct messages yet!')).findsOne();
       check(find.text('Why not start a conversation?')).findsOne();
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('page builds; conversations appear in order', (tester) async {
+      prepareBoringImageHttpClient();
       final user1 = eg.user(userId: 1);
       final user2 = eg.user(userId: 2);
 
@@ -94,9 +98,11 @@ void main() {
       check(items[0].narrow).equals(DmNarrow.ofMessage(message3, selfUserId: eg.selfUser.userId));
       check(items[1].narrow).equals(DmNarrow.ofMessage(message2, selfUserId: eg.selfUser.userId));
       check(items[2].narrow).equals(DmNarrow.ofMessage(message1, selfUserId: eg.selfUser.userId));
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('fling to scroll down', (tester) async {
+      prepareBoringImageHttpClient();
       final List<User> users = [];
       final List<DmMessage> messages = [];
       for (int i = 1; i <= 30; i++) {
@@ -115,9 +121,11 @@ void main() {
         const Offset(0, -200), 4000);
       await tester.pumpAndSettle();
       check(tester.any(oldestConversationFinder)).isTrue(); // onscreen
+      debugNetworkImageHttpClientProvider = null;
     });
 
     testWidgets('opens new DM sheet on New DM button tap', (tester) async {
+      prepareBoringImageHttpClient();
       Route<dynamic>? lastPushedRoute;
       Route<dynamic>? lastPoppedRoute;
       final testNavObserver = TestNavigatorObserver()
@@ -141,6 +149,7 @@ void main() {
         // TODO not sure why a 1ms fudge is needed; investigate.
         + Duration(milliseconds: 1));
       check(find.byType(NewDmPicker)).findsNothing();
+      debugNetworkImageHttpClientProvider = null;
     });
   });
 
@@ -218,31 +227,38 @@ void main() {
 
       group('self-1:1', () {
         testWidgets('has right title/avatar', (tester) async {
+          prepareBoringImageHttpClient();
           final message = eg.dmMessage(from: eg.selfUser, to: []);
           await setupPage(tester, users: [], dmMessages: [message]);
 
           checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
           checkTitle(tester, eg.selfUser.fullName);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('short name takes one line', (tester) async {
+          prepareBoringImageHttpClient();
           const name = 'Short name';
           final selfUser = eg.user(fullName: name);
           await setupPage(tester, selfUser: selfUser, users: [],
             dmMessages: [eg.dmMessage(from: selfUser, to: [])]);
           checkTitle(tester, name, 1);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('very long name takes two lines (must be ellipsized)', (tester) async {
+          prepareBoringImageHttpClient();
           const name = 'Long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name';
           final selfUser = eg.user(fullName: name);
           await setupPage(tester, selfUser: selfUser, users: [],
             dmMessages: [eg.dmMessage(from: selfUser, to: [])]);
           checkTitle(tester, name, 2);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         group('User status', () {
           testWidgets('emoji & text are set -> emoji is displayed, text is not', (tester) async {
+            prepareBoringImageHttpClient();
             final message = eg.dmMessage(from: eg.selfUser, to: []);
             await setupPage(tester, dmMessages: [message], users: []);
             await store.changeUserStatus(eg.selfUser.userId, UserStatusChange(
@@ -253,9 +269,11 @@ void main() {
 
             checkFindsStatusEmoji(tester, find.text('\u{1f6e0}'));
             check(find.textContaining('Busy')).findsNothing();
+            debugNetworkImageHttpClientProvider = null;
           });
 
           testWidgets('emoji is not set, text is set -> text is not displayed', (tester) async {
+            prepareBoringImageHttpClient();
             final message = eg.dmMessage(from: eg.selfUser, to: []);
             await setupPage(tester, dmMessages: [message], users: []);
             await store.changeUserStatus(eg.selfUser.userId, UserStatusChange(
@@ -263,31 +281,37 @@ void main() {
             await tester.pump();
 
             check(find.textContaining('Busy')).findsNothing();
+            debugNetworkImageHttpClientProvider = null;
           });
         });
 
         testWidgets('unread counts', (tester) async {
+          prepareBoringImageHttpClient();
           final message = eg.dmMessage(from: eg.selfUser, to: []);
           await setupPage(tester, users: [], dmMessages: [message]);
 
           checkUnreadCount(tester, 1);
           await markMessageAsRead(tester, message);
           checkUnreadCount(tester, 0);
+          debugNetworkImageHttpClientProvider = null;
         });
       });
 
       group('1:1', () {
         group('has right title/avatar', () {
           testWidgets('non-muted user', (tester) async {
+            prepareBoringImageHttpClient();
             final user = eg.user(userId: 1);
             final message = eg.dmMessage(from: eg.selfUser, to: [user]);
             await setupPage(tester, users: [user], dmMessages: [message]);
 
             checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
             checkTitle(tester, user.fullName);
+            debugNetworkImageHttpClientProvider = null;
           });
 
           testWidgets('muted user', (tester) async {
+            prepareBoringImageHttpClient();
             final user = eg.user(userId: 1);
             final message = eg.dmMessage(from: eg.selfUser, to: [user]);
             await setupPage(tester,
@@ -297,10 +321,12 @@ void main() {
 
             final narrow = DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId);
             check(findConversationItem(narrow)).findsNothing();
+            debugNetworkImageHttpClientProvider = null;
           });
         });
 
         testWidgets('no error when user somehow missing from user store', (tester) async {
+          prepareBoringImageHttpClient();
           final user = eg.user(userId: 1);
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester,
@@ -310,24 +336,30 @@ void main() {
 
           checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
           checkTitle(tester, '(unknown user)');
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('short name takes one line', (tester) async {
+          prepareBoringImageHttpClient();
           final user = eg.user(userId: 1, fullName: 'Short name');
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester, users: [user], dmMessages: [message]);
           checkTitle(tester, user.fullName, 1);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('very long name takes two lines (must be ellipsized)', (tester) async {
+          prepareBoringImageHttpClient();
           final user = eg.user(userId: 1, fullName: 'Long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name long name');
           final message = eg.dmMessage(from: eg.selfUser, to: [user]);
           await setupPage(tester, users: [user], dmMessages: [message]);
           checkTitle(tester, user.fullName, 2);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         group('User status', () {
           testWidgets('emoji & text are set -> emoji is displayed, text is not', (tester) async {
+            prepareBoringImageHttpClient();
             final user = eg.user();
             final message = eg.dmMessage(from: eg.selfUser, to: [user]);
             await setupPage(tester, users: [user], dmMessages: [message]);
@@ -339,9 +371,11 @@ void main() {
 
             checkFindsStatusEmoji(tester, find.text('\u{1f6e0}'));
             check(find.textContaining('Busy')).findsNothing();
+            debugNetworkImageHttpClientProvider = null;
           });
 
           testWidgets('emoji is not set, text is set -> text is not displayed', (tester) async {
+            prepareBoringImageHttpClient();
             final user = eg.user();
             final message = eg.dmMessage(from: eg.selfUser, to: [user]);
             await setupPage(tester, users: [user], dmMessages: [message]);
@@ -350,16 +384,19 @@ void main() {
             await tester.pump();
 
             check(find.textContaining('Busy')).findsNothing();
+            debugNetworkImageHttpClientProvider = null;
           });
         });
 
         testWidgets('unread counts', (tester) async {
+          prepareBoringImageHttpClient();
           final message = eg.dmMessage(from: eg.otherUser, to: [eg.selfUser]);
           await setupPage(tester, users: [], dmMessages: [message]);
 
           checkUnreadCount(tester, 1);
           await markMessageAsRead(tester, message);
           checkUnreadCount(tester, 0);
+          debugNetworkImageHttpClientProvider = null;
         });
       });
 
@@ -374,6 +411,7 @@ void main() {
 
         group('has right title/avatar', () {
           testWidgets('no users muted', (tester) async {
+            prepareBoringImageHttpClient();
             final users = usersList(2);
             final user0 = users[0];
             final user1 = users[1];
@@ -382,9 +420,11 @@ void main() {
 
             checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
             checkTitle(tester, '${user0.fullName}, ${user1.fullName}');
+            debugNetworkImageHttpClientProvider = null;
           });
 
           testWidgets('some users muted', (tester) async {
+            prepareBoringImageHttpClient();
             final users = usersList(2);
             final user0 = users[0];
             final user1 = users[1];
@@ -396,9 +436,11 @@ void main() {
 
             checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
             checkTitle(tester, 'Muted user, ${user1.fullName}');
+            debugNetworkImageHttpClientProvider = null;
           });
 
           testWidgets('all users muted', (tester) async {
+            prepareBoringImageHttpClient();
             final users = usersList(2);
             final user0 = users[0];
             final user1 = users[1];
@@ -410,10 +452,12 @@ void main() {
 
             final narrow = DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId);
             check(findConversationItem(narrow)).findsNothing();
+            debugNetworkImageHttpClientProvider = null;
           });
         });
 
         testWidgets('no error when one user somehow missing from user store', (tester) async {
+          prepareBoringImageHttpClient();
           final users = usersList(2);
           final user0 = users[0];
           final user1 = users[1];
@@ -425,23 +469,29 @@ void main() {
 
           checkAvatar(tester, DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId));
           checkTitle(tester, '${user0.fullName}, (unknown user)');
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('few names takes one line', (tester) async {
+          prepareBoringImageHttpClient();
           final users = usersList(2);
           final message = eg.dmMessage(from: eg.selfUser, to: users);
           await setupPage(tester, users: users, dmMessages: [message]);
           checkTitle(tester, users.map((u) => u.fullName).join(', '), 1);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('very many names takes two lines (must be ellipsized)', (tester) async {
+          prepareBoringImageHttpClient();
           final users = usersList(40);
           final message = eg.dmMessage(from: eg.selfUser, to: users);
           await setupPage(tester, users: users, dmMessages: [message]);
           checkTitle(tester, users.map((u) => u.fullName).join(', '), 2);
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('status emoji & text are set -> none of them is displayed', (tester) async {
+          prepareBoringImageHttpClient();
           final users = usersList(4);
           final message = eg.dmMessage(from: eg.selfUser, to: users);
           await setupPage(tester, users: users, dmMessages: [message]);
@@ -453,15 +503,18 @@ void main() {
 
           check(find.text('\u{1f6e0}')).findsNothing();
           check(find.textContaining('Busy')).findsNothing();
+          debugNetworkImageHttpClientProvider = null;
         });
 
         testWidgets('unread counts', (tester) async {
+          prepareBoringImageHttpClient();
           final message = eg.dmMessage(from: eg.thirdUser, to: [eg.selfUser, eg.otherUser]);
           await setupPage(tester, users: [], dmMessages: [message]);
 
           checkUnreadCount(tester, 1);
           await markMessageAsRead(tester, message);
           checkUnreadCount(tester, 0);
+          debugNetworkImageHttpClientProvider = null;
         });
       });
     });
@@ -471,6 +524,7 @@ void main() {
         required DmMessage message,
         required List<User> users
       }) async {
+        prepareBoringImageHttpClient();
         final expectedNarrow = DmNarrow.ofMessage(message, selfUserId: eg.selfUser.userId);
         final pushedRoutes = <Route<dynamic>>[];
         final testNavObserver = TestNavigatorObserver()
@@ -486,6 +540,7 @@ void main() {
         check(pushedRoutes).last.isA<WidgetRoute>().page
           .isA<MessageListPage>()
           .initNarrow.equals(expectedNarrow);
+        debugNetworkImageHttpClientProvider = null;
       }
 
       testWidgets('1:1', (tester) async {

--- a/test/widgets/store_test.dart
+++ b/test/widgets/store_test.dart
@@ -17,6 +17,7 @@ import '../model/binding.dart';
 import '../example_data.dart' as eg;
 import '../model/store_checks.dart';
 import '../model/test_store.dart';
+import '../test_images.dart';
 import '../test_navigation.dart';
 
 /// A widget whose state uses [PerAccountStoreAwareStateMixin].
@@ -279,6 +280,7 @@ void main() {
       await tester.pump();
     }
 
+    prepareBoringImageHttpClient();
     addTearDown(testBinding.reset);
 
     final user1 = eg.user();
@@ -335,6 +337,8 @@ void main() {
     check(findAccount1PageContent).findsNothing();
     check(findLoadingPage).findsNothing();
     check(findAccount2PageContent).findsOne();
+
+    debugNetworkImageHttpClientProvider = null;
   });
 
   testWidgets('PerAccountStoreAwareStateMixin', (tester) async {

--- a/test/widgets/subscription_list_test.dart
+++ b/test/widgets/subscription_list_test.dart
@@ -16,6 +16,7 @@ import 'package:zulip/widgets/counter_badge.dart';
 import '../flutter_checks.dart';
 import '../model/binding.dart';
 import '../example_data.dart' as eg;
+import '../test_images.dart';
 import 'test_app.dart';
 
 void main() {
@@ -59,12 +60,14 @@ void main() {
   }
 
   testWidgets('empty', (tester) async {
+    prepareBoringImageHttpClient();
     await setupStreamListPage(tester, subscriptions: []);
     check(getItemCount()).equals(0);
     check(isPinnedHeaderInTree()).isFalse();
     check(isUnpinnedHeaderInTree()).isFalse();
     check(find.text('You’re not subscribed to any channels yet.')).findsOne();
     check(find.text('Try going to All channels and joining some of them.')).findsOne();
+    debugNetworkImageHttpClientProvider = null;
   });
 
   testWidgets('basic subscriptions', (tester) async {


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip-flutter/issues/1606.

ZulipAppBar.titleSpacing is dropped because, now with the realm icon
leading widget, the gap between title and leading icon would be unusual
on Android where the title is not center-ed.

The home page now always renders a network image (the realm icon),
so widget tests must install a fake image HTTP client with
prepareBoringImageHttpClient; add that to the affected tests.

| Inbox (Circular) | Inbox (Square) | Channels | DMs |
| - | - | - | - |
| <img width="1080" height="2340" alt="flutter_02" src="https://github.com/user-attachments/assets/799a48f1-8627-43b0-a430-2ea6b2a342dc" /> | <img width="1080" height="2340" alt="flutter_01" src="https://github.com/user-attachments/assets/a9365379-5492-485f-a0ea-e57a3f1c4e99" /> | <img width="1080" height="2340" alt="flutter_03" src="https://github.com/user-attachments/assets/09ebc4c7-83c4-4b28-86e8-dd2d4cd9c3c1" /> | <img width="1080" height="2340" alt="flutter_04" src="https://github.com/user-attachments/assets/faf18b8a-b74a-4f6b-a4b0-36a89bb1e095" /> |



