### PR TITLE
internal_link: Escape single quote, bang, and star in hash components

### DIFF
--- a/lib/model/internal_link.dart
+++ b/lib/model/internal_link.dart
@@ -11,12 +11,15 @@ part 'internal_link.g.dart';
 
 const _hashReplacements = {
   "%": ".",
+  "!": ".21",
+  "'": ".27",
   "(": ".28",
   ")": ".29",
+  "*": ".2A",
   ".": ".2E",
 };
 
-final _encodeHashComponentRegex = RegExp(r'[%().]');
+final _encodeHashComponentRegex = RegExp(r"[%!'()*.]");
 
 // Corresponds to encodeHashComponent in Zulip web;
 // see web/shared/src/internal_url.ts.

--- a/test/model/compose_test.dart
+++ b/test/model/compose_test.dart
@@ -372,7 +372,7 @@ hello
 
       check(channelLink(channels[1 - 1], store: store)).equals('[#&#96;code&#96;](#narrow/channel/1-.60code.60)');
       check(channelLink(channels[2 - 1], store: store)).equals('[#score &gt; 90](#narrow/channel/2-score-.3E-90)');
-      check(channelLink(channels[3 - 1], store: store)).equals('[#A&#42;](#narrow/channel/3-A*)');
+      check(channelLink(channels[3 - 1], store: store)).equals('[#A&#42;](#narrow/channel/3-A.2A)');
       check(channelLink(channels[4 - 1], store: store)).equals('[#R&amp;D](#narrow/channel/4-R.26D)');
       check(channelLink(channels[5 - 1], store: store)).equals('[#UI &#91;v2&#93;](#narrow/channel/5-UI-.5Bv2.5D)');
       check(channelLink(channels[6 - 1], store: store)).equals('[#Save &#36;&#36;](#narrow/channel/6-Save-.24.24)');

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -108,6 +108,51 @@ void main() {
                     zulipFeatureLevel: 249,
                     '#narrow/stream/48-mobile-team/topic/Welcome.20screen.20UI');
       });
+
+      // Mirrors Zulip web's shared encodeHashComponent fixture,
+      // driven through a topic operand:
+      //   https://github.com/zulip/zulip/blob/9c6bbba27/zerver/tests/fixtures/url_encoding_test_cases.json
+      test('encode each character like Zulip web', () {
+        void checkTopic(String topic, String expectedEncoded) {
+          checkNarrow(channelId: 1, name: 'general', topic: topic,
+            '#narrow/channel/1-general/topic/$expectedEncoded');
+        }
+        checkTopic('-', '-');
+        checkTopic('_', '_');
+        checkTopic('~', '~');
+        checkTopic(' ', '.20');
+        checkTopic('!', '.21');
+        checkTopic('"', '.22');
+        checkTopic('#', '.23');
+        checkTopic(r'$', '.24');
+        checkTopic('%', '.25');
+        checkTopic('&', '.26');
+        checkTopic("'", '.27');
+        checkTopic('(', '.28');
+        checkTopic(')', '.29');
+        checkTopic('*', '.2A');
+        checkTopic('+', '.2B');
+        checkTopic(',', '.2C');
+        checkTopic('.', '.2E');
+        checkTopic('/', '.2F');
+        checkTopic(':', '.3A');
+        checkTopic(';', '.3B');
+        checkTopic('<', '.3C');
+        checkTopic('=', '.3D');
+        checkTopic('>', '.3E');
+        checkTopic('?', '.3F');
+        checkTopic('@', '.40');
+        checkTopic('[', '.5B');
+        checkTopic(r'\', '.5C');
+        checkTopic(']', '.5D');
+        checkTopic('^', '.5E');
+        checkTopic('`', '.60');
+        checkTopic('{', '.7B');
+        checkTopic('|', '.7C');
+        checkTopic('}', '.7D');
+        checkTopic('https://zulip.example',
+                   'https.3A.2F.2Fzulip.2Eexample');
+      });
     });
 
     test('DmNarrow', () {

--- a/test/model/internal_link_test.dart
+++ b/test/model/internal_link_test.dart
@@ -88,6 +88,7 @@ void main() {
         checkNarrow(channelId: 415, name: 'chat.zulip.org', '#narrow/channel/415-chat.2Ezulip.2Eorg');
         checkNarrow(channelId: 419, name: 'français',       '#narrow/channel/419-fran.C3.A7ais');
         checkNarrow(channelId: 403, name: 'Hshs[™~}(.',     '#narrow/channel/403-Hshs.5B.E2.84.A2~.7D.28.2E');
+        checkNarrow(channelId: 404, name: "a'b*c!d",        '#narrow/channel/404-a.27b.2Ac.21d');
         checkNarrow(channelId: 60,  name: 'twitter', nearMessageId: 1570686, '#narrow/channel/60-twitter/near/1570686');
 
         checkNarrow(channelId: 48,  name: 'mobile', topic: 'Welcome screen UI',


### PR DESCRIPTION
These characters passed through _encodeHashComponent unescaped, since Dart's Uri.encodeComponent (like JS encodeURIComponent) leaves them alone. An unescaped single quote in particular can fool plain-text URL-detection heuristics into truncating a narrow link.

Mirror Zulip web's encodeHashComponent, which encodes all of ! ' ( ) * . and %.

Fixes: https://github.com/zulip/zulip-flutter/issues/2105

Screen capture:

https://github.com/user-attachments/assets/3ce80c3d-f3a4-4960-9ded-01ba4ab940f8

