### PR TITLE
provision-vm: Install shellcheck, for the tools/check suite

### DIFF
--- a/tools/provision-vm
+++ b/tools/provision-vm
@@ -55,9 +55,12 @@ fi
 #   package:sodium's build hook compiles libsodium.
 # gh: GitHub CLI, for reading issues and PRs and for
 #   authenticating `git fetch`; see docs/howto/lima.md.
+# ShellCheck: for the `shellcheck` suite in tools/check, which CI runs.
+#   (Capitalized because a comment starting `# shellcheck` is a directive.)
 run_visibly sudo apt-get update
 run_visibly sudo apt-get install -y \
-    curl git unzip xz-utils zip libsqlite3-dev build-essential gh
+    curl git unzip xz-utils zip libsqlite3-dev build-essential gh \
+    shellcheck
 
 rootdir=$(cd "$this_dir"/.. && pwd -P)
 cd "$rootdir"


### PR DESCRIPTION
CI effectively runs the `shellcheck` suite on every push: it invokes tools/check --all, and GitHub's runners happen to ship shellcheck preinstalled.  Install it in the VM too, so that shell-script changes can be checked before pushing rather than found out about in CI.