### PR TITLE
theme: Choose channel colors client-side for unsubscribed channels 

### DIFF
--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -46,6 +46,21 @@ mixin ChannelStore on UserStore {
   /// All the channel folders, including archived ones, indexed by ID.
   Map<int, ChannelFolder> get channelFolders;
 
+  /// The base color to use for the given channel, as 0xffRRGGBB.
+  ///
+  /// For a channel the self-user is subscribed to, this is
+  /// [Subscription.color], the color the server holds for the subscription.
+  ///
+  /// The server assigns a color only on subscribing.  For other channels,
+  /// we choose a color client-side from [kChannelColorPalette],
+  /// the way the web app does: avoiding colors already claimed by
+  /// other channels, until the palette runs out.
+  /// The choice lasts for the lifetime of this store,
+  /// like web's choices last for the lifetime of a page.
+  ///
+  /// Returns null if the channel isn't known to the store.
+  int? channelColor(int channelId);
+
   static int compareChannelsByName(ZulipStream a, ZulipStream b) {
     // A user gave feedback wanting zulip-flutter to match web in putting
     // emoji-prefixed channels first; see #1202.
@@ -407,6 +422,9 @@ mixin ProxyChannelStore on ChannelStore {
   Map<int, ChannelFolder> get channelFolders => channelStore.channelFolders;
 
   @override
+  int? channelColor(int channelId) => channelStore.channelColor(channelId);
+
+  @override
   UserTopicVisibilityPolicy topicVisibilityPolicy(int streamId, TopicName topic) =>
     channelStore.topicVisibilityPolicy(streamId, topic);
 
@@ -426,6 +444,19 @@ abstract class HasChannelStore extends HasUserStore with ChannelStore, ProxyChan
   @override
   final ChannelStore channelStore;
 }
+
+/// The palette the web app assigns channel colors from, as 0xffRRGGBB.
+///
+/// See:
+///   https://github.com/zulip/zulip/blob/c6d410659/web/src/color_data.ts#L6-L31
+const kChannelColorPalette = [
+  0xff76ce90, 0xfffae589, 0xffa6c7e5, 0xffe79ab5,
+  0xffbfd56f, 0xfff4ae55, 0xffb0a5fd, 0xffaddfe5,
+  0xfff5ce6e, 0xffc2726a, 0xff94c849, 0xffbd86e5,
+  0xffee7e4a, 0xffa6dcbf, 0xff95a5fd, 0xff53a063,
+  0xff9987e1, 0xffe4523d, 0xffc2c2c2, 0xff4f8de4,
+  0xffc6a8ad, 0xffe7cc4d, 0xffc8bebf, 0xffa47462,
+];
 
 /// The implementation of [ChannelStore] that does the work.
 ///
@@ -475,7 +506,11 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
     required this.subscriptions,
     required this.channelFolders,
     required this.topicVisibility,
-  });
+  }) {
+    for (final subscription in subscriptions.values) {
+      _claimChannelColor(subscription.color);
+    }
+  }
 
   @override
   final Map<int, ZulipStream> streams;
@@ -485,6 +520,81 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
   final Map<int, Subscription> subscriptions;
   @override
   final Map<int, ChannelFolder> channelFolders;
