### PR TITLE
msglist: Give stopword feedback when a search has no results 

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -882,6 +882,10 @@
   "@emptyMessageListSearch": {
     "description": "Placeholder for the 'Search' page when there are no messages."
   },
+  "emptyMessageListSearchStopwords": "Common words were excluded from your search:",
+  "@emptyMessageListSearchStopwords": {
+    "description": "Extra detail in the placeholder for the 'Search' page when the search ignored some very common words in the query. The search query is shown below this text, with the ignored words struck through."
+  },
   "messageListGroupYouWithYourself": "Messages with yourself",
   "@messageListGroupYouWithYourself": {
     "description": "Message list recipient header for a DM group that only includes yourself."

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -64,6 +64,8 @@ class InitialSnapshot {
 
   final List<ZulipStream> streams;
 
+  final List<String> stopWords;
+
   // In register-queue, the name of this field is the singular "user_status",
   // even though it actually contains user status information for all the users
   // that the self-user has access to. Therefore, we prefer to use the plural form.
@@ -196,6 +198,7 @@ class InitialSnapshot {
     required this.unreadMsgs,
     required this.starredMessages,
     required this.streams,
+    required this.stopWords,
     required this.userStatuses,
     required this.userSettings,
     required this.userTopics,

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -77,6 +77,9 @@ InitialSnapshot _$InitialSnapshotFromJson(
   streams: (json['streams'] as List<dynamic>)
       .map((e) => ZulipStream.fromJson(e as Map<String, dynamic>))
       .toList(),
+  stopWords: (json['stop_words'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
   userStatuses: (json['user_status'] as Map<String, dynamic>).map(
     (k, e) => MapEntry(
       int.parse(k),
@@ -204,6 +207,7 @@ Map<String, dynamic> _$InitialSnapshotToJson(
   'unread_msgs': instance.unreadMsgs,
   'starred_messages': instance.starredMessages,
   'streams': instance.streams,
+  'stop_words': instance.stopWords,
   'user_status': instance.userStatuses.map((k, e) => MapEntry(k.toString(), e)),
   'user_settings': instance.userSettings,
   'user_topics': instance.userTopics,

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -1350,6 +1350,12 @@ abstract class ZulipLocalizations {
   /// **'No search results.'**
   String get emptyMessageListSearch;
 
+  /// Extra detail in the placeholder for the 'Search' page when the search ignored some very common words in the query. The search query is shown below this text, with the ignored words struck through.
+  ///
+  /// In en, this message translates to:
+  /// **'Common words were excluded from your search:'**
+  String get emptyMessageListSearchStopwords;
+
   /// Message list recipient header for a DM group that only includes yourself.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -757,6 +757,10 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Keine Suchergebnisse.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Nachrichten mit dir selbst';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -745,6 +745,10 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Sin resultados de búsqueda.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Mensajes contigo mismo';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -741,6 +741,10 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -761,6 +761,10 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Aucun résultat de recherche.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages avec vous même';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -753,6 +753,10 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Nessun risultato trovato.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messaggi con te stesso';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -716,6 +716,10 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get emptyMessageListSearch => '検索結果はありません。';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => '自分とのメッセージ';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nn.dart
+++ b/lib/generated/l10n/zulip_localizations_nn.dart
@@ -736,6 +736,10 @@ class ZulipLocalizationsNn extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Ingen søkjeresultat.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Meldingar med deg sjølv';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -747,6 +747,10 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Brak wyników wyszukiwania.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Zapiski na własne konto';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -747,6 +747,10 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Ничего не найдено.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Сообщения с собой';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -758,6 +758,10 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Ni zadetkov iskanja.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Sporočila sebi';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_so.dart
+++ b/lib/generated/l10n/zulip_localizations_so.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsSo extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -748,6 +748,10 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get emptyMessageListSearch => 'Немає результатів пошуку.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Повідомлення з собою';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -733,6 +733,10 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get emptyMessageListSearch => 'No search results.';
 
   @override
+  String get emptyMessageListSearchStopwords =>
+      'Common words were excluded from your search:';
+
+  @override
   String get messageListGroupYouWithYourself => 'Messages with yourself';
 
   @override

--- a/lib/model/realm.dart
+++ b/lib/model/realm.dart
@@ -97,6 +97,11 @@ mixin RealmStore on PerAccountStoreBase, UserGroupStore {
   int get maxChannelNameLength;
   int get maxTopicLength;
 
+  /// The stopwords used by the server's full-text search.
+  ///
+  /// Search for "stop_words" in https://zulip.com/api/register-queue.
+  List<String> get stopWords;
+
   //|//////////////////////////////
   // Realm settings with their own events.
 
@@ -149,6 +154,14 @@ mixin RealmStore on PerAccountStoreBase, UserGroupStore {
     }
     return topic;
   }
+
+  /// Whether the given word is one of the [stopWords]
+  /// that the server's full-text search ignores.
+  ///
+  /// The comparison is case-insensitive,
+  /// matching how the server's search treats stopwords;
+  /// see https://zulip.com/help/search-for-messages .
+  bool isStopWord(String word) => stopWords.contains(word.toLowerCase());
 
   /// Whether the self-user has passed the realm's waiting period
   /// to be a full member.
@@ -231,6 +244,8 @@ mixin ProxyRealmStore on RealmStore {
   @override
   int get maxTopicLength => realmStore.maxTopicLength;
   @override
+  List<String> get stopWords => realmStore.stopWords;
+  @override
   List<CustomProfileField> get customProfileFields => realmStore.customProfileFields;
   @override
   bool selfHasPassedWaitingPeriod({required DateTime byDate}) =>
@@ -290,6 +305,7 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
     realmDefaultExternalAccounts = initialSnapshot.realmDefaultExternalAccounts,
     maxChannelNameLength = initialSnapshot.maxChannelNameLength,
     maxTopicLength = initialSnapshot.maxTopicLength,
+    stopWords = initialSnapshot.stopWords,
     customProfileFields = _sortCustomProfileFields(initialSnapshot.customProfileFields);
 
   @override
@@ -480,6 +496,9 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
   final int maxChannelNameLength;
   @override
   final int maxTopicLength;
+
+  @override
+  final List<String> stopWords;
 
   @override
   List<CustomProfileField> customProfileFields;

--- a/lib/widgets/message_list.dart
+++ b/lib/widgets/message_list.dart
@@ -1435,9 +1435,31 @@ class _EmptyMessageListPlaceholder extends StatelessWidget {
           onTapMessageLink: () => PlatformActions.launchUrl(context,
             store.tryResolveUrl('/help/star-a-message')!));
 
-      case KeywordSearchNarrow():
+      case KeywordSearchNarrow(:final keyword):
+        final words = keyword.split(RegExp(r'\s+'));
+        final hasStopWords = words.any(store.isStopWord);
+
+        TextSpan? stopWordsFeedback;
+        if (hasStopWords) {
+          const strikethrough = TextStyle(decoration: TextDecoration.lineThrough);
+          final keywordWithStopWordsStruck = <TextSpan>[];
+          for (final word in words) {
+            if (keywordWithStopWordsStruck.isNotEmpty) {
+              keywordWithStopWordsStruck.add(const TextSpan(text: ' '));
+            }
+            keywordWithStopWordsStruck.add(
+              TextSpan(text: word, style: store.isStopWord(word) ? strikethrough : null));
+          }
+          stopWordsFeedback = TextSpan(children: [
+            TextSpan(text: zulipLocalizations.emptyMessageListSearchStopwords),
+            const TextSpan(text: '\n'),
+            ...keywordWithStopWordsStruck,
+          ]);
+        }
+
         return PageBodyEmptyContentPlaceholder(
-          header: zulipLocalizations.emptyMessageListSearch);
+          header: zulipLocalizations.emptyMessageListSearch,
+          messageSpan: stopWordsFeedback);
     }
   }
 }

--- a/lib/widgets/page.dart
+++ b/lib/widgets/page.dart
@@ -256,6 +256,7 @@ class PageBodyEmptyContentPlaceholder extends StatelessWidget {
     this.headerWithLinkMarkup,
     this.onTapHeaderLink,
     this.message,
+    this.messageSpan,
     this.messageWithLinkMarkup,
     this.onTapMessageLink,
   }) : assert(
@@ -266,6 +267,7 @@ class PageBodyEmptyContentPlaceholder extends StatelessWidget {
   final String? headerWithLinkMarkup;
   final VoidCallback? onTapHeaderLink;
   final String? message;
+  final InlineSpan? messageSpan;
   final String? messageWithLinkMarkup;
   final VoidCallback? onTapMessageLink;
 
@@ -309,6 +311,12 @@ class PageBodyEmptyContentPlaceholder extends StatelessWidget {
         textAlign: TextAlign.center,
         style: _messageStyle(context),
         message!);
+    }
+    if (messageSpan != null) {
+      return Text.rich(
+        textAlign: TextAlign.center,
+        style: _messageStyle(context),
+        messageSpan!);
     }
     if (messageWithLinkMarkup != null) {
       return TextWithLink(

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1429,6 +1429,7 @@ InitialSnapshot initialSnapshot({
   UnreadMessagesSnapshot? unreadMsgs,
   List<int>? starredMessages,
   List<ZulipStream>? streams,
+  List<String>? stopWords,
   Map<int, UserStatusChange>? userStatuses,
   UserSettings? userSettings,
   List<UserTopicItem>? userTopics,
@@ -1495,6 +1496,7 @@ InitialSnapshot initialSnapshot({
     unreadMsgs: unreadMsgs ?? _unreadMsgs(),
     starredMessages: starredMessages ?? [],
     streams: streams ?? [], // TODO add streams to default
+    stopWords: stopWords ?? [],
     userStatuses: userStatuses ?? {},
     userSettings: userSettings ?? _userSettings(),
     userTopics: userTopics ?? [],

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -73,6 +73,7 @@ void main() {
     List<Subscription>? subscriptions,
     UnreadMessagesSnapshot? unreadMsgs,
     List<int>? starredMessages,
+    List<String>? stopWords,
     int? zulipFeatureLevel,
     List<NavigatorObserver> navObservers = const [],
     bool skipAssertAccountExists = false,
@@ -88,7 +89,8 @@ void main() {
       streams: streams,
       subscriptions: subscriptions,
       unreadMsgs: unreadMsgs,
-      starredMessages: starredMessages));
+      starredMessages: starredMessages,
+      stopWords: stopWords));
     store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
     connection = store.connection as FakeApiConnection;
 
@@ -432,6 +434,18 @@ void main() {
     Finder findTextInPlaceholder(String text) =>
       find.descendant(of: findPlaceholder, matching: find.textContaining(text));
 
+    List<String> struckWords(Text text) {
+      final words = <String>[];
+      text.textSpan!.visitChildren((span) {
+        if (span is TextSpan
+            && span.style?.decoration == TextDecoration.lineThrough) {
+          words.add(span.text!);
+        }
+        return true;
+      });
+      return words;
+    }
+
     Future<void> checkLink(WidgetTester tester, {
         required String linkText, required Uri expectedUrl}) async {
       await tester.tapOnText(find.textRange.ofSubstring(linkText));
@@ -655,6 +669,33 @@ void main() {
     testWidgets('Search, non-empty keyword', (tester) async {
       await setupMessageListPage(tester, narrow: KeywordSearchNarrow('hello'), messages: []);
       check(findTextInPlaceholder('No search results.')).findsOne();
+    });
+
+    testWidgets('Search, keyword contains stopwords', (tester) async {
+      await setupMessageListPage(tester,
+        narrow: KeywordSearchNarrow('the example a'), messages: [],
+        stopWords: ['the', 'a']);
+      check(findTextInPlaceholder('No search results.')).findsOne();
+      final message = tester.widget<Text>(findTextInPlaceholder(
+        'Common words were excluded from your search:\nthe example a'));
+      check(struckWords(message)).deepEquals(['the', 'a']);
+    });
+
+    testWidgets('Search, stopword matched case-insensitively', (tester) async {
+      await setupMessageListPage(tester,
+        narrow: KeywordSearchNarrow('The'), messages: [],
+        stopWords: ['the', 'a']);
+      final message = tester.widget<Text>(findTextInPlaceholder(
+        'Common words were excluded from your search:\nThe'));
+      check(struckWords(message)).deepEquals(['The']);
+    });
+
+    testWidgets('Search, no stopwords in keyword', (tester) async {
+      await setupMessageListPage(tester,
+        narrow: KeywordSearchNarrow('example'), messages: [],
+        stopWords: ['the', 'a']);
+      check(findTextInPlaceholder('No search results.')).findsOne();
+      check(findTextInPlaceholder('Common words were excluded')).findsNothing();
     });
 
     testWidgets('when `messages` empty but `outboxMessages` not empty, show outboxes, not placeholder', (tester) async {


### PR DESCRIPTION
The server's full-text search ignores certain very common words ("stopwords"), so a query consisting only of such words gets no results, which can be confusing.  Following the example of Zulip web, when a search comes up empty, show the query with the ignored words struck through.

The split of the first two commits is inline with patterns adopted before. e.g. https://github.com/zulip/zulip-flutter/pull/1987/commits 

https://github.com/zulip/zulip/pull/39806 was opened when a bug was observed while working on this issue.

Fixes #1811 .

| Before | After |
| --- | --- |
| <img width="390" height="844" src="https://github.com/user-attachments/assets/92297776-b12c-4fb6-ad33-b135b7189626" /> | <img width="390" height="844" src="https://github.com/user-attachments/assets/fde0d09f-f28d-43b6-ab7c-95759a06de89" /> |
| <img width="390" height="844" src="https://github.com/user-attachments/assets/9665ad83-1697-4274-b1ad-b5b6c0213aa4" /> | <img width="390" height="844" src="https://github.com/user-attachments/assets/a6786954-079a-40cc-abf6-c02387fec1e2" /> |
| <img width="390" height="844" src="https://github.com/user-attachments/assets/d1e6d6c5-0842-432d-ba40-64053a25c9e5" /> | <img width="390" height="844" src="https://github.com/user-attachments/assets/cb3c70f9-1458-4ce8-81c1-6424bcf3972e" /> |
| <img width="390" height="844" src="https://github.com/user-attachments/assets/92bb54d6-5975-4338-b595-19fc6b2ee98a" /> | <img width="390" height="844" src="https://github.com/user-attachments/assets/426a6ba7-5f59-4530-ac54-641acac0370e" /> |
