### PR TITLE
action_sheet: Group and order buttons by scope in action sheets

### DIFF
--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -521,29 +521,26 @@ void showChannelActionSheet(BuildContext context, {
   final channel = store.streams[channelId];
   final isSubscribed = channel is Subscription;
   final buttonSections = [
-    if (!isSubscribed
-        && channel != null && store.selfHasContentAccess(channel))
-      [SubscribeButton(pageContext: pageContext, channelId: channelId)],
+    // Affects only the self-user.
     [
-      // This section has frequent actions, with only short-term effects.
+      if (isSubscribed)
+        UnsubscribeButton(pageContext: pageContext, channelId: channelId)
+      else if (channel != null && store.selfHasContentAccess(channel))
+        SubscribeButton(pageContext: pageContext, channelId: channelId),
+      if (isSubscribed)
+        PinUnpinButton(pageContext: pageContext, channelId: channelId,
+          isPinned: channel.pinToTop),
       if (unreadCount > 0)
         MarkChannelAsReadButton(pageContext: pageContext, channelId: channelId),
+    ],
+    // No effect.
+    [
       if (showTopicListButton)
         TopicListButton(pageContext: pageContext, channelId: channelId),
       if (!isOnChannelFeed)
         ChannelFeedButton(pageContext: pageContext, channelId: channelId),
-      CopyChannelLinkButton(channelId: channelId, pageContext: pageContext)
+      CopyChannelLinkButton(channelId: channelId, pageContext: pageContext),
     ],
-    [
-      // This section has settings for the channel or subscription.
-      if (isSubscribed)
-        PinUnpinButton(pageContext: pageContext, channelId: channelId,
-          isPinned: channel.pinToTop),
-      // (It's harmless that this section can be empty; in that case
-      // it ends up rendering to nothing.)
-    ],
-    if (isSubscribed)
-      [UnsubscribeButton(pageContext: pageContext, channelId: channelId)],
   ];
 
   final header = BottomSheetHeader(
@@ -776,8 +773,6 @@ void showTopicActionSheet(BuildContext context, {
   final store = PerAccountStoreWidget.of(pageContext);
   final subscription = store.subscriptions[channelId];
 
-  final optionButtons = <ActionSheetMenuItemButton>[];
-
   // TODO(server-7): simplify this condition away
   final supportsUnmutingTopics = store.zulipFeatureLevel >= 170;
   // TODO(server-8): simplify this condition away
@@ -838,33 +833,38 @@ void showTopicActionSheet(BuildContext context, {
       }
     }
   }
-  optionButtons.addAll(visibilityOptions.map((to) {
-    return UserTopicUpdateButton(
-      currentVisibilityPolicy: visibilityPolicy,
-      newVisibilityPolicy: to,
-      narrow: TopicNarrow(channelId, topic),
-      pageContext: pageContext);
-  }));
-
-  // TODO: check for other cases that may disallow this action (e.g.: time
-  //   limit for editing topics).
-  if (someMessageIdInTopic != null && topic.displayName != null) {
-    optionButtons.add(ResolveUnresolveButton(pageContext: pageContext,
-      topic: topic,
-      someMessageIdInTopic: someMessageIdInTopic));
-  }
 
   final unreadCount = store.unreads.countInTopicNarrow(channelId, topic);
-  if (unreadCount > 0) {
-    optionButtons.add(MarkTopicAsReadButton(
-      channelId: channelId,
-      topic: topic,
-      pageContext: pageContext));
-  }
-
-  optionButtons.add(CopyTopicLinkButton(
-    narrow: TopicNarrow(channelId, topic, with_: someMessageIdInTopic),
-    pageContext: pageContext));
+  final buttonSections = [
+    // Affects everyone.
+    [
+      // TODO: check for other cases that may disallow this action (e.g.: time
+      //   limit for editing topics).
+      if (someMessageIdInTopic != null && topic.displayName != null)
+        ResolveUnresolveButton(pageContext: pageContext,
+          topic: topic,
+          someMessageIdInTopic: someMessageIdInTopic),
+    ],
+    // Affects only the self-user.
+    [
+      ...visibilityOptions.map((to) => UserTopicUpdateButton(
+        currentVisibilityPolicy: visibilityPolicy,
+        newVisibilityPolicy: to,
+        narrow: TopicNarrow(channelId, topic),
+        pageContext: pageContext)),
+      if (unreadCount > 0)
+        MarkTopicAsReadButton(
+          channelId: channelId,
+          topic: topic,
+          pageContext: pageContext),
+    ],
+    // No effect.
+    [
+      CopyTopicLinkButton(
+        narrow: TopicNarrow(channelId, topic, with_: someMessageIdInTopic),
+        pageContext: pageContext),
+    ],
+  ];
 
   final header = BottomSheetHeader(
     buildTitle: (baseStyle) => Text.rich(
@@ -879,7 +879,7 @@ void showTopicActionSheet(BuildContext context, {
   _showActionSheet(pageContext,
     header: header,
     headerScrollable: false,
-    buttonSections: [optionButtons]);
+    buttonSections: buttonSections);
 }
 
 class UserTopicUpdateButton extends ActionSheetMenuItemButton {
@@ -1136,21 +1136,22 @@ void showDmActionSheet(BuildContext context, {required DmNarrow narrow}) {
   final unreadCount = store.unreads.countInDmNarrow(narrow);
 
   final buttonSections = [
-    // TODO(#1534) Button to show list of participants as a separate page?
-
+    // Affects only the self-user.
     [
+      if (unreadCount > 0)
+        MarkDmConversationAsReadButton(pageContext: pageContext, narrow: narrow),
+      // TODO(#2113) Mute/unmute button
+    ],
+    // No effect.
+    [
+      // TODO(#1534) Button to show list of participants as a separate page?
       if (otherRecipientIds.isEmpty)
         ViewProfileButton(pageContext: pageContext,
           userId: store.selfUserId)
       else if (otherRecipientIds.length == 1)
         ViewProfileButton(pageContext: pageContext,
           userId: otherRecipientIds.single),
-
-      if (unreadCount > 0)
-        MarkDmConversationAsReadButton(pageContext: pageContext, narrow: narrow),
     ],
-
-    // TODO(#2113) Mute/unmute button
   ];
 
   final header = BottomSheetHeader(
@@ -1256,13 +1257,17 @@ void showMessageActionSheet({required BuildContext context, required Message mes
   final canReport = reportChannelId != null && reportChannelId != -1;
 
   final buttonSections = [
+    // Affects everyone.
     [
       if (popularEmojiLoaded)
         ReactionButtons(message: message, pageContext: pageContext),
-      if (hasReactions)
-        ViewReactionsButton(message: message, pageContext: pageContext),
-      if (readReceiptsEnabled)
-        ViewReadReceiptsButton(message: message, pageContext: pageContext),
+      if (_getShouldShowEditButton(pageContext, message))
+        EditButton(message: message, pageContext: pageContext),
+      if (store.selfCanDeleteMessage(message.id, atDate: now))
+        DeleteMessageButton(message: message, pageContext: pageContext),
+    ],
+    // Affects only the self-user.
+    [
       StarButton(message: message, pageContext: pageContext),
       if (isComposeBoxOffered)
         QuoteAndReplyButton(message: message, pageContext: pageContext),
@@ -1271,16 +1276,19 @@ void showMessageActionSheet({required BuildContext context, required Message mes
       if (isSenderMuted)
         // The message must have been revealed in order to open this action sheet.
         UnrevealMutedMessageButton(message: message, pageContext: pageContext),
+    ],
+    // No effect.
+    [
+      if (hasReactions)
+        ViewReactionsButton(message: message, pageContext: pageContext),
+      if (readReceiptsEnabled)
+        ViewReadReceiptsButton(message: message, pageContext: pageContext),
       CopyMessageTextButton(message: message, pageContext: pageContext),
       CopyMessageLinkButton(message: message, pageContext: pageContext),
       ShareButton(message: message, pageContext: pageContext),
-      if (_getShouldShowEditButton(pageContext, message))
-        EditButton(message: message, pageContext: pageContext),
+      if (canReport)
+        ReportMessageButton(message: message, pageContext: pageContext),
     ],
-    if (canReport)
-      [ReportMessageButton(message: message, pageContext: pageContext)],
-    if (store.selfCanDeleteMessage(message.id, atDate: now))
-      [DeleteMessageButton(message: message, pageContext: pageContext)],
   ];
 
   _showActionSheet(pageContext,

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -1269,8 +1269,6 @@ void showMessageActionSheet({required BuildContext context, required Message mes
     // Affects only the self-user.
     [
       StarButton(message: message, pageContext: pageContext),
-      if (isComposeBoxOffered)
-        QuoteAndReplyButton(message: message, pageContext: pageContext),
       if (isMessageRead)
         MarkAsUnreadButton(message: message, pageContext: pageContext),
       if (isSenderMuted)
@@ -1279,10 +1277,12 @@ void showMessageActionSheet({required BuildContext context, required Message mes
     ],
     // No effect.
     [
-      if (hasReactions)
-        ViewReactionsButton(message: message, pageContext: pageContext),
       if (readReceiptsEnabled)
         ViewReadReceiptsButton(message: message, pageContext: pageContext),
+      if (hasReactions)
+        ViewReactionsButton(message: message, pageContext: pageContext),
+      if (isComposeBoxOffered)
+        QuoteAndReplyButton(message: message, pageContext: pageContext),
       CopyMessageTextButton(message: message, pageContext: pageContext),
       CopyMessageLinkButton(message: message, pageContext: pageContext),
       ShareButton(message: message, pageContext: pageContext),

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -44,6 +44,9 @@ import 'user.dart';
 /// [header] should not use vertical padding to position itself on the sheet.
 /// It will be wrapped in vertical padding
 /// and, if [headerScrollable], a scroll view and an [InsetShadowBox].
+///
+/// Empty lists in [buttonSections] are dropped,
+/// so callers don't need to filter those out themselves.
 void _showActionSheet(
   BuildContext pageContext, {
   Widget? header,
@@ -116,8 +119,10 @@ void _showActionSheet(
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     spacing: 8,
-                    children: buttonSections.map((buttons) =>
-                      MenuButtonsShape(buttons: buttons)).toList())))),
+                    children: buttonSections
+                      .where((buttons) => buttons.isNotEmpty)
+                      .map((buttons) => MenuButtonsShape(buttons: buttons))
+                      .toList())))),
               const BottomSheetDismissButton(style: BottomSheetDismissButtonStyle.cancel),
             ])));
 

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -852,14 +852,15 @@ void main() {
         ]);
       }
 
+      transitionDurationObserver = TransitionDurationObserver();
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        navigatorObservers: [transitionDurationObserver],
         child: const HomePage()));
       await tester.pump();
       check(find.byType(InboxPageBody)).findsOne();
 
       await tester.longPress(find.text(topic));
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
+      await transitionDurationObserver.pumpPastTransition(tester);
     }
 
     Future<void> showFromAppBar(WidgetTester tester, {
@@ -872,9 +873,11 @@ void main() {
       final effectiveMessages = messages ?? [someMessage];
       assert(effectiveMessages.every((m) => m.topic.apiName == effectiveTopic.apiName));
 
+      transitionDurationObserver = TransitionDurationObserver();
       connection.prepare(json: eg.newestGetMessagesResult(
         foundOldest: true, messages: effectiveMessages).toJson());
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        navigatorObservers: [transitionDurationObserver],
         child: MessageListPage(
           initNarrow: TopicNarrow(effectiveChannel.streamId, effectiveTopic))));
       // global store, per-account store, and message list get loaded
@@ -886,8 +889,7 @@ void main() {
           effectiveTopic.unresolve().displayName ?? eg.defaultRealmEmptyTopicDisplayName,
           findRichText: true));
       await tester.longPress(topicRow);
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
+      await transitionDurationObserver.pumpPastTransition(tester);
     }
 
     Future<void> showFromRecipientHeader(WidgetTester tester, {
@@ -895,9 +897,11 @@ void main() {
     }) async {
       final effectiveMessage = message ?? someMessage;
 
+      transitionDurationObserver = TransitionDurationObserver();
       connection.prepare(json: eg.newestGetMessagesResult(
         foundOldest: true, messages: [effectiveMessage]).toJson());
       await tester.pumpWidget(TestZulipApp(accountId: eg.selfAccount.id,
+        navigatorObservers: [transitionDurationObserver],
         child: const MessageListPage(initNarrow: CombinedFeedNarrow())));
       // global store, per-account store, and message list get loaded
       await tester.pumpAndSettle();
@@ -907,8 +911,7 @@ void main() {
         matching: find.textContaining(
           effectiveMessage.topic.unresolve().displayName!,
           findRichText: true)));
-      // sheet appears onscreen; default duration of bottom-sheet enter animation
-      await tester.pump(const Duration(milliseconds: 250));
+      await transitionDurationObserver.pumpPastTransition(tester);
     }
 
     final actionSheetFinder = find.byType(BottomSheet);

--- a/test/widgets/action_sheet_test.dart
+++ b/test/widgets/action_sheet_test.dart
@@ -411,6 +411,21 @@ void main() {
         await showFromTopicListAppBar(tester);
         checkButtons();
       });
+
+      testWidgets('button order', (tester) async {
+        await prepare();
+        await showFromInbox(tester);
+        final buttons = tester.widgetList<ZulipMenuItemButton>(
+          find.descendant(of: actionSheetFinder, matching: find.byType(ZulipMenuItemButton)));
+        check(buttons.map((b) => b.label).toList()).deepEquals([
+          'Unsubscribe',
+          'Pin to top',
+          'Mark channel as read',
+          'List of topics',
+          'Channel feed',
+          'Copy link to channel',
+        ]);
+      });
     });
 
     group('SubscribeButton', () {


### PR DESCRIPTION
Fixes #2383.

This PR reorders and groups buttons in the action sheets (`showTopicActionSheet`, `showChannelActionSheet`, `showMessageActionSheet`, and `showDmActionSheet`) to follow the approved design proposal in #2383, grouping options by who they affect (affects everyone, affects only me, or no effect).

Changes made:
- Topic action sheet: Place "Mark as resolved" at the top in its own section, followed by user topic settings (follow/mute) and "Mark topic as read", and "Copy link to topic" in the bottom section.
- Channel action sheet: Move "Unsubscribe" / "Subscribe" to the top alongside "Pin to top" and "Mark channel as read", followed by navigation and link options.
- Message action sheet: Group quick-reacts, edit, and delete in the top section; star, quote & reply, mark as unread, and hide muted message in the middle section; and view reactions, view read receipts, copy text/link, share, and report message in the bottom section.
- DM action sheet: Group "Mark as read" in the top section when unread messages exist, followed by "View profile".

Tested by adding a unit test for button ordering in `test/widgets/action_sheet_test.dart` and verifying `tools/check` passes cleanly.