+
+  @override
+  int? channelColor(int channelId) {
+    return switch (streams[channelId]) {
+      Subscription(:final color) => color,
+      ZulipStream() => _clientChannelColors[channelId] ??= _pickChannelColor(),
+      null => null,
+    };
+  }
+
+  /// The colors chosen client-side for unsubscribed channels, by channel ID.
+  final Map<int, int> _clientChannelColors = {};
+
+  /// The palette colors available for [_pickChannelColor] to choose from.
+  ///
+  /// A color is removed when a channel claims it,
+  /// and once all colors have been claimed the whole palette
+  /// becomes available again (see [_claimChannelColor]).
+  late final List<int> _unusedChannelColors = _shuffledChannelColors.toList();
+
+  /// The palette, in the order this store draws colors from it.
+  ///
+  /// Like web, we shuffle the palette to prevent bias
+  /// toward "early" colors:
+  ///   https://github.com/zulip/zulip/blob/c6d410659/web/src/color_data.ts#L33-L36
+  /// Web shuffles once per page load; we shuffle once per store.
+  final List<int> _shuffledChannelColors = _shuffleChannelColors();
+
+  static List<int> _shuffleChannelColors() {
+    final colors = kChannelColorPalette.toList(growable: false);
+    if (!debugDisableColorShuffle) colors.shuffle();
+    return colors;
+  }
+
+  /// In debug mode, controls whether the channel color palette
+  /// is shuffled, for use by tests that need deterministic choices.
+  ///
+  /// Outside of debug mode, this is always false and the setter
+  /// has no effect.
+  static bool get debugDisableColorShuffle {
+    bool result = false;
+    assert(() {
+      result = _debugDisableColorShuffle;
+      return true;
+    }());
+    return result;
+  }
+  static bool _debugDisableColorShuffle = false;
+  static set debugDisableColorShuffle(bool value) {
+    assert(() {
+      _debugDisableColorShuffle = value;
+      return true;
+    }());
+  }
+
+  /// Choose a color for a channel the server doesn't assign one to.
+  ///
+  /// Web picks the same way:
+  ///   https://github.com/zulip/zulip/blob/c6d410659/web/src/color_data.ts#L33-L57
+  /// except that web picks eagerly, for all channels,
+  /// as it loads channel data;
+  /// we pick lazily, when a channel's color is first asked for.
+  int _pickChannelColor() {
+    final color = _unusedChannelColors.first;
+    _claimChannelColor(color);
+    return color;
+  }
+
+  void _claimChannelColor(int color) {
+    _unusedChannelColors.remove(color);
+    if (_unusedChannelColors.isEmpty) {
+      // All palette colors are in use; start the palette over, like web.
+      _unusedChannelColors.addAll(_shuffledChannelColors);
+    }
+  }
 
   @override
   Map<int, TopicKeyedMap<UserTopicVisibilityPolicy>> get debugTopicVisibility => topicVisibility;
@@ -600,6 +710,7 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
           streams[subscription.streamId] = subscription;
           streamsByName[subscription.name] = subscription;
           subscriptions[subscription.streamId] = subscription;
+          _claimChannelColor(subscription.color);
         }
 
       case SubscriptionRemoveEvent():
