### PR TITLE
[3/n] api: Audit `RealmWildcardMentionPolicy`, `RealmDeleteOwnMessagePolicy` for unknown values

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1405,8 +1405,9 @@ class DeleteMessageEvent extends Event {
 
   final List<int> messageIds;
   // final int messageId; // Not present; we support the bulk_message_deletion capability
-  // The server never actually sends "direct" here yet (it's "private" instead),
-  // but we accept both forms for forward-compatibility.
+  // The server never actually sends "channel" or "direct" here yet
+  // (it's "stream" or "private" instead), but we accept both the old
+  // and new forms for forward-compatibility.
   @MessageTypeConverter()
   final MessageType messageType;
   final int? streamId;
@@ -1423,7 +1424,7 @@ class DeleteMessageEvent extends Event {
   factory DeleteMessageEvent.fromJson(Map<String, dynamic> json) {
     final result = _$DeleteMessageEventFromJson(json);
     // Crunchy-shell validation
-    if (result.messageType == .stream) {
+    if (result.messageType == .channel) {
       result.streamId as int;
       result.topic as String;
     }
@@ -1512,8 +1513,9 @@ class UpdateMessageFlagsRemoveEvent extends UpdateMessageFlagsEvent {
 /// As in [UpdateMessageFlagsRemoveEvent.messageDetails].
 @JsonSerializable(fieldRename: FieldRename.snake)
 class UpdateMessageFlagsMessageDetail {
-  // The server never actually sends "direct" here yet (it's "private" instead),
-  // but we accept both forms for forward-compatibility.
+  // The server never actually sends "channel" or "direct" here yet
+  // (it's "stream" or "private" instead), but we accept both the old
+  // and new forms for forward-compatibility.
   @MessageTypeConverter()
   final MessageType type;
   final bool? mentioned;
@@ -1533,7 +1535,7 @@ class UpdateMessageFlagsMessageDetail {
     final result = _$UpdateMessageFlagsMessageDetailFromJson(json);
     // Crunchy-shell validation
     switch (result.type) {
-      case .stream:
+      case .channel:
         result.streamId as int;
         result.topic as String;
       case .direct:
@@ -1590,6 +1592,8 @@ class TypingEvent extends Event {
   String get type => 'typing';
 
   final TypingOp op;
+  // The server never actually sends "channel" here yet (it's "stream" instead),
+  // but we accept both forms for forward-compatibility.
   @MessageTypeConverter()
   final MessageType messageType;
   @JsonKey(readValue: _readSenderId)
@@ -1623,7 +1627,7 @@ class TypingEvent extends Event {
     final result = _$TypingEventFromJson(json);
     // Crunchy-shell validation
     switch (result.messageType) {
-      case .stream:
+      case .channel:
         result.streamId as int;
         result.topic as String;
       case .direct:

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1727,6 +1727,7 @@ class ReactionEvent extends Event {
   @JsonKey(includeToJson: true)
   String get type => 'reaction';
 
+  @JsonKey(unknownEnumValue: ReactionOp.unknown)
   final ReactionOp op;
 
   final String emojiName;
@@ -1758,6 +1759,9 @@ class ReactionEvent extends Event {
 enum ReactionOp {
   add,
   remove,
+
+  /// A new, unrecognized operation.
+  unknown;
 }
 
 /// A Zulip event of type `heartbeat`: https://zulip.com/api/get-events#heartbeat

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1434,30 +1434,6 @@ class DeleteMessageEvent extends Event {
   Map<String, dynamic> toJson() => _$DeleteMessageEventToJson(this);
 }
 
-/// As in [DeleteMessageEvent.messageType],
-/// [UpdateMessageFlagsMessageDetail.type],
-/// or [TypingEvent.messageType].
-@JsonEnum(alwaysCreate: true)
-enum MessageType {
-  stream,
-  direct;
-}
-
-class MessageTypeConverter extends JsonConverter<MessageType, String> {
-  const MessageTypeConverter();
-
-  @override
-  MessageType fromJson(String json) {
-    if (json == 'private') json = 'direct'; // TODO(server-future)
-    return $enumDecode(_$MessageTypeEnumMap, json);
-  }
-
-  @override
-  String toJson(MessageType object) {
-    return _$MessageTypeEnumMap[object]!;
-  }
-}
-
 /// A Zulip event of type `update_message_flags`.
 ///
 /// For the corresponding API docs, see subclasses.

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1591,6 +1591,7 @@ class TypingEvent extends Event {
   @JsonKey(includeToJson: true)
   String get type => 'typing';
 
+  @JsonKey(unknownEnumValue: TypingOp.unknown)
   final TypingOp op;
   // The server never actually sends "channel" here yet (it's "stream" instead),
   // but we accept both forms for forward-compatibility.
@@ -1644,7 +1645,10 @@ class TypingEvent extends Event {
 @JsonEnum(fieldRename: FieldRename.snake)
 enum TypingOp {
   start,
-  stop;
+  stop,
+
+  /// A new, unrecognized operation.
+  unknown;
 
   String toJson() => _$TypingOpEnumMap[this]!;
 }

--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -1423,7 +1423,7 @@ class DeleteMessageEvent extends Event {
   factory DeleteMessageEvent.fromJson(Map<String, dynamic> json) {
     final result = _$DeleteMessageEventFromJson(json);
     // Crunchy-shell validation
-    if (result.messageType == MessageType.stream) {
+    if (result.messageType == .stream) {
       result.streamId as int;
       result.topic as String;
     }
@@ -1557,10 +1557,10 @@ class UpdateMessageFlagsMessageDetail {
     final result = _$UpdateMessageFlagsMessageDetailFromJson(json);
     // Crunchy-shell validation
     switch (result.type) {
-      case MessageType.stream:
+      case .stream:
         result.streamId as int;
         result.topic as String;
-      case MessageType.direct:
+      case .direct:
         result.userIds as List<int>;
     }
     return result;
@@ -1647,10 +1647,10 @@ class TypingEvent extends Event {
     final result = _$TypingEventFromJson(json);
     // Crunchy-shell validation
     switch (result.messageType) {
-      case MessageType.stream:
+      case .stream:
         result.streamId as int;
         result.topic as String;
-      case MessageType.direct:
+      case .direct:
         result.recipientIds as List<int>;
     }
     return result;

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -1061,7 +1061,11 @@ const _$SubmessageTypeEnumMap = {
 
 TypingEvent _$TypingEventFromJson(Map<String, dynamic> json) => TypingEvent(
   id: (json['id'] as num).toInt(),
-  op: $enumDecode(_$TypingOpEnumMap, json['op']),
+  op: $enumDecode(
+    _$TypingOpEnumMap,
+    json['op'],
+    unknownValue: TypingOp.unknown,
+  ),
   messageType: const MessageTypeConverter().fromJson(
     json['message_type'] as String,
   ),
@@ -1085,7 +1089,11 @@ Map<String, dynamic> _$TypingEventToJson(TypingEvent instance) =>
       'topic': instance.topic,
     };
 
-const _$TypingOpEnumMap = {TypingOp.start: 'start', TypingOp.stop: 'stop'};
+const _$TypingOpEnumMap = {
+  TypingOp.start: 'start',
+  TypingOp.stop: 'stop',
+  TypingOp.unknown: 'unknown',
+};
 
 PresenceEvent _$PresenceEventFromJson(Map<String, dynamic> json) =>
     PresenceEvent(

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -1139,7 +1139,11 @@ const _$PresenceStatusEnumMap = {
 ReactionEvent _$ReactionEventFromJson(Map<String, dynamic> json) =>
     ReactionEvent(
       id: (json['id'] as num).toInt(),
-      op: $enumDecode(_$ReactionOpEnumMap, json['op']),
+      op: $enumDecode(
+        _$ReactionOpEnumMap,
+        json['op'],
+        unknownValue: ReactionOp.unknown,
+      ),
       emojiName: json['emoji_name'] as String,
       emojiCode: json['emoji_code'] as String,
       reactionType: $enumDecode(_$ReactionTypeEnumMap, json['reaction_type']),
@@ -1162,6 +1166,7 @@ Map<String, dynamic> _$ReactionEventToJson(ReactionEvent instance) =>
 const _$ReactionOpEnumMap = {
   ReactionOp.add: 'add',
   ReactionOp.remove: 'remove',
+  ReactionOp.unknown: 'unknown',
 };
 
 const _$ReactionTypeEnumMap = {

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -1167,8 +1167,3 @@ HeartbeatEvent _$HeartbeatEventFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$HeartbeatEventToJson(HeartbeatEvent instance) =>
     <String, dynamic>{'id': instance.id, 'type': instance.type};
-
-const _$MessageTypeEnumMap = {
-  MessageType.stream: 'stream',
-  MessageType.direct: 'direct',
-};

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -94,7 +94,7 @@ class InitialSnapshot {
   /// The policy for who can use wildcard mentions in large channels.
   ///
   /// Search for "realm_wildcard_mention_policy" in https://zulip.com/api/register-queue.
-  final RealmWildcardMentionPolicy realmWildcardMentionPolicy;
+  final RealmWildcardMentionPolicy? realmWildcardMentionPolicy; // TODO(server-10) remove
 
   @JsonKey(unknownEnumValue: RealmTopicsPolicy.unknown)
   final RealmTopicsPolicy? realmTopicsPolicy; // TODO(server-11)

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -240,7 +240,12 @@ enum RealmWildcardMentionPolicy {
   fullMembers(apiValue: 3),
   admins(apiValue: 5),
   nobody(apiValue: 6),
-  moderators(apiValue: 7);
+  moderators(apiValue: 7),
+
+  // We don't accept an unknown value. `realm_wildcard_mention_policy` is
+  // deprecated in server-10, making future additions to this enum unlikely.
+  // unknown(apiValue: null),
+  ;
 
   const RealmWildcardMentionPolicy({required this.apiValue});
 

--- a/lib/api/model/initial_snapshot.dart
+++ b/lib/api/model/initial_snapshot.dart
@@ -260,7 +260,12 @@ enum RealmDeleteOwnMessagePolicy {
   admins(apiValue: 2),
   fullMembers(apiValue: 3),
   moderators(apiValue: 4),
-  everyone(apiValue: 5);
+  everyone(apiValue: 5),
+
+  // We don't accept an unknown value. `realm_delete_own_message_policy` is
+  // removed in server-10, making future additions to this enum impossible.
+  // unknown(apiValue: -100),
+  ;
 
   const RealmDeleteOwnMessagePolicy({required this.apiValue});
 

--- a/lib/api/model/initial_snapshot.g.dart
+++ b/lib/api/model/initial_snapshot.g.dart
@@ -107,7 +107,7 @@ InitialSnapshot _$InitialSnapshotFromJson(
     _$RealmDeleteOwnMessagePolicyEnumMap,
     json['realm_delete_own_message_policy'],
   ),
-  realmWildcardMentionPolicy: $enumDecode(
+  realmWildcardMentionPolicy: $enumDecodeNullable(
     _$RealmWildcardMentionPolicyEnumMap,
     json['realm_wildcard_mention_policy'],
   ),

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1289,6 +1289,30 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
   Map<String, dynamic> toJson();
 }
 
+/// As in [DeleteMessageEvent.messageType],
+/// [UpdateMessageFlagsMessageDetail.type],
+/// or [TypingEvent.messageType].
+@JsonEnum(alwaysCreate: true)
+enum MessageType {
+  stream,
+  direct;
+}
+
+class MessageTypeConverter extends JsonConverter<MessageType, String> {
+  const MessageTypeConverter();
+
+  @override
+  MessageType fromJson(String json) {
+    if (json == 'private') json = 'direct'; // TODO(server-future)
+    return $enumDecode(_$MessageTypeEnumMap, json);
+  }
+
+  @override
+  String toJson(MessageType object) {
+    return _$MessageTypeEnumMap[object]!;
+  }
+}
+
 /// https://zulip.com/api/update-message-flags#available-flags
 @JsonEnum(fieldRename: FieldRename.snake, alwaysCreate: true)
 enum MessageFlag {

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1221,7 +1221,10 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
   @JsonKey(name: 'submessages', readValue: _readPoll, fromJson: Poll.fromJson, toJson: Poll.toJson)
   Poll? poll;
 
-  String get type;
+  // The server never actually sends "channel" or "direct" here yet
+  // (it's "stream" or "private" instead), but we accept both the old
+  // and new forms for forward-compatibility.
+  MessageType get type;
 
   // final List<TopicLink> topicLinks; // TODO handle
   // final string type; // handled by runtime type of object
@@ -1280,18 +1283,17 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
   // TODO(dart): This has to be a static method, because factories/constructors
   //   do not support type parameters: https://github.com/dart-lang/language/issues/647
   static Message fromJson(Map<String, dynamic> json) {
-    final type = json['type'] as String;
-    if (type == 'stream') return StreamMessage.fromJson(json);
-    if (type == 'private') return DmMessage.fromJson(json);
-    throw Exception("Message.fromJson: unexpected message type $type");
+    return switch (MessageType.fromJson(json['type'] as String)) {
+      .channel => StreamMessage.fromJson(json),
+      .direct => DmMessage.fromJson(json),
+    };
   }
 
   Map<String, dynamic> toJson();
 }
 
-/// As in [DeleteMessageEvent.messageType],
-/// [UpdateMessageFlagsMessageDetail.type],
-/// or [TypingEvent.messageType].
+/// As in [Message.type], [DeleteMessageEvent.messageType],
+/// [UpdateMessageFlagsMessageDetail.type], or [TypingEvent.messageType].
 @JsonEnum(alwaysCreate: true)
 enum MessageType {
   channel,
@@ -1370,7 +1372,7 @@ enum MessageFlag {
 class StreamMessage extends Message<StreamConversation> {
   @override
   @JsonKey(includeToJson: true)
-  String get type => 'stream';
+  MessageType get type => .channel;
 
   @JsonKey(includeToJson: true)
   int get streamId => conversation.streamId;
@@ -1424,7 +1426,7 @@ class StreamMessage extends Message<StreamConversation> {
 class DmMessage extends Message<DmConversation> {
   @override
   @JsonKey(includeToJson: true)
-  String get type => 'private';
+  MessageType get type => .direct;
 
   /// The user IDs of all users in the thread, sorted numerically, as in
   /// `display_recipient` from the server.

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1296,6 +1296,11 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
 enum MessageType {
   stream,
   direct;
+
+  factory MessageType.fromJson(String json) {
+    if (json == 'private') json = 'direct'; // TODO(server-future)
+    return $enumDecode(_$MessageTypeEnumMap, json);
+  }
 }
 
 class MessageTypeConverter extends JsonConverter<MessageType, String> {
@@ -1303,8 +1308,7 @@ class MessageTypeConverter extends JsonConverter<MessageType, String> {
 
   @override
   MessageType fromJson(String json) {
-    if (json == 'private') json = 'direct'; // TODO(server-future)
-    return $enumDecode(_$MessageTypeEnumMap, json);
+    return MessageType.fromJson(json);
   }
 
   @override

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1294,11 +1294,14 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
 /// or [TypingEvent.messageType].
 @JsonEnum(alwaysCreate: true)
 enum MessageType {
-  stream,
+  channel,
   direct;
 
   factory MessageType.fromJson(String json) {
-    if (json == 'private') json = 'direct'; // TODO(server-future)
+    switch (json) {
+      case 'stream': json = 'channel'; // TODO(server-future)
+      case 'private': json = 'direct'; // TODO(server-future)
+    }
     return $enumDecode(_$MessageTypeEnumMap, json);
   }
 }

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -1297,7 +1297,14 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
 @JsonEnum(alwaysCreate: true)
 enum MessageType {
   channel,
-  direct;
+  direct,
+
+  // We don't accept an unknown message type because we generally cannot decide
+  // how to interpret such data. In particular, when a message with an unknown
+  // type is received from the server, we cannot determine which message model
+  // to instantiate: either [StreamMessage] or [DmMessage]. See [Message.fromJson].
+  // unknown,
+  ;
 
   factory MessageType.fromJson(String json) {
     switch (json) {

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -504,7 +504,7 @@ Map<String, dynamic> _$StreamMessageToJson(StreamMessage instance) =>
       'flags': instance.flags,
       'match_content': instance.matchContent,
       'match_subject': instance.matchTopic,
-      'type': instance.type,
+      'type': _$MessageTypeEnumMap[instance.type]!,
       'stream_id': instance.streamId,
       'subject': instance.topic,
       'display_recipient': instance.displayRecipient,
@@ -514,6 +514,11 @@ const _$MessageEditStateEnumMap = {
   MessageEditState.none: 'none',
   MessageEditState.edited: 'edited',
   MessageEditState.moved: 'moved',
+};
+
+const _$MessageTypeEnumMap = {
+  MessageType.channel: 'channel',
+  MessageType.direct: 'direct',
 };
 
 DmMessage _$DmMessageFromJson(Map<String, dynamic> json) => DmMessage(
@@ -558,7 +563,7 @@ Map<String, dynamic> _$DmMessageToJson(DmMessage instance) => <String, dynamic>{
   'flags': instance.flags,
   'match_content': instance.matchContent,
   'match_subject': instance.matchTopic,
-  'type': instance.type,
+  'type': _$MessageTypeEnumMap[instance.type]!,
   'display_recipient': DmMessage._allRecipientIdsToJson(
     instance.allRecipientIds,
   ),
@@ -615,11 +620,6 @@ const _$SubscriptionPropertyEnumMap = {
   SubscriptionProperty.emailNotifications: 'email_notifications',
   SubscriptionProperty.wildcardMentionsNotify: 'wildcard_mentions_notify',
   SubscriptionProperty.unknown: 'unknown',
-};
-
-const _$MessageTypeEnumMap = {
-  MessageType.channel: 'channel',
-  MessageType.direct: 'direct',
 };
 
 const _$MessageFlagEnumMap = {

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -618,7 +618,7 @@ const _$SubscriptionPropertyEnumMap = {
 };
 
 const _$MessageTypeEnumMap = {
-  MessageType.stream: 'stream',
+  MessageType.channel: 'channel',
   MessageType.direct: 'direct',
 };
 

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -617,6 +617,11 @@ const _$SubscriptionPropertyEnumMap = {
   SubscriptionProperty.unknown: 'unknown',
 };
 
+const _$MessageTypeEnumMap = {
+  MessageType.stream: 'stream',
+  MessageType.direct: 'direct',
+};
+
 const _$MessageFlagEnumMap = {
   MessageFlag.read: 'read',
   MessageFlag.starred: 'starred',

--- a/lib/api/route/typing.dart
+++ b/lib/api/route/typing.dart
@@ -7,7 +7,11 @@ import 'messages.dart';
 Future<void> setTypingStatus(ApiConnection connection, {
   required TypingOp op,
   required MessageDestination destination,
-}) {
+}) async {
+  if (op == .unknown) {
+    assert(false, 'TypingOp.unknown is not supported when setting typing status.');
+    return;
+  }
   switch (destination) {
     case StreamDestination():
       final supportsTypeChannel = connection.zulipFeatureLevel! >= 248; // TODO(server-9)

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -836,14 +836,14 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
     if (message == null) return;
 
     switch (event.op) {
-      case ReactionOp.add:
+      case .add:
         (message.reactions ??= Reactions([])).add(Reaction(
           emojiName: event.emojiName,
           emojiCode: event.emojiCode,
           reactionType: event.reactionType,
           userId: event.userId,
         ));
-      case ReactionOp.remove:
+      case .remove:
         if (message.reactions == null) { // TODO(log)
           return;
         }

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -7,7 +7,6 @@ import 'package:flutter/foundation.dart';
 
 import '../api/exception.dart';
 import '../api/model/events.dart';
-import '../api/model/initial_snapshot.dart';
 import '../api/model/model.dart';
 import '../api/route/messages.dart';
 import '../log.dart';
@@ -185,20 +184,20 @@ mixin MessageStore on ChannelStore {
     // but pre-291 servers shouldn't be giving us an unknown role.)
 
     switch (realmDeleteOwnMessagePolicy!) {
-      case RealmDeleteOwnMessagePolicy.everyone:
+      case .everyone:
         return true;
-      case RealmDeleteOwnMessagePolicy.members:
+      case .members:
         return role.isAtLeast(UserRole.member);
-      case RealmDeleteOwnMessagePolicy.fullMembers: {
+      case .fullMembers: {
         if (!role.isAtLeast(UserRole.member)) return false;
         if (role == UserRole.member) {
           return selfHasPassedWaitingPeriod(byDate: atDate);
         }
         return true;
       }
-      case RealmDeleteOwnMessagePolicy.moderators:
+      case .moderators:
         return role.isAtLeast(UserRole.moderator);
-      case RealmDeleteOwnMessagePolicy.admins:
+      case .admins:
         return role.isAtLeast(UserRole.administrator);
     }
   }

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -832,6 +832,8 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
   }
 
   void handleReactionEvent(ReactionEvent event) {
+    if (event.op == .unknown) return;
+
     final message = messages[event.messageId];
     if (message == null) return;
 
@@ -852,6 +854,8 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
           emojiCode: event.emojiCode,
           userId: event.userId,
         );
+      case .unknown:
+        // Shouldn't reach here because of the early return.
     }
     _notifyMessageListViewsForOneMessage(event.messageId);
   }

--- a/lib/model/narrow.dart
+++ b/lib/model/narrow.dart
@@ -241,7 +241,7 @@ class DmNarrow extends Narrow implements SendableNarrow {
     UpdateMessageFlagsMessageDetail detail, {
     required int selfUserId,
   }) {
-    assert(detail.type == MessageType.direct);
+    assert(detail.type == .direct);
     return DmNarrow.withOtherUsers(detail.userIds!, selfUserId: selfUserId);
   }
 

--- a/lib/model/realm.dart
+++ b/lib/model/realm.dart
@@ -76,7 +76,7 @@ mixin RealmStore on PerAccountStoreBase, UserGroupStore {
   // Realm settings previously found in realm/update_dict events,
   // but now deprecated.
 
-  RealmWildcardMentionPolicy get realmWildcardMentionPolicy; // TODO(server-10) remove
+  RealmWildcardMentionPolicy? get realmWildcardMentionPolicy; // TODO(server-10) remove
   RealmDeleteOwnMessagePolicy? get realmDeleteOwnMessagePolicy; // TODO(server-10) remove
 
   //|//////////////////////////////
@@ -217,7 +217,7 @@ mixin ProxyRealmStore on RealmStore {
   @override
   int get realmWaitingPeriodThreshold => realmStore.realmWaitingPeriodThreshold;
   @override
-  RealmWildcardMentionPolicy get realmWildcardMentionPolicy => realmStore.realmWildcardMentionPolicy;
+  RealmWildcardMentionPolicy? get realmWildcardMentionPolicy => realmStore.realmWildcardMentionPolicy;
   @override
   RealmDeleteOwnMessagePolicy? get realmDeleteOwnMessagePolicy => realmStore.realmDeleteOwnMessagePolicy;
   @override
@@ -458,7 +458,7 @@ class RealmStoreImpl extends HasUserGroupStore with RealmStore {
   final int realmWaitingPeriodThreshold;
 
   @override
-  final RealmWildcardMentionPolicy realmWildcardMentionPolicy;
+  final RealmWildcardMentionPolicy? realmWildcardMentionPolicy;
   @override
   final RealmDeleteOwnMessagePolicy? realmDeleteOwnMessagePolicy;
 

--- a/lib/model/recent_senders.dart
+++ b/lib/model/recent_senders.dart
@@ -87,7 +87,7 @@ class RecentSenders {
   }
 
   void handleDeleteMessageEvent(DeleteMessageEvent event, Map<int, Message> cachedMessages) {
-    if (event.messageType != .stream) return;
+    if (event.messageType != .channel) return;
 
     final messagesByUser = <int, List<int>>{};
     for (final id in event.messageIds) {

--- a/lib/model/recent_senders.dart
+++ b/lib/model/recent_senders.dart
@@ -87,7 +87,7 @@ class RecentSenders {
   }
 
   void handleDeleteMessageEvent(DeleteMessageEvent event, Map<int, Message> cachedMessages) {
-    if (event.messageType != MessageType.stream) return;
+    if (event.messageType != .stream) return;
 
     final messagesByUser = <int, List<int>>{};
     for (final id in event.messageIds) {

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -65,7 +65,7 @@ class TypingStatus extends HasRealmStore with ChangeNotifier {
     SendableNarrow narrow = switch (event.messageType) {
       .direct => DmNarrow(
         allRecipientIds: event.recipientIds!, selfUserId: selfUserId),
-      .stream => TopicNarrow(event.streamId!, event.topic!),
+      .channel => TopicNarrow(event.streamId!, event.topic!),
     };
 
     bool hasUpdate = false;

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -62,6 +62,8 @@ class TypingStatus extends HasRealmStore with ChangeNotifier {
   }
 
   void handleTypingEvent(TypingEvent event) {
+    if (event.op == .unknown) return;
+
     SendableNarrow narrow = switch (event.messageType) {
       .direct => DmNarrow(
         allRecipientIds: event.recipientIds!, selfUserId: selfUserId),
@@ -74,6 +76,8 @@ class TypingStatus extends HasRealmStore with ChangeNotifier {
         hasUpdate = _addTypist(narrow, event.senderId);
       case .stop:
         hasUpdate = _removeTypist(narrow, event.senderId);
+      case .unknown:
+        // Shouldn't reach here because of the early return.
     }
 
     if (hasUpdate) {

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -70,9 +70,9 @@ class TypingStatus extends HasRealmStore with ChangeNotifier {
 
     bool hasUpdate = false;
     switch (event.op) {
-      case TypingOp.start:
+      case .start:
         hasUpdate = _addTypist(narrow, event.senderId);
-      case TypingOp.stop:
+      case .stop:
         hasUpdate = _removeTypist(narrow, event.senderId);
     }
 
@@ -176,7 +176,7 @@ class TypingNotifier extends HasRealmStore {
 
     unawaited(setTypingStatus(
       connection,
-      op: TypingOp.start,
+      op: .start,
       destination: _currentDestination!.destination));
   }
 
@@ -190,7 +190,7 @@ class TypingNotifier extends HasRealmStore {
 
     unawaited(setTypingStatus(
       connection,
-      op: TypingOp.stop,
+      op: .stop,
       destination: destination.destination));
   }
 

--- a/lib/model/typing_status.dart
+++ b/lib/model/typing_status.dart
@@ -63,9 +63,9 @@ class TypingStatus extends HasRealmStore with ChangeNotifier {
 
   void handleTypingEvent(TypingEvent event) {
     SendableNarrow narrow = switch (event.messageType) {
-      MessageType.direct => DmNarrow(
+      .direct => DmNarrow(
         allRecipientIds: event.recipientIds!, selfUserId: selfUserId),
-      MessageType.stream => TopicNarrow(event.streamId!, event.topic!),
+      .stream => TopicNarrow(event.streamId!, event.topic!),
     };
 
     bool hasUpdate = false;

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -412,13 +412,13 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
   void handleDeleteMessageEvent(DeleteMessageEvent event) {
     mentions.removeAll(event.messageIds);
     switch (event.messageType) {
-      case MessageType.stream:
+      case .stream:
         // All the messages are in [event.streamId] and [event.topic],
         // so we can be more efficient than _removeAllInStreamsAndDms.
         final streamId = event.streamId!;
         final topic = event.topic!;
         _removeAllInStreamTopic(Set.of(event.messageIds), streamId, topic);
-      case MessageType.direct:
+      case .direct:
         _removeAllInStreamsAndDms(event.messageIds, expectOnlyDms: true);
     }
     for (final messageId in event.messageIds) {
@@ -490,13 +490,13 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
                 mentions.add(messageId);
               }
               switch (detail.type) {
-                case MessageType.stream:
+                case .stream:
                   final UpdateMessageFlagsMessageDetail(:streamId, :topic) = detail;
                   locatorMap[messageId] = TopicNarrow(streamId!, topic!);
                   final topics = (newlyUnreadInStreams[streamId] ??= makeTopicKeyedMap());
                   final messageIds = (topics[topic] ??= QueueList());
                   messageIds.add(messageId);
-                case MessageType.direct:
+                case .direct:
                   final narrow = DmNarrow.ofUpdateMessageFlagsMessageDetail(selfUserId: selfUserId,
                     detail);
                   locatorMap[messageId] = narrow;

--- a/lib/model/unreads.dart
+++ b/lib/model/unreads.dart
@@ -412,7 +412,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
   void handleDeleteMessageEvent(DeleteMessageEvent event) {
     mentions.removeAll(event.messageIds);
     switch (event.messageType) {
-      case .stream:
+      case .channel:
         // All the messages are in [event.streamId] and [event.topic],
         // so we can be more efficient than _removeAllInStreamsAndDms.
         final streamId = event.streamId!;
@@ -490,7 +490,7 @@ class Unreads extends PerAccountStoreBase with ChangeNotifier {
                 mentions.add(messageId);
               }
               switch (detail.type) {
-                case .stream:
+                case .channel:
                   final UpdateMessageFlagsMessageDetail(:streamId, :topic) = detail;
                   locatorMap[messageId] = TopicNarrow(streamId!, topic!);
                   final topics = (newlyUnreadInStreams[streamId] ??= makeTopicKeyedMap());

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -85,6 +85,7 @@ extension UpdateMessageFlagsMessageDetailCheck on Subject<UpdateMessageFlagsMess
 }
 
 extension TypingEventChecks on Subject<TypingEvent> {
+  Subject<TypingOp> get op => has((e) => e.op, 'op');
   Subject<MessageType> get messageType => has((e) => e.messageType, 'messageType');
   Subject<int> get senderId => has((e) => e.senderId, 'senderId');
   Subject<List<int>?> get recipientIds => has((e) => e.recipientIds, 'recipientIds');

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -93,6 +93,10 @@ extension TypingEventChecks on Subject<TypingEvent> {
   Subject<TopicName?> get topic => has((e) => e.topic, 'topic');
 }
 
+extension ReactionEventChecks on Subject<ReactionEvent> {
+  Subject<ReactionOp> get op => has((e) => e.op, 'op');
+}
+
 extension HeartbeatEventChecks on Subject<HeartbeatEvent> {
   // No properties not covered by Event.
 }

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -360,6 +360,16 @@ void main() {
       'recipients': [1, 2, 3].map((e) => {'user_id': e, 'email': '$e@example.com'}).toList(),
     };
 
+    test('handle unknown op', () {
+      check(TypingEvent.fromJson(directMessageJson))
+        .op.equals(.start);
+
+      for (final unknown in ['unknown_op', '']) {
+        check(TypingEvent.fromJson({...directMessageJson, 'op': unknown}))
+          .op.equals(.unknown);
+      }
+    });
+
     test('direct message typing events', () {
       check(TypingEvent.fromJson(directMessageJson))
         ..recipientIds.isNotNull().deepEquals([1, 2, 3])

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -245,6 +245,7 @@ void main() {
       'message_type': 'private',
     })).returnsNormally();
 
+    // TODO(server-future): remove
     final baseJsonStream = {
       'id': 1,
       'type': 'delete_message',
@@ -252,21 +253,31 @@ void main() {
       'message_type': 'stream',
     };
 
-    check(() => DeleteMessageEvent.fromJson({
-      ...baseJsonStream
-    })).throws<void>();
+    // Future server.
+    final baseJsonChannel = {
+      'id': 1,
+      'type': 'delete_message',
+      'message_ids': [1, 2, 3],
+      'message_type': 'channel',
+    };
 
-    check(() => DeleteMessageEvent.fromJson({
-      ...baseJsonStream, 'stream_id': 1, 'topic': 'some topic',
-    })).returnsNormally();
+    for (final baseJson in [baseJsonStream, baseJsonChannel]) {
+      check(() => DeleteMessageEvent.fromJson({
+        ...baseJson
+      })).throws<void>();
 
-    check(() => DeleteMessageEvent.fromJson({
-      ...baseJsonStream, 'stream_id': 1,
-    })).throws<void>();
+      check(() => DeleteMessageEvent.fromJson({
+        ...baseJson, 'stream_id': 1, 'topic': 'some topic',
+      })).returnsNormally();
 
-    check(() => DeleteMessageEvent.fromJson({
-      ...baseJsonStream, 'topic': 'some topic',
-    })).throws<void>();
+      check(() => DeleteMessageEvent.fromJson({
+        ...baseJson, 'stream_id': 1,
+      })).throws<void>();
+
+      check(() => DeleteMessageEvent.fromJson({
+        ...baseJson, 'topic': 'some topic',
+      })).throws<void>();
+    }
   });
 
   test('delete_message: private -> direct', () {
@@ -276,6 +287,17 @@ void main() {
       'message_ids': [1, 2, 3],
       'message_type': 'private',
     })).messageType.equals(.direct);
+  });
+
+  test('delete_message: stream -> channel', () {
+    check(DeleteMessageEvent.fromJson({
+      'id': 1,
+      'type': 'delete_message',
+      'message_ids': [1, 2, 3],
+      'message_type': 'stream',
+      'stream_id': 1,
+      'topic': 'some topic',
+    })).messageType.equals(.channel);
   });
 
   group('update_message_flags/remove', () {
@@ -312,6 +334,16 @@ void main() {
           }}})).messageDetails.isNotNull()
                .values.single.type.equals(.direct);
     });
+
+    test('stream -> channel', () {
+      check(UpdateMessageFlagsRemoveEvent.fromJson({
+        ...baseJson,
+        'flag': 'read',
+        'message_details': {
+          '123': {'type': 'stream', 'mentioned': false, 'stream_id': 1, 'topic': 'some topic'}
+        }})).messageDetails.isNotNull()
+            .values.single.type.equals(.channel);
+    });
   });
 
   group('typing status event', () {
@@ -346,16 +378,32 @@ void main() {
       })).messageType.equals(.direct);
     });
 
-    test('stream type missing streamId/topic', () {
-      check(() => TypingEvent.fromJson({
-        ...baseJson, 'message_type': 'stream', 'stream_id': 123, 'topic': 'foo'}))
-        .returnsNormally();
-      check(() => TypingEvent.fromJson({
-        ...baseJson, 'message_type': 'stream'})).throws<void>();
-      check(() => TypingEvent.fromJson({
-        ...baseJson, 'message_type': 'stream', 'topic': 'foo'})).throws<void>();
-      check(() => TypingEvent.fromJson({
-        ...baseJson, 'message_type': 'stream', 'stream_id': 123})).throws<void>();
+    test('stream/channel type missing streamId/topic', () {
+      // TODO(server-future): remove
+      final baseJsonStream = {...baseJson, 'message_type': 'stream'};
+      // Future server.
+      final baseJsonChannel = {...baseJson, 'message_type': 'channel'};
+
+      for (final baseJson in [baseJsonStream, baseJsonChannel]) {
+        check(() => TypingEvent.fromJson({
+          ...baseJson, 'stream_id': 123, 'topic': 'foo'}))
+          .returnsNormally();
+        check(() => TypingEvent.fromJson({
+          ...baseJson})).throws<void>();
+        check(() => TypingEvent.fromJson({
+          ...baseJson, 'topic': 'foo'})).throws<void>();
+        check(() => TypingEvent.fromJson({
+          ...baseJson, 'stream_id': 123})).throws<void>();
+      }
+    });
+
+    test('stream -> channel', () {
+      check(TypingEvent.fromJson({
+        ...baseJson,
+        'stream_id': 123,
+        'topic': 'foo',
+        'message_type': 'stream',
+      })).messageType.equals(.channel);
     });
 
     test('direct type sort recipient ids', () {

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -423,4 +423,25 @@ void main() {
       })).recipientIds.isNotNull().deepEquals([1, 2, 4, 8, 10]);
     });
   });
+
+  group('reaction event', () {
+    final json = Map<String, dynamic>.unmodifiable({
+      'id': 1,
+      'type': 'reaction',
+      'op': 'add',
+      'emoji_name': '+1',
+      'emoji_code': '1f44d',
+      'reaction_type': 'unicode_emoji',
+      'user_id': 100,
+      'message_id': 1000,
+    });
+
+    test('handle unknown op', () {
+      check(ReactionEvent.fromJson(json)).op.equals(.add);
+
+      for (final unknown in ['unknown_op', '']) {
+        check(ReactionEvent.fromJson({...json, 'op': unknown})).op.equals(.unknown);
+      }
+    });
+  });
 }

--- a/test/api/model/events_test.dart
+++ b/test/api/model/events_test.dart
@@ -275,7 +275,7 @@ void main() {
       'type': 'delete_message',
       'message_ids': [1, 2, 3],
       'message_type': 'private',
-    })).messageType.equals(MessageType.direct);
+    })).messageType.equals(.direct);
   });
 
   group('update_message_flags/remove', () {
@@ -310,7 +310,7 @@ void main() {
             ...messageDetail,
             'type': 'private',
           }}})).messageDetails.isNotNull()
-               .values.single.type.equals(MessageType.direct);
+               .values.single.type.equals(.direct);
     });
   });
 
@@ -343,7 +343,7 @@ void main() {
       check(TypingEvent.fromJson({
         ...directMessageJson,
         'message_type': 'private',
-      })).messageType.equals(MessageType.direct);
+      })).messageType.equals(.direct);
     });
 
     test('stream type missing streamId/topic', () {

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -109,7 +109,7 @@ extension MessageChecks on Subject<Message> {
   Subject<String> get senderFullName => has((e) => e.senderFullName, 'senderFullName');
   Subject<String> get senderRealmStr => has((e) => e.senderRealmStr, 'senderRealmStr');
   Subject<Poll?> get poll => has((e) => e.poll, 'poll');
-  Subject<String> get type => has((e) => e.type, 'type');
+  Subject<MessageType> get type => has((e) => e.type, 'type');
   Subject<List<MessageFlag>> get flags => has((e) => e.flags, 'flags');
   Subject<String?> get matchContent => has((e) => e.matchContent, 'matchContent');
   Subject<String?> get matchTopic => has((e) => e.matchTopic, 'matchTopic');

--- a/test/api/model/model_test.dart
+++ b/test/api/model/model_test.dart
@@ -149,6 +149,33 @@ void main() {
     Map<String, dynamic> baseStreamJson() =>
       deepToJson(eg.streamMessage()) as Map<String, dynamic>;
 
+    Map<String, dynamic> baseDmJson() =>
+      deepToJson(eg.dmMessage(from: eg.selfUser, to: [])) as Map<String, dynamic>;
+
+    test('type: stream -> channel', () {
+      check(baseStreamJson()['type']).equals('channel');
+      check(Message.fromJson(baseStreamJson()))
+        .isA<StreamMessage>()
+        .type.equals(.channel);
+
+      check(Message.fromJson(baseStreamJson()
+        ..['type'] = 'stream'
+      )).isA<StreamMessage>()
+        .type.equals(.channel);
+    });
+
+    test('type: private -> direct', () {
+      check(baseDmJson()['type']).equals('direct');
+      check(Message.fromJson(baseDmJson()))
+        .isA<DmMessage>()
+        .type.equals(.direct);
+
+      check(Message.fromJson(baseDmJson()
+        ..['type'] = 'private'
+      )).isA<DmMessage>()
+        .type.equals(.direct);
+    });
+
     test('subject -> topic', () {
       check(baseStreamJson()).not((it) => it.containsKey('topic'));
       check(Message.fromJson(baseStreamJson()

--- a/test/api/route/typing_test.dart
+++ b/test/api/route/typing_test.dart
@@ -43,16 +43,16 @@ void main() {
   }
 
   test('send typing status start for topic', () {
-    return checkSetTypingStatusForTopic(TypingOp.start, 'start');
+    return checkSetTypingStatusForTopic(.start, 'start');
   });
 
   test('send typing status stop for topic', () {
-    return checkSetTypingStatusForTopic(TypingOp.stop, 'stop');
+    return checkSetTypingStatusForTopic(.stop, 'stop');
   });
 
   test('send typing status start for dm', () {
     return FakeApiConnection.with_((connection) {
-      return checkSetTypingStatus(connection, TypingOp.start,
+      return checkSetTypingStatus(connection, .start,
         destination: const DmDestination(userIds: userIds),
         expectedBodyFields: {
           'op': 'start',
@@ -64,7 +64,7 @@ void main() {
 
   test('legacy: use "stream" instead of "channel"', () {
     return FakeApiConnection.with_(zulipFeatureLevel: 247, (connection) {
-      return checkSetTypingStatus(connection, TypingOp.start,
+      return checkSetTypingStatus(connection, .start,
         destination: const StreamDestination(streamId, TopicName(topic)),
         expectedBodyFields: {
           'op': 'start',
@@ -77,7 +77,7 @@ void main() {
 
   test('legacy: use to=[streamId] instead of stream_id=streamId', () {
     return FakeApiConnection.with_(zulipFeatureLevel: 214, (connection) {
-      return checkSetTypingStatus(connection, TypingOp.start,
+      return checkSetTypingStatus(connection, .start,
         destination: const StreamDestination(streamId, TopicName(topic)),
         expectedBodyFields: {
           'op': 'start',
@@ -90,7 +90,7 @@ void main() {
 
   test('legacy: use "private" instead of "direct"', () {
     return FakeApiConnection.with_(zulipFeatureLevel: 173, (connection) {
-      return checkSetTypingStatus(connection, TypingOp.start,
+      return checkSetTypingStatus(connection, .start,
         destination: const DmDestination(userIds: userIds),
         expectedBodyFields: {
           'op': 'start',

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1107,7 +1107,7 @@ DeleteMessageEvent deleteMessageEvent(List<StreamMessage> messages) {
   return DeleteMessageEvent(
     id: 0,
     messageIds: messages.map((message) => message.id).toList(),
-    messageType: .stream,
+    messageType: .channel,
     streamId: messages[0].streamId,
     topic: messages[0].topic,
   );
@@ -1255,7 +1255,7 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
         message.id,
         switch (message) {
           StreamMessage() => UpdateMessageFlagsMessageDetail(
-            type: .stream,
+            type: .channel,
             mentioned: mentioned,
             streamId: message.streamId,
             topic: message.topic,
@@ -1293,7 +1293,7 @@ TypingEvent typingEvent(SendableNarrow narrow, TypingOp op, int senderId) {
   switch (narrow) {
     case TopicNarrow():
       return TypingEvent(id: 0, op: op, senderId: senderId,
-        messageType: .stream,
+        messageType: .channel,
         streamId: narrow.channelId,
         topic: narrow.topic,
         recipientIds: null);

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -801,7 +801,7 @@ StreamMessage streamMessage({
     'subject': topic ?? _defaultTopic,
     'submessages': submessages ?? [],
     'timestamp': timestamp ?? 1678139636,
-    'type': 'stream',
+    'type': 'channel',
     'match_content': matchContent,
     'match_subject': matchTopic,
   }) as Map<String, dynamic>);
@@ -844,7 +844,7 @@ DmMessage dmMessage({
     'subject': '',
     'submessages': submessages ?? [],
     'timestamp': timestamp ?? 1678139636,
-    'type': 'private',
+    'type': 'direct',
   }) as Map<String, dynamic>);
 }
 

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1107,7 +1107,7 @@ DeleteMessageEvent deleteMessageEvent(List<StreamMessage> messages) {
   return DeleteMessageEvent(
     id: 0,
     messageIds: messages.map((message) => message.id).toList(),
-    messageType: MessageType.stream,
+    messageType: .stream,
     streamId: messages[0].streamId,
     topic: messages[0].topic,
   );
@@ -1255,14 +1255,14 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
         message.id,
         switch (message) {
           StreamMessage() => UpdateMessageFlagsMessageDetail(
-            type: MessageType.stream,
+            type: .stream,
             mentioned: mentioned,
             streamId: message.streamId,
             topic: message.topic,
             userIds: null,
           ),
           DmMessage() => UpdateMessageFlagsMessageDetail(
-            type: MessageType.direct,
+            type: .direct,
             mentioned: mentioned,
             streamId: null,
             topic: null,
@@ -1293,13 +1293,13 @@ TypingEvent typingEvent(SendableNarrow narrow, TypingOp op, int senderId) {
   switch (narrow) {
     case TopicNarrow():
       return TypingEvent(id: 0, op: op, senderId: senderId,
-        messageType: MessageType.stream,
+        messageType: .stream,
         streamId: narrow.channelId,
         topic: narrow.topic,
         recipientIds: null);
     case DmNarrow():
       return TypingEvent(id: 0, op: op, senderId: senderId,
-        messageType: MessageType.direct,
+        messageType: .direct,
         recipientIds: narrow.allRecipientIds,
         streamId: null,
         topic: null);

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -1503,7 +1503,7 @@ InitialSnapshot initialSnapshot({
     realmCanDeleteAnyMessageGroup: realmCanDeleteAnyMessageGroup,
     realmCanDeleteOwnMessageGroup: realmCanDeleteOwnMessageGroup,
     realmDeleteOwnMessagePolicy: realmDeleteOwnMessagePolicy,
-    realmWildcardMentionPolicy: realmWildcardMentionPolicy ?? RealmWildcardMentionPolicy.everyone,
+    realmWildcardMentionPolicy: realmWildcardMentionPolicy ?? .everyone,
     // no default; allow `null` to simulate servers without this
     realmTopicsPolicy: realmTopicsPolicy,
     realmMandatoryTopics: realmMandatoryTopics ?? true,

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -2193,7 +2193,7 @@ void main() {
       await store.addMessage(message);
 
       await store.handleEvent(
-        eg.reactionEvent(eg.unicodeEmojiReaction, ReactionOp.add, message.id));
+        eg.reactionEvent(eg.unicodeEmojiReaction, .add, message.id));
 
       check(notifiedCount1).equals(3); // fetch, new-message event, reaction event
       check(notifiedCount2).equals(3); // fetch, new-message event, reaction event
@@ -2236,7 +2236,7 @@ void main() {
     test('ReactionEvent is applied even when message not in any msglists', () async {
       await checkApplied(
         mkEvent: (message) =>
-          eg.reactionEvent(eg.unicodeEmojiReaction, ReactionOp.add, message.id),
+          eg.reactionEvent(eg.unicodeEmojiReaction, .add, message.id),
         doCheckMessageAfterFetch:
           (messageSubject) => messageSubject.reactions.isNotNull().total.equals(1),
       );

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -1915,7 +1915,7 @@ void main() {
       final message = store.messages.values.single;
 
       await store.handleEvent(
-        eg.reactionEvent(eg.unicodeEmojiReaction, ReactionOp.add, originalMessage.id));
+        eg.reactionEvent(eg.unicodeEmojiReaction, .add, originalMessage.id));
       checkNotifiedOnce();
       check(store.messages).values.single
         ..identicalTo(message)
@@ -1927,7 +1927,7 @@ void main() {
       await prepare();
       await prepareMessages([someMessage]);
       await store.handleEvent(
-        eg.reactionEvent(eg.unicodeEmojiReaction, ReactionOp.add, 1000));
+        eg.reactionEvent(eg.unicodeEmojiReaction, .add, 1000));
       checkNotNotified();
       check(store.messages).values.single
         .reactions.isNull();
@@ -1959,7 +1959,7 @@ void main() {
       final message = store.messages.values.single;
 
       await store.handleEvent(
-        eg.reactionEvent(eventReaction, ReactionOp.remove, originalMessage.id));
+        eg.reactionEvent(eventReaction, .remove, originalMessage.id));
       checkNotifiedOnce();
       check(store.messages).values.single
         ..identicalTo(message)
@@ -1971,7 +1971,7 @@ void main() {
       await prepare();
       await prepareMessages([someMessage]);
       await store.handleEvent(
-        eg.reactionEvent(eg.unicodeEmojiReaction, ReactionOp.remove, 1000));
+        eg.reactionEvent(eg.unicodeEmojiReaction, .remove, 1000));
       checkNotNotified();
       check(store.messages).values.single
         .reactions.isNotNull().jsonEquals([eg.unicodeEmojiReaction]);

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -1365,7 +1365,7 @@ void main() {
               timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
               inRealmCanDeleteAnyMessageGroup: false,
               isChannelArchived: false,
-              realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.everyone,
+              realmDeleteOwnMessagePolicy: .everyone,
               selfUserRole: UserRole.member,
           )))
             ..equals(await evaluate(
@@ -1385,7 +1385,7 @@ void main() {
               timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
               inRealmCanDeleteAnyMessageGroup: false,
               isChannelArchived: false,
-              realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.admins,
+              realmDeleteOwnMessagePolicy: .admins,
               selfUserRole: UserRole.administrator,
           )))
             ..equals(await evaluate(
@@ -1405,7 +1405,7 @@ void main() {
               timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
               inRealmCanDeleteAnyMessageGroup: false,
               isChannelArchived: false,
-              realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.admins,
+              realmDeleteOwnMessagePolicy: .admins,
               selfUserRole: UserRole.moderator,
           )))..equals(await evaluate(
               CanDeleteMessageParams.pre407(
@@ -1429,7 +1429,7 @@ void main() {
               senderConfig: CanDeleteMessageSenderConfig.otherHuman,
               timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
               isChannelArchived: false,
-              realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.everyone,
+              realmDeleteOwnMessagePolicy: .everyone,
               selfUserRole: UserRole.member,
           )))..equals(await evaluate(
               CanDeleteMessageParams.pre291(
@@ -1437,7 +1437,7 @@ void main() {
                 timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
                 inRealmCanDeleteAnyMessageGroup: false,
                 isChannelArchived: false,
-                realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.everyone,
+                realmDeleteOwnMessagePolicy: .everyone,
                 selfUserRole: UserRole.member)))
             ..isFalse();
         });
@@ -1448,7 +1448,7 @@ void main() {
               senderConfig: CanDeleteMessageSenderConfig.otherHuman,
               timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
               isChannelArchived: false,
-              realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.everyone,
+              realmDeleteOwnMessagePolicy: .everyone,
               selfUserRole: UserRole.administrator,
           )))..equals(await evaluate(
               CanDeleteMessageParams.pre291(
@@ -1456,7 +1456,7 @@ void main() {
                 timeLimitConfig: CanDeleteMessageTimeLimitConfig.notLimited,
                 inRealmCanDeleteAnyMessageGroup: true,
                 isChannelArchived: false,
-                realmDeleteOwnMessagePolicy: RealmDeleteOwnMessagePolicy.everyone,
+                realmDeleteOwnMessagePolicy: .everyone,
                 selfUserRole: UserRole.administrator)))
             ..isTrue();
         });

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -179,7 +179,7 @@ void main() {
     model.handleDeleteMessageEvent(DeleteMessageEvent(
       id: 0,
       messageIds: [messages[1].id],
-      messageType: .stream,
+      messageType: .channel,
       streamId: stream.streamId,
       topic: eg.t('oThEr'),
     ), {messages[1].id: messages[1]});

--- a/test/model/recent_senders_test.dart
+++ b/test/model/recent_senders_test.dart
@@ -179,7 +179,7 @@ void main() {
     model.handleDeleteMessageEvent(DeleteMessageEvent(
       id: 0,
       messageIds: [messages[1].id],
-      messageType: MessageType.stream,
+      messageType: .stream,
       streamId: stream.streamId,
       topic: eg.t('oThEr'),
     ), {messages[1].id: messages[1]});

--- a/test/model/typing_status_test.dart
+++ b/test/model/typing_status_test.dart
@@ -88,7 +88,7 @@ void main() {
 
     typistsByNarrow.forEach((narrow, typists) {
       for (final typist in typists) {
-        handleTypingEvent(narrow, TypingOp.start, typist);
+        handleTypingEvent(narrow, .start, typist);
         checkNotifiedOnce();
       }
     });
@@ -114,15 +114,15 @@ void main() {
     test('add typists in separate narrows', () {
       prepareModel();
 
-      handleTypingEvent(dmNarrow, TypingOp.start, eg.otherUser);
+      handleTypingEvent(dmNarrow, .start, eg.otherUser);
       checkTypists({dmNarrow: [eg.otherUser]});
       checkNotifiedOnce();
 
-      handleTypingEvent(groupNarrow, TypingOp.start, eg.thirdUser);
+      handleTypingEvent(groupNarrow, .start, eg.thirdUser);
       checkTypists({dmNarrow: [eg.otherUser], groupNarrow: [eg.thirdUser]});
       checkNotifiedOnce();
 
-      handleTypingEvent(topicNarrow, TypingOp.start, eg.fourthUser);
+      handleTypingEvent(topicNarrow, .start, eg.fourthUser);
       checkTypists({
         dmNarrow: [eg.otherUser],
         groupNarrow: [eg.thirdUser],
@@ -133,7 +133,7 @@ void main() {
     test('add a typist in the same narrow', () {
       prepareModel(typistsByNarrow: {groupNarrow: [eg.otherUser]});
 
-      handleTypingEvent(groupNarrow, TypingOp.start, eg.thirdUser);
+      handleTypingEvent(groupNarrow, .start, eg.thirdUser);
       checkTypists({groupNarrow: [eg.otherUser, eg.thirdUser]});
       checkNotifiedOnce();
     });
@@ -142,7 +142,7 @@ void main() {
       prepareModel();
 
       model.handleTypingEvent(
-        eg.typingEvent(groupNarrow, TypingOp.start, eg.selfUser.userId));
+        eg.typingEvent(groupNarrow, .start, eg.selfUser.userId));
       checkTypists({});
       checkNotNotified();
     });
@@ -152,7 +152,7 @@ void main() {
     test('remove a typist from an unknown narrow', () {
       prepareModel(typistsByNarrow:  {groupNarrow: [eg.otherUser]});
 
-      handleTypingEvent(dmNarrow, TypingOp.stop, eg.otherUser);
+      handleTypingEvent(dmNarrow, .stop, eg.otherUser);
       checkTypists({groupNarrow: [eg.otherUser]});
       checkNotNotified();
     });
@@ -160,7 +160,7 @@ void main() {
     test('remove an unknown typist from a known narrow', () {
       prepareModel(typistsByNarrow:  {groupNarrow: [eg.otherUser]});
 
-      handleTypingEvent(groupNarrow, TypingOp.stop, eg.thirdUser);
+      handleTypingEvent(groupNarrow, .stop, eg.thirdUser);
       checkTypists({groupNarrow: [eg.otherUser]});
       checkNotNotified();
     });
@@ -170,7 +170,7 @@ void main() {
         groupNarrow: [eg.otherUser, eg.thirdUser],
       });
 
-      handleTypingEvent(groupNarrow, TypingOp.stop, eg.otherUser);
+      handleTypingEvent(groupNarrow, .stop, eg.otherUser);
       checkTypists({groupNarrow: [eg.thirdUser]});
       checkNotifiedOnce();
     });
@@ -178,7 +178,7 @@ void main() {
     test('remove all typists in a narrow', () {
       prepareModel(typistsByNarrow: {dmNarrow: [eg.otherUser]});
 
-      handleTypingEvent(dmNarrow, TypingOp.stop, eg.otherUser);
+      handleTypingEvent(dmNarrow, .stop, eg.otherUser);
       checkTypists({});
       checkNotifiedOnce();
     });
@@ -190,15 +190,15 @@ void main() {
         topicNarrow: [eg.fourthUser],
       });
 
-      handleTypingEvent(groupNarrow, TypingOp.stop, eg.thirdUser);
+      handleTypingEvent(groupNarrow, .stop, eg.thirdUser);
       checkTypists({dmNarrow: [eg.otherUser], topicNarrow: [eg.fourthUser]});
       checkNotifiedOnce();
 
-      handleTypingEvent(dmNarrow, TypingOp.stop, eg.otherUser);
+      handleTypingEvent(dmNarrow, .stop, eg.otherUser);
       checkTypists({topicNarrow: [eg.fourthUser]});
       checkNotifiedOnce();
 
-      handleTypingEvent(topicNarrow, TypingOp.stop, eg.fourthUser);
+      handleTypingEvent(topicNarrow, .stop, eg.fourthUser);
       checkTypists({});
       checkNotifiedOnce();
     });
@@ -222,7 +222,7 @@ void main() {
       prepareModel(typistsByNarrow: {dmNarrow: [eg.otherUser]});
       check(async.pendingTimers).length.equals(1);
 
-      handleTypingEvent(dmNarrow, TypingOp.stop, eg.otherUser);
+      handleTypingEvent(dmNarrow, .stop, eg.otherUser);
       checkTypists({});
       check(async.pendingTimers).isEmpty();
       checkNotifiedOnce();
@@ -235,7 +235,7 @@ void main() {
       async.elapse(const Duration(seconds: 10));
       checkTypists({dmNarrow: [eg.otherUser]});
       // The timer should restart from the event.
-      handleTypingEvent(dmNarrow, TypingOp.start, eg.otherUser);
+      handleTypingEvent(dmNarrow, .start, eg.otherUser);
       check(async.pendingTimers).length.equals(1);
       checkNotNotified();
 
@@ -282,7 +282,7 @@ void main() {
       await prepare();
       connection.prepare(json: {});
       model.keystroke(narrow);
-      checkTypingRequest(TypingOp.start, narrow);
+      checkTypingRequest(.start, narrow);
 
       // Finish the pending API request first,
       // so that the idle timer is the only timer left.
@@ -316,7 +316,7 @@ void main() {
       async.elapse(const Duration(milliseconds: 1));
       // t = typingStoppedWaitPeriod + 100ms:
       //   The new timer expires and the "typing stopped" notice is sent.
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     }));
 
     test('start typing repeatedly does not resend "typing started" notices', () => awaitFakeAsync((async) async {
@@ -342,12 +342,12 @@ void main() {
       // t > typingStartedWaitPeriod: Resume sending "typing started" notices.
       connection.prepare(json: {});
       model.keystroke(narrow);
-      checkTypingRequest(TypingOp.start, narrow);
+      checkTypingRequest(.start, narrow);
 
       // Ensures that a "typing stopped" notice is sent when the test ends.
       connection.prepare(json: {});
       async.flushTimers();
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     }));
 
     test('after stopped wait period, send a "typing stopped" notice', () => awaitFakeAsync((async) async {
@@ -355,7 +355,7 @@ void main() {
 
       connection.prepare(json: {});
       async.elapse(store.serverTypingStoppedWaitPeriod);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
       check(async.pendingTimers).isEmpty();
     }));
 
@@ -364,7 +364,7 @@ void main() {
 
       connection.prepare(json: {});
       model.stoppedComposing();
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
 
       async.elapse(Duration.zero);
       check(async.pendingTimers).isEmpty();
@@ -375,19 +375,19 @@ void main() {
 
       connection.prepare(json: {});
       model.stoppedComposing();
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
 
       // The "typing started" notice would have been throttled if we did not
       // reset the TypingNotifier internal states before sending the "typing
       // stopped" notice.
       connection.prepare(json: {});
       model.keystroke(narrow);
-      checkTypingRequest(TypingOp.start, narrow);
+      checkTypingRequest(.start, narrow);
 
       // Ensures that a "typing stopped" notice is sent when the test ends.
       connection.prepare(json: {});
       async.flushTimers();
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     }));
 
     test('disposing store cancels the idle timer', () => awaitFakeAsync((async) async {
@@ -411,7 +411,7 @@ void main() {
       // t = 0ms: Start typing. The idle timer is set to typingStoppedWaitPeriod.
       connection.prepare(json: {});
       model.keystroke(topicNarrow);
-      checkTypingRequest(TypingOp.start, topicNarrow);
+      checkTypingRequest(.start, topicNarrow);
 
       async.elapse(Duration.zero);
       check(async.pendingTimers).single;
@@ -424,7 +424,7 @@ void main() {
       connection.prepare(json: {});
       model.keystroke(dmNarrow);
       checkSetTypingStatusRequests(connection.takeRequests(),
-        [(TypingOp.stop, topicNarrow), (TypingOp.start, dmNarrow)]);
+        [(.stop, topicNarrow), (.start, dmNarrow)]);
 
       async.elapse(Duration.zero);
       check(async.pendingTimers).single;
@@ -440,7 +440,7 @@ void main() {
       async.elapse(waitTime);
       // t = typingStoppedPeriod + 100ms:
       //   The new timer has expired, and a "typing stopped" notice is expected.
-      checkTypingRequest(TypingOp.stop, dmNarrow);
+      checkTypingRequest(.stop, dmNarrow);
     }));
 
     test('start typing in a different destination resets typing started wait timeout', () => awaitFakeAsync((async) async {
@@ -457,7 +457,7 @@ void main() {
       // t = 0ms: Start typing. The typing started time is set to 0ms.
       connection.prepare(json: {});
       model.keystroke(topicNarrow);
-      checkTypingRequest(TypingOp.start, topicNarrow);
+      checkTypingRequest(.start, topicNarrow);
 
       async.elapse(waitInterval);
       // t = waitInterval * 1:
@@ -469,7 +469,7 @@ void main() {
       connection.prepare(json: {});
       model.keystroke(dmNarrow);
       checkSetTypingStatusRequests(connection.takeRequests(),
-        [(TypingOp.stop, topicNarrow), (TypingOp.start, dmNarrow)]);
+        [(.stop, topicNarrow), (.start, dmNarrow)]);
 
       while (async.elapsed <= store.serverTypingStartedWaitPeriod) {
         // t <= typingStartedWaitPeriod: "still typing" requests are throttled.
@@ -494,12 +494,12 @@ void main() {
       //   enough time since the last time we sent a "typing started" notice.
       connection.prepare(json: {});
       model.keystroke(dmNarrow);
-      checkTypingRequest(TypingOp.start, dmNarrow);
+      checkTypingRequest(.start, dmNarrow);
 
       // Ensures that a "typing stopped" notice is sent when the test ends.
       connection.prepare(json: {});
       async.flushTimers();
-      checkTypingRequest(TypingOp.stop, dmNarrow);
+      checkTypingRequest(.stop, dmNarrow);
     }));
   });
 }

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -855,7 +855,7 @@ void main() {
         final event = switch (message) {
           StreamMessage() => DeleteMessageEvent(
             id: 0,
-            messageType: MessageType.stream,
+            messageType: .stream,
             messageIds: [message.id],
             streamId: message.streamId,
             topic: () {
@@ -867,7 +867,7 @@ void main() {
           ),
           DmMessage() => DeleteMessageEvent(
             id: 0,
-            messageType: MessageType.direct,
+            messageType: .direct,
             messageIds: [message.id],
             streamId: null,
             topic: null,
@@ -888,7 +888,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [11, 12],
-        messageType: MessageType.stream,
+        messageType: .stream,
         streamId: stream1.streamId,
         topic: eg.t('a'),
       ));
@@ -897,7 +897,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [13, 14],
-        messageType: MessageType.stream,
+        messageType: .stream,
         streamId: stream2.streamId,
         topic: eg.t('b'),
       ));
@@ -906,7 +906,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        messageType: MessageType.direct,
+        messageType: .direct,
         streamId: null,
         topic: null,
       ));
@@ -922,7 +922,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [message.id],
-        messageType: MessageType.stream,
+        messageType: .stream,
         streamId: message.streamId,
         topic: message.topic,
       ));
@@ -941,7 +941,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [message.id],
-        messageType: MessageType.direct,
+        messageType: .direct,
         streamId: null,
         topic: null,
       ));
@@ -1373,7 +1373,7 @@ void main() {
             messages: [message1.id, message2.id, message3.id, message4.id],
             messageDetails: {
               message1.id: UpdateMessageFlagsMessageDetail(
-                type: MessageType.stream,
+                type: .stream,
                 mentioned: false,
                 streamId: stream.streamId,
                 topic: eg.t(topic),
@@ -1381,7 +1381,7 @@ void main() {
               ),
               // message 2 and 3 have their details missing
               message4.id: UpdateMessageFlagsMessageDetail(
-                type: MessageType.direct,
+                type: .direct,
                 mentioned: false,
                 streamId: null,
                 topic: null,

--- a/test/model/unreads_test.dart
+++ b/test/model/unreads_test.dart
@@ -855,7 +855,7 @@ void main() {
         final event = switch (message) {
           StreamMessage() => DeleteMessageEvent(
             id: 0,
-            messageType: .stream,
+            messageType: .channel,
             messageIds: [message.id],
             streamId: message.streamId,
             topic: () {
@@ -888,7 +888,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [11, 12],
-        messageType: .stream,
+        messageType: .channel,
         streamId: stream1.streamId,
         topic: eg.t('a'),
       ));
@@ -897,7 +897,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [13, 14],
-        messageType: .stream,
+        messageType: .channel,
         streamId: stream2.streamId,
         topic: eg.t('b'),
       ));
@@ -922,7 +922,7 @@ void main() {
       model.handleDeleteMessageEvent(DeleteMessageEvent(
         id: 0,
         messageIds: [message.id],
-        messageType: .stream,
+        messageType: .channel,
         streamId: message.streamId,
         topic: message.topic,
       ));
@@ -1373,7 +1373,7 @@ void main() {
             messages: [message1.id, message2.id, message3.id, message4.id],
             messageDetails: {
               message1.id: UpdateMessageFlagsMessageDetail(
-                type: .stream,
+                type: .channel,
                 mentioned: false,
                 streamId: stream.streamId,
                 topic: eg.t(topic),

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -845,7 +845,7 @@ void main() {
     Future<void> checkStartTyping(WidgetTester tester, SendableNarrow narrow) async {
       connection.prepare(json: {});
       await enterContent(tester, 'hello world');
-      checkTypingRequest(TypingOp.start, narrow);
+      checkTypingRequest(.start, narrow);
     }
 
     testWidgets('smoke TopicNarrow', (tester) async {
@@ -856,7 +856,7 @@ void main() {
 
       connection.prepare(json: {});
       await tester.pump(store.serverTypingStoppedWaitPeriod);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     });
 
     testWidgets('smoke DmNarrow', (tester) async {
@@ -868,7 +868,7 @@ void main() {
 
       connection.prepare(json: {});
       await tester.pump(store.serverTypingStoppedWaitPeriod);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     });
 
     testWidgets('smoke ChannelNarrow', (tester) async {
@@ -882,7 +882,7 @@ void main() {
 
       connection.prepare(json: {});
       await tester.pump(store.serverTypingStoppedWaitPeriod);
-      checkTypingRequest(TypingOp.stop, destinationNarrow);
+      checkTypingRequest(.stop, destinationNarrow);
     });
 
     testWidgets('clearing text sends a "typing stopped" notice', (tester) async {
@@ -893,7 +893,7 @@ void main() {
 
       connection.prepare(json: {});
       await enterContent(tester, '');
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     });
 
     testWidgets('hitting send button sends a "typing stopped" notice', (tester) async {
@@ -909,7 +909,7 @@ void main() {
       await tester.tap(sendButtonFinder);
       await tester.pump(Duration.zero);
       final requests = connection.takeRequests();
-      checkSetTypingStatusRequests([requests.first], [(TypingOp.stop, narrow)]);
+      checkSetTypingStatusRequests([requests.first], [(.stop, narrow)]);
       check(requests).length.equals(2);
     });
 
@@ -940,7 +940,7 @@ void main() {
       connection.prepare(json: {});
       (await ZulipApp.navigator).pop();
       await tester.pump(Duration.zero);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     });
 
     testWidgets('for content input, unfocusing sends a "typing stopped" notice', (tester) async {
@@ -955,7 +955,7 @@ void main() {
       connection.prepare(json: {});
       FocusManager.instance.primaryFocus!.unfocus();
       await tester.pump(Duration.zero);
-      checkTypingRequest(TypingOp.stop, destinationNarrow);
+      checkTypingRequest(.stop, destinationNarrow);
     });
 
     testWidgets('selection change sends a "typing started" notice', (tester) async {
@@ -966,17 +966,17 @@ void main() {
 
       connection.prepare(json: {});
       await tester.pump(store.serverTypingStoppedWaitPeriod);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
 
       connection.prepare(json: {});
       controller!.content.selection =
         const TextSelection(baseOffset: 0, extentOffset: 2);
-      checkTypingRequest(TypingOp.start, narrow);
+      checkTypingRequest(.start, narrow);
 
       // Ensures that a "typing stopped" notice is sent when the test ends.
       connection.prepare(json: {});
       await tester.pump(store.serverTypingStoppedWaitPeriod);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
     });
 
     testWidgets('unfocusing app sends a "typing stopped" notice', (tester) async {
@@ -994,7 +994,7 @@ void main() {
       WidgetsBinding.instance.handleAppLifecycleStateChanged(
         AppLifecycleState.hidden);
       await tester.pump(Duration.zero);
-      checkTypingRequest(TypingOp.stop, narrow);
+      checkTypingRequest(.stop, narrow);
 
       WidgetsBinding.instance.handleAppLifecycleStateChanged(
         AppLifecycleState.paused);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1176,19 +1176,19 @@ void main() {
         await tester.pump();
         check(finder.evaluate()).isEmpty();
         await checkTyping(tester,
-          eg.typingEvent(narrow, TypingOp.start, eg.otherUser.userId),
+          eg.typingEvent(narrow, .start, eg.otherUser.userId),
           expected: 'Other User is typing…');
         await checkTyping(tester,
-          eg.typingEvent(narrow, TypingOp.start, eg.selfUser.userId),
+          eg.typingEvent(narrow, .start, eg.selfUser.userId),
           expected: 'Other User is typing…');
         await checkTyping(tester,
-          eg.typingEvent(narrow, TypingOp.start, eg.thirdUser.userId),
+          eg.typingEvent(narrow, .start, eg.thirdUser.userId),
           expected: 'Other User and Third User are typing…');
         await checkTyping(tester,
-          eg.typingEvent(narrow, TypingOp.start, eg.fourthUser.userId),
+          eg.typingEvent(narrow, .start, eg.fourthUser.userId),
           expected: 'Several people are typing…');
         await checkTyping(tester,
-          eg.typingEvent(narrow, TypingOp.stop, eg.otherUser.userId),
+          eg.typingEvent(narrow, .stop, eg.otherUser.userId),
           expected: 'Third User and Fourth User are typing…');
         // Verify that typing indicators expire after a set duration.
         await tester.pump(const Duration(seconds: 15));
@@ -1202,7 +1202,7 @@ void main() {
       await setupMessageListPage(tester,
         narrow: narrow, users: [], messages: [streamMessage]);
       await checkTyping(tester,
-        eg.typingEvent(narrow, TypingOp.start, 1000),
+        eg.typingEvent(narrow, .start, 1000),
         expected: '(unknown user) is typing…',
       );
       // Wait for the pending timers to end.
@@ -1214,18 +1214,18 @@ void main() {
         narrow: topicNarrow, users: users, messages: [streamMessage]);
 
       await checkTyping(tester,
-        eg.typingEvent(topicNarrow, TypingOp.start, eg.otherUser.userId),
+        eg.typingEvent(topicNarrow, .start, eg.otherUser.userId),
         expected: 'Other User is typing…');
 
       await checkTyping(tester,
-        eg.typingEvent(topicNarrow, TypingOp.start, eg.thirdUser.userId),
+        eg.typingEvent(topicNarrow, .start, eg.thirdUser.userId),
         expected: 'Other User and Third User are typing…');
 
       await store.setMutedUsers([eg.otherUser.userId]);
       await tester.pump();
 
       await checkTyping(tester,
-        eg.typingEvent(topicNarrow, TypingOp.start, eg.thirdUser.userId),
+        eg.typingEvent(topicNarrow, .start, eg.thirdUser.userId),
         expected: 'Third User is typing…', // no "Other User"
       );
 


### PR DESCRIPTION
Towards #1982.
Rebased atop #2391.
Next #2393.

<details>
<summary>The order in which enums are audited:</summary>

Goes through all the enums defined in `lib/api` (from top to bottom, both through the files and inside the files). Makes the enums accept unknown values or explains why we don't/can't accept them. For finding enum definitions inside a file, I used `enum [^{]+\{` regex in VSCode "Find" feature (`Cmd+F` shortcut).

I have also taken the opportunity of going through all the API enums to use dot shorthands in their usages. To find all the usages of `FooEnum`, I used `\bFooEnum(\.\w+)` regex in VSCode "Search: Find in Files" feature (`Shift+Cmd+F` shortcut) with case-sensitivity on and used the capture group (`$1`) as the replacement.

</details>