### PR TITLE
Add reusable ZulipCheckbox widget for #2309

### DIFF
--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -850,3 +850,26 @@ class Toggle extends StatelessWidget {
     );
   }
 }
+
+class ZulipCheckbox extends StatelessWidget {
+  const ZulipCheckbox({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Checkbox(
+      value: value,
+      onChanged: (bool? newValue) {
+        if (newValue != null) {
+          onChanged(newValue);
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements an initial reusable `ZulipCheckbox` widget as a wrapper around Flutter's `Checkbox`, following the existing `Toggle` widget as a starting point.

This is an initial implementation for #2309. I'd appreciate feedback on the public API and whether this aligns with the intended design for this widget.

## Testing

- `dart analyze`