@@ -624,6 +735,7 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
         switch (event.property) {
           case SubscriptionProperty.color:
             subscription.color                  = event.value as int;
+            _claimChannelColor(subscription.color);
           case SubscriptionProperty.isMuted:
             // TODO(#1255) update [MessageListView] if affected
             subscription.isMuted                = event.value as bool;

--- a/lib/widgets/all_channels.dart
+++ b/lib/widgets/all_channels.dart
@@ -95,7 +95,6 @@ class AllChannelsListEntry extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final designVariables = DesignVariables.of(context);
     final channel = this.channel;
-    final Subscription? subscription = channel is Subscription ? channel : null;
     final hasContentAccess = store.selfHasContentAccess(channel);
 
     return InkWell(
@@ -108,7 +107,7 @@ class AllChannelsListEntry extends StatelessWidget {
           child: Row(spacing: 6, children: [
             Icon(
               size: 20,
-              color: colorSwatchFor(context, subscription).iconOnPlainBackground,
+              color: colorSwatchFor(context, channel.streamId).iconOnPlainBackground,
               iconDataForStream(channel)),
             Expanded(
               child: Text(

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -392,7 +392,7 @@ class _ChannelLinkAutocompleteItem extends StatelessWidget {
         padding: EdgeInsetsDirectional.fromSTEB(12, 4, 10, 4),
         child: Row(spacing: 10, children: [
           SizedBox.square(dimension: 24, child: Icon(iconDataForStream(channel),
-            size: 18, color: colorSwatchFor(context, store.subscriptions[channel.streamId]))),
+            size: 18, color: colorSwatchFor(context, channel.streamId))),
           Expanded(child: Text(channel.name,
             overflow: TextOverflow.ellipsis,
             style: TextStyle(

--- a/lib/widgets/counter_badge.dart
+++ b/lib/widgets/counter_badge.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-import 'store.dart';
 import 'text.dart';
 import 'theme.dart';
 
@@ -40,7 +39,6 @@ class CounterBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final store = PerAccountStoreWidget.of(context);
     final designVariables = DesignVariables.of(context);
 
     final Color textColor;
@@ -48,8 +46,7 @@ class CounterBadge extends StatelessWidget {
     if (channelIdForBackground != null) {
       textColor = designVariables.unreadCountBadgeTextForChannel;
 
-      final subscription = store.subscriptions[channelIdForBackground!];
-      final swatch = colorSwatchFor(context, subscription);
+      final swatch = colorSwatchFor(context, channelIdForBackground!);
       backgroundColor = swatch.unreadCountBadgeBackground;
     } else {
       textColor = switch (kind) {

--- a/lib/widgets/inbox.dart
+++ b/lib/widgets/inbox.dart
@@ -443,7 +443,7 @@ class InboxChannelHeaderItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
 
-    final swatch = colorSwatchFor(context, subscription);
+    final swatch = colorSwatchFor(context, subscription.streamId);
 
     Widget result = Material(
       // The Figma uses a gradient background, which we decided we didn't like:
@@ -560,8 +560,7 @@ class InboxTopicItem extends StatelessWidget {
       :topic, :count, :hasMention, :lastUnreadId) = data;
 
     final store = PerAccountStoreWidget.of(context);
-    final subscription = store.subscriptions[streamId];
-    final swatch = colorSwatchFor(context, subscription);
+    final swatch = colorSwatchFor(context, streamId);
 
     final designVariables = DesignVariables.of(context);
     final visibilityIcon = iconDataForTopicVisibilityPolicy(

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -453,7 +453,6 @@ class _MessageListPageState extends State<MessageListPage> implements MessageLis
 //   to customize by composition in a reasonable way.
 abstract class _MessageListAppBar {
   static AppBar build(BuildContext context, {required Narrow narrow}) {
-    final store = PerAccountStoreWidget.of(context);
     final messageListTheme = MessageListTheme.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
@@ -468,9 +467,8 @@ abstract class _MessageListAppBar {
 
       case ChannelNarrow(:final channelId):
       case TopicNarrow(:final channelId):
-        final subscription = store.subscriptions[channelId];
         appBarBackgroundColor =
-          colorSwatchFor(context, subscription).barBackground;
+          colorSwatchFor(context, channelId).barBackground;
         // All recipient headers will match this color; remove distracting line
         // (but are recipient headers even needed for topic narrows?)
         removeAppBarBottomBorder = true;
@@ -584,7 +582,6 @@ class MessageListAppBarTitle extends StatelessWidget {
   Widget _buildStreamRow(BuildContext context, {
     ZulipStream? stream,
   }) {
-    final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
     // A null [Icon.icon] makes a blank space.
@@ -592,7 +589,7 @@ class MessageListAppBarTitle extends StatelessWidget {
     Color? iconColor;
     if (stream != null) {
       icon = iconDataForStream(stream);
-      iconColor = colorSwatchFor(context, store.subscriptions[stream.streamId])
+      iconColor = colorSwatchFor(context, stream.streamId)
         .iconOnBarBackground;
     }
 
@@ -1870,7 +1867,7 @@ class StreamMessageRecipientHeader extends StatelessWidget {
     final streamId = message.conversation.streamId;
     final topic = message.conversation.topic;
 
-    final swatch = colorSwatchFor(context, store.subscriptions[streamId]);
+    final swatch = colorSwatchFor(context, streamId);
     final backgroundColor = swatch.barBackground;
     final iconColor = swatch.iconOnBarBackground;
 

--- a/lib/widgets/subscription_list.dart
+++ b/lib/widgets/subscription_list.dart
@@ -292,7 +292,7 @@ class SubscriptionItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final designVariables = DesignVariables.of(context);
 
-    final swatch = colorSwatchFor(context, subscription);
+    final swatch = colorSwatchFor(context, subscription.streamId);
     final hasUnreads = (unreadCount > 0);
     final opacity = subscription.isMuted ? 0.55 : 1.0;
     return Material(

--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -886,8 +886,7 @@ InlineSpan channelTopicLabelSpan({
   final zulipLocalizations = ZulipLocalizations.of(context);
   final store = PerAccountStoreWidget.of(context);
   final channel = store.streams[channelId];
-  final subscription = store.subscriptions[channelId];
-  final swatch = colorSwatchFor(context, subscription);
+  final swatch = colorSwatchFor(context, channelId);
   final channelIcon = channel != null ? iconDataForStream(channel) : null;
   final baselineType = localizedTextBaseline(context);
 

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../api/model/model.dart';
+import '../model/channel.dart';
 import '../model/settings.dart';
 import 'compose_box.dart';
 import 'content.dart';
@@ -915,15 +915,19 @@ const kDefaultChannelColorSwatchBaseColor = 0xffc2c2c2;
 
 /// The theme-appropriate [ChannelColorSwatch] for the given channel ID.
 ///
-/// For a channel the self-user is subscribed to,
-/// this is based on [Subscription.color].
+/// This is based on the channel's base color from the store;
+/// see [ChannelStore.channelColor].
+/// If [channelId] is null or the channel isn't in the store,
+/// it's based on [kDefaultChannelColorSwatchBaseColor].
 ///
 /// For how this value is cached, see [ChannelColorSwatches.forBaseColor].
-// TODO(#188) pick different colors for unsubscribed channels
 ChannelColorSwatch colorSwatchFor(BuildContext context, int? channelId) {
-  final subscription = channelId == null
-    ? null : PerAccountStoreWidget.of(context).subscriptions[channelId];
-  return DesignVariables.of(context)
-    .channelColorSwatches.forBaseColor(
-      subscription?.color ?? kDefaultChannelColorSwatchBaseColor);
+  final swatches = DesignVariables.of(context).channelColorSwatches;
+  final channelBaseColor = channelId == null
+    ? null : PerAccountStoreWidget.of(context).channelColor(channelId);
+  if (channelBaseColor == null) {
+    // No channel, or a channel not known to the store.
+    return swatches.forBaseColor(kDefaultChannelColorSwatchBaseColor);
+  }
+  return swatches.forBaseColor(channelBaseColor);
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -913,14 +913,16 @@ class DesignVariables extends ThemeExtension<DesignVariables> {
 //   https://github.com/zulip/zulip/blob/b248e2d93/web/src/stream_data.ts#L40
 const kDefaultChannelColorSwatchBaseColor = 0xffc2c2c2;
 
-/// The theme-appropriate [ChannelColorSwatch] based on [subscription.color].
+/// The theme-appropriate [ChannelColorSwatch] for the given channel ID.
 ///
-/// If [subscription] is null, [ChannelColorSwatch] will be based on
-/// [kDefaultChannelColorSwatchBaseColor].
+/// For a channel the self-user is subscribed to,
+/// this is based on [Subscription.color].
 ///
 /// For how this value is cached, see [ChannelColorSwatches.forBaseColor].
 // TODO(#188) pick different colors for unsubscribed channels
-ChannelColorSwatch colorSwatchFor(BuildContext context, Subscription? subscription) {
+ChannelColorSwatch colorSwatchFor(BuildContext context, int? channelId) {
+  final subscription = channelId == null
+    ? null : PerAccountStoreWidget.of(context).subscriptions[channelId];
   return DesignVariables.of(context)
     .channelColorSwatches.forBaseColor(
       subscription?.color ?? kDefaultChannelColorSwatchBaseColor);

--- a/lib/widgets/topic_list.dart
+++ b/lib/widgets/topic_list.dart
@@ -33,10 +33,9 @@ class TopicListPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
-    final appBarBackgroundColor = colorSwatchFor(
-      context, store.subscriptions[channelId]).barBackground;
+    final appBarBackgroundColor = colorSwatchFor(context, channelId)
+      .barBackground;
 
     return PageRoot(child: Scaffold(
       appBar: ZulipAppBar(
@@ -71,8 +70,8 @@ class _TopicListAppBarTitle extends StatelessWidget {
     final designVariables = DesignVariables.of(context);
     final store = PerAccountStoreWidget.of(context);
     final stream = store.streams[channelId];
-    final channelIconColor = colorSwatchFor(context,
-      store.subscriptions[channelId]).iconOnBarBackground;
+    final channelIconColor = colorSwatchFor(context, channelId)
+      .iconOnBarBackground;
 
     // A null [Icon.icon] makes a blank space.
     final icon = stream != null ? iconDataForStream(stream) : null;

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -157,6 +157,98 @@ void main() {
     });
   });
 
+  group('channelColor', () {
+    setUp(() {
+      ChannelStoreImpl.debugDisableColorShuffle = true;
+      addTearDown(() => ChannelStoreImpl.debugDisableColorShuffle = false);
+    });
+
+    test('subscribed channel: server-assigned color', () {
+      final channel = eg.stream();
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [channel],
+        subscriptions: [eg.subscription(channel, color: 0xffff0000)]));
+      check(store.channelColor(channel.streamId)).equals(0xffff0000);
+    });
+
+    test('unknown channel: null', () {
+      final store = eg.store(initialSnapshot: eg.initialSnapshot());
+      check(store.channelColor(eg.stream().streamId)).isNull();
+    });
+
+    test('unsubscribed channel: unused palette color, stable across calls', () {
+      final channel1 = eg.stream();
+      final channel2 = eg.stream();
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [channel1, channel2]));
+      check(store.channelColor(channel1.streamId)).equals(kChannelColorPalette[0]);
+      check(store.channelColor(channel2.streamId)).equals(kChannelColorPalette[1]);
+      check(store.channelColor(channel1.streamId)).equals(kChannelColorPalette[0]);
+    });
+
+    test('skip colors of subscriptions in initial snapshot', () {
+      final subscribed = eg.stream();
+      final unsubscribed = eg.stream();
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [subscribed, unsubscribed],
+        subscriptions: [
+          eg.subscription(subscribed, color: kChannelColorPalette[0])]));
+      check(store.channelColor(unsubscribed.streamId))
+        .equals(kChannelColorPalette[1]);
+    });
+
+    test('skip color claimed by new subscription', () async {
+      final channel1 = eg.stream();
+      final channel2 = eg.stream();
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [channel1, channel2]));
+      await store.addSubscription(
+        eg.subscription(channel1, color: kChannelColorPalette[0]));
+      check(store.channelColor(channel2.streamId))
+        .equals(kChannelColorPalette[1]);
+    });
+
+    test('skip color claimed by subscription color change', () async {
+      final channel1 = eg.stream();
+      final channel2 = eg.stream();
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [channel1, channel2],
+        subscriptions: [
+          eg.subscription(channel1, color: kChannelColorPalette[0])]));
+      await store.handleEvent(SubscriptionUpdateEvent(id: 1,
+        channelId: channel1.streamId,
+        property: SubscriptionProperty.color,
+        value: kChannelColorPalette[1]));
+      check(store.channelColor(channel2.streamId))
+        .equals(kChannelColorPalette[2]);
+    });
+
+    test('with shuffle: distinct palette colors, stable across calls', () {
+      ChannelStoreImpl.debugDisableColorShuffle = false;
+      final channel1 = eg.stream();
+      final channel2 = eg.stream();
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: [channel1, channel2]));
+      final color1 = store.channelColor(channel1.streamId)!;
+      final color2 = store.channelColor(channel2.streamId)!;
+      check(kChannelColorPalette).contains(color1);
+      check(kChannelColorPalette).contains(color2);
+      check(color1).not((it) => it.equals(color2));
+      check(store.channelColor(channel1.streamId)).equals(color1);
+    });
+
+    test('palette starts over when all colors are used', () {
+      final channels = List.generate(kChannelColorPalette.length + 1,
+        (_) => eg.stream());
+      final store = eg.store(initialSnapshot: eg.initialSnapshot(
+        streams: channels));
+      for (final (i, channel) in channels.indexed) {
+        check(store.channelColor(channel.streamId)).equals(
+          kChannelColorPalette[i % kChannelColorPalette.length]);
+      }
+    });
+  });
+
   group('ChannelFolderEvent', () {
     group('add', () {
       test('smoke', () async {

--- a/test/widgets/all_channels_test.dart
+++ b/test/widgets/all_channels_test.dart
@@ -189,8 +189,7 @@ void main() {
         find.descendant(of: findElement, matching: finder);
 
       final icon = tester.widget<Icon>(findInRow(find.byIcon(iconDataForStream(channel))));
-      final maybeSubscription = channel is Subscription ? channel : null;
-      final colorSwatch = colorSwatchFor(element, maybeSubscription);
+      final colorSwatch = colorSwatchFor(element, channel.streamId);
       check(icon).color.equals(colorSwatch.iconOnPlainBackground);
 
       check(findInRow(find.text(channel.name))).findsOne();

--- a/test/widgets/theme_test.dart
+++ b/test/widgets/theme_test.dart
@@ -151,40 +151,52 @@ void main() {
     testWidgets('light–dark animation', (tester) async {
       addTearDown(testBinding.reset);
 
-      final subscription = eg.subscription(eg.stream(), color: baseColor);
+      final channel = eg.stream();
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+        streams: [channel],
+        subscriptions: [eg.subscription(channel, color: baseColor)]));
 
       tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
       addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);
 
-      await tester.pumpWidget(const TestZulipApp());
-      await tester.pump();
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
 
       final element = tester.element(find.byType(Placeholder));
       // Compares all the swatch's members; see [ColorSwatch]'s `operator ==`.
-      check(colorSwatchFor(element, subscription))
+      check(colorSwatchFor(element, channel.streamId))
         .isSameColorSwatchAs(ChannelColorSwatch.light(baseColor));
 
       tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
       await tester.pump();
 
       await tester.pump(kThemeAnimationDuration * 0.4);
-      check(colorSwatchFor(element, subscription))
+      check(colorSwatchFor(element, channel.streamId))
         .isSameColorSwatchAs(ChannelColorSwatch.lerp(
           ChannelColorSwatch.light(baseColor),
           ChannelColorSwatch.dark(baseColor),
           0.4)!);
 
       await tester.pump(kThemeAnimationDuration * 0.6);
-      check(colorSwatchFor(element, subscription))
+      check(colorSwatchFor(element, channel.streamId))
         .isSameColorSwatchAs(ChannelColorSwatch.dark(baseColor));
     });
 
-    testWidgets('fallback to default base color when no subscription', (tester) async {
-      await tester.pumpWidget(const TestZulipApp());
-      await tester.pump();
+    testWidgets('fallback to default base color when channel unknown', (tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
+
       final element = tester.element(find.byType(Placeholder));
       check(colorSwatchFor(element, null)).isSameColorSwatchAs(
         ChannelColorSwatch.light(kDefaultChannelColorSwatchBaseColor));
+      final channelNotInStore = eg.stream();
+      check(colorSwatchFor(element, channelNotInStore.streamId))
+        .isSameColorSwatchAs(
+          ChannelColorSwatch.light(kDefaultChannelColorSwatchBaseColor));
     });
   });
 }

--- a/test/widgets/theme_test.dart
+++ b/test/widgets/theme_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zulip/model/channel.dart';
 import 'package:zulip/model/settings.dart';
 import 'package:zulip/widgets/channel_colors.dart';
 import 'package:zulip/widgets/text.dart';
@@ -181,6 +182,28 @@ void main() {
       await tester.pump(kThemeAnimationDuration * 0.6);
       check(colorSwatchFor(element, channel.streamId))
         .isSameColorSwatchAs(ChannelColorSwatch.dark(baseColor));
+    });
+
+    testWidgets('client-side color for unsubscribed channel', (tester) async {
+      // Regression test for: https://github.com/zulip/zulip-flutter/issues/1848
+      addTearDown(testBinding.reset);
+      ChannelStoreImpl.debugDisableColorShuffle = true;
+      addTearDown(() => ChannelStoreImpl.debugDisableColorShuffle = false);
+      final subscribed = eg.stream();
+      final unsubscribed = eg.stream();
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot(
+        streams: [subscribed, unsubscribed],
+        subscriptions: [
+          eg.subscription(subscribed, color: kChannelColorPalette[0])]));
+      await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id));
+      await tester.pump(); // global store
+      await tester.pump(); // per-account store
+
+      final element = tester.element(find.byType(Placeholder));
+      // An unused palette color; for the details of the choice,
+      // see ChannelStore.channelColor and its tests.
+      check(colorSwatchFor(element, unsubscribed.streamId))
+        .isSameColorSwatchAs(ChannelColorSwatch.light(kChannelColorPalette[1]));
     });
 
     testWidgets('fallback to default base color when channel unknown', (tester) async {


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip-flutter/issues/1848

The server assigns a color only to channels the self-user is subscribed to, so unsubscribed channels (as on the new "All channels" page) were all shown in the same default gray.

Instead, choose a color client-side, the way the web app does: pick an unused color from the same 24-color palette web assigns channel colors from, shuffled to prevent bias toward early colors, and starting the palette over when it runs out.

The assignments live in ChannelStore, so a color choice lasts as long as the event queue.  That makes the store reset the analogue of a page reload on web, where the assignment also resets.  Unlike web, which picks colors for all channels eagerly as it loads channel data, we pick lazily, when a channel's color is first needed.

CZO: https://chat.zulip.org/#narrow/channel/516-mobile-dev-help/topic/Unsubscribed.20channel.20colour/with/2495728

| | Before | After |
|---|---|---|
| All channels (light) | <img width="1206" height="2622" alt="01-all-channels-light" src="https://github.com/user-attachments/assets/eda20d39-ef23-4cc3-af09-37862a678a96" /> | <img width="1206" height="2622" alt="01-all-channels-light" src="https://github.com/user-attachments/assets/67725e27-5c90-4111-a34b-9e63568fc574" /> |
| Unsubscribed channel (light) | <img width="1206" height="2622" alt="02-unsub-channel-light" src="https://github.com/user-attachments/assets/0b70cd5b-f092-4f64-975f-a74ae88714e7" /> | <img width="1206" height="2622" alt="02-unsub-channel-light" src="https://github.com/user-attachments/assets/ef7b3dc9-425d-4f0f-907e-aee2845c00f5" /> |
| All channels (dark) | <img width="1206" height="2622" alt="03-all-channels-dark" src="https://github.com/user-attachments/assets/1feaa6e3-6655-4292-a7bd-2bb53f85d5e2" /> | <img width="1206" height="2622" alt="03-all-channels-dark" src="https://github.com/user-attachments/assets/ab3f39cb-2343-4d58-9306-0e82d20350f8" /> |
| Unsubscribed channel (dark) | <img width="1206" height="2622" alt="04-unsub-channel-dark" src="https://github.com/user-attachments/assets/2d135fac-cfdd-4057-834e-57f36558fbe3" /> | <img width="1206" height="2622" alt="04-unsub-channel-dark" src="https://github.com/user-attachments/assets/55071c4e-056f-4c7b-97ed-7cda828241c4" /> |
