### PR TITLE
store: Abort poll backoff when the app returns to the foreground

### DIFF
--- a/lib/api/backoff.dart
+++ b/lib/api/backoff.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 /// A machine that can sleep for increasing durations, for network backoff.
@@ -90,7 +91,14 @@ class BackoffMachine {
   /// the smallest durations up to one microsecond instead of down to zero.
   /// Because in the real world any delay takes nonzero time, this mainly
   /// affects tests that use fake time, and keeps their behavior more realistic.
-  Future<void> wait() async {
+  ///
+  /// If [abortTrigger] completes before the wait duration has elapsed,
+  /// the wait ends early at that point.
+  /// The wait still counts in [waitsCompleted],
+  /// and the next wait's duration grows as usual.
+  /// The [abortTrigger] future must not complete with an error.
+  /// (This matches the contract of `Abortable.abortTrigger` in package:http.)
+  Future<void> wait({Future<void>? abortTrigger}) async {
     assert(!_debugWaitInProgress, 'Previous wait still in progress.');
     assert(() {
       _debugWaitInProgress = true;
@@ -100,7 +108,14 @@ class BackoffMachine {
     final duration = debugDuration ?? _maxDuration(const Duration(microseconds: 1),
                                                    _bound * Random().nextDouble());
     _bound = _minDuration(maxBound, _bound * base);
-    await Future<void>.delayed(duration);
+    final completer = Completer<void>();
+    final timer = Timer(duration, completer.complete);
+    unawaited(abortTrigger?.then((_) {
+      if (completer.isCompleted) return;
+      timer.cancel();
+      completer.complete();
+    }));
+    await completer.future;
     _waitsCompleted++;
     assert(() {
       _debugWaitInProgress = false;

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart' as file_picker;
 import 'package:firebase_core/firebase_core.dart' as firebase_core;
 import 'package:firebase_messaging/firebase_messaging.dart' as firebase_messaging;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:image_picker/image_picker.dart' as image_picker;
 import 'package:image_picker_android/image_picker_android.dart' as image_picker_android;
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart' as image_picker_platform;
@@ -137,6 +138,10 @@ abstract class ZulipBinding {
   ///
   /// Outside tests, this just calls the [Stopwatch] constructor.
   Stopwatch stopwatch();
+
+  /// A broadcast stream of the app's lifecycle-state changes,
+  /// via [AppLifecycleListener.onStateChange].
+  Stream<AppLifecycleState> get appLifecycleStateChanges;
 
   /// Provides device and operating system information,
   /// via package:device_info_plus.
@@ -466,6 +471,24 @@ class LiveZulipBinding extends ZulipBinding {
 
   @override
   Stopwatch stopwatch() => Stopwatch();
+
+  @override
+  Stream<AppLifecycleState> get appLifecycleStateChanges {
+    // Created lazily, because [AppLifecycleListener] requires
+    // [WidgetsBinding], and this binding is also initialized in a context
+    // that lacks one: the FCM background isolate
+    // (see _initBackgroundIsolate in lib/notifications/receive.dart).
+    return _appLifecycleStateChanges ??= _createAppLifecycleStateChanges();
+  }
+  Stream<AppLifecycleState>? _appLifecycleStateChanges;
+
+  Stream<AppLifecycleState> _createAppLifecycleStateChanges() {
+    final controller = StreamController<AppLifecycleState>.broadcast();
+    // The listener registers itself with [WidgetsBinding];
+    // it's never disposed, because the stream is for the life of the app.
+    AppLifecycleListener(onStateChange: controller.add);
+    return controller.stream;
+  }
 
   @override
   Future<BaseDeviceInfo?> get deviceInfo => _deviceInfo;

--- a/lib/model/presence.dart
+++ b/lib/model/presence.dart
@@ -24,6 +24,8 @@ class Presence extends HasRealmStore with ChangeNotifier {
 
   Map<int, PerUserPresence> _map;
 
+  // TODO: Observe ZulipBinding.appLifecycleStateChanges instead, so that
+  //   this logic can run (and be tested) without a widgets binding.
   AppLifecycleListener? _appLifecycleListener;
 
   void _handleLifecycleStateChange(AppLifecycleState newState) {

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show AppLifecycleState;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:path_provider_foundation/path_provider_foundation.dart';
@@ -22,6 +23,7 @@ import '../log.dart';
 import '../notifications/ios_service.dart';
 import 'actions.dart';
 import 'autocomplete.dart';
+import 'binding.dart';
 import 'database.dart';
 import 'emoji.dart';
 import 'localizations.dart';
@@ -1622,6 +1624,9 @@ class UpdateMachine {
 
   void poll() async {
     assert(!_disposed);
+    assert(_appLifecycleSubscription == null);
+    _appLifecycleSubscription = ZulipBinding.instance.appLifecycleStateChanges
+      .listen(_handleAppLifecycleStateChange);
     try {
       while (true) {
         if (_debugLoopSignal != null) {
@@ -1688,6 +1693,32 @@ class UpdateMachine {
 
   BackoffMachine? _pollBackoffMachine;
 
+  @visibleForTesting
+  BackoffMachine? get debugPollBackoffMachine => _pollBackoffMachine;
+
+  StreamSubscription<AppLifecycleState>? _appLifecycleSubscription;
+
+  /// Non-null just when the most recent poll failure suggests
+  /// the device was asleep or the app was in the background,
+  /// so that waking should discard the accumulated backoff state.
+  ///
+  /// Completing it aborts the backoff wait in progress, if any.
+  /// See [_handleAppLifecycleStateChange].
+  Completer<void>? _pollBackoffAbortTrigger;
+
+  void _handleAppLifecycleStateChange(AppLifecycleState state) {
+    assert(!_disposed); // The subscription is canceled in [dispose].
+    if (state != .resumed) return;
+    if (_pollBackoffAbortTrigger case final trigger?) {
+      // Retry immediately, and if the network still isn't back
+      // (it can take a moment after waking), let backoff start over small.
+      assert(debugLog('App returned to foreground; aborting poll backoff.'));
+      _pollBackoffMachine = null;
+      _pollBackoffAbortTrigger = null;
+      trigger.complete();
+    }
+  }
+
   /// This controls when we start to report transient errors to the user when
   /// polling.
   ///
@@ -1714,6 +1745,7 @@ class UpdateMachine {
     // (See comments on that code for why this behavior is helpful.)
     // If server logs show pressure from too many requests, we can investigate.
     _pollBackoffMachine = null;
+    _pollBackoffAbortTrigger = null;
 
     store.isRecoveringEventStream = false;
     _accumulatedTransientFailureCount = 0;
@@ -1743,10 +1775,14 @@ class UpdateMachine {
     }
 
     bool shouldReportToUser;
+    bool abortBackoffOnWake = false;
     switch (error) {
       case NetworkException(kind: .connectionFailed):
         // A failed connection is common when the app returns from sleep.
         shouldReportToUser = false;
+        // Probably the OS cut off network access while the app was in
+        // the background; see #1884.
+        abortBackoffOnWake = true;
 
       case NetworkException():
       case Server5xxException():
@@ -1774,7 +1810,9 @@ class UpdateMachine {
     if (shouldReportToUser) {
       _maybeReportToUserTransientError(error);
     }
-    await (_pollBackoffMachine ??= BackoffMachine()).wait();
+    _pollBackoffAbortTrigger = abortBackoffOnWake ? Completer() : null;
+    await (_pollBackoffMachine ??= BackoffMachine())
+      .wait(abortTrigger: _pollBackoffAbortTrigger?.future);
     if (_disposed) return;
     assert(debugLog('… Backoff wait complete, retrying poll.'));
   }
@@ -1892,6 +1930,7 @@ class UpdateMachine {
   /// requests to error. [PerAccountStore.dispose] does that.
   void dispose() {
     assert(!_disposed);
+    _appLifecycleSubscription?.cancel();
     _disposed = true;
   }
 

--- a/test/api/backoff_test.dart
+++ b/test/api/backoff_test.dart
@@ -122,6 +122,48 @@ void main() {
     });
   });
 
+  test('BackoffMachine wait aborts early when abortTrigger fires', () => awaitFakeAsync((async) async {
+    BackoffMachine.debugDuration = const Duration(seconds: 10);
+    addTearDown(() => BackoffMachine.debugDuration = null);
+    final backoffMachine = BackoffMachine();
+    final abortTrigger = Completer<void>();
+    final futureDuration = measureWait(
+      backoffMachine.wait(abortTrigger: abortTrigger.future));
+    async.elapse(const Duration(seconds: 1));
+    abortTrigger.complete();
+    async.flushMicrotasks();
+    check(async.pendingTimers).isEmpty();
+    check(await futureDuration).equals(const Duration(seconds: 1));
+    check(backoffMachine.waitsCompleted).equals(1);
+
+    // The machine remains usable for further waits.
+    final nextWait = measureWait(backoffMachine.wait());
+    async.elapse(const Duration(seconds: 10));
+    check(await nextWait).equals(const Duration(seconds: 10));
+    check(backoffMachine.waitsCompleted).equals(2);
+  }));
+
+  test('BackoffMachine wait runs full duration when abortTrigger never fires', () => awaitFakeAsync((async) async {
+    BackoffMachine.debugDuration = const Duration(seconds: 10);
+    addTearDown(() => BackoffMachine.debugDuration = null);
+    final abortTrigger = Completer<void>();
+    final futureDuration = measureWait(
+      BackoffMachine().wait(abortTrigger: abortTrigger.future));
+    async.elapse(const Duration(seconds: 10));
+    check(await futureDuration).equals(const Duration(seconds: 10));
+    check(async.pendingTimers).isEmpty();
+  }));
+
+  test('BackoffMachine wait aborts immediately when abortTrigger already fired', () => awaitFakeAsync((async) async {
+    BackoffMachine.debugDuration = const Duration(seconds: 10);
+    addTearDown(() => BackoffMachine.debugDuration = null);
+    final futureDuration = measureWait(
+      BackoffMachine().wait(abortTrigger: Future.value()));
+    async.flushMicrotasks();
+    check(async.pendingTimers).isEmpty();
+    check(await futureDuration).equals(Duration.zero);
+  }));
+
   test('BackoffMachine handles long backoff safely', () => awaitFakeAsync(
     flushTimeout: Duration(hours: 12),
     (async) async {

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -8,6 +8,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show AppLifecycleState;
 import 'package:sodium/sodium.dart' as sodium;
 import 'package:test/fake.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
@@ -77,6 +78,7 @@ class TestZulipBinding extends ZulipBinding {
     _resetCanLaunchUrl();
     _resetLaunchUrl();
     _resetCloseInAppWebView();
+    _resetAppLifecycleStateChanges();
     _resetDeviceInfo();
     _resetPackageInfo();
     _resetFirebase();
@@ -255,6 +257,24 @@ class TestZulipBinding extends ZulipBinding {
 
   @override
   Stopwatch stopwatch() => clock.stopwatch();
+
+  void _resetAppLifecycleStateChanges() {
+    _appLifecycleStateChanges = null;
+  }
+
+  /// Simulate an app-lifecycle-state change,
+  /// causing [appLifecycleStateChanges] to fire.
+  void notifyAppLifecycleStateChanged(AppLifecycleState state) {
+    _appLifecycleStateChangesController.add(state);
+  }
+
+  StreamController<AppLifecycleState> get _appLifecycleStateChangesController =>
+    _appLifecycleStateChanges ??= StreamController.broadcast();
+  StreamController<AppLifecycleState>? _appLifecycleStateChanges;
+
+  @override
+  Stream<AppLifecycleState> get appLifecycleStateChanges =>
+    _appLifecycleStateChangesController.stream;
 
   /// The value that `ZulipBinding.instance.deviceInfo` should return.
   BaseDeviceInfo deviceInfoResult = _defaultDeviceInfoResult;

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -806,6 +806,8 @@ void main() {
       int? lastEventId,
       int? eventQueueLongpollTimeoutSeconds,
     }) async {
+      // The poll loop subscribes to testBinding.appLifecycleStateChanges.
+      addTearDown(testBinding.reset);
       globalStore = eg.globalStore();
       await globalStore.add(eg.selfAccount, eg.initialSnapshot(
         lastEventId: lastEventId,
@@ -1074,6 +1076,109 @@ void main() {
 
     test('reloads on handleEvent error', () {
       checkReload(prepareHandleEventError);
+    });
+
+    group('abort backoff on app wake', () {
+      test('abort wait in progress', () => awaitFakeAsync((async) async {
+        // Regression test for: https://github.com/zulip/zulip-flutter/issues/1884
+        BackoffMachine.debugDuration = const Duration(seconds: 10);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        // Make the request, inducing a network failure in it.
+        prepareNetworkExceptionConnectionFailed();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        checkLastRequest(lastEventId: 1);
+        check(store).isRecoveringEventStream.isTrue();
+        check(async.pendingTimers).length.equals(1);
+
+        // On coming to the foreground, polling resumes immediately,
+        // well before the backoff duration has elapsed.
+        // (The second, redundant resume event checks that
+        // a duplicate doesn't complete the abort trigger twice.)
+        connection.prepare(json: GetEventsResult(events: [
+          HeartbeatEvent(id: 2),
+        ], queueId: null).toJson());
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        // The wake also discarded the accumulated backoff state.
+        check(updateMachine.debugPollBackoffMachine).isNull();
+        async.elapse(Duration.zero);
+        check(updateMachine.lastEventId).equals(2);
+        check(store).isRecoveringEventStream.isFalse();
+      }));
+
+      test('reset backoff state on resume with no wait in progress', () => awaitFakeAsync((async) async {
+        // A resume means the preceding connection failures were probably
+        // sleep-induced, so the grown backoff state is discarded even when
+        // there's no wait in progress to abort: if polling fails again
+        // after the wake (the network can take a moment to come back),
+        // backoff should start over small.
+        BackoffMachine.debugDuration = const Duration(seconds: 10);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        // Fail, and wait out the backoff normally.
+        prepareNetworkExceptionConnectionFailed();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        async.flushTimers();
+        check(updateMachine.debugPollBackoffMachine).isNotNull();
+
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+        check(updateMachine.debugPollBackoffMachine).isNull();
+      }));
+
+      test('no abort when backoff is from non-network error', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 10);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        prepareServer5xxException();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        checkLastRequest(lastEventId: 1);
+        check(async.pendingTimers).length.equals(1);
+
+        // Coming to the foreground doesn't cut the backoff short,
+        // and doesn't discard the accumulated backoff state either.
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+        check(connection.lastRequest).isNull();
+        check(async.pendingTimers).length.equals(1);
+        check(updateMachine.debugPollBackoffMachine).isNotNull();
+
+        // Polling continues after the backoff.
+        connection.prepare(json: GetEventsResult(events: [
+          HeartbeatEvent(id: 2),
+        ], queueId: null).toJson());
+        async.flushTimers();
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        check(updateMachine.lastEventId).equals(2);
+      }));
+
+      test('no effect when no backoff in progress', () => awaitFakeAsync((async) async {
+        await preparePoll(lastEventId: 1);
+
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+        check(connection.lastRequest).isNull();
+        check(async.pendingTimers).isEmpty();
+      }));
+
+      test('no effect after dispose', () => awaitFakeAsync((async) async {
+        await preparePoll(lastEventId: 1);
+
+        updateMachine.dispose();
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+      }));
     });
 
     group('report error', () {


### PR DESCRIPTION
Fixes #1884.

I tested this manually on an Android device. First, I disabled `BackoffMachine`'s "jitter" to eliminate randomness as a factor in how much time is spent idly in backoff:

```diff
diff --git lib/api/backoff.dart lib/api/backoff.dart
index c014b1b9d..3c10596f6 100644
--- lib/api/backoff.dart
+++ lib/api/backoff.dart
@@ -106,7 +106,7 @@ class BackoffMachine {
     }());
     assert(_bound <= maxBound);
     final duration = debugDuration ?? _maxDuration(const Duration(microseconds: 1),
-                                                   _bound * Random().nextDouble());
+                                                   _bound);
     _bound = _minDuration(maxBound, _bound * base);
     final completer = Completer<void>();
     final timer = Timer(duration, completer.complete);
```

Then:
- Open the app; wait for `/register` to complete
- Put the app in the background
- Wait a few seconds for the app's connection to die, then watch a burst of "Backing off, then will retry…" in the logs. Wait 15s or so until the backoff waits are long.
- Just after one of those logs (so at the start of a long backoff), foreground the app to restore the connection:
  - **Before:** The app would wait through the whole backoff wait (several seconds), with the progress indicator showing: https://github.com/user-attachments/assets/ecf81c2e-3995-4120-8008-ae10b67f7384
  - **After:** The backoff wait aborts and the retry happens immediately, so the progress indicator shows only briefly.  https://github.com/user-attachments/assets/0790488a-beff-4250-bbfa-f07678a739a4