### PR TITLE
notif: Open Android notifications at the message they're for

### DIFF
--- a/android/app/src/main/kotlin/com/zulip/flutter/AndroidNotifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/AndroidNotifications.g.kt
@@ -484,7 +484,15 @@ data class Person (
 data class MessagingStyleMessage (
   val text: String,
   val timestampMs: Long,
-  val person: Person
+  val person: Person,
+  /**
+   * Entries from this message's own extras bundle, like [Notification.extras].
+   *
+   * These round-trip through
+   * [AndroidNotificationHostApi.getActiveNotifications], filtered to the keys
+   * in its `desiredMessageExtras`.
+   */
+  val extras: Map<String, String>
 )
  {
   companion object {
@@ -492,7 +500,8 @@ data class MessagingStyleMessage (
       val text = pigeonVar_list[0] as String
       val timestampMs = pigeonVar_list[1] as Long
       val person = pigeonVar_list[2] as Person
-      return MessagingStyleMessage(text, timestampMs, person)
+      val extras = pigeonVar_list[3] as Map<String, String>
+      return MessagingStyleMessage(text, timestampMs, person, extras)
     }
   }
   fun toList(): List<Any?> {
@@ -500,6 +509,7 @@ data class MessagingStyleMessage (
       text,
       timestampMs,
       person,
+      extras,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -510,7 +520,7 @@ data class MessagingStyleMessage (
       return true
     }
     val other = other as MessagingStyleMessage
-    return AndroidNotificationsPigeonUtils.deepEquals(this.text, other.text) && AndroidNotificationsPigeonUtils.deepEquals(this.timestampMs, other.timestampMs) && AndroidNotificationsPigeonUtils.deepEquals(this.person, other.person)
+    return AndroidNotificationsPigeonUtils.deepEquals(this.text, other.text) && AndroidNotificationsPigeonUtils.deepEquals(this.timestampMs, other.timestampMs) && AndroidNotificationsPigeonUtils.deepEquals(this.person, other.person) && AndroidNotificationsPigeonUtils.deepEquals(this.extras, other.extras)
   }
 
   override fun hashCode(): Int {
@@ -518,10 +528,11 @@ data class MessagingStyleMessage (
     result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.text)
     result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.timestampMs)
     result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.person)
+    result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.extras)
     return result
   }
   override fun toString(): String {
-    return "MessagingStyleMessage(text=$text, timestampMs=$timestampMs, person=$person)"
+    return "MessagingStyleMessage(text=$text, timestampMs=$timestampMs, person=$person, extras=$extras)"
   }
 }
 
@@ -924,19 +935,22 @@ interface AndroidNotificationHostApi {
    * optionally combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`
    * for each notification's [Notification.messagingStyle].
    *
-   * The keys of entries to fetch from notification's extras bundle must be
-   * specified in the [desiredNotificationExtras] list. If this list is empty, then
-   * [Notification.extras] will also be empty. If value of the matched entry
-   * is not of type string or is null, then that entry will be skipped.
+   * The keys of entries to fetch from each notification's own extras bundle
+   * ([Notification.extras]) must be specified in [desiredNotificationExtras],
+   * and those to fetch from each MessagingStyle message's extras bundle
+   * ([MessagingStyleMessage.extras]) in [desiredMessageExtras]. For an empty
+   * list, the corresponding map will also be empty. If the value of a matched
+   * entry is not of type string or is null, then that entry will be skipped.
    *
    * Each notification's [Notification.messagingStyle] is populated only when
-   * [includeMessagingStyle] is true; otherwise it is null.
+   * [includeMessagingStyle] is true; otherwise it is null, and
+   * [desiredMessageExtras] has no effect.
    *
    * See:
    *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
    *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
    */
-  fun getActiveNotifications(desiredNotificationExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification>
+  fun getActiveNotifications(desiredNotificationExtras: List<String>, desiredMessageExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification>
   /**
    * Corresponds to `androidx.core.app.NotificationManagerCompat.cancel`.
    *
@@ -1075,9 +1089,10 @@ interface AndroidNotificationHostApi {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val desiredNotificationExtrasArg = args[0] as List<String>
-            val includeMessagingStyleArg = args[1] as Boolean
+            val desiredMessageExtrasArg = args[1] as List<String>
+            val includeMessagingStyleArg = args[2] as Boolean
             val wrapped: List<Any?> = try {
-              listOf(api.getActiveNotifications(desiredNotificationExtrasArg, includeMessagingStyleArg))
+              listOf(api.getActiveNotifications(desiredNotificationExtrasArg, desiredMessageExtrasArg, includeMessagingStyleArg))
             } catch (exception: Throwable) {
               AndroidNotificationsPigeonUtils.wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/AndroidNotifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/AndroidNotifications.g.kt
@@ -925,7 +925,7 @@ interface AndroidNotificationHostApi {
    * for each notification's [Notification.messagingStyle].
    *
    * The keys of entries to fetch from notification's extras bundle must be
-   * specified in the [desiredExtras] list. If this list is empty, then
+   * specified in the [desiredNotificationExtras] list. If this list is empty, then
    * [Notification.extras] will also be empty. If value of the matched entry
    * is not of type string or is null, then that entry will be skipped.
    *
@@ -936,7 +936,7 @@ interface AndroidNotificationHostApi {
    *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
    *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
    */
-  fun getActiveNotifications(desiredExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification>
+  fun getActiveNotifications(desiredNotificationExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification>
   /**
    * Corresponds to `androidx.core.app.NotificationManagerCompat.cancel`.
    *
@@ -1074,10 +1074,10 @@ interface AndroidNotificationHostApi {
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val desiredExtrasArg = args[0] as List<String>
+            val desiredNotificationExtrasArg = args[0] as List<String>
             val includeMessagingStyleArg = args[1] as Boolean
             val wrapped: List<Any?> = try {
-              listOf(api.getActiveNotifications(desiredExtrasArg, includeMessagingStyleArg))
+              listOf(api.getActiveNotifications(desiredNotificationExtrasArg, includeMessagingStyleArg))
             } catch (exception: Throwable) {
               AndroidNotificationsPigeonUtils.wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/AndroidNotifications.g.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/AndroidNotifications.g.kt
@@ -589,20 +589,27 @@ data class MessagingStyle (
  */
 data class Notification (
   val group: String,
-  val extras: Map<String, String>
+  val extras: Map<String, String>,
+  /**
+   * The notification's messaging style, if any, via
+   * `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
+   */
+  val messagingStyle: MessagingStyle? = null
 )
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): Notification {
       val group = pigeonVar_list[0] as String
       val extras = pigeonVar_list[1] as Map<String, String>
-      return Notification(group, extras)
+      val messagingStyle = pigeonVar_list[2] as MessagingStyle?
+      return Notification(group, extras, messagingStyle)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
       group,
       extras,
+      messagingStyle,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -613,17 +620,18 @@ data class Notification (
       return true
     }
     val other = other as Notification
-    return AndroidNotificationsPigeonUtils.deepEquals(this.group, other.group) && AndroidNotificationsPigeonUtils.deepEquals(this.extras, other.extras)
+    return AndroidNotificationsPigeonUtils.deepEquals(this.group, other.group) && AndroidNotificationsPigeonUtils.deepEquals(this.extras, other.extras) && AndroidNotificationsPigeonUtils.deepEquals(this.messagingStyle, other.messagingStyle)
   }
 
   override fun hashCode(): Int {
     var result = javaClass.hashCode()
     result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.group)
     result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.extras)
+    result = 31 * result + AndroidNotificationsPigeonUtils.deepHash(this.messagingStyle)
     return result
   }
   override fun toString(): String {
-    return "Notification(group=$group, extras=$extras)"
+    return "Notification(group=$group, extras=$extras, messagingStyle=$messagingStyle)"
   }
 }
 
@@ -912,30 +920,23 @@ interface AndroidNotificationHostApi {
    */
   fun notify(tag: String?, id: Long, autoCancel: Boolean?, channelId: String, color: Long?, contentIntent: PendingIntent?, contentText: String?, contentTitle: String?, extras: Map<String, String>?, groupKey: String?, inboxStyle: InboxStyle?, isGroupSummary: Boolean?, messagingStyle: MessagingStyle?, number: Long?, smallIconResourceName: String?)
   /**
-   * Wraps `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
-   * combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
-   *
-   * Returns the messaging style, if any, of an active notification
-   * that has tag `tag`.  If there are several such notifications,
-   * an arbitrary one of them is used.
-   * Returns null if there are no such notifications.
-   *
-   * See:
-   *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getActiveNotifications()
-   *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
-   */
-  fun getActiveNotificationMessagingStyleByTag(tag: String): MessagingStyle?
-  /**
-   * Corresponds to `androidx.core.app.NotificationManagerCompat.getActiveNotifications`.
+   * Corresponds to `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
+   * optionally combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`
+   * for each notification's [Notification.messagingStyle].
    *
    * The keys of entries to fetch from notification's extras bundle must be
    * specified in the [desiredExtras] list. If this list is empty, then
-   * [Notifications.extras] will also be empty. If value of the matched entry
+   * [Notification.extras] will also be empty. If value of the matched entry
    * is not of type string or is null, then that entry will be skipped.
    *
-   * See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
+   * Each notification's [Notification.messagingStyle] is populated only when
+   * [includeMessagingStyle] is true; otherwise it is null.
+   *
+   * See:
+   *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
+   *   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
    */
-  fun getActiveNotifications(desiredExtras: List<String>): List<StatusBarNotification>
+  fun getActiveNotifications(desiredExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification>
   /**
    * Corresponds to `androidx.core.app.NotificationManagerCompat.cancel`.
    *
@@ -1069,30 +1070,14 @@ interface AndroidNotificationHostApi {
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotificationMessagingStyleByTag$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val tagArg = args[0] as String
-            val wrapped: List<Any?> = try {
-              listOf(api.getActiveNotificationMessagingStyleByTag(tagArg))
-            } catch (exception: Throwable) {
-              AndroidNotificationsPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
         val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotifications$separatedMessageChannelSuffix", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val desiredExtrasArg = args[0] as List<String>
+            val includeMessagingStyleArg = args[1] as Boolean
             val wrapped: List<Any?> = try {
-              listOf(api.getActiveNotifications(desiredExtrasArg))
+              listOf(api.getActiveNotifications(desiredExtrasArg, includeMessagingStyleArg))
             } catch (exception: Throwable) {
               AndroidNotificationsPigeonUtils.wrapError(exception)
             }

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -238,7 +238,7 @@ private class AndroidNotificationHost(val context: Context)
         NotificationManagerCompat.from(context).notify(tag, id.toInt(), notification)
     }
 
-    override fun getActiveNotifications(desiredExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification> {
+    override fun getActiveNotifications(desiredNotificationExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification> {
         return NotificationManagerCompat.from(context).activeNotifications.map { statusBarNotification ->
             val notification = statusBarNotification.notification
             val messagingStyle = if (!includeMessagingStyle) null else NotificationCompat.MessagingStyle
@@ -260,7 +260,7 @@ private class AndroidNotificationHost(val context: Context)
                 statusBarNotification.tag,
                 Notification(
                     notification.group,
-                    desiredExtras
+                    desiredNotificationExtras
                         .mapNotNull { key ->
                             notification.extras.getString(key)?.let { value ->
                                 key to value

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -238,15 +238,13 @@ private class AndroidNotificationHost(val context: Context)
         NotificationManagerCompat.from(context).notify(tag, id.toInt(), notification)
     }
 
-    override fun getActiveNotificationMessagingStyleByTag(tag: String): MessagingStyle? {
-        val activeNotification = NotificationManagerCompat.from(context)
-            .activeNotifications
-            .find { it.tag == tag }
-        activeNotification?.notification?.let { notification ->
-            NotificationCompat.MessagingStyle
+    override fun getActiveNotifications(desiredExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification> {
+        return NotificationManagerCompat.from(context).activeNotifications.map { statusBarNotification ->
+            val notification = statusBarNotification.notification
+            val messagingStyle = if (!includeMessagingStyle) null else NotificationCompat.MessagingStyle
                 .extractMessagingStyleFromNotification(notification)
                 ?.let { style ->
-                    return MessagingStyle(
+                    MessagingStyle(
                         toPigeonPerson(style.user),
                         style.conversationTitle!!.toString(),
                         style.messages.map { MessagingStyleMessage(
@@ -257,23 +255,18 @@ private class AndroidNotificationHost(val context: Context)
                         style.isGroupConversation,
                     )
                 }
-        }
-        return null
-    }
-
-    override fun getActiveNotifications(desiredExtras: List<String>): List<StatusBarNotification> {
-        return NotificationManagerCompat.from(context).activeNotifications.map {
             StatusBarNotification(
-                it.id.toLong(),
-                it.tag,
+                statusBarNotification.id.toLong(),
+                statusBarNotification.tag,
                 Notification(
-                    it.notification.group,
+                    notification.group,
                     desiredExtras
                         .mapNotNull { key ->
-                            it.notification.extras.getString(key)?.let { value ->
+                            notification.extras.getString(key)?.let { value ->
                                 key to value
                             } }
-                        .toMap()
+                        .toMap(),
+                    messagingStyle,
                 ),
             )
         }

--- a/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
+++ b/android/app/src/main/kotlin/com/zulip/flutter/ZulipPlugin.kt
@@ -222,12 +222,16 @@ private class AndroidNotificationHost(val context: Context)
                 val style = NotificationCompat.MessagingStyle(toAndroidPerson(messagingStyle.user))
                     .setConversationTitle(messagingStyle.conversationTitle)
                     .setGroupConversation(messagingStyle.isGroupConversation)
-                messagingStyle.messages.forEach {
-                    style.addMessage(NotificationCompat.MessagingStyle.Message(
-                        it.text,
-                        it.timestampMs,
-                        toAndroidPerson(it.person),
-                    ))
+                messagingStyle.messages.forEach { message ->
+                    val androidMessage = NotificationCompat.MessagingStyle.Message(
+                        message.text,
+                        message.timestampMs,
+                        toAndroidPerson(message.person),
+                    )
+                    message.extras.forEach { (key, value) ->
+                        androidMessage.extras.putString(key, value)
+                    }
+                    style.addMessage(androidMessage)
                 }
                 setStyle(style)
             }
@@ -238,7 +242,7 @@ private class AndroidNotificationHost(val context: Context)
         NotificationManagerCompat.from(context).notify(tag, id.toInt(), notification)
     }
 
-    override fun getActiveNotifications(desiredNotificationExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification> {
+    override fun getActiveNotifications(desiredNotificationExtras: List<String>, desiredMessageExtras: List<String>, includeMessagingStyle: Boolean): List<StatusBarNotification> {
         return NotificationManagerCompat.from(context).activeNotifications.map { statusBarNotification ->
             val notification = statusBarNotification.notification
             val messagingStyle = if (!includeMessagingStyle) null else NotificationCompat.MessagingStyle
@@ -247,10 +251,16 @@ private class AndroidNotificationHost(val context: Context)
                     MessagingStyle(
                         toPigeonPerson(style.user),
                         style.conversationTitle!!.toString(),
-                        style.messages.map { MessagingStyleMessage(
-                            it.text!!.toString(),
-                            it.timestamp,
-                            toPigeonPerson(it.person!!)
+                        style.messages.map { message -> MessagingStyleMessage(
+                            message.text!!.toString(),
+                            message.timestamp,
+                            toPigeonPerson(message.person!!),
+                            desiredMessageExtras
+                                .mapNotNull { key ->
+                                    message.extras.getString(key)?.let { value ->
+                                        key to value
+                                    } }
+                                .toMap(),
                         ) },
                         style.isGroupConversation,
                     )

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -417,6 +417,7 @@ class MessagingStyleMessage {
     required this.text,
     required this.timestampMs,
     required this.person,
+    required this.extras,
   });
 
   String text;
@@ -425,11 +426,19 @@ class MessagingStyleMessage {
 
   Person person;
 
+  /// Entries from this message's own extras bundle, like [Notification.extras].
+  ///
+  /// These round-trip through
+  /// [AndroidNotificationHostApi.getActiveNotifications], filtered to the keys
+  /// in its `desiredMessageExtras`.
+  Map<String, String> extras;
+
   List<Object?> _toList() {
     return <Object?>[
       text,
       timestampMs,
       person,
+      extras,
     ];
   }
 
@@ -442,6 +451,7 @@ class MessagingStyleMessage {
       text: result[0]! as String,
       timestampMs: result[1]! as int,
       person: result[2]! as Person,
+      extras: (result[3]! as Map<Object?, Object?>).cast<String, String>(),
     );
   }
 
@@ -454,7 +464,7 @@ class MessagingStyleMessage {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(text, other.text) && _deepEquals(timestampMs, other.timestampMs) && _deepEquals(person, other.person);
+    return _deepEquals(text, other.text) && _deepEquals(timestampMs, other.timestampMs) && _deepEquals(person, other.person) && _deepEquals(extras, other.extras);
   }
 
   @override
@@ -463,7 +473,7 @@ class MessagingStyleMessage {
 
   @override
   String toString() {
-    return 'MessagingStyleMessage(text: $text, timestampMs: $timestampMs, person: $person)';
+    return 'MessagingStyleMessage(text: $text, timestampMs: $timestampMs, person: $person, extras: $extras)';
   }
 }
 
@@ -964,25 +974,28 @@ class AndroidNotificationHostApi {
   /// optionally combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`
   /// for each notification's [Notification.messagingStyle].
   ///
-  /// The keys of entries to fetch from notification's extras bundle must be
-  /// specified in the [desiredNotificationExtras] list. If this list is empty, then
-  /// [Notification.extras] will also be empty. If value of the matched entry
-  /// is not of type string or is null, then that entry will be skipped.
+  /// The keys of entries to fetch from each notification's own extras bundle
+  /// ([Notification.extras]) must be specified in [desiredNotificationExtras],
+  /// and those to fetch from each MessagingStyle message's extras bundle
+  /// ([MessagingStyleMessage.extras]) in [desiredMessageExtras]. For an empty
+  /// list, the corresponding map will also be empty. If the value of a matched
+  /// entry is not of type string or is null, then that entry will be skipped.
   ///
   /// Each notification's [Notification.messagingStyle] is populated only when
-  /// [includeMessagingStyle] is true; otherwise it is null.
+  /// [includeMessagingStyle] is true; otherwise it is null, and
+  /// [desiredMessageExtras] has no effect.
   ///
   /// See:
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
-  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredNotificationExtras, required bool includeMessagingStyle}) async {
+  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredNotificationExtras, required List<String> desiredMessageExtras, required bool includeMessagingStyle, }) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotifications$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[desiredNotificationExtras, includeMessagingStyle]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[desiredNotificationExtras, desiredMessageExtras, includeMessagingStyle]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -537,16 +537,22 @@ class Notification {
   Notification({
     required this.group,
     required this.extras,
+    this.messagingStyle,
   });
 
   String group;
 
   Map<String, String> extras;
 
+  /// The notification's messaging style, if any, via
+  /// `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
+  MessagingStyle? messagingStyle;
+
   List<Object?> _toList() {
     return <Object?>[
       group,
       extras,
+      messagingStyle,
     ];
   }
 
@@ -558,6 +564,7 @@ class Notification {
     return Notification(
       group: result[0]! as String,
       extras: (result[1]! as Map<Object?, Object?>).cast<String, String>(),
+      messagingStyle: result[2] as MessagingStyle?,
     );
   }
 
@@ -570,7 +577,7 @@ class Notification {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(group, other.group) && _deepEquals(extras, other.extras);
+    return _deepEquals(group, other.group) && _deepEquals(extras, other.extras) && _deepEquals(messagingStyle, other.messagingStyle);
   }
 
   @override
@@ -579,7 +586,7 @@ class Notification {
 
   @override
   String toString() {
-    return 'Notification(group: $group, extras: $extras)';
+    return 'Notification(group: $group, extras: $extras, messagingStyle: $messagingStyle)';
   }
 }
 
@@ -953,52 +960,29 @@ class AndroidNotificationHostApi {
     ;
   }
 
-  /// Wraps `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
-  /// combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
-  ///
-  /// Returns the messaging style, if any, of an active notification
-  /// that has tag `tag`.  If there are several such notifications,
-  /// an arbitrary one of them is used.
-  /// Returns null if there are no such notifications.
-  ///
-  /// See:
-  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getActiveNotifications()
-  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
-  Future<MessagingStyle?> getActiveNotificationMessagingStyleByTag(String tag) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotificationMessagingStyleByTag$pigeonVar_messageChannelSuffix';
-    final pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[tag]);
-    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
-
-    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
-    return pigeonVar_replyValue as MessagingStyle?;
-  }
-
-  /// Corresponds to `androidx.core.app.NotificationManagerCompat.getActiveNotifications`.
+  /// Corresponds to `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
+  /// optionally combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`
+  /// for each notification's [Notification.messagingStyle].
   ///
   /// The keys of entries to fetch from notification's extras bundle must be
   /// specified in the [desiredExtras] list. If this list is empty, then
-  /// [Notifications.extras] will also be empty. If value of the matched entry
+  /// [Notification.extras] will also be empty. If value of the matched entry
   /// is not of type string or is null, then that entry will be skipped.
   ///
-  /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
-  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredExtras}) async {
+  /// Each notification's [Notification.messagingStyle] is populated only when
+  /// [includeMessagingStyle] is true; otherwise it is null.
+  ///
+  /// See:
+  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
+  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
+  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredExtras, required bool includeMessagingStyle}) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotifications$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[desiredExtras]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[desiredExtras, includeMessagingStyle]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(

--- a/lib/host/android_notifications.g.dart
+++ b/lib/host/android_notifications.g.dart
@@ -965,7 +965,7 @@ class AndroidNotificationHostApi {
   /// for each notification's [Notification.messagingStyle].
   ///
   /// The keys of entries to fetch from notification's extras bundle must be
-  /// specified in the [desiredExtras] list. If this list is empty, then
+  /// specified in the [desiredNotificationExtras] list. If this list is empty, then
   /// [Notification.extras] will also be empty. If value of the matched entry
   /// is not of type string or is null, then that entry will be skipped.
   ///
@@ -975,14 +975,14 @@ class AndroidNotificationHostApi {
   /// See:
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
-  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredExtras, required bool includeMessagingStyle}) async {
+  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredNotificationExtras, required bool includeMessagingStyle}) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.zulip.AndroidNotificationHostApi.getActiveNotifications$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[desiredExtras, includeMessagingStyle]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[desiredNotificationExtras, includeMessagingStyle]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -237,7 +237,7 @@ class NotificationDisplayManager {
 
     final activeNotifications =
       await _androidHost.getActiveNotifications(
-        desiredExtras: const [], includeMessagingStyle: true);
+        desiredNotificationExtras: const [], includeMessagingStyle: true);
     final oldNotification =
       activeNotifications.firstWhereOrNull((notif) => notif.tag == conversationKey);
     final oldMessagingStyle = oldNotification?.notification.messagingStyle;
@@ -362,7 +362,7 @@ class NotificationDisplayManager {
     //   https://github.com/zulip/zulip-mobile/pull/4842#pullrequestreview-725817909
     var haveRemaining = false;
     final activeNotifications = await _androidHost.getActiveNotifications(
-      desiredExtras: [kExtraLastMessageId], includeMessagingStyle: false);
+      desiredNotificationExtras: [kExtraLastMessageId], includeMessagingStyle: false);
     for (final statusBarNotification in activeNotifications) {
       // The StatusBarNotification object describes an active notification in the UI.
       // Its `.tag`, `.id`, and `.notification` are the same values as we passed to
@@ -452,7 +452,7 @@ class NotificationDisplayManager {
 
     final groupKey = _groupKey(realmUrl, userId);
     final activeNotifications = await _androidHost.getActiveNotifications(
-      desiredExtras: [], includeMessagingStyle: false);
+      desiredNotificationExtras: [], includeMessagingStyle: false);
     for (final statusBarNotification in activeNotifications) {
       if (statusBarNotification.notification.group == groupKey) {
         await _androidHost.cancel(

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
@@ -234,8 +235,12 @@ class NotificationDisplayManager {
     final groupKey = _groupKey(data.realmUrl, data.userId);
     final conversationKey = _conversationKey(data, groupKey);
 
-    final oldMessagingStyle = await _androidHost
-      .getActiveNotificationMessagingStyleByTag(conversationKey);
+    final activeNotifications =
+      await _androidHost.getActiveNotifications(
+        desiredExtras: const [], includeMessagingStyle: true);
+    final oldNotification =
+      activeNotifications.firstWhereOrNull((notif) => notif.tag == conversationKey);
+    final oldMessagingStyle = oldNotification?.notification.messagingStyle;
 
     final MessagingStyle messagingStyle;
     if (oldMessagingStyle != null) {
@@ -357,7 +362,7 @@ class NotificationDisplayManager {
     //   https://github.com/zulip/zulip-mobile/pull/4842#pullrequestreview-725817909
     var haveRemaining = false;
     final activeNotifications = await _androidHost.getActiveNotifications(
-      desiredExtras: [kExtraLastMessageId]);
+      desiredExtras: [kExtraLastMessageId], includeMessagingStyle: false);
     for (final statusBarNotification in activeNotifications) {
       // The StatusBarNotification object describes an active notification in the UI.
       // Its `.tag`, `.id`, and `.notification` are the same values as we passed to
@@ -447,7 +452,7 @@ class NotificationDisplayManager {
 
     final groupKey = _groupKey(realmUrl, userId);
     final activeNotifications = await _androidHost.getActiveNotifications(
-      desiredExtras: []);
+      desiredExtras: [], includeMessagingStyle: false);
     for (final statusBarNotification in activeNotifications) {
       if (statusBarNotification.notification.group == groupKey) {
         await _androidHost.cancel(

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -235,9 +235,10 @@ class NotificationDisplayManager {
     final groupKey = _groupKey(data.realmUrl, data.userId);
     final conversationKey = _conversationKey(data, groupKey);
 
-    final activeNotifications =
-      await _androidHost.getActiveNotifications(
-        desiredNotificationExtras: const [], includeMessagingStyle: true);
+    final activeNotifications = await _androidHost.getActiveNotifications(
+      desiredNotificationExtras: const [],
+      desiredMessageExtras: const [kExtraZulipMessageId],
+      includeMessagingStyle: true);
     final oldNotification =
       activeNotifications.firstWhereOrNull((notif) => notif.tag == conversationKey);
     final oldMessagingStyle = oldNotification?.notification.messagingStyle;
@@ -273,7 +274,8 @@ class NotificationDisplayManager {
       person: Person(
         key: _personKey(data.realmUrl, data.senderId),
         name: data.senderFullName,
-        iconBitmap: await _fetchBitmap(data.senderAvatarUrl))));
+        iconBitmap: await _fetchBitmap(data.senderAvatarUrl)),
+      extras: {kExtraZulipMessageId: data.messageId.toString()}));
 
     final intentDataUrl = notificationUrlForNotifPayload(data);
 
@@ -362,7 +364,9 @@ class NotificationDisplayManager {
     //   https://github.com/zulip/zulip-mobile/pull/4842#pullrequestreview-725817909
     var haveRemaining = false;
     final activeNotifications = await _androidHost.getActiveNotifications(
-      desiredNotificationExtras: [kExtraLastMessageId], includeMessagingStyle: false);
+      desiredNotificationExtras: const [kExtraLastMessageId],
+      desiredMessageExtras: const [],
+      includeMessagingStyle: false);
     for (final statusBarNotification in activeNotifications) {
       // The StatusBarNotification object describes an active notification in the UI.
       // Its `.tag`, `.id`, and `.notification` are the same values as we passed to
@@ -452,7 +456,9 @@ class NotificationDisplayManager {
 
     final groupKey = _groupKey(realmUrl, userId);
     final activeNotifications = await _androidHost.getActiveNotifications(
-      desiredNotificationExtras: [], includeMessagingStyle: false);
+      desiredNotificationExtras: const [],
+      desiredMessageExtras: const [],
+      includeMessagingStyle: false);
     for (final statusBarNotification in activeNotifications) {
       if (statusBarNotification.notification.group == groupKey) {
         await _androidHost.cancel(
@@ -476,6 +482,13 @@ class NotificationDisplayManager {
   /// clear that specific notification.
   @visibleForTesting
   static const kExtraLastMessageId = 'lastZulipMessageId';
+
+  /// A key we use in [MessagingStyleMessage.extras] for the [Message.id] of
+  /// the Zulip message that message represents.
+  ///
+  /// We use this to open the notification at a specific message (#1565).
+  @visibleForTesting
+  static const kExtraZulipMessageId = 'zulipMessageId';
 
   static String _conversationKey(NotifPayloadNewMessage data, String groupKey) {
     final conversation = switch (data.recipient) {

--- a/lib/notifications/display.dart
+++ b/lib/notifications/display.dart
@@ -243,6 +243,25 @@ class NotificationDisplayManager {
       activeNotifications.firstWhereOrNull((notif) => notif.tag == conversationKey);
     final oldMessagingStyle = oldNotification?.notification.messagingStyle;
 
+    // Choose the anchor for the notification's intent URL;
+    // see [NotificationOpenPayload.messageId].
+    // Each MessagingStyle message carries its Zulip message ID, so we take
+    // the earliest one we have.  Android keeps only the latest
+    // MessagingStyle.MAXIMUM_RETAINED_MESSAGES of the group, so this can be
+    // later than the group's true first, and may not even be shown in the
+    // drawer; that's fine.  See:
+    //   https://developer.android.com/reference/android/app/Notification.MessagingStyle#MAXIMUM_RETAINED_MESSAGES
+    final int firstMessageId;
+    if (oldMessagingStyle == null) {
+      firstMessageId = data.messageId;
+    } else {
+      final firstMessageIdStr =
+        oldMessagingStyle.messages.firstOrNull?.extras[kExtraZulipMessageId];
+      firstMessageId = firstMessageIdStr == null
+        ? data.messageId // TODO(log)
+        : int.parse(firstMessageIdStr, radix: 10);
+    }
+
     final MessagingStyle messagingStyle;
     if (oldMessagingStyle != null) {
       messagingStyle = oldMessagingStyle;
@@ -277,7 +296,7 @@ class NotificationDisplayManager {
         iconBitmap: await _fetchBitmap(data.senderAvatarUrl)),
       extras: {kExtraZulipMessageId: data.messageId.toString()}));
 
-    final intentDataUrl = notificationUrlForNotifPayload(data);
+    final intentDataUrl = notificationUrlForNotifPayload(data, messageId: firstMessageId);
 
     await _androidHost.notify(
       id: kNotificationId,
@@ -439,7 +458,9 @@ class NotificationDisplayManager {
     };
   }
 
-  static Uri notificationUrlForNotifPayload(NotifPayloadNewMessage data) {
+  static Uri notificationUrlForNotifPayload(NotifPayloadNewMessage data, {
+    required int? messageId,
+  }) {
     return NotificationOpenPayload(
       realmUrl: data.realmUrl,
       userId: data.userId,
@@ -448,7 +469,8 @@ class NotificationDisplayManager {
           TopicNarrow(channelId, topic),
         NotifPayloadDmRecipient(:var allRecipientIds) =>
           DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
-      }).buildNotificationUrl();
+      },
+      messageId: messageId).buildNotificationUrl();
   }
 
   static Future<void> removeNotificationsForAccount(Uri realmUrl, int userId) async {

--- a/lib/notifications/ios_service.dart
+++ b/lib/notifications/ios_service.dart
@@ -95,7 +95,8 @@ class _IosNotifFlutterApiImpl extends IosNotifFlutterApi {
     final subtitle =
       NotificationDisplayManager.subtitleForNotifPayloadOnIos(data);
     final notificationUrl =
-      NotificationDisplayManager.notificationUrlForNotifPayload(data);
+      // TODO(#1565): Open at specific message on iOS too.
+      NotificationDisplayManager.notificationUrlForNotifPayload(data, messageId: null);
 
     return ImprovedNotificationContent(
       title: title,

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../api/model/model.dart';
+import '../api/route/messages.dart' show NumericAnchor;
 import '../generated/l10n/zulip_localizations.dart';
 import '../host/notifications.dart';
 import '../log.dart';
@@ -166,8 +167,13 @@ class NotificationOpenService {
       // by opening the notification.
       navigator.popUntil((route) => route is PageRoute);
 
-      // TODO(#1565): Scroll to the specific message if nearby; else jump there,
-      //   or push a new page anchored there.
+      final messageId = data.messageId;
+      if (messageId != null) {
+        // TODO: Scroll to the message if it's already nearby,
+        //   instead of fetching the message list afresh anchored there.
+        MessageListPage.stateOfRoute(currentPageRoute)
+          ?.refresh(NumericAnchor(messageId));
+      }
       return;
     }
 

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -135,8 +135,8 @@ class NotificationOpenService {
 
     return MessageListPage.buildRoute(
       accountId: account.id,
-      // TODO(#1565): Open at specific message, not just conversation
-      narrow: data.narrow);
+      narrow: data.narrow,
+      initAnchorMessageId: data.messageId);
   }
 
   /// Navigate appropriately for opening the given notification.
@@ -176,8 +176,8 @@ class NotificationOpenService {
     }
     unawaited(navigator.push(MessageListPage.buildRoute(
       accountId: account.id,
-      // TODO(#1565): Open at specific message, not just conversation
-      narrow: data.narrow)));
+      narrow: data.narrow,
+      initAnchorMessageId: data.messageId)));
   }
 
   /// Navigate appropriately for opening the notification described by
@@ -269,10 +269,23 @@ class NotificationOpenPayload {
   final int userId;
   final Narrow narrow;
 
+  /// The message to open the message list at,
+  /// or null to open at its default anchor.
+  ///
+  /// When a notification represents several messages in a conversation,
+  /// this is the earliest of them,
+  /// so that opening the notification shows the whole batch (#1565).
+  ///
+  /// Null when the notification doesn't identify a message:
+  /// from iOS (TODO(#1565)),
+  /// or from a notification created before this field existed.
+  final int? messageId;
+
   NotificationOpenPayload({
     required this.realmUrl,
     required this.userId,
     required this.narrow,
+    required this.messageId,
   });
 
   /// A key to set the notification URL (created via [buildNotificationUrl]) in
@@ -357,7 +370,8 @@ class NotificationOpenPayload {
       return NotificationOpenPayload(
         realmUrl: Uri.parse(realmUrl),
         userId: userId,
-        narrow: narrow);
+        narrow: narrow,
+        messageId: null);
     } else {
       // TODO(dart): simplify after https://github.com/dart-lang/language/issues/2537
       throw const FormatException();
@@ -402,10 +416,16 @@ class NotificationOpenPayload {
           throw const FormatException();
       }
 
+      final messageId = switch (url.queryParameters['message_id']) {
+        final messageIdStr? => int.parse(messageIdStr, radix: 10),
+        null => null,
+      };
+
       return NotificationOpenPayload(
         realmUrl: realmUrl,
         userId: userId,
         narrow: narrow,
+        messageId: messageId,
       );
     } else {
       // TODO(dart): simplify after https://github.com/dart-lang/language/issues/2537
@@ -431,7 +451,8 @@ class NotificationOpenPayload {
             'all_recipient_ids': allRecipientIds.join(','),
           },
           _ => throw UnsupportedError('Found an unexpected Narrow of type ${narrow.runtimeType}.'),
-        })
+        }),
+        if (messageId != null) 'message_id': messageId.toString(),
       },
     );
   }

--- a/pigeon/android_notifications.dart
+++ b/pigeon/android_notifications.dart
@@ -137,10 +137,14 @@ class MessagingStyle {
 ///
 /// See: https://developer.android.com/reference/kotlin/android/app/Notification
 class Notification {
-  Notification({required this.group, required this.extras});
+  Notification({required this.group, required this.extras, required this.messagingStyle});
 
   final String group;
   final Map<String, String> extras;
+
+  /// The notification's messaging style, if any, via
+  /// `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
+  final MessagingStyle? messagingStyle;
   // Various other properties too; add them if needed.
 }
 
@@ -276,28 +280,25 @@ abstract class AndroidNotificationHostApi {
     // Keep them alphabetized, for easy comparison with that class's docs.
   });
 
-  /// Wraps `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
-  /// combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`.
-  ///
-  /// Returns the messaging style, if any, of an active notification
-  /// that has tag `tag`.  If there are several such notifications,
-  /// an arbitrary one of them is used.
-  /// Returns null if there are no such notifications.
-  ///
-  /// See:
-  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat#getActiveNotifications()
-  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
-  MessagingStyle? getActiveNotificationMessagingStyleByTag(String tag);
-
-  /// Corresponds to `androidx.core.app.NotificationManagerCompat.getActiveNotifications`.
+  /// Corresponds to `androidx.core.app.NotificationManagerCompat.getActiveNotifications`,
+  /// optionally combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`
+  /// for each notification's [Notification.messagingStyle].
   ///
   /// The keys of entries to fetch from notification's extras bundle must be
   /// specified in the [desiredExtras] list. If this list is empty, then
-  /// [Notifications.extras] will also be empty. If value of the matched entry
+  /// [Notification.extras] will also be empty. If value of the matched entry
   /// is not of type string or is null, then that entry will be skipped.
   ///
-  /// See: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
-  List<StatusBarNotification> getActiveNotifications({required List<String> desiredExtras});
+  /// Each notification's [Notification.messagingStyle] is populated only when
+  /// [includeMessagingStyle] is true; otherwise it is null.
+  ///
+  /// See:
+  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
+  ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
+  List<StatusBarNotification> getActiveNotifications({
+    required List<String> desiredExtras,
+    required bool includeMessagingStyle,
+  });
 
   /// Corresponds to `androidx.core.app.NotificationManagerCompat.cancel`.
   ///

--- a/pigeon/android_notifications.dart
+++ b/pigeon/android_notifications.dart
@@ -285,7 +285,7 @@ abstract class AndroidNotificationHostApi {
   /// for each notification's [Notification.messagingStyle].
   ///
   /// The keys of entries to fetch from notification's extras bundle must be
-  /// specified in the [desiredExtras] list. If this list is empty, then
+  /// specified in the [desiredNotificationExtras] list. If this list is empty, then
   /// [Notification.extras] will also be empty. If value of the matched entry
   /// is not of type string or is null, then that entry will be skipped.
   ///
@@ -296,7 +296,7 @@ abstract class AndroidNotificationHostApi {
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
   List<StatusBarNotification> getActiveNotifications({
-    required List<String> desiredExtras,
+    required List<String> desiredNotificationExtras,
     required bool includeMessagingStyle,
   });
 

--- a/pigeon/android_notifications.dart
+++ b/pigeon/android_notifications.dart
@@ -109,11 +109,19 @@ class MessagingStyleMessage {
     required this.text,
     required this.timestampMs,
     required this.person,
+    required this.extras,
   });
 
   final String text;
   final int timestampMs;
   final Person person;
+
+  /// Entries from this message's own extras bundle, like [Notification.extras].
+  ///
+  /// These round-trip through
+  /// [AndroidNotificationHostApi.getActiveNotifications], filtered to the keys
+  /// in its `desiredMessageExtras`.
+  final Map<String, String> extras;
 }
 
 /// Corresponds to `androidx.core.app.NotificationCompat.MessagingStyle`
@@ -284,19 +292,23 @@ abstract class AndroidNotificationHostApi {
   /// optionally combined with `androidx.core.app.NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification`
   /// for each notification's [Notification.messagingStyle].
   ///
-  /// The keys of entries to fetch from notification's extras bundle must be
-  /// specified in the [desiredNotificationExtras] list. If this list is empty, then
-  /// [Notification.extras] will also be empty. If value of the matched entry
-  /// is not of type string or is null, then that entry will be skipped.
+  /// The keys of entries to fetch from each notification's own extras bundle
+  /// ([Notification.extras]) must be specified in [desiredNotificationExtras],
+  /// and those to fetch from each MessagingStyle message's extras bundle
+  /// ([MessagingStyleMessage.extras]) in [desiredMessageExtras]. For an empty
+  /// list, the corresponding map will also be empty. If the value of a matched
+  /// entry is not of type string or is null, then that entry will be skipped.
   ///
   /// Each notification's [Notification.messagingStyle] is populated only when
-  /// [includeMessagingStyle] is true; otherwise it is null.
+  /// [includeMessagingStyle] is true; otherwise it is null, and
+  /// [desiredMessageExtras] has no effect.
   ///
   /// See:
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationManagerCompat?hl=en#getActiveNotifications()
   ///   https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.MessagingStyle#extractMessagingStyleFromNotification(android.app.Notification)
   List<StatusBarNotification> getActiveNotifications({
     required List<String> desiredNotificationExtras,
+    required List<String> desiredMessageExtras,
     required bool includeMessagingStyle,
   });
 

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -931,7 +931,8 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
                 person: Person(
                   key: message.person.key,
                   name: message.person.name,
-                  iconBitmap: null)),
+                  iconBitmap: null),
+                extras: message.extras),
             ).toList(growable: false));
       _activeNotifications[(id, tag)] = StatusBarNotification(
         id: id,
@@ -946,10 +947,12 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
   @override
   Future<List<StatusBarNotification>> getActiveNotifications({
     required List<String> desiredNotificationExtras,
+    required List<String> desiredMessageExtras,
     required bool includeMessagingStyle,
   }) async {
     return _activeNotifications.values.map((statusNotif) {
       final notificationExtras = statusNotif.notification.extras;
+      final storedMessagingStyle = statusNotif.notification.messagingStyle;
       return StatusBarNotification(
         id: statusNotif.id,
         tag: statusNotif.tag,
@@ -960,8 +963,22 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
               if (notificationExtras[key] != null)
                 key: notificationExtras[key]!,
           },
-          messagingStyle: includeMessagingStyle
-            ? statusNotif.notification.messagingStyle : null));
+          messagingStyle: !includeMessagingStyle || storedMessagingStyle == null
+            ? null
+            : MessagingStyle(
+                user: storedMessagingStyle.user,
+                conversationTitle: storedMessagingStyle.conversationTitle,
+                isGroupConversation: storedMessagingStyle.isGroupConversation,
+                messages: storedMessagingStyle.messages.map((message) =>
+                  MessagingStyleMessage(
+                    text: message.text,
+                    timestampMs: message.timestampMs,
+                    person: message.person,
+                    extras: {
+                      for (final key in desiredMessageExtras)
+                        if (message.extras[key] != null)
+                          key: message.extras[key]!,
+                    })).toList(growable: false))));
     }).toList(growable: false);
   }
 

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -881,6 +881,17 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
     _activeNotifications.clear();
   }
 
+  /// Clears the [MessagingStyleMessage.extras] on all active notifications.
+  void clearActiveNotificationMessageExtras() {
+    for (final statusNotif in _activeNotifications.values) {
+      final messagingStyle = statusNotif.notification.messagingStyle;
+      if (messagingStyle == null) continue;
+      for (final message in messagingStyle.messages) {
+        message.extras.clear();
+      }
+    }
+  }
+
   @override
   Future<void> notify({
     String? tag,

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -876,12 +876,9 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
   Iterable<StatusBarNotification> get activeNotifications => _activeNotifications.values;
   final Map<(int, String?), StatusBarNotification> _activeNotifications = {};
 
-  final Map<String, MessagingStyle?> _activeNotificationsMessagingStyle = {};
-
   /// Clears all active notifications that have been created via [notify].
   void clearActiveNotifications() {
     _activeNotifications.clear();
-    _activeNotificationsMessagingStyle.clear();
   }
 
   @override
@@ -921,12 +918,7 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
     ));
 
     if (tag != null) {
-      _activeNotifications[(id, tag)] = StatusBarNotification(
-        id: id,
-        notification: Notification(group: groupKey ?? '', extras: extras ?? {}),
-        tag: tag);
-
-      _activeNotificationsMessagingStyle[tag] = messagingStyle == null
+      final storedMessagingStyle = messagingStyle == null
         ? null
         : MessagingStyle(
             user: messagingStyle.user,
@@ -941,23 +933,35 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
                   name: message.person.name,
                   iconBitmap: null)),
             ).toList(growable: false));
+      _activeNotifications[(id, tag)] = StatusBarNotification(
+        id: id,
+        notification: Notification(
+          group: groupKey ?? '',
+          extras: extras ?? {},
+          messagingStyle: storedMessagingStyle),
+        tag: tag);
     }
   }
 
   @override
-  Future<MessagingStyle?> getActiveNotificationMessagingStyleByTag(String tag) async =>
-    _activeNotificationsMessagingStyle[tag];
-
-  @override
-  Future<List<StatusBarNotification>> getActiveNotifications({required List<String> desiredExtras}) async {
+  Future<List<StatusBarNotification>> getActiveNotifications({
+    required List<String> desiredExtras,
+    required bool includeMessagingStyle,
+  }) async {
     return _activeNotifications.values.map((statusNotif) {
       final notificationExtras = statusNotif.notification.extras;
-      statusNotif.notification.extras = {
-        for (final key in desiredExtras)
-          if (notificationExtras[key] != null)
-            key: notificationExtras[key]!,
-      };
-      return statusNotif;
+      return StatusBarNotification(
+        id: statusNotif.id,
+        tag: statusNotif.tag,
+        notification: Notification(
+          group: statusNotif.notification.group,
+          extras: {
+            for (final key in desiredExtras)
+              if (notificationExtras[key] != null)
+                key: notificationExtras[key]!,
+          },
+          messagingStyle: includeMessagingStyle
+            ? statusNotif.notification.messagingStyle : null));
     }).toList(growable: false);
   }
 

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -945,7 +945,7 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
 
   @override
   Future<List<StatusBarNotification>> getActiveNotifications({
-    required List<String> desiredExtras,
+    required List<String> desiredNotificationExtras,
     required bool includeMessagingStyle,
   }) async {
     return _activeNotifications.values.map((statusNotif) {
@@ -956,7 +956,7 @@ class FakeAndroidNotificationHostApi implements AndroidNotificationHostApi {
         notification: Notification(
           group: statusNotif.notification.group,
           extras: {
-            for (final key in desiredExtras)
+            for (final key in desiredNotificationExtras)
               if (notificationExtras[key] != null)
                 key: notificationExtras[key]!,
           },

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -505,6 +505,10 @@ void main() {
           return (Subject<Object?> it) => it.isA<MessagingStyleMessage>()
             ..text.equals(messageData.content)
             ..timestampMs.equals(messageData.time * 1000)
+            ..extras.deepEquals({
+              NotificationDisplayManager.kExtraZulipMessageId:
+                messageData.messageId.toString(),
+            })
             ..person.which((it) => it.isNotNull()
               ..iconBitmap.which((it) => (isLast && expectedIconBitmap != null)
                 ? it.isNotNull().deepEquals(expectedIconBitmap) : it.isNull())
@@ -1407,6 +1411,7 @@ extension on Subject<MessagingStyleMessage> {
   Subject<String> get text => has((x) => x.text, 'text');
   Subject<int> get timestampMs => has((x) => x.timestampMs, 'timestampMs');
   Subject<Person> get person => has((x) => x.person, 'person');
+  Subject<Map<String, String>> get extras => has((x) => x.extras, 'extras');
 }
 
 extension on Subject<Notification> {

--- a/test/notifications/display_test.dart
+++ b/test/notifications/display_test.dart
@@ -488,11 +488,13 @@ void main() {
         realmUrl: data.realmUrl,
         userId: data.userId,
         narrow: switch (data.recipient) {
-        NotifPayloadChannelRecipient(:var channelId, :var topic) =>
-          TopicNarrow(channelId, topic),
-        NotifPayloadDmRecipient(:var allRecipientIds) =>
-          DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
-      }).buildNotificationUrl();
+          NotifPayloadChannelRecipient(:var channelId, :var topic) =>
+            TopicNarrow(channelId, topic),
+          NotifPayloadDmRecipient(:var allRecipientIds) =>
+            DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
+        },
+        // The notification opens at the earliest message of the conversation.
+        messageId: messageStyleMessages.first.messageId).buildNotificationUrl();
       expectedSummaryText ??= account.realmName
         ?? data.realmName
         ?? data.realmUrl.toString();
@@ -704,6 +706,49 @@ void main() {
         expectedIsGroupConversation: true,
         expectedTitle: expectedTitle,
         expectedTagComponent: expectedTagComponent);
+    })));
+
+    test('stream message: existing notification messages lack message IDs', () => runWithHttpClient(() => awaitFakeAsync((async) async {
+      await init();
+      final stream = eg.stream();
+      final topic = eg.t('topic 1');
+      final message1 = eg.streamMessage(topic: topic.toJson(), stream: stream);
+      final data1 = notifPayloadNewMessage(message1, streamName: stream.name);
+      final message2 = eg.streamMessage(topic: topic.toJson(), stream: stream);
+      final data2 = notifPayloadNewMessage(message2, streamName: stream.name);
+      final message3 = eg.streamMessage(topic: topic.toJson(), stream: stream);
+      final data3 = notifPayloadNewMessage(message3, streamName: stream.name);
+
+      void checkOpensAtMessage(int expectedMessageId, {
+        required int expectedNumMessages,
+      }) {
+        check(testBinding.androidNotificationHost.takeNotifyCalls()).first
+          ..messagingStyle.isNotNull().messages.length.equals(expectedNumMessages)
+          ..contentIntent.isNotNull().intent.dataUrl.equals(
+              NotificationOpenPayload(
+                realmUrl: data1.realmUrl,
+                userId: data1.userId,
+                narrow: TopicNarrow(stream.streamId, topic),
+                messageId: expectedMessageId,
+              ).buildNotificationUrl().toString());
+      }
+
+      await receiveNotification(async, data1);
+      checkOpensAtMessage(message1.id, expectedNumMessages: 1);
+
+      // The messages on the existing notification record their Zulip message
+      // IDs, so we open at the earliest of them.
+      await receiveNotification(async, data2);
+      checkOpensAtMessage(message1.id, expectedNumMessages: 2);
+
+      // Simulate a notification posted by a version of the app from before
+      // we recorded each message's Zulip message ID.
+      testBinding.androidNotificationHost.clearActiveNotificationMessageExtras();
+
+      // With no message ID recorded on the existing notification,
+      // we open at the new message instead.
+      await receiveNotification(async, data3);
+      checkOpensAtMessage(message3.id, expectedNumMessages: 3);
     })));
 
     test('stream message: multiple messages, different topics', () => runWithHttpClient(() => awaitFakeAsync((async) async {

--- a/test/notifications/ios_service_test.dart
+++ b/test/notifications/ios_service_test.dart
@@ -75,7 +75,9 @@ void main() {
           TopicNarrow(channelId, topic),
         NotifPayloadDmRecipient(:var allRecipientIds) =>
           DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
-      }).buildNotificationUrl();
+      },
+      // TODO(#1565): also open at the specific message on iOS
+      messageId: null).buildNotificationUrl();
 
     check(result)
       ..title.equals(expectedTitle)

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -152,11 +152,14 @@ void main() {
         realmUrl: data.realmUrl,
         userId: data.userId,
         narrow: switch (data.recipient) {
-        NotifPayloadChannelRecipient(:var channelId, :var topic) =>
-          TopicNarrow(channelId, topic),
-        NotifPayloadDmRecipient(:var allRecipientIds) =>
-          DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
-      }).buildNotificationUrl();
+          NotifPayloadChannelRecipient(:var channelId, :var topic) =>
+            TopicNarrow(channelId, topic),
+          NotifPayloadDmRecipient(:var allRecipientIds) =>
+            DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
+        },
+        // TODO(#1565): also open at the specific message on iOS
+        messageId: defaultTargetPlatform == TargetPlatform.iOS
+          ? null : data.messageId).buildNotificationUrl();
     }
 
     Map<String, Object?> messageApnsPayload(
@@ -233,9 +236,12 @@ void main() {
     void matchesNavigation(Subject<Route<void>> route, Account account, Message message) {
       route.isA<MaterialAccountWidgetRoute>()
         ..accountId.equals(account.id)
-        ..page.isA<MessageListPage>()
-          .initNarrow.equals(SendableNarrow.ofMessage(message,
-            selfUserId: account.userId));
+        ..page.isA<MessageListPage>().which((it) => it
+          ..initNarrow.equals(SendableNarrow.ofMessage(message,
+            selfUserId: account.userId))
+          // TODO(#1565): also open at the specific message on iOS
+          ..initAnchorMessageId.equals(
+              defaultTargetPlatform == TargetPlatform.iOS ? null : message.id));
     }
 
     Future<void> checkOpenNotification(
@@ -605,24 +611,28 @@ void main() {
         realmUrl: Uri.parse('http://chat.example'),
         userId: 1001,
         narrow: DmNarrow(allRecipientIds: [1001, 1002], selfUserId: 1001),
+        messageId: 123,
       );
       var url = payload.buildNotificationUrl();
       check(NotificationOpenPayload.parseNotificationUrl(url))
         ..realmUrl.equals(payload.realmUrl)
         ..userId.equals(payload.userId)
-        ..narrow.equals(payload.narrow);
+        ..narrow.equals(payload.narrow)
+        ..messageId.equals(payload.messageId);
 
       // Topic narrow
       payload = NotificationOpenPayload(
         realmUrl: Uri.parse('http://chat.example'),
         userId: 1001,
         narrow: eg.topicNarrow(1, 'topic A'),
+        messageId: 456,
       );
       url = payload.buildNotificationUrl();
       check(NotificationOpenPayload.parseNotificationUrl(url))
         ..realmUrl.equals(payload.realmUrl)
         ..userId.equals(payload.userId)
-        ..narrow.equals(payload.narrow);
+        ..narrow.equals(payload.narrow)
+        ..messageId.equals(payload.messageId);
     });
 
     group('parseLegacyIosApnsPayload', () {
@@ -638,7 +648,8 @@ void main() {
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<DmNarrow>()
-            ..otherRecipientIds.deepEquals([1002]));
+            ..otherRecipientIds.deepEquals([1002]))
+          ..messageId.isNull();
       });
 
       test('smoke group DM', () {
@@ -654,7 +665,8 @@ void main() {
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<DmNarrow>()
-            ..otherRecipientIds.deepEquals([1002, 1003]));
+            ..otherRecipientIds.deepEquals([1002, 1003]))
+          ..messageId.isNull();
       });
 
       test('smoke topic message', () {
@@ -671,7 +683,8 @@ void main() {
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<TopicNarrow>()
             ..channelId.equals(1)
-            ..topic.equals(TopicName('topic A')));
+            ..topic.equals(TopicName('topic A')))
+          ..messageId.isNull();
       });
     });
 
@@ -681,6 +694,27 @@ void main() {
           realmUrl: Uri.parse('http://chat.example'),
           userId: 1001,
           narrow: DmNarrow(allRecipientIds: [1001, 1002], selfUserId: 1001),
+          messageId: 123,
+        ).buildNotificationUrl();
+        check(url)
+          ..scheme.equals('zulip')
+          ..host.equals('notification')
+          ..queryParameters.deepEquals({
+            'realm_url': 'http://chat.example',
+            'user_id': '1001',
+            'narrow_type': 'dm',
+            'all_recipient_ids': '1001,1002',
+            'message_id': '123',
+          });
+      });
+
+      test('smoke DM, without a message ID', () {
+        // TODO(#1565): iOS omits the message ID for now.
+        final url = NotificationOpenPayload(
+          realmUrl: Uri.parse('http://chat.example'),
+          userId: 1001,
+          narrow: DmNarrow(allRecipientIds: [1001, 1002], selfUserId: 1001),
+          messageId: null,
         ).buildNotificationUrl();
         check(url)
           ..scheme.equals('zulip')
@@ -698,6 +732,28 @@ void main() {
           realmUrl: Uri.parse('http://chat.example'),
           userId: 1001,
           narrow: eg.topicNarrow(1, 'topic A'),
+          messageId: 123,
+        ).buildNotificationUrl();
+        check(url)
+          ..scheme.equals('zulip')
+          ..host.equals('notification')
+          ..queryParameters.deepEquals({
+            'realm_url': 'http://chat.example',
+            'user_id': '1001',
+            'narrow_type': 'topic',
+            'channel_id': '1',
+            'topic': 'topic A',
+            'message_id': '123',
+          });
+      });
+
+      test('smoke topic, without a message ID', () {
+        // TODO(#1565): iOS omits the message ID for now.
+        final url = NotificationOpenPayload(
+          realmUrl: Uri.parse('http://chat.example'),
+          userId: 1001,
+          narrow: eg.topicNarrow(1, 'topic A'),
+          messageId: null,
         ).buildNotificationUrl();
         check(url)
           ..scheme.equals('zulip')
@@ -722,16 +778,60 @@ void main() {
             'user_id': '1001',
             'narrow_type': 'dm',
             'all_recipient_ids': '1001,1002',
+            'message_id': '123',
           });
         check(NotificationOpenPayload.parseNotificationUrl(url))
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<DmNarrow>()
             ..allRecipientIds.deepEquals([1001, 1002])
-            ..otherRecipientIds.deepEquals([1002]));
+            ..otherRecipientIds.deepEquals([1002]))
+          ..messageId.equals(123);
+      });
+
+      test('smoke DM, without a message ID', () {
+        // TODO(#1565): iOS omits the message ID for now.
+        final url = Uri(
+          scheme: 'zulip',
+          host: 'notification',
+          queryParameters: <String, String>{
+            'realm_url': 'http://chat.example',
+            'user_id': '1001',
+            'narrow_type': 'dm',
+            'all_recipient_ids': '1001,1002',
+          });
+        check(NotificationOpenPayload.parseNotificationUrl(url))
+          ..realmUrl.equals(Uri.parse('http://chat.example'))
+          ..userId.equals(1001)
+          ..narrow.which((it) => it.isA<DmNarrow>()
+            ..allRecipientIds.deepEquals([1001, 1002])
+            ..otherRecipientIds.deepEquals([1002]))
+          ..messageId.isNull();
       });
 
       test('smoke topic', () {
+        final url = Uri(
+          scheme: 'zulip',
+          host: 'notification',
+          queryParameters: <String, String>{
+            'realm_url': 'http://chat.example',
+            'user_id': '1001',
+            'narrow_type': 'topic',
+            'channel_id': '1',
+            'topic': 'topic A',
+            'message_id': '123',
+          });
+        check(NotificationOpenPayload.parseNotificationUrl(url))
+          ..realmUrl.equals(Uri.parse('http://chat.example'))
+          ..userId.equals(1001)
+          ..narrow.which((it) => it.isA<TopicNarrow>()
+            ..channelId.equals(1)
+            ..topic.equals(eg.t('topic A')))
+          ..messageId.equals(123);
+      });
+
+      test('smoke topic, without a message ID', () {
+        // TODO(#1565): iOS omits the message ID for now.
         final url = Uri(
           scheme: 'zulip',
           host: 'notification',
@@ -747,7 +847,8 @@ void main() {
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<TopicNarrow>()
             ..channelId.equals(1)
-            ..topic.equals(eg.t('topic A')));
+            ..topic.equals(eg.t('topic A')))
+          ..messageId.isNull();
       });
 
       test('fails when missing any expected query parameters', () {
@@ -853,4 +954,5 @@ extension on Subject<NotificationOpenPayload> {
   Subject<Uri> get realmUrl => has((x) => x.realmUrl, 'realmUrl');
   Subject<int> get userId => has((x) => x.userId, 'userId');
   Subject<Narrow> get narrow => has((x) => x.narrow, 'narrow');
+  Subject<int?> get messageId => has((x) => x.messageId, 'messageId');
 }

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_checks/flutter_checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/notifications.dart';
@@ -462,6 +463,12 @@ void main() {
         await transitionDurationObserver.pumpPastTransition(tester);
       }
 
+      /// Prepare the response to the fetch made on opening the page at [anchor].
+      void prepareFetchAtMessage(int anchor, {required List<Message> messages}) {
+        connection.prepare(json: eg.nearGetMessagesResult(anchor: anchor,
+          foundOldest: true, foundNewest: true, messages: messages).toJson());
+      }
+
       testWidgets('at same conversation, dedupes page', (tester) async {
         final stream = eg.stream();
         final message1 = eg.streamMessage(stream: stream, topic: 'a');
@@ -470,14 +477,38 @@ void main() {
           messages: [message1]);
 
         final message2 = eg.streamMessage(stream: stream, topic: 'a');
+        prepareFetchAtMessage(message2.id, messages: [message1, message2]);
         await openNotification(tester, eg.selfAccount, message2);
         check(lastPoppedRoute).isNull();
         check(pushedRoutes).isEmpty();
 
         final message3 = eg.streamMessage(stream: stream, topic: 'A');
+        prepareFetchAtMessage(message3.id, messages: [message1, message2, message3]);
         await openNotification(tester, eg.selfAccount, message3);
         check(lastPoppedRoute).isNull();
         check(pushedRoutes).isEmpty();
+      });
+
+      testWidgets('at same conversation, page moves to the message', (tester) async {
+        final stream = eg.stream();
+        final message1 = eg.streamMessage(stream: stream, topic: 'a',
+          content: '<p>message 1</p>');
+        await prepareMessageListPage(tester,
+          narrow: TopicNarrow.ofMessage(message1),
+          messages: [message1]);
+
+        // The page doesn't show the message the notification is for…
+        final message2 = eg.streamMessage(stream: stream, topic: 'a',
+          content: '<p>message 2</p>');
+        check(find.text('message 2')).findsNothing();
+
+        // … until the notification is opened, which brings it into view
+        // on the same page, without pushing another one.
+        prepareFetchAtMessage(message2.id, messages: [message1, message2]);
+        await openNotification(tester, eg.selfAccount, message2);
+        await tester.pump();
+        check(pushedRoutes).isEmpty();
+        check(find.text('message 2')).findsOne();
       });
 
       testWidgets('at different conversation, proceeds normally', (tester) async {
@@ -530,6 +561,7 @@ void main() {
         pushedRoutes.clear();
 
         final message2 = eg.streamMessage(stream: stream, topic: 'a');
+        prepareFetchAtMessage(message2.id, messages: [message1, message2]);
         await openNotification(tester, eg.selfAccount, message2);
         // The dialog was popped (and nothing was pushed).
         check(lastPoppedRoute).equals(pushed);


### PR DESCRIPTION
Fixes-partly https://github.com/zulip/zulip-flutter/issues/1565.

Tapping a notification navigated to the conversation, landing on the
first unread, which in a long thread can be thousands of messages back
and unrelated to the notification.  Instead open at the message the
notification was for, or the earliest message when it groups several.