### PR TITLE
autocomplete: Follow can_mention_group setting for user groups

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -20,92 +20,149 @@ sealed class Event {
     switch (json['type'] as String) {
       case 'realm_emoji':
         switch (json['op'] as String) {
-          case 'add': return RealmEmojiAddEvent.fromJson(json);
-          case 'update_one': return RealmEmojiUpdateOneEvent.fromJson(json);
-          case 'update': return RealmEmojiUpdateEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return RealmEmojiAddEvent.fromJson(json);
+          case 'update_one':
+            return RealmEmojiUpdateOneEvent.fromJson(json);
+          case 'update':
+            return RealmEmojiUpdateEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
-      case 'alert_words': return AlertWordsEvent.fromJson(json);
+      case 'alert_words':
+        return AlertWordsEvent.fromJson(json);
       case 'user_settings':
         switch (json['op'] as String) {
-          case 'update': return UserSettingsUpdateEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'update':
+            return UserSettingsUpdateEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
       case 'device':
         switch (json['op'] as String) {
-          case 'add': return DeviceAddEvent.fromJson(json);
-          case 'remove': return DeviceRemoveEvent.fromJson(json);
-          case 'update': return DeviceUpdateEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return DeviceAddEvent.fromJson(json);
+          case 'remove':
+            return DeviceRemoveEvent.fromJson(json);
+          case 'update':
+            return DeviceUpdateEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
-      case 'custom_profile_fields': return CustomProfileFieldsEvent.fromJson(json);
+      case 'custom_profile_fields':
+        return CustomProfileFieldsEvent.fromJson(json);
       case 'user_group':
         switch (json['op'] as String) {
-          case 'add': return UserGroupAddEvent.fromJson(json);
-          case 'update': return UserGroupUpdateEvent.fromJson(json);
-          case 'add_members': return UserGroupAddMembersEvent.fromJson(json);
-          case 'remove_members': return UserGroupRemoveMembersEvent.fromJson(json);
-          case 'add_subgroups': return UserGroupAddSubgroupsEvent.fromJson(json);
-          case 'remove_subgroups': return UserGroupRemoveSubgroupsEvent.fromJson(json);
-          case 'remove': return UserGroupRemoveEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return UserGroupAddEvent.fromJson(json);
+          case 'update':
+            return UserGroupUpdateEvent.fromJson(json);
+          case 'add_members':
+            return UserGroupAddMembersEvent.fromJson(json);
+          case 'remove_members':
+            return UserGroupRemoveMembersEvent.fromJson(json);
+          case 'add_subgroups':
+            return UserGroupAddSubgroupsEvent.fromJson(json);
+          case 'remove_subgroups':
+            return UserGroupRemoveSubgroupsEvent.fromJson(json);
+          case 'remove':
+            return UserGroupRemoveEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
       case 'realm_user':
         switch (json['op'] as String) {
-          case 'add': return RealmUserAddEvent.fromJson(json);
-          case 'remove': return RealmUserRemoveEvent.fromJson(json);
-          case 'update': return RealmUserUpdateEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return RealmUserAddEvent.fromJson(json);
+          case 'remove':
+            return RealmUserRemoveEvent.fromJson(json);
+          case 'update':
+            return RealmUserUpdateEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
       case 'saved_snippets':
         switch (json['op'] as String) {
-          case 'add': return SavedSnippetsAddEvent.fromJson(json);
-          case 'update': return SavedSnippetsUpdateEvent.fromJson(json);
-          case 'remove': return SavedSnippetsRemoveEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return SavedSnippetsAddEvent.fromJson(json);
+          case 'update':
+            return SavedSnippetsUpdateEvent.fromJson(json);
+          case 'remove':
+            return SavedSnippetsRemoveEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
       case 'stream':
         switch (json['op'] as String) {
-          case 'create': return ChannelCreateEvent.fromJson(json);
-          case 'delete': return ChannelDeleteEvent.fromJson(json);
-          case 'update': return ChannelUpdateEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'create':
+            return ChannelCreateEvent.fromJson(json);
+          case 'delete':
+            return ChannelDeleteEvent.fromJson(json);
+          case 'update':
+            return ChannelUpdateEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
       case 'subscription':
         switch (json['op'] as String) {
-          case 'add': return SubscriptionAddEvent.fromJson(json);
-          case 'remove': return SubscriptionRemoveEvent.fromJson(json);
-          case 'update': return SubscriptionUpdateEvent.fromJson(json);
-          case 'peer_add': return SubscriptionPeerAddEvent.fromJson(json);
-          case 'peer_remove': return SubscriptionPeerRemoveEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return SubscriptionAddEvent.fromJson(json);
+          case 'remove':
+            return SubscriptionRemoveEvent.fromJson(json);
+          case 'update':
+            return SubscriptionUpdateEvent.fromJson(json);
+          case 'peer_add':
+            return SubscriptionPeerAddEvent.fromJson(json);
+          case 'peer_remove':
+            return SubscriptionPeerRemoveEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
       case 'channel_folder':
         switch (json['op'] as String) {
-          case 'add': return ChannelFolderAddEvent.fromJson(json);
-          case 'reorder': return ChannelFolderReorderEvent.fromJson(json);
-          case 'update': return ChannelFolderUpdateEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return ChannelFolderAddEvent.fromJson(json);
+          case 'reorder':
+            return ChannelFolderReorderEvent.fromJson(json);
+          case 'update':
+            return ChannelFolderUpdateEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
-      case 'user_status': return UserStatusEvent.fromJson(json);
-      case 'user_topic': return UserTopicEvent.fromJson(json);
-      case 'muted_users': return MutedUsersEvent.fromJson(json);
-      case 'message': return MessageEvent.fromJson(json);
-      case 'update_message': return UpdateMessageEvent.fromJson(json);
-      case 'delete_message': return DeleteMessageEvent.fromJson(json);
+      case 'user_status':
+        return UserStatusEvent.fromJson(json);
+      case 'user_topic':
+        return UserTopicEvent.fromJson(json);
+      case 'muted_users':
+        return MutedUsersEvent.fromJson(json);
+      case 'message':
+        return MessageEvent.fromJson(json);
+      case 'update_message':
+        return UpdateMessageEvent.fromJson(json);
+      case 'delete_message':
+        return DeleteMessageEvent.fromJson(json);
       case 'update_message_flags':
         switch (json['op'] as String) {
-          case 'add': return UpdateMessageFlagsAddEvent.fromJson(json);
-          case 'remove': return UpdateMessageFlagsRemoveEvent.fromJson(json);
-          default: return UnexpectedEvent.fromJson(json);
+          case 'add':
+            return UpdateMessageFlagsAddEvent.fromJson(json);
+          case 'remove':
+            return UpdateMessageFlagsRemoveEvent.fromJson(json);
+          default:
+            return UnexpectedEvent.fromJson(json);
         }
-      case 'submessage': return SubmessageEvent.fromJson(json);
-      case 'typing': return TypingEvent.fromJson(json);
-      case 'presence': return PresenceEvent.fromJson(json);
-      case 'reaction': return ReactionEvent.fromJson(json);
-      case 'heartbeat': return HeartbeatEvent.fromJson(json);
+      case 'submessage':
+        return SubmessageEvent.fromJson(json);
+      case 'typing':
+        return TypingEvent.fromJson(json);
+      case 'presence':
+        return PresenceEvent.fromJson(json);
+      case 'reaction':
+        return ReactionEvent.fromJson(json);
+      case 'heartbeat':
+        return HeartbeatEvent.fromJson(json);
       // TODO add many more event types
-      default: return UnexpectedEvent.fromJson(json);
+      default:
+        return UnexpectedEvent.fromJson(json);
     }
   }
 
@@ -152,7 +209,7 @@ class RealmEmojiAddEvent extends RealmEmojiEvent {
   RealmEmojiAddEvent({required super.id, required this.emoji});
 
   factory RealmEmojiAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$RealmEmojiAddEventFromJson(json);
+      _$RealmEmojiAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$RealmEmojiAddEventToJson(this);
@@ -178,7 +235,7 @@ class RealmEmojiUpdateOneEvent extends RealmEmojiEvent {
   });
 
   factory RealmEmojiUpdateOneEvent.fromJson(Map<String, dynamic> json) =>
-    _$RealmEmojiUpdateOneEventFromJson(json);
+      _$RealmEmojiUpdateOneEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$RealmEmojiUpdateOneEventToJson(this);
@@ -191,7 +248,7 @@ class RealmEmojiUpdateData {
   RealmEmojiUpdateData({required this.deactivated});
 
   factory RealmEmojiUpdateData.fromJson(Map<String, dynamic> json) =>
-    _$RealmEmojiUpdateDataFromJson(json);
+      _$RealmEmojiUpdateDataFromJson(json);
 
   Map<String, dynamic> toJson() => _$RealmEmojiUpdateDataToJson(this);
 }
@@ -210,7 +267,7 @@ class RealmEmojiUpdateEvent extends RealmEmojiEvent {
   RealmEmojiUpdateEvent({required super.id, required this.realmEmoji});
 
   factory RealmEmojiUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$RealmEmojiUpdateEventFromJson(json);
+      _$RealmEmojiUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$RealmEmojiUpdateEventToJson(this);
@@ -228,7 +285,7 @@ class AlertWordsEvent extends Event {
   AlertWordsEvent({required super.id, required this.alertWords});
 
   factory AlertWordsEvent.fromJson(Map<String, dynamic> json) =>
-    _$AlertWordsEventFromJson(json);
+      _$AlertWordsEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$AlertWordsEventToJson(this);
@@ -283,7 +340,7 @@ class UserSettingsUpdateEvent extends Event {
   });
 
   factory UserSettingsUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$UserSettingsUpdateEventFromJson(json);
+      _$UserSettingsUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserSettingsUpdateEventToJson(this);
@@ -315,7 +372,7 @@ class DeviceAddEvent extends DeviceEvent {
   DeviceAddEvent({required super.id, required super.deviceId});
 
   factory DeviceAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$DeviceAddEventFromJson(json);
+      _$DeviceAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$DeviceAddEventToJson(this);
@@ -331,7 +388,7 @@ class DeviceRemoveEvent extends DeviceEvent {
   DeviceRemoveEvent({required super.id, required super.deviceId});
 
   factory DeviceRemoveEvent.fromJson(Map<String, dynamic> json) =>
-    _$DeviceRemoveEventFromJson(json);
+      _$DeviceRemoveEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$DeviceRemoveEventToJson(this);
@@ -372,7 +429,7 @@ class DeviceUpdateEvent extends DeviceEvent {
   });
 
   factory DeviceUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$DeviceUpdateEventFromJson(json);
+      _$DeviceUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$DeviceUpdateEventToJson(this);
@@ -390,7 +447,7 @@ class CustomProfileFieldsEvent extends Event {
   CustomProfileFieldsEvent({required super.id, required this.fields});
 
   factory CustomProfileFieldsEvent.fromJson(Map<String, dynamic> json) =>
-    _$CustomProfileFieldsEventFromJson(json);
+      _$CustomProfileFieldsEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$CustomProfileFieldsEventToJson(this);
@@ -421,7 +478,8 @@ class UserGroupAddEvent extends UserGroupEvent {
 
   UserGroupAddEvent({required super.id, required this.group});
 
-  factory UserGroupAddEvent.fromJson(Map<String, dynamic> json) => _$UserGroupAddEventFromJson(json);
+  factory UserGroupAddEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupAddEventToJson(this);
@@ -437,9 +495,14 @@ class UserGroupUpdateEvent extends UserGroupEvent {
   final int groupId;
   final UserGroupUpdateData data;
 
-  UserGroupUpdateEvent({required super.id, required this.groupId, required this.data});
+  UserGroupUpdateEvent({
+    required super.id,
+    required this.groupId,
+    required this.data,
+  });
 
-  factory UserGroupUpdateEvent.fromJson(Map<String, dynamic> json) => _$UserGroupUpdateEventFromJson(json);
+  factory UserGroupUpdateEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupUpdateEventToJson(this);
@@ -450,10 +513,16 @@ class UserGroupUpdateData {
   final String? name;
   final String? description;
   final bool? deactivated;
+  final GroupSettingValue? canMentionGroup;
+  UserGroupUpdateData({
+    required this.name,
+    required this.description,
+    required this.deactivated,
+    required this.canMentionGroup,
+  });
 
-  UserGroupUpdateData({required this.name, required this.description, required this.deactivated});
-
-  factory UserGroupUpdateData.fromJson(Map<String, dynamic> json) => _$UserGroupUpdateDataFromJson(json);
+  factory UserGroupUpdateData.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupUpdateDataFromJson(json);
 
   Map<String, dynamic> toJson() => _$UserGroupUpdateDataToJson(this);
 }
@@ -468,9 +537,14 @@ class UserGroupAddMembersEvent extends UserGroupEvent {
   final int groupId;
   final List<int> userIds;
 
-  UserGroupAddMembersEvent({required super.id, required this.groupId, required this.userIds});
+  UserGroupAddMembersEvent({
+    required super.id,
+    required this.groupId,
+    required this.userIds,
+  });
 
-  factory UserGroupAddMembersEvent.fromJson(Map<String, dynamic> json) => _$UserGroupAddMembersEventFromJson(json);
+  factory UserGroupAddMembersEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupAddMembersEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupAddMembersEventToJson(this);
@@ -486,9 +560,14 @@ class UserGroupRemoveMembersEvent extends UserGroupEvent {
   final int groupId;
   final List<int> userIds;
 
-  UserGroupRemoveMembersEvent({required super.id, required this.groupId, required this.userIds});
+  UserGroupRemoveMembersEvent({
+    required super.id,
+    required this.groupId,
+    required this.userIds,
+  });
 
-  factory UserGroupRemoveMembersEvent.fromJson(Map<String, dynamic> json) => _$UserGroupRemoveMembersEventFromJson(json);
+  factory UserGroupRemoveMembersEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupRemoveMembersEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupRemoveMembersEventToJson(this);
@@ -504,9 +583,14 @@ class UserGroupAddSubgroupsEvent extends UserGroupEvent {
   final int groupId;
   final List<int> directSubgroupIds;
 
-  UserGroupAddSubgroupsEvent({required super.id, required this.groupId, required this.directSubgroupIds});
+  UserGroupAddSubgroupsEvent({
+    required super.id,
+    required this.groupId,
+    required this.directSubgroupIds,
+  });
 
-  factory UserGroupAddSubgroupsEvent.fromJson(Map<String, dynamic> json) => _$UserGroupAddSubgroupsEventFromJson(json);
+  factory UserGroupAddSubgroupsEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupAddSubgroupsEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupAddSubgroupsEventToJson(this);
@@ -522,9 +606,14 @@ class UserGroupRemoveSubgroupsEvent extends UserGroupEvent {
   final int groupId;
   final List<int> directSubgroupIds;
 
-  UserGroupRemoveSubgroupsEvent({required super.id, required this.groupId, required this.directSubgroupIds});
+  UserGroupRemoveSubgroupsEvent({
+    required super.id,
+    required this.groupId,
+    required this.directSubgroupIds,
+  });
 
-  factory UserGroupRemoveSubgroupsEvent.fromJson(Map<String, dynamic> json) => _$UserGroupRemoveSubgroupsEventFromJson(json);
+  factory UserGroupRemoveSubgroupsEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupRemoveSubgroupsEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupRemoveSubgroupsEventToJson(this);
@@ -541,7 +630,8 @@ class UserGroupRemoveEvent extends UserGroupEvent {
 
   UserGroupRemoveEvent({required super.id, required this.groupId});
 
-  factory UserGroupRemoveEvent.fromJson(Map<String, dynamic> json) => _$UserGroupRemoveEventFromJson(json);
+  factory UserGroupRemoveEvent.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupRemoveEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserGroupRemoveEventToJson(this);
@@ -573,7 +663,7 @@ class RealmUserAddEvent extends RealmUserEvent {
   RealmUserAddEvent({required super.id, required this.person});
 
   factory RealmUserAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$RealmUserAddEventFromJson(json);
+      _$RealmUserAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$RealmUserAddEventToJson(this);
@@ -592,12 +682,18 @@ class RealmUserRemoveEvent extends RealmUserEvent {
   factory RealmUserRemoveEvent.fromJson(Map<String, dynamic> json) {
     return RealmUserRemoveEvent(
       id: json['id'] as int,
-      userId: (json['person'] as Map<String, dynamic>)['user_id'] as int);
+      userId: (json['person'] as Map<String, dynamic>)['user_id'] as int,
+    );
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return {'id': id, 'type': type, 'op': op, 'person': {'user_id': userId}};
+    return {
+      'id': id,
+      'type': type,
+      'op': op,
+      'person': {'user_id': userId},
+    };
   }
 }
 
@@ -608,12 +704,18 @@ class RealmUserUpdateCustomProfileField {
   final String? value;
   final String? renderedValue;
 
-  RealmUserUpdateCustomProfileField({required this.id, required this.value, required this.renderedValue});
+  RealmUserUpdateCustomProfileField({
+    required this.id,
+    required this.value,
+    required this.renderedValue,
+  });
 
-  factory RealmUserUpdateCustomProfileField.fromJson(Map<String, dynamic> json) =>
-    _$RealmUserUpdateCustomProfileFieldFromJson(json);
+  factory RealmUserUpdateCustomProfileField.fromJson(
+    Map<String, dynamic> json,
+  ) => _$RealmUserUpdateCustomProfileFieldFromJson(json);
 
-  Map<String, dynamic> toJson() => _$RealmUserUpdateCustomProfileFieldToJson(this);
+  Map<String, dynamic> toJson() =>
+      _$RealmUserUpdateCustomProfileFieldToJson(this);
 }
 
 /// A [RealmUserEvent] with op `update`: https://zulip.com/api/get-events#realm_user-update
@@ -623,39 +725,56 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   @JsonKey(includeToJson: true)
   String get op => 'update';
 
-  @JsonKey(readValue: _readFromPerson) final int userId;
+  @JsonKey(readValue: _readFromPerson)
+  final int userId;
 
-  @JsonKey(readValue: _readFromPerson) final String? fullName;
-  @JsonKey(readValue: _readFromPerson) final String? avatarUrl;
+  @JsonKey(readValue: _readFromPerson)
+  final String? fullName;
+  @JsonKey(readValue: _readFromPerson)
+  final String? avatarUrl;
   // @JsonKey(readValue: _readFromPerson) final String? avatarSource; // TODO obsolete?
   // @JsonKey(readValue: _readFromPerson) final String? avatarUrlMedium; // TODO obsolete?
-  @JsonKey(readValue: _readFromPerson) final int? avatarVersion;
-  @JsonKey(readValue: _readFromPerson) final String? timezone;
-  @JsonKey(readValue: _readFromPerson) final int? botOwnerId;
-  @JsonKey(readValue: _readFromPerson, unknownEnumValue: UserRole.unknown) final UserRole? role;
+  @JsonKey(readValue: _readFromPerson)
+  final int? avatarVersion;
+  @JsonKey(readValue: _readFromPerson)
+  final String? timezone;
+  @JsonKey(readValue: _readFromPerson)
+  final int? botOwnerId;
+  @JsonKey(readValue: _readFromPerson, unknownEnumValue: UserRole.unknown)
+  final UserRole? role;
 
   @JsonKey(readValue: _readNullableStringFromPerson)
   @NullableStringJsonConverter()
   final JsonNullable<String>? deliveryEmail;
 
-  @JsonKey(readValue: _readFromPerson) final RealmUserUpdateCustomProfileField? customProfileField;
-  @JsonKey(readValue: _readFromPerson) final String? newEmail;
-  @JsonKey(readValue: _readFromPerson) final bool? isActive;
+  @JsonKey(readValue: _readFromPerson)
+  final RealmUserUpdateCustomProfileField? customProfileField;
+  @JsonKey(readValue: _readFromPerson)
+  final String? newEmail;
+  @JsonKey(readValue: _readFromPerson)
+  final bool? isActive;
 
   static Object? _readFromPerson(Map<dynamic, dynamic> json, String key) {
     return (json['person'] as Map<String, dynamic>)[key];
   }
 
   static JsonNullable<String>? _readNullableStringFromPerson(
-      Map<dynamic, dynamic> json, String key) {
+    Map<dynamic, dynamic> json,
+    String key,
+  ) {
     // We can't just say `readValue: _readNullableFromPerson<String>`,
     // because json_serializable drops the type argument in the generated code.
     return _readNullableFromPerson<String>(json, key);
   }
 
   static JsonNullable<T>? _readNullableFromPerson<T extends Object>(
-      Map<dynamic, dynamic> json, String key) {
-    return JsonNullable.readFromJson(json['person'] as Map<String, dynamic>, key);
+    Map<dynamic, dynamic> json,
+    String key,
+  ) {
+    return JsonNullable.readFromJson(
+      json['person'] as Map<String, dynamic>,
+      key,
+    );
   }
 
   RealmUserUpdateEvent({
@@ -677,7 +796,7 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   });
 
   factory RealmUserUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$RealmUserUpdateEventFromJson(json);
+      _$RealmUserUpdateEventFromJson(json);
 
   // TODO make round-trip (see _readFromPerson)
   @override
@@ -706,7 +825,7 @@ class SavedSnippetsAddEvent extends SavedSnippetsEvent {
   SavedSnippetsAddEvent({required super.id, required this.savedSnippet});
 
   factory SavedSnippetsAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$SavedSnippetsAddEventFromJson(json);
+      _$SavedSnippetsAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SavedSnippetsAddEventToJson(this);
@@ -723,7 +842,7 @@ class SavedSnippetsUpdateEvent extends SavedSnippetsEvent {
   SavedSnippetsUpdateEvent({required super.id, required this.savedSnippet});
 
   factory SavedSnippetsUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$SavedSnippetsUpdateEventFromJson(json);
+      _$SavedSnippetsUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SavedSnippetsUpdateEventToJson(this);
@@ -740,7 +859,7 @@ class SavedSnippetsRemoveEvent extends SavedSnippetsEvent {
   SavedSnippetsRemoveEvent({required super.id, required this.savedSnippetId});
 
   factory SavedSnippetsRemoveEvent.fromJson(Map<String, dynamic> json) =>
-    _$SavedSnippetsRemoveEventFromJson(json);
+      _$SavedSnippetsRemoveEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SavedSnippetsRemoveEventToJson(this);
@@ -772,7 +891,7 @@ class ChannelCreateEvent extends ChannelEvent {
   ChannelCreateEvent({required super.id, required this.streams});
 
   factory ChannelCreateEvent.fromJson(Map<String, dynamic> json) =>
-    _$ChannelCreateEventFromJson(json);
+      _$ChannelCreateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ChannelCreateEventToJson(this);
@@ -795,14 +914,14 @@ class ChannelDeleteEvent extends ChannelEvent {
 
     final channels = json['streams'] as List<dynamic>;
     return channels
-      .map((c) => (c as Map<String, dynamic>)['stream_id'] as int)
-      .toList();
+        .map((c) => (c as Map<String, dynamic>)['stream_id'] as int)
+        .toList();
   }
 
   ChannelDeleteEvent({required super.id, required this.channelIds});
 
   factory ChannelDeleteEvent.fromJson(Map<String, dynamic> json) =>
-    _$ChannelDeleteEventFromJson(json);
+      _$ChannelDeleteEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ChannelDeleteEventToJson(this);
@@ -884,7 +1003,7 @@ class ChannelUpdateEvent extends ChannelEvent {
   }
 
   factory ChannelUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$ChannelUpdateEventFromJson(json);
+      _$ChannelUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ChannelUpdateEventToJson(this);
@@ -916,7 +1035,7 @@ class SubscriptionAddEvent extends SubscriptionEvent {
   SubscriptionAddEvent({required super.id, required this.subscriptions});
 
   factory SubscriptionAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$SubscriptionAddEventFromJson(json);
+      _$SubscriptionAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubscriptionAddEventToJson(this);
@@ -934,14 +1053,14 @@ class SubscriptionRemoveEvent extends SubscriptionEvent {
 
   static List<int> _readChannelIds(Map<dynamic, dynamic> json, String key) {
     return (json['subscriptions'] as List<dynamic>)
-      .map((e) => (e as Map<String, dynamic>)['stream_id'] as int)
-      .toList();
+        .map((e) => (e as Map<String, dynamic>)['stream_id'] as int)
+        .toList();
   }
 
   SubscriptionRemoveEvent({required super.id, required this.channelIds});
 
   factory SubscriptionRemoveEvent.fromJson(Map<String, dynamic> json) =>
-    _$SubscriptionRemoveEventFromJson(json);
+      _$SubscriptionRemoveEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubscriptionRemoveEventToJson(this);
@@ -998,7 +1117,7 @@ class SubscriptionUpdateEvent extends SubscriptionEvent {
   });
 
   factory SubscriptionUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$SubscriptionUpdateEventFromJson(json);
+      _$SubscriptionUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubscriptionUpdateEventToJson(this);
@@ -1022,7 +1141,7 @@ class SubscriptionPeerAddEvent extends SubscriptionEvent {
   });
 
   factory SubscriptionPeerAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$SubscriptionPeerAddEventFromJson(json);
+      _$SubscriptionPeerAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubscriptionPeerAddEventToJson(this);
@@ -1046,7 +1165,7 @@ class SubscriptionPeerRemoveEvent extends SubscriptionEvent {
   });
 
   factory SubscriptionPeerRemoveEvent.fromJson(Map<String, dynamic> json) =>
-    _$SubscriptionPeerRemoveEventFromJson(json);
+      _$SubscriptionPeerRemoveEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubscriptionPeerRemoveEventToJson(this);
@@ -1079,7 +1198,7 @@ class ChannelFolderAddEvent extends ChannelFolderEvent {
   ChannelFolderAddEvent({required super.id, required this.channelFolder});
 
   factory ChannelFolderAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$ChannelFolderAddEventFromJson(json);
+      _$ChannelFolderAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ChannelFolderAddEventToJson(this);
@@ -1103,7 +1222,7 @@ class ChannelFolderUpdateEvent extends ChannelFolderEvent {
   });
 
   factory ChannelFolderUpdateEvent.fromJson(Map<String, dynamic> json) =>
-    _$ChannelFolderUpdateEventFromJson(json);
+      _$ChannelFolderUpdateEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ChannelFolderUpdateEventToJson(this);
@@ -1125,7 +1244,7 @@ class ChannelFolderChange {
   });
 
   factory ChannelFolderChange.fromJson(Map<String, dynamic> json) =>
-    _$ChannelFolderChangeFromJson(json);
+      _$ChannelFolderChangeFromJson(json);
 
   Map<String, dynamic> toJson() => _$ChannelFolderChangeToJson(this);
 }
@@ -1143,7 +1262,7 @@ class ChannelFolderReorderEvent extends ChannelFolderEvent {
   ChannelFolderReorderEvent({required super.id, required this.order});
 
   factory ChannelFolderReorderEvent.fromJson(Map<String, dynamic> json) =>
-    _$ChannelFolderReorderEventFromJson(json);
+      _$ChannelFolderReorderEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ChannelFolderReorderEventToJson(this);
@@ -1162,7 +1281,9 @@ class UserStatusEvent extends Event {
   final UserStatusChange change;
 
   static Object? _readChange(Map<dynamic, dynamic> json, String key) {
-    assert(json is Map<String, dynamic>); // value came through `fromJson` with this type
+    assert(
+      json is Map<String, dynamic>,
+    ); // value came through `fromJson` with this type
     return json;
   }
 
@@ -1173,7 +1294,7 @@ class UserStatusEvent extends Event {
   });
 
   factory UserStatusEvent.fromJson(Map<String, dynamic> json) =>
-    _$UserStatusEventFromJson(json);
+      _$UserStatusEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => {
@@ -1205,7 +1326,7 @@ class UserTopicEvent extends Event {
   });
 
   factory UserTopicEvent.fromJson(Map<String, dynamic> json) =>
-    _$UserTopicEventFromJson(json);
+      _$UserTopicEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UserTopicEventToJson(this);
@@ -1223,7 +1344,7 @@ class MutedUsersEvent extends Event {
   MutedUsersEvent({required super.id, required this.mutedUsers});
 
   factory MutedUsersEvent.fromJson(Map<String, dynamic> json) =>
-    _$MutedUsersEventFromJson(json);
+      _$MutedUsersEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$MutedUsersEventToJson(this);
@@ -1244,7 +1365,11 @@ class MessageEvent extends Event {
   // events and in the get-messages results is that `matchContent` and
   // `matchTopic` are absent here.  Already [Message.matchContent] and
   // [Message.matchTopic] are optional, so no action is needed on that.
-  @JsonKey(readValue: _readMessageValue, fromJson: Message.fromJson, includeToJson: false)
+  @JsonKey(
+    readValue: _readMessageValue,
+    fromJson: Message.fromJson,
+    includeToJson: false,
+  )
   final Message message;
 
   // When present, this equals the "local_id" parameter
@@ -1254,20 +1379,30 @@ class MessageEvent extends Event {
   //   https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/local_id.2C.20queue_id.2Fsender_queue_id/near/2135340
   final String? localMessageId;
 
-  MessageEvent({required super.id, required this.message, required this.localMessageId});
+  MessageEvent({
+    required super.id,
+    required this.message,
+    required this.localMessageId,
+  });
 
-  static Map<String, dynamic> _readMessageValue(Map<dynamic, dynamic> json, String key) =>
-    {...json['message'] as Map<String, dynamic>, 'flags': json['flags']};
+  static Map<String, dynamic> _readMessageValue(
+    Map<dynamic, dynamic> json,
+    String key,
+  ) => {...json['message'] as Map<String, dynamic>, 'flags': json['flags']};
 
   factory MessageEvent.fromJson(Map<String, dynamic> json) =>
-    _$MessageEventFromJson(json);
+      _$MessageEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() {
     final messageJson = message.toJson();
     final flags = messageJson['flags'];
     messageJson.remove('flags');
-    return {..._$MessageEventToJson(this), 'message': messageJson, 'flags': flags};
+    return {
+      ..._$MessageEventToJson(this),
+      'message': messageJson,
+      'flags': flags,
+    };
   }
 }
 
@@ -1288,7 +1423,11 @@ class UpdateMessageEvent extends Event {
 
   // final String? streamName; // ignore
 
-  @JsonKey(readValue: _readMoveData, fromJson: UpdateMessageMoveData.tryParseFromJson, includeToJson: false)
+  @JsonKey(
+    readValue: _readMoveData,
+    fromJson: UpdateMessageMoveData.tryParseFromJson,
+    includeToJson: false,
+  )
   final UpdateMessageMoveData? moveData;
 
   // final List<TopicLink> topicLinks; // TODO handle
@@ -1317,14 +1456,19 @@ class UpdateMessageEvent extends Event {
     required this.isMeMessage,
   });
 
-  static Map<String, dynamic> _readMoveData(Map<dynamic, dynamic> json, String key) {
+  static Map<String, dynamic> _readMoveData(
+    Map<dynamic, dynamic> json,
+    String key,
+  ) {
     // Parsing [UpdateMessageMoveData] requires `json`, not the default `json[key]`.
-    assert(json is Map<String, dynamic>); // value came through `fromJson` with this type
+    assert(
+      json is Map<String, dynamic>,
+    ); // value came through `fromJson` with this type
     return json as Map<String, dynamic>;
   }
 
   factory UpdateMessageEvent.fromJson(Map<String, dynamic> json) =>
-    _$UpdateMessageEventFromJson(json);
+      _$UpdateMessageEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UpdateMessageEventToJson(this);
@@ -1360,21 +1504,25 @@ class UpdateMessageMoveData {
     final newStreamIdRaw = (json['new_stream_id'] as num?)?.toInt();
     final newStreamId = newStreamIdRaw ?? origStreamId;
 
-    final origTopic = json['orig_subject'] == null ? null
-      : TopicName.fromJson(json['orig_subject'] as String);
-    final newTopicRaw = json['subject'] == null ? null
-      : TopicName.fromJson(json['subject'] as String);
+    final origTopic = json['orig_subject'] == null
+        ? null
+        : TopicName.fromJson(json['orig_subject'] as String);
+    final newTopicRaw = json['subject'] == null
+        ? null
+        : TopicName.fromJson(json['subject'] as String);
     final newTopic = newTopicRaw ?? origTopic;
 
     final propagateModeString = json['propagate_mode'] as String?;
-    final propagateMode = propagateModeString == null ? null
-      : PropagateMode.fromRawString(propagateModeString);
+    final propagateMode = propagateModeString == null
+        ? null
+        : PropagateMode.fromRawString(propagateModeString);
 
     if (newStreamId == origStreamId && newTopic == origTopic) {
       if (propagateMode != null) {
         throw FormatException(
           'Malformed UpdateMessageEvent: incoherent message-move fields; '
-          'propagate_mode present but no new channel or topic');
+          'propagate_mode present but no new channel or topic',
+        );
       }
       return null;
     }
@@ -1438,10 +1586,7 @@ class DeleteMessageEvent extends Event {
 /// [UpdateMessageFlagsMessageDetail.type],
 /// or [TypingEvent.messageType].
 @JsonEnum(alwaysCreate: true)
-enum MessageType {
-  stream,
-  direct;
-}
+enum MessageType { stream, direct }
 
 class MessageTypeConverter extends JsonConverter<MessageType, String> {
   const MessageTypeConverter();
@@ -1496,7 +1641,7 @@ class UpdateMessageFlagsAddEvent extends UpdateMessageFlagsEvent {
   });
 
   factory UpdateMessageFlagsAddEvent.fromJson(Map<String, dynamic> json) =>
-    _$UpdateMessageFlagsAddEventFromJson(json);
+      _$UpdateMessageFlagsAddEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$UpdateMessageFlagsAddEventToJson(this);
@@ -1566,7 +1711,8 @@ class UpdateMessageFlagsMessageDetail {
     return result;
   }
 
-  Map<String, dynamic> toJson() => _$UpdateMessageFlagsMessageDetailToJson(this);
+  Map<String, dynamic> toJson() =>
+      _$UpdateMessageFlagsMessageDetailToJson(this);
 }
 
 /// A Zulip event of type `submessage`: https://zulip.com/api/get-events#submessage
@@ -1578,6 +1724,7 @@ class SubmessageEvent extends Event {
 
   @JsonKey(unknownEnumValue: SubmessageType.unknown)
   final SubmessageType msgType;
+
   /// [SubmessageData] encoded in JSON.
   // We cannot parse the String into one of the [SubmessageData] classes because
   // information from other submessages are required. Specifically, we need
@@ -1598,7 +1745,7 @@ class SubmessageEvent extends Event {
   });
 
   factory SubmessageEvent.fromJson(Map<String, dynamic> json) =>
-    _$SubmessageEventFromJson(json);
+      _$SubmessageEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubmessageEventToJson(this);
@@ -1639,8 +1786,10 @@ class TypingEvent extends Event {
 
   static List<int>? _recipientIdsFromJson(Object? json) {
     if (json == null) return null;
-    return (json as List<Object?>).map(
-      (item) => (item as Map<String, Object?>)['user_id'] as int).toList()..sort();
+    return (json as List<Object?>)
+        .map((item) => (item as Map<String, Object?>)['user_id'] as int)
+        .toList()
+      ..sort();
   }
 
   factory TypingEvent.fromJson(Map<String, dynamic> json) {
@@ -1692,7 +1841,7 @@ class PresenceEvent extends Event {
   });
 
   factory PresenceEvent.fromJson(Map<String, dynamic> json) =>
-    _$PresenceEventFromJson(json);
+      _$PresenceEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$PresenceEventToJson(this);
@@ -1714,7 +1863,8 @@ class PresenceEvent extends Event {
 // TODO(#1611) update comment about #1611
 @JsonSerializable(fieldRename: FieldRename.snake)
 class PerClientPresence {
-  final String client; // always "website" (on 7.0+, so on all supported servers)
+  final String
+  client; // always "website" (on 7.0+, so on all supported servers)
   final PresenceStatus status;
   final int timestamp;
   final bool pushable; // always false (on 7.0+, so on all supported servers)
@@ -1727,7 +1877,7 @@ class PerClientPresence {
   });
 
   factory PerClientPresence.fromJson(Map<String, dynamic> json) =>
-    _$PerClientPresenceFromJson(json);
+      _$PerClientPresenceFromJson(json);
 
   Map<String, dynamic> toJson() => _$PerClientPresenceToJson(this);
 }
@@ -1763,7 +1913,7 @@ class ReactionEvent extends Event {
   });
 
   factory ReactionEvent.fromJson(Map<String, dynamic> json) =>
-    _$ReactionEventFromJson(json);
+      _$ReactionEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$ReactionEventToJson(this);
@@ -1771,10 +1921,7 @@ class ReactionEvent extends Event {
 
 /// The type of [ReactionEvent.op].
 @JsonEnum(fieldRename: FieldRename.snake)
-enum ReactionOp {
-  add,
-  remove,
-}
+enum ReactionOp { add, remove }
 
 /// A Zulip event of type `heartbeat`: https://zulip.com/api/get-events#heartbeat
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -1786,7 +1933,7 @@ class HeartbeatEvent extends Event {
   HeartbeatEvent({required super.id});
 
   factory HeartbeatEvent.fromJson(Map<String, dynamic> json) =>
-    _$HeartbeatEventFromJson(json);
+      _$HeartbeatEventFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$HeartbeatEventToJson(this);

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -268,6 +268,9 @@ UserGroupUpdateData _$UserGroupUpdateDataFromJson(Map<String, dynamic> json) =>
       name: json['name'] as String?,
       description: json['description'] as String?,
       deactivated: json['deactivated'] as bool?,
+      canMentionGroup: json['can_mention_group'] == null
+          ? null
+          : GroupSettingValue.fromJson(json['can_mention_group']),
     );
 
 Map<String, dynamic> _$UserGroupUpdateDataToJson(
@@ -276,6 +279,7 @@ Map<String, dynamic> _$UserGroupUpdateDataToJson(
   'name': instance.name,
   'description': instance.description,
   'deactivated': instance.deactivated,
+  'can_mention_group': instance.canMentionGroup,
 };
 
 UserGroupAddMembersEvent _$UserGroupAddMembersEventFromJson(

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -32,7 +32,8 @@ class GroupSettingValueNamed extends GroupSettingValue {
 
   const GroupSettingValueNamed(this.groupId);
 
-  factory GroupSettingValueNamed.fromJson(int json) => GroupSettingValueNamed(json);
+  factory GroupSettingValueNamed.fromJson(int json) =>
+      GroupSettingValueNamed(json);
 
   @override
   int toJson() => groupId;
@@ -47,10 +48,13 @@ class GroupSettingValueNameless extends GroupSettingValue {
   final List<int> directMembers;
   final List<int> directSubgroups;
 
-  GroupSettingValueNameless({required this.directMembers, required this.directSubgroups});
+  GroupSettingValueNameless({
+    required this.directMembers,
+    required this.directSubgroups,
+  });
 
   factory GroupSettingValueNameless.fromJson(Map<String, dynamic> json) =>
-    _$GroupSettingValueNamelessFromJson(json);
+      _$GroupSettingValueNamelessFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$GroupSettingValueNamelessToJson(this);
@@ -82,7 +86,7 @@ class CustomProfileField {
   });
 
   factory CustomProfileField.fromJson(Map<String, dynamic> json) =>
-    _$CustomProfileFieldFromJson(json);
+      _$CustomProfileFieldFromJson(json);
 
   Map<String, dynamic> toJson() => _$CustomProfileFieldToJson(this);
 }
@@ -100,9 +104,7 @@ enum CustomProfileFieldType {
   pronouns(apiValue: 8),
   unknown(apiValue: null);
 
-  const CustomProfileFieldType({
-    required this.apiValue
-  });
+  const CustomProfileFieldType({required this.apiValue});
 
   final int? apiValue;
 
@@ -123,13 +125,21 @@ class CustomProfileFieldChoiceDataItem {
 
   const CustomProfileFieldChoiceDataItem({required this.text});
 
-  factory CustomProfileFieldChoiceDataItem.fromJson(Map<String, dynamic> json) =>
-    _$CustomProfileFieldChoiceDataItemFromJson(json);
+  factory CustomProfileFieldChoiceDataItem.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CustomProfileFieldChoiceDataItemFromJson(json);
 
-  Map<String, dynamic> toJson() => _$CustomProfileFieldChoiceDataItemToJson(this);
+  Map<String, dynamic> toJson() =>
+      _$CustomProfileFieldChoiceDataItemToJson(this);
 
-  static Map<String, CustomProfileFieldChoiceDataItem> parseFieldDataChoices(Map<String, dynamic> json) =>
-    json.map((k, v) => MapEntry(k, CustomProfileFieldChoiceDataItem.fromJson(v as Map<String, dynamic>)));
+  static Map<String, CustomProfileFieldChoiceDataItem> parseFieldDataChoices(
+    Map<String, dynamic> json,
+  ) => json.map(
+    (k, v) => MapEntry(
+      k,
+      CustomProfileFieldChoiceDataItem.fromJson(v as Map<String, dynamic>),
+    ),
+  );
 }
 
 /// The realm-level field data for an "external account" custom profile field.
@@ -149,10 +159,12 @@ class CustomProfileFieldExternalAccountData {
     required this.urlPattern,
   });
 
-  factory CustomProfileFieldExternalAccountData.fromJson(Map<String, dynamic> json) =>
-    _$CustomProfileFieldExternalAccountDataFromJson(json);
+  factory CustomProfileFieldExternalAccountData.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CustomProfileFieldExternalAccountDataFromJson(json);
 
-  Map<String, dynamic> toJson() => _$CustomProfileFieldExternalAccountDataToJson(this);
+  Map<String, dynamic> toJson() =>
+      _$CustomProfileFieldExternalAccountDataToJson(this);
 }
 
 /// An item in the [InitialSnapshot.mutedUsers] or [MutedUsersEvent].
@@ -169,7 +181,7 @@ class MutedUserItem {
   const MutedUserItem({required this.id});
 
   factory MutedUserItem.fromJson(Map<String, dynamic> json) =>
-    _$MutedUserItemFromJson(json);
+      _$MutedUserItemFromJson(json);
 
   Map<String, dynamic> toJson() => _$MutedUserItemToJson(this);
 }
@@ -207,7 +219,7 @@ class RealmEmojiItem {
   });
 
   factory RealmEmojiItem.fromJson(Map<String, dynamic> json) =>
-    _$RealmEmojiItemFromJson(json);
+      _$RealmEmojiItemFromJson(json);
 
   Map<String, dynamic> toJson() => _$RealmEmojiItemToJson(this);
 }
@@ -225,7 +237,8 @@ class UserStatus {
   /// The emoji part, or null if unset.
   final StatusEmoji? emoji;
 
-  const UserStatus({required this.text, required this.emoji}) : assert(text != '');
+  const UserStatus({required this.text, required this.emoji})
+    : assert(text != '');
 
   static const UserStatus zero = UserStatus(text: null, emoji: null);
 
@@ -249,13 +262,14 @@ class StatusEmoji {
     required this.emojiName,
     required this.emojiCode,
     required this.reactionType,
-  }) : assert(emojiName != ''), assert(emojiCode != '');
+  }) : assert(emojiName != ''),
+       assert(emojiCode != '');
 
   @override
   bool operator ==(Object other) {
     if (other is! StatusEmoji) return false;
     return (emojiName, emojiCode, reactionType) ==
-      (other.emojiName, other.emojiCode, other.reactionType);
+        (other.emojiName, other.emojiCode, other.reactionType);
   }
 
   @override
@@ -275,13 +289,21 @@ class UserStatusChange {
     return UserStatus(text: text.or(old.text), emoji: emoji.or(old.emoji));
   }
 
-  UserStatusChange copyWith({Option<String?>? text, Option<StatusEmoji?>? emoji}) {
-    return UserStatusChange(text: text ?? this.text, emoji: emoji ?? this.emoji);
+  UserStatusChange copyWith({
+    Option<String?>? text,
+    Option<StatusEmoji?>? emoji,
+  }) {
+    return UserStatusChange(
+      text: text ?? this.text,
+      emoji: emoji ?? this.emoji,
+    );
   }
 
   factory UserStatusChange.fromJson(Map<String, dynamic> json) {
     return UserStatusChange(
-      text: _textFromJson(json), emoji: _emojiFromJson(json));
+      text: _textFromJson(json),
+      emoji: _emojiFromJson(json),
+    );
   }
 
   static Option<String?> _textFromJson(Map<String, dynamic> json) {
@@ -305,25 +327,27 @@ class UserStatusChange {
       //   https://chat.zulip.org/#narrow/channel/378-api-design/topic/user.20status/near/2203132
       return OptionSome(null);
     } else {
-      return OptionSome(StatusEmoji(
-        emojiName: emojiName,
-        emojiCode: emojiCode,
-        reactionType: ReactionType.fromApiValue(reactionType)));
+      return OptionSome(
+        StatusEmoji(
+          emojiName: emojiName,
+          emojiCode: emojiCode,
+          reactionType: ReactionType.fromApiValue(reactionType),
+        ),
+      );
     }
   }
 
   Map<String, dynamic> toJson() {
     return {
-      if (text case OptionSome<String?>(:var value))
-        'status_text': value ?? '',
+      if (text case OptionSome<String?>(:var value)) 'status_text': value ?? '',
       if (emoji case OptionSome<StatusEmoji?>(:var value))
         ...value == null
-          ? {'emoji_name': '', 'emoji_code': '', 'reaction_type': ''}
-          : {
-              'emoji_name': value.emojiName,
-              'emoji_code': value.emojiCode,
-              'reaction_type': value.reactionType,
-            },
+            ? {'emoji_name': '', 'emoji_code': '', 'reaction_type': ''}
+            : {
+                'emoji_name': value.emojiName,
+                'emoji_code': value.emojiCode,
+                'reaction_type': value.reactionType,
+              },
     };
   }
 }
@@ -340,8 +364,7 @@ enum UserSettingName {
   displayEmojiReactionUsers,
   emojiset,
   webInboxShowChannelFolders,
-  presenceEnabled,
-  ;
+  presenceEnabled;
 
   /// Get a [UserSettingName] from a raw, snake-case string we recognize, else null.
   ///
@@ -350,8 +373,9 @@ enum UserSettingName {
   static UserSettingName? fromRawString(String raw) => _byRawString[raw];
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.snake`
-  static final _byRawString = _$UserSettingNameEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byRawString = _$UserSettingNameEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 
   String toJson() => _$UserSettingNameEnumMap[this]!;
 }
@@ -367,14 +391,14 @@ enum TwentyFourHourTimeMode {
   //   https://chat.zulip.org/#narrow/channel/378-api-design/topic/.60user_settings.2Etwenty_four_hour_time.60/near/2220696
   // TODO(server-future) Write down what server N starts sending null;
   //   adjust the comment; leave a TODO(server-N) to delete the comment
-  localeDefault(apiValue: null),
-  ;
+  localeDefault(apiValue: null);
 
   const TwentyFourHourTimeMode({required this.apiValue});
 
   final bool? apiValue;
 
-  static bool? staticToJson(TwentyFourHourTimeMode instance) => instance.apiValue;
+  static bool? staticToJson(TwentyFourHourTimeMode instance) =>
+      instance.apiValue;
 
   bool? toJson() => TwentyFourHourTimeMode.staticToJson(this);
 
@@ -401,8 +425,9 @@ enum Emojiset {
   static Emojiset fromRawString(String raw) => _byRawString[raw] ?? unknown;
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.kebab`
-  static final _byRawString = _$EmojisetEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byRawString = _$EmojisetEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 
   String toJson() => _$EmojisetEnumMap[this]!;
 }
@@ -424,7 +449,7 @@ class ClientDevice {
   });
 
   factory ClientDevice.fromJson(Map<String, dynamic> json) =>
-    _$ClientDeviceFromJson(json);
+      _$ClientDeviceFromJson(json);
 
   Map<String, dynamic> toJson() => _$ClientDeviceToJson(this);
 }
@@ -448,6 +473,7 @@ class UserGroup {
   // TODO(server-10): [deactivated] new in FL 290; previously no groups were deactivated
   @JsonKey(defaultValue: false)
   bool deactivated;
+  GroupSettingValue? canMentionGroup;
 
   // TODO(#814): GroupSettingValue canAddMembersGroup, etc.; add to update event too
 
@@ -459,9 +485,11 @@ class UserGroup {
     required this.description,
     required this.isSystemGroup,
     required this.deactivated,
+    required this.canMentionGroup,
   });
 
-  factory UserGroup.fromJson(Map<String, dynamic> json) => _$UserGroupFromJson(json);
+  factory UserGroup.fromJson(Map<String, dynamic> json) =>
+      _$UserGroupFromJson(json);
 
   Map<String, dynamic> toJson() => _$UserGroupToJson(this);
 }
@@ -512,7 +540,10 @@ class User {
   @JsonKey(defaultValue: false)
   final bool isSystemBot;
 
-  static Map<String, dynamic>? _readProfileData(Map<dynamic, dynamic> json, String key) {
+  static Map<String, dynamic>? _readProfileData(
+    Map<dynamic, dynamic> json,
+    String key,
+  ) {
     final value = (json[key] as Map<String, dynamic>?);
     // Represent `{}` as `null`, to avoid allocating a huge number
     // of LinkedHashMap data structures that we can do without.
@@ -560,14 +591,14 @@ class ProfileFieldUserData {
   });
 
   factory ProfileFieldUserData.fromJson(Map<String, dynamic> json) =>
-    _$ProfileFieldUserDataFromJson(json);
+      _$ProfileFieldUserDataFromJson(json);
 
   Map<String, dynamic> toJson() => _$ProfileFieldUserDataToJson(this);
 }
 
 /// As in [User.role].
 @JsonEnum(valueField: "apiValue")
-enum UserRole{
+enum UserRole {
   owner(apiValue: 100),
   administrator(apiValue: 200),
   moderator(apiValue: 300),
@@ -575,9 +606,7 @@ enum UserRole{
   guest(apiValue: 600),
   unknown(apiValue: null);
 
-  const UserRole({
-    required this.apiValue,
-  });
+  const UserRole({required this.apiValue});
 
   final int? apiValue;
 
@@ -598,13 +627,10 @@ class PerUserPresence {
   final int activeTimestamp;
   final int idleTimestamp;
 
-  PerUserPresence({
-    required this.activeTimestamp,
-    required this.idleTimestamp,
-  });
+  PerUserPresence({required this.activeTimestamp, required this.idleTimestamp});
 
   factory PerUserPresence.fromJson(Map<String, dynamic> json) =>
-    _$PerUserPresenceFromJson(json);
+      _$PerUserPresenceFromJson(json);
 
   Map<String, dynamic> toJson() => _$PerUserPresenceToJson(this);
 }
@@ -637,7 +663,7 @@ class SavedSnippet {
   final int dateCreated;
 
   factory SavedSnippet.fromJson(Map<String, Object?> json) =>
-    _$SavedSnippetFromJson(json);
+      _$SavedSnippetFromJson(json);
 
   Map<String, dynamic> toJson() => _$SavedSnippetToJson(this);
 }
@@ -684,8 +710,10 @@ class ZulipStream {
   bool historyPublicToSubscribers;
   int? messageRetentionDays;
   // TODO(server-11) remove default value
-  @JsonKey(defaultValue: ChannelTopicsPolicy.inherit,
-    unknownEnumValue: ChannelTopicsPolicy.unknown)
+  @JsonKey(
+    defaultValue: ChannelTopicsPolicy.inherit,
+    unknownEnumValue: ChannelTopicsPolicy.unknown,
+  )
   ChannelTopicsPolicy topicsPolicy;
   @JsonKey(name: 'stream_post_policy')
   ChannelPostPolicy? channelPostPolicy; // TODO(server-10) remove
@@ -753,7 +781,7 @@ class ZulipStream {
   }
 
   factory ZulipStream.fromJson(Map<String, dynamic> json) =>
-    _$ZulipStreamFromJson(json);
+      _$ZulipStreamFromJson(json);
 
   Map<String, dynamic> toJson() => _$ZulipStreamToJson(this);
 }
@@ -796,8 +824,9 @@ enum ChannelPropertyName {
   static ChannelPropertyName? fromRawString(String raw) => _byRawString[raw];
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.snake`
-  static final _byRawString = _$ChannelPropertyNameEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byRawString = _$ChannelPropertyNameEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 }
 
 /// A value of [ZulipStream.topicsPolicy].
@@ -814,16 +843,18 @@ enum ChannelTopicsPolicy {
 
   /// The [ChannelTopicsPolicy] corresponding to the given [RealmTopicsPolicy].
   static ChannelTopicsPolicy forRealmPolicy(RealmTopicsPolicy realmPolicy) =>
-    switch (realmPolicy) {
-      .allowEmptyTopic   => .allowEmptyTopic,
-      .disableEmptyTopic => .disableEmptyTopic,
-      .unknown           => .unknown,
-    };
+      switch (realmPolicy) {
+        .allowEmptyTopic => .allowEmptyTopic,
+        .disableEmptyTopic => .disableEmptyTopic,
+        .unknown => .unknown,
+      };
 
-  static ChannelTopicsPolicy fromApiValue(String value) => _byApiValue[value] ?? unknown;
+  static ChannelTopicsPolicy fromApiValue(String value) =>
+      _byApiValue[value] ?? unknown;
 
-  static final _byApiValue = _$ChannelTopicsPolicyEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byApiValue = _$ChannelTopicsPolicyEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 }
 
 /// Policy for which users can post to the stream.
@@ -838,9 +869,7 @@ enum ChannelPostPolicy {
   moderators(apiValue: 4),
   unknown(apiValue: null);
 
-  const ChannelPostPolicy({
-    required this.apiValue,
-  });
+  const ChannelPostPolicy({required this.apiValue});
 
   final int? apiValue;
 
@@ -848,8 +877,9 @@ enum ChannelPostPolicy {
 
   static ChannelPostPolicy fromApiValue(int value) => _byApiValue[value]!;
 
-  static final _byApiValue = _$ChannelPostPolicyEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byApiValue = _$ChannelPostPolicyEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 }
 
 /// As in `subscriptions` in the initial snapshot.
@@ -912,7 +942,7 @@ class Subscription extends ZulipStream {
   });
 
   factory Subscription.fromJson(Map<String, dynamic> json) =>
-    _$SubscriptionFromJson(json);
+      _$SubscriptionFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SubscriptionToJson(this);
@@ -944,10 +974,12 @@ enum SubscriptionProperty {
 
   String toJson() => _$SubscriptionPropertyEnumMap[this]!;
 
-  static SubscriptionProperty fromRawString(String raw) => _byRawString[raw] ?? unknown;
+  static SubscriptionProperty fromRawString(String raw) =>
+      _byRawString[raw] ?? unknown;
 
-  static final _byRawString = _$SubscriptionPropertyEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byRawString = _$SubscriptionPropertyEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 }
 
 /// As in `channel_folders` in the initial snapshot.
@@ -977,7 +1009,7 @@ class ChannelFolder {
   });
 
   factory ChannelFolder.fromJson(Map<String, dynamic> json) =>
-    _$ChannelFolderFromJson(json);
+      _$ChannelFolderFromJson(json);
 
   Map<String, dynamic> toJson() => _$ChannelFolderToJson(this);
 }
@@ -1017,11 +1049,14 @@ String? tryParseEmojiCodeToUnicode(String emojiCode) {
   // >   https://raw.githubusercontent.com/iamcal/emoji-data/a8174c74675355c8c6a9564516b2e961fe7257ef/emoji_pretty.json
   // > [link fixed to permalink; original comment says "master" for the commit]
   try {
-    return String.fromCharCodes(emojiCode.split('-')
-      .map((hex) => int.parse(hex, radix: 16)));
-  } on FormatException { // thrown by `int.parse`
+    return String.fromCharCodes(
+      emojiCode.split('-').map((hex) => int.parse(hex, radix: 16)),
+    );
+  } on FormatException {
+    // thrown by `int.parse`
     return null;
-  } on ArgumentError { // thrown by `String.fromCharCodes`
+  } on ArgumentError {
+    // thrown by `String.fromCharCodes`
     return null;
   }
 }
@@ -1079,7 +1114,7 @@ extension type const TopicName(String _value) {
 
   /// A [TopicName] with [resolvedTopicPrefixRegexp] stripped if present.
   TopicName unresolve() =>
-    TopicName(_value.replaceFirst(resolvedTopicPrefixRegexp, ''));
+      TopicName(_value.replaceFirst(resolvedTopicPrefixRegexp, ''));
 
   /// Whether [this] and [other] have the same canonical form,
   /// using [canonicalize].
@@ -1120,16 +1155,20 @@ class StreamConversation extends Conversation {
   @JsonKey(required: true, disallowNullValue: true)
   String? displayRecipient;
 
-  StreamConversation(this.streamId, this.topic, {required this.displayRecipient});
+  StreamConversation(
+    this.streamId,
+    this.topic, {
+    required this.displayRecipient,
+  });
 
   factory StreamConversation.fromJson(Map<String, dynamic> json) =>
-    _$StreamConversationFromJson(json);
+      _$StreamConversationFromJson(json);
 
   @override
   bool isSameAs(Conversation other) {
-    return other is StreamConversation
-      && streamId == other.streamId
-      && topic.isSameAs(other.topic);
+    return other is StreamConversation &&
+        streamId == other.streamId &&
+        topic.isSameAs(other.topic);
   }
 }
 
@@ -1147,7 +1186,8 @@ class DmConversation extends Conversation {
 
   bool _equalIdSequences(Iterable<int> xs, Iterable<int> ys) {
     if (xs.length != ys.length) return false;
-    final xs_ = xs.iterator; final ys_ = ys.iterator;
+    final xs_ = xs.iterator;
+    final ys_ = ys.iterator;
     while (xs_.moveNext() && ys_.moveNext()) {
       if (xs_.current != ys_.current) return false;
     }
@@ -1196,7 +1236,10 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
   final String contentType;
 
   // final List<MessageEditHistory> editHistory; // TODO handle
-  @JsonKey(readValue: MessageEditState._readFromMessage, fromJson: Message._messageEditStateFromJson)
+  @JsonKey(
+    readValue: MessageEditState._readFromMessage,
+    fromJson: Message._messageEditStateFromJson,
+  )
   MessageEditState editState;
 
   @override
@@ -1218,7 +1261,12 @@ sealed class Message<T extends Conversation> extends MessageBase<T> {
   final String senderRealmStr;
 
   /// Poll data if "submessages" describe a poll, `null` otherwise.
-  @JsonKey(name: 'submessages', readValue: _readPoll, fromJson: Poll.fromJson, toJson: Poll.toJson)
+  @JsonKey(
+    name: 'submessages',
+    readValue: _readPoll,
+    fromJson: Poll.fromJson,
+    toJson: Poll.toJson,
+  )
   Poll? poll;
 
   String get type;
@@ -1312,7 +1360,9 @@ enum MessageFlag {
   static MessageFlag fromRawString(String raw) => _byRawString[raw] ?? unknown;
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.snake`
-  static final _byRawString = _$MessageFlagEnumMap.map((key, value) => MapEntry(value, key));
+  static final _byRawString = _$MessageFlagEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 
   String toJson() => _$MessageFlagEnumMap[this]!;
 
@@ -1358,7 +1408,10 @@ class StreamMessage extends Message<StreamConversation> {
   @JsonKey(readValue: _readConversation, includeToJson: false)
   StreamConversation conversation;
 
-  static Map<String, dynamic> _readConversation(Map<dynamic, dynamic> json, String key) {
+  static Map<String, dynamic> _readConversation(
+    Map<dynamic, dynamic> json,
+    String key,
+  ) {
     return json as Map<String, dynamic>;
   }
 
@@ -1383,7 +1436,7 @@ class StreamMessage extends Message<StreamConversation> {
   });
 
   factory StreamMessage.fromJson(Map<String, dynamic> json) =>
-    _$StreamMessageFromJson(json);
+      _$StreamMessageFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$StreamMessageToJson(this);
@@ -1405,22 +1458,38 @@ class DmMessage extends Message<DmConversation> {
   /// included.
   // TODO(server): Document that it's all users.  That statement is based on
   //   reverse-engineering notes in zulip-mobile:src/api/modelTypes.js at PmMessage.
-  @JsonKey(name: 'display_recipient', toJson: _allRecipientIdsToJson, includeToJson: true)
+  @JsonKey(
+    name: 'display_recipient',
+    toJson: _allRecipientIdsToJson,
+    includeToJson: true,
+  )
   List<int> get allRecipientIds => conversation.allRecipientIds;
 
   @override
-  @JsonKey(name: 'display_recipient', fromJson: _conversationFromJson, includeToJson: false)
+  @JsonKey(
+    name: 'display_recipient',
+    fromJson: _conversationFromJson,
+    includeToJson: false,
+  )
   final DmConversation conversation;
 
-  static List<Map<String, dynamic>> _allRecipientIdsToJson(List<int> allRecipientIds) {
+  static List<Map<String, dynamic>> _allRecipientIdsToJson(
+    List<int> allRecipientIds,
+  ) {
     return allRecipientIds.map((element) => {'id': element}).toList();
   }
 
   static DmConversation _conversationFromJson(List<dynamic> json) {
-    return DmConversation(allRecipientIds: json.map(
-      (element) => ((element as Map<String, dynamic>)['id'] as num).toInt()
-    ).toList(growable: false)
-     ..sort());
+    return DmConversation(
+      allRecipientIds:
+          json
+              .map(
+                (element) =>
+                    ((element as Map<String, dynamic>)['id'] as num).toInt(),
+              )
+              .toList(growable: false)
+            ..sort(),
+    );
   }
 
   DmMessage({
@@ -1444,7 +1513,7 @@ class DmMessage extends Message<DmConversation> {
   });
 
   factory DmMessage.fromJson(Map<String, dynamic> json) =>
-    _$DmMessageFromJson(json);
+      _$DmMessageFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$DmMessageToJson(this);
@@ -1461,7 +1530,10 @@ enum MessageEditState {
   /// The Zulip "resolved topics" feature is implemented by renaming the topic;
   /// but for purposes of [Message.editState], we want to ignore such renames.
   /// This method identifies topic moves that should be ignored in that context.
-  static bool topicMoveWasResolveOrUnresolve(TopicName topic, TopicName prevTopic) {
+  static bool topicMoveWasResolveOrUnresolve(
+    TopicName topic,
+    TopicName prevTopic,
+  ) {
     // Implemented to match web; see analyze_edit_history in zulip/zulip's
     // web/src/message_list_view.ts.
     //
@@ -1470,28 +1542,33 @@ enum MessageEditState {
     // using [TopicName.resolvedTopicPrefixRegexp], to be performance-sensitive.
     // Discussion:
     //   https://github.com/zulip/zulip-flutter/pull/1242#discussion_r1917592157
-    if (topic.apiName.startsWith(TopicName.resolvedTopicPrefix)
-        && topic.apiName.substring(TopicName.resolvedTopicPrefix.length) == prevTopic.apiName) {
+    if (topic.apiName.startsWith(TopicName.resolvedTopicPrefix) &&
+        topic.apiName.substring(TopicName.resolvedTopicPrefix.length) ==
+            prevTopic.apiName) {
       return true;
     }
 
-    if (prevTopic.apiName.startsWith(TopicName.resolvedTopicPrefix)
-        && prevTopic.apiName.substring(TopicName.resolvedTopicPrefix.length) == topic.apiName) {
+    if (prevTopic.apiName.startsWith(TopicName.resolvedTopicPrefix) &&
+        prevTopic.apiName.substring(TopicName.resolvedTopicPrefix.length) ==
+            topic.apiName) {
       return true;
     }
 
     return false;
   }
 
-  static MessageEditState _readFromMessage(Map<dynamic, dynamic> json, String key) {
+  static MessageEditState _readFromMessage(
+    Map<dynamic, dynamic> json,
+    String key,
+  ) {
     // Adapted from `analyze_edit_history` in the web app:
     //   https://github.com/zulip/zulip/blob/c31cebbf68a93927d41e9947427c2dd4d46503e3/web/src/message_list_view.js#L68-L118
     final editHistory = json['edit_history'] as List<dynamic>?;
     final lastEditTimestamp = json['last_edit_timestamp'] as int?;
     if (editHistory == null) {
       return (lastEditTimestamp != null)
-        ? MessageEditState.edited
-        : MessageEditState.none;
+          ? MessageEditState.edited
+          : MessageEditState.none;
     }
 
     // Edit history should never be empty whenever it is present
@@ -1540,8 +1617,9 @@ enum PropagateMode {
   static PropagateMode fromRawString(String raw) => _byRawString[raw]!;
 
   // _$…EnumMap is thanks to `alwaysCreate: true` and `fieldRename: FieldRename.snake`
-  static final _byRawString = _$PropagateModeEnumMap
-    .map((key, value) => MapEntry(value, key));
+  static final _byRawString = _$PropagateModeEnumMap.map(
+    (key, value) => MapEntry(value, key),
+  );
 }
 
 /// The [DateTime] corresponding to a UNIX timestamp, in UTC seconds.

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -143,6 +143,9 @@ UserGroup _$UserGroupFromJson(Map<String, dynamic> json) => UserGroup(
   description: json['description'] as String,
   isSystemGroup: json['is_system_group'] as bool,
   deactivated: json['deactivated'] as bool? ?? false,
+  canMentionGroup: json['can_mention_group'] == null
+      ? null
+      : GroupSettingValue.fromJson(json['can_mention_group']),
 );
 
 Map<String, dynamic> _$UserGroupToJson(UserGroup instance) => <String, dynamic>{
@@ -153,6 +156,7 @@ Map<String, dynamic> _$UserGroupToJson(UserGroup instance) => <String, dynamic>{
   'description': instance.description,
   'is_system_group': instance.isSystemGroup,
   'deactivated': instance.deactivated,
+  'can_mention_group': instance.canMentionGroup,
 };
 
 User _$UserFromJson(Map<String, dynamic> json) => User(

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -21,12 +21,13 @@ extension ComposeContentAutocomplete on ComposeContentController {
   // in long messages, we bound how far back we look for the intent's start.
   int get _maxLookbackForAutocompleteIntent {
     return 1 // intent character, e.g. "#"
-      + 2 // some optional characters e.g., "_" for silent mention or "**"
-
-      // Per the API doc, maxChannelNameLength is in Unicode code points.
-      // We walk the string by UTF-16 code units, and there might be one or two
-      // of those encoding each Unicode code point.
-      + 2 * store.maxChannelNameLength;
+        +
+        2 // some optional characters e.g., "_" for silent mention or "**"
+        // Per the API doc, maxChannelNameLength is in Unicode code points.
+        // We walk the string by UTF-16 code units, and there might be one or two
+        // of those encoding each Unicode code point.
+        +
+        2 * store.maxChannelNameLength;
   }
 
   AutocompleteIntent<ComposeAutocompleteQuery>? autocompleteIntent() {
@@ -58,7 +59,10 @@ extension ComposeContentAutocomplete on ComposeContentController {
         final match = _emojiIntentRegex.matchAsPrefix(textUntilCursor, pos);
         if (match == null) continue;
       } else if (charAtPos == '#') {
-        final match = _channelLinkIntentRegex.matchAsPrefix(textUntilCursor, pos);
+        final match = _channelLinkIntentRegex.matchAsPrefix(
+          textUntilCursor,
+          pos,
+        );
         if (match == null) continue;
       } else {
         continue;
@@ -79,14 +83,20 @@ extension ComposeContentAutocomplete on ComposeContentController {
         if (match == null) continue;
         query = EmojiAutocompleteQuery(match[1]!);
       } else if (charAtPos == '#') {
-        final match = _channelLinkIntentRegex.matchAsPrefix(textUntilCursor, pos);
+        final match = _channelLinkIntentRegex.matchAsPrefix(
+          textUntilCursor,
+          pos,
+        );
         if (match == null) continue;
         query = ChannelLinkAutocompleteQuery(match[1] ?? match[2]!);
       } else {
         continue;
       }
-      return AutocompleteIntent(syntaxStart: pos, textEditingValue: value,
-        query: query);
+      return AutocompleteIntent(
+        syntaxStart: pos,
+        textEditingValue: value,
+        query: query,
+      );
     }
 
     return null;
@@ -98,7 +108,8 @@ extension ComposeTopicAutocomplete on ComposeTopicController {
     return AutocompleteIntent(
       syntaxStart: 0,
       query: TopicAutocompleteQuery(value.text),
-      textEditingValue: value);
+      textEditingValue: value,
+    );
   }
 }
 
@@ -117,15 +128,22 @@ final RegExp _mentionIntentRegex = (() {
 
   // TODO(#1967): ignore immediate "**" after '@' sign
   return RegExp(
-    beforeAtSign
-    + r'@(_?)' // capture, so we can distinguish silent mentions
-    + r'(|'
-      // Reject on whitespace right after "@" or "@_". Emails can't start with
-      // it, and full_name can't either (it's run through Python's `.strip()`).
-      + r'[^\s' + fullNameAndEmailCharExclusions + r']'
-      + r'[^'   + fullNameAndEmailCharExclusions + r']*'
-    + r')$',
-    unicode: true);
+    beforeAtSign +
+        r'@(_?)' // capture, so we can distinguish silent mentions
+        +
+        r'(|'
+        // Reject on whitespace right after "@" or "@_". Emails can't start with
+        // it, and full_name can't either (it's run through Python's `.strip()`).
+        +
+        r'[^\s' +
+        fullNameAndEmailCharExclusions +
+        r']' +
+        r'[^' +
+        fullNameAndEmailCharExclusions +
+        r']*' +
+        r')$',
+    unicode: true,
+  );
 })();
 
 final RegExp _emojiIntentRegex = (() {
@@ -168,18 +186,26 @@ final RegExp _emojiIntentRegex = (() {
   /// at any point in the query.
   const nameCharacters = r'_\p{Letter}\p{Number}';
 
-  return RegExp(unicode: true,
-    before
-    + r':'
-    + r'(|'
-      // Recognize '+' only as part of '+1', the only emoji name that has it.
-      + r'\+1?|'
-      // Reject on whitespace right after ':'; interpret that
-      // as the user choosing to get out of the emoji autocomplete.
-      // Similarly reject starting with ':-', which is common for emoticons.
-      + r'['    + nameCharacters + r']'
-      + r'[-\s' + nameCharacters + r']*'
-    + r')$');
+  return RegExp(
+    unicode: true,
+    before +
+        r':' +
+        r'(|'
+        // Recognize '+' only as part of '+1', the only emoji name that has it.
+        +
+        r'\+1?|'
+        // Reject on whitespace right after ':'; interpret that
+        // as the user choosing to get out of the emoji autocomplete.
+        // Similarly reject starting with ':-', which is common for emoticons.
+        +
+        r'[' +
+        nameCharacters +
+        r']' +
+        r'[-\s' +
+        nameCharacters +
+        r']*' +
+        r')$',
+  );
 })();
 
 final RegExp _channelLinkIntentRegex = () {
@@ -209,31 +235,42 @@ final RegExp _channelLinkIntentRegex = () {
 
   // TODO(upstream): maybe use duplicate-named capture groups for better readability?
   //   https://github.com/dart-lang/sdk/issues/61337
-  return RegExp(unicode: true,
-    before
-    + r'#'
-    // As Web, match both '#channel' and '#**channel'. In both cases, the raw
-    // query is going to be 'channel'. Matching the second case ('#**channel')
-    // is useful when the user selects a channel from the autocomplete list, but
-    // then starts pressing "backspace" to edit the query and choose another
-    // option, instead of clearing the entire query and starting from scratch.
-    + r'(?:'
-      // Case '#channel': right after '#', reject whitespace as well as '**'.
-      + r'(?!\s|\*\*)([^' + nameCharExclusions + r']*)'
-      + r'|'
-      // Case '#**channel': right after '#**', reject whitespace.
-      // Also, make sure that the remaining query doesn't contain '**',
-      // otherwise '#**channel**' (which is a completed channel link syntax) and
-      // any text followed by that will always match.
-      + r'\*\*(?!\s)'
-      + r'((?:'
-        + r'[^*' + nameCharExclusions + r']'
-        + r'|'
-        + r'\*[^*' + nameCharExclusions + r']'
-        + r'|'
-        + r'\*$'
-      + r')*)'
-    + r')$');
+  return RegExp(
+    unicode: true,
+    before +
+        r'#'
+        // As Web, match both '#channel' and '#**channel'. In both cases, the raw
+        // query is going to be 'channel'. Matching the second case ('#**channel')
+        // is useful when the user selects a channel from the autocomplete list, but
+        // then starts pressing "backspace" to edit the query and choose another
+        // option, instead of clearing the entire query and starting from scratch.
+        +
+        r'(?:'
+        // Case '#channel': right after '#', reject whitespace as well as '**'.
+        +
+        r'(?!\s|\*\*)([^' +
+        nameCharExclusions +
+        r']*)' +
+        r'|'
+        // Case '#**channel': right after '#**', reject whitespace.
+        // Also, make sure that the remaining query doesn't contain '**',
+        // otherwise '#**channel**' (which is a completed channel link syntax) and
+        // any text followed by that will always match.
+        +
+        r'\*\*(?!\s)' +
+        r'((?:' +
+        r'[^*' +
+        nameCharExclusions +
+        r']' +
+        r'|' +
+        r'\*[^*' +
+        nameCharExclusions +
+        r']' +
+        r'|' +
+        r'\*$' +
+        r')*)' +
+        r')$',
+  );
 }();
 
 /// The text controller's recognition that the user might want autocomplete UI.
@@ -360,7 +397,11 @@ class AutocompleteViewManager {
 ///  * On reassemble, call [reassemble].
 ///  * When the object will no longer be used, call [dispose] to free
 ///    resources on the [PerAccountStore].
-abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extends AutocompleteResult> extends ChangeNotifier {
+abstract class AutocompleteView<
+  QueryT extends AutocompleteQuery,
+  ResultT extends AutocompleteResult
+>
+    extends ChangeNotifier {
   /// Construct a view-model for an autocomplete interaction,
   /// and begin the search for the initial query.
   AutocompleteView({required this.store, required this._query}) {
@@ -461,7 +502,8 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
     final query = _query;
 
     final iterator = candidates.iterator;
-    outer: while (true) {
+    outer:
+    while (true) {
       assert(_query == query);
       if (await shouldStop()) return true;
       assert(_query == query);
@@ -488,11 +530,14 @@ abstract class AutocompleteView<QueryT extends AutocompleteQuery, ResultT extend
 
 /// An [AutocompleteView] for an autocomplete interaction
 /// in the compose box's content input.
-typedef ComposeAutocompleteView = AutocompleteView<ComposeAutocompleteQuery, ComposeAutocompleteResult>;
+typedef ComposeAutocompleteView =
+    AutocompleteView<ComposeAutocompleteQuery, ComposeAutocompleteResult>;
 
 /// An [AutocompleteView] for an @-mention autocomplete interaction,
 /// an example of a [ComposeAutocompleteView].
-class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery, MentionAutocompleteResult> {
+class MentionAutocompleteView
+    extends
+        AutocompleteView<MentionAutocompleteQuery, MentionAutocompleteResult> {
   MentionAutocompleteView._({
     required super.store,
     required super.query,
@@ -573,23 +618,33 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
       case MentionsNarrow():
       case StarredMessagesNarrow():
       case KeywordSearchNarrow():
-        assert(false, 'No compose box, thus no autocomplete is available in ${narrow.runtimeType}.');
+        assert(
+          false,
+          'No compose box, thus no autocomplete is available in ${narrow.runtimeType}.',
+        );
     }
 
     // The [TopicKeyedMap] lookup calls [TopicName.canonicalize] each time,
     // so do it once here rather than O(n log n) times in the sort.
     final getRecencyInTopic = (channelId != null && topic != null)
-      ? store.recentSenders.latestMessageIdBySenderInTopic(
-          channelId: channelId, topic: topic)
-      : null;
+        ? store.recentSenders.latestMessageIdBySenderInTopic(
+            channelId: channelId,
+            topic: topic,
+          )
+        : null;
 
-    return (userA, userB) => _compareByRelevance(userA, userB,
+    return (userA, userB) => _compareByRelevance(
+      userA,
+      userB,
       channelId: channelId,
       getRecencyInTopic: getRecencyInTopic,
-      store: store);
+      store: store,
+    );
   }
 
-  static int _compareByRelevance(User userA, User userB, {
+  static int _compareByRelevance(
+    User userA,
+    User userB, {
     required int? channelId,
     required int? Function(int senderId)? getRecencyInTopic,
     required PerAccountStore store,
@@ -597,10 +652,13 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     // TODO(#618): give preference to subscribed users first
 
     if (channelId != null) {
-      final recencyResult = compareByRecency(userA, userB,
+      final recencyResult = compareByRecency(
+        userA,
+        userB,
         channelId: channelId,
         getRecencyInTopic: getRecencyInTopic,
-        store: store);
+        store: store,
+      );
       if (recencyResult != 0) return recencyResult;
     }
     final dmsResult = compareByDms(userA, userB, store: store);
@@ -628,7 +686,9 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   ///
   /// See [RecentSenders.latestMessageIdBySenderInTopic].
   @visibleForTesting
-  static int compareByRecency(User userA, User userB, {
+  static int compareByRecency(
+    User userA,
+    User userB, {
     required int channelId,
     required int? Function(int senderId)? getRecencyInTopic,
     required PerAccountStore store,
@@ -636,15 +696,21 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     if (getRecencyInTopic != null) {
       final result = -compareRecentMessageIds(
         getRecencyInTopic(userA.userId),
-        getRecencyInTopic(userB.userId));
+        getRecencyInTopic(userB.userId),
+      );
       if (result != 0) return result;
     }
 
     return -compareRecentMessageIds(
       store.recentSenders.latestMessageIdOfSenderInChannel(
-        channelId: channelId, senderId: userA.userId),
+        channelId: channelId,
+        senderId: userA.userId,
+      ),
       store.recentSenders.latestMessageIdOfSenderInChannel(
-        channelId: channelId, senderId: userB.userId));
+        channelId: channelId,
+        senderId: userB.userId,
+      ),
+    );
   }
 
   /// Determines which of the two users is more recent in DM conversations.
@@ -653,7 +719,11 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   /// returns a positive number if [userB] is more recent than [userA],
   /// and returns `0` if both [userA] and [userB] are equally recent
   /// or there is no DM exchanged with them whatsoever.
-  static int compareByDms(User userA, User userB, {required PerAccountStore store}) {
+  static int compareByDms(
+    User userA,
+    User userB, {
+    required PerAccountStore store,
+  }) {
     final recentDms = store.recentDmConversationsView;
     final aLatestMessageId = recentDms.latestMessagesByRecipient[userA.userId];
     final bLatestMessageId = recentDms.latestMessagesByRecipient[userB.userId];
@@ -671,9 +741,9 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   static int compareRecentMessageIds(int? a, int? b) {
     return switch ((a, b)) {
       (int a, int b) => a.compareTo(b),
-      (int(),     _) => 1,
-      (_,     int()) => -1,
-      _              => 0,
+      (int(), _) => 1,
+      (_, int()) => -1,
+      _ => 0,
     };
   }
 
@@ -683,26 +753,37 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     return switch ((userA.isBot, userB.isBot)) {
       (false, true) => -1,
       (true, false) => 1,
-      _             => 0,
+      _ => 0,
     };
   }
 
   /// Comparator that orders alphabetically by [User.fullName].
   @visibleForTesting
-  static int compareByAlphabeticalOrder(User userA, User userB,
-      {required PerAccountStore store}) {
+  static int compareByAlphabeticalOrder(
+    User userA,
+    User userB, {
+    required PerAccountStore store,
+  }) {
     final userAName = store.autocompleteViewManager.autocompleteDataCache
-      .normalizedNameForUser(userA);
+        .normalizedNameForUser(userA);
     final userBName = store.autocompleteViewManager.autocompleteDataCache
-      .normalizedNameForUser(userB);
-    return userAName.compareTo(userBName); // TODO(i18n): add locale-aware sorting
+        .normalizedNameForUser(userB);
+    return userAName.compareTo(
+      userBName,
+    ); // TODO(i18n): add locale-aware sorting
   }
 
-  static List<UserGroup> _userGroupsByRelevance({required PerAccountStore store}) {
+  static List<UserGroup> _userGroupsByRelevance({
+    required PerAccountStore store,
+  }) {
     return store.activeGroups
-      // TODO(#1776) Follow new "Who can mention this group" setting instead
-      .where((userGroup) => !userGroup.isSystemGroup)
-      .toList()
+        // TODO(#1776) Follow new "Who can mention this group" setting instead
+        .where(
+          (userGroup) =>
+              userGroup.canMentionGroup == null ||
+              store.selfInGroupSetting(userGroup.canMentionGroup!)
+        )
+        .toList()
       ..sort(_userGroupComparator(store: store));
   }
 
@@ -713,16 +794,21 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     // that ranking takes precedence over this.
 
     return (userGroupA, userGroupB) =>
-      compareGroupsByAlphabeticalOrder(userGroupA, userGroupB, store: store);
+        compareGroupsByAlphabeticalOrder(userGroupA, userGroupB, store: store);
   }
 
-  static int compareGroupsByAlphabeticalOrder(UserGroup userGroupA, UserGroup userGroupB,
-      {required PerAccountStore store}) {
+  static int compareGroupsByAlphabeticalOrder(
+    UserGroup userGroupA,
+    UserGroup userGroupB, {
+    required PerAccountStore store,
+  }) {
     final groupAName = store.autocompleteViewManager.autocompleteDataCache
-      .normalizedNameForUserGroup(userGroupA);
+        .normalizedNameForUserGroup(userGroupA);
     final groupBName = store.autocompleteViewManager.autocompleteDataCache
-      .normalizedNameForUserGroup(userGroupB);
-    return groupAName.compareTo(groupBName); // TODO(i18n): add locale-aware sorting
+        .normalizedNameForUserGroup(userGroupB);
+    return groupAName.compareTo(
+      groupBName,
+    ); // TODO(i18n): add locale-aware sorting
   }
 
   void computeWildcardMentionResults({
@@ -732,7 +818,10 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
     if (query.silent) return;
 
     bool tryOption(WildcardMentionOption option) {
-      final result = query.testWildcardOption(option, localizations: localizations);
+      final result = query.testWildcardOption(
+        option,
+        localizations: localizations,
+      );
       if (result == null) return false;
       results.add(result);
       return true;
@@ -740,17 +829,22 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
 
     // Only one of the (all, everyone, channel, stream) channel wildcards are
     // shown.
-    all: {
+    all:
+    {
       if (tryOption(WildcardMentionOption.all)) break all;
       if (tryOption(WildcardMentionOption.everyone)) break all;
       if (isComposingChannelMessage) {
-        final isChannelWildcardAvailable = store.zulipFeatureLevel >= 247; // TODO(server-9)
-        if (isChannelWildcardAvailable && tryOption(WildcardMentionOption.channel)) break all;
+        final isChannelWildcardAvailable =
+            store.zulipFeatureLevel >= 247; // TODO(server-9)
+        if (isChannelWildcardAvailable &&
+            tryOption(WildcardMentionOption.channel))
+          break all;
         if (tryOption(WildcardMentionOption.stream)) break all;
       }
     }
 
-    final isTopicWildcardAvailable = store.zulipFeatureLevel >= 224; // TODO(server-8)
+    final isTopicWildcardAvailable =
+        store.zulipFeatureLevel >= 224; // TODO(server-8)
     if (isComposingChannelMessage && isTopicWildcardAvailable) {
       tryOption(WildcardMentionOption.topic);
     }
@@ -760,28 +854,46 @@ class MentionAutocompleteView extends AutocompleteView<MentionAutocompleteQuery,
   Future<List<MentionAutocompleteResult>?> computeResults() async {
     final unsorted = <MentionAutocompleteResult>[];
     // Give priority to wildcard mentions.
-    computeWildcardMentionResults(results: unsorted,
-      isComposingChannelMessage: narrow is ChannelNarrow || narrow is TopicNarrow);
+    computeWildcardMentionResults(
+      results: unsorted,
+      isComposingChannelMessage:
+          narrow is ChannelNarrow || narrow is TopicNarrow,
+    );
 
-    if (await filterCandidates(filter: _testUser,
-        candidates: sortedUsers, results: unsorted)) {
+    if (await filterCandidates(
+      filter: _testUser,
+      candidates: sortedUsers,
+      results: unsorted,
+    )) {
       return null;
     }
 
-    if (await filterCandidates(filter: _testUserGroup,
-        candidates: sortedUserGroups, results: unsorted)) {
+    if (await filterCandidates(
+      filter: _testUserGroup,
+      candidates: sortedUserGroups,
+      results: unsorted,
+    )) {
       return null;
     }
 
-    return bucketSort(unsorted,
-      (r) => r.rank, numBuckets: MentionAutocompleteQuery._numResultRanks);
+    return bucketSort(
+      unsorted,
+      (r) => r.rank,
+      numBuckets: MentionAutocompleteQuery._numResultRanks,
+    );
   }
 
-  MentionAutocompleteResult? _testUser(MentionAutocompleteQuery query, User user) {
+  MentionAutocompleteResult? _testUser(
+    MentionAutocompleteQuery query,
+    User user,
+  ) {
     return query.testUser(user, store);
   }
 
-  MentionAutocompleteResult? _testUserGroup(MentionAutocompleteQuery query, UserGroup userGroup) {
+  MentionAutocompleteResult? _testUserGroup(
+    MentionAutocompleteQuery query,
+    UserGroup userGroup,
+  ) {
     return query.testUserGroup(userGroup, store);
   }
 }
@@ -818,7 +930,10 @@ abstract class AutocompleteQuery {
 
   late final List<String> _normalizedWords;
 
-  static final RegExp _regExpStripMarkCharacters = RegExp(r'\p{M}', unicode: true);
+  static final RegExp _regExpStripMarkCharacters = RegExp(
+    r'\p{M}',
+    unicode: true,
+  );
 
   static String lowercaseAndStripDiacritics(String input) {
     // Anders reports that this is what web does; see discussion:
@@ -917,17 +1032,27 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
     required Narrow narrow,
   }) {
     return MentionAutocompleteView.init(
-      store: store, localizations: localizations, narrow: narrow, query: this);
+      store: store,
+      localizations: localizations,
+      narrow: narrow,
+      query: this,
+    );
   }
 
-  WildcardMentionAutocompleteResult? testWildcardOption(WildcardMentionOption wildcardOption, {
-      required ZulipLocalizations localizations}) {
+  WildcardMentionAutocompleteResult? testWildcardOption(
+    WildcardMentionOption wildcardOption, {
+    required ZulipLocalizations localizations,
+  }) {
     final localized = wildcardOption.localizedCanonicalString(localizations);
-    final matches = wildcardOption.canonicalString.contains(_normalized)
-      || AutocompleteQuery.lowercaseAndStripDiacritics(localized).contains(_normalized);
+    final matches =
+        wildcardOption.canonicalString.contains(_normalized) ||
+        AutocompleteQuery.lowercaseAndStripDiacritics(localized)
+            .contains(_normalized);
     if (!matches) return null;
     return WildcardMentionAutocompleteResult(
-      wildcardOption: wildcardOption, rank: _rankWildcardResult);
+      wildcardOption: wildcardOption,
+      rank: _rankWildcardResult,
+    );
   }
 
   MentionAutocompleteResult? testUser(User user, PerAccountStore store) {
@@ -937,7 +1062,8 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
     final cache = store.autocompleteViewManager.autocompleteDataCache;
     final nameMatchQuality = _matchName(
       normalizedName: cache.normalizedNameForUser(user),
-      normalizedNameWords: cache.normalizedNameWordsForUser(user));
+      normalizedNameWords: cache.normalizedNameWordsForUser(user),
+    );
     bool? matchesEmail;
     if (nameMatchQuality == null) {
       matchesEmail = _matchEmail(user, cache);
@@ -946,8 +1072,12 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
 
     return UserMentionAutocompleteResult(
       userId: user.userId,
-      rank: _rankUserResult(user,
-        nameMatchQuality: nameMatchQuality, matchesEmail: matchesEmail));
+      rank: _rankUserResult(
+        user,
+        nameMatchQuality: nameMatchQuality,
+        matchesEmail: matchesEmail,
+      ),
+    );
   }
 
   bool _matchEmail(User user, AutocompleteDataCache cache) {
@@ -956,18 +1086,23 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
     return normalizedEmail.startsWith(_normalized);
   }
 
-  MentionAutocompleteResult? testUserGroup(UserGroup userGroup, PerAccountStore store) {
+  MentionAutocompleteResult? testUserGroup(
+    UserGroup userGroup,
+    PerAccountStore store,
+  ) {
     final cache = store.autocompleteViewManager.autocompleteDataCache;
 
     final nameMatchQuality = _matchName(
       normalizedName: cache.normalizedNameForUserGroup(userGroup),
-      normalizedNameWords: cache.normalizedNameWordsForUserGroup(userGroup));
+      normalizedNameWords: cache.normalizedNameWordsForUserGroup(userGroup),
+    );
 
     if (nameMatchQuality == null) return null;
 
     return UserGroupMentionAutocompleteResult(
       groupId: userGroup.id,
-      rank: _rankUserGroupResult(userGroup, nameMatchQuality: nameMatchQuality));
+      rank: _rankUserGroupResult(userGroup, nameMatchQuality: nameMatchQuality),
+    );
   }
 
   /// A measure of a wildcard result's quality in the context of the query,
@@ -983,15 +1118,16 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
   /// callers should skip computing [matchesEmail] and pass null for that.
   ///
   /// See also [_rankWildcardResult] and [_rankUserGroupResult].
-  static int _rankUserResult(User user, {
+  static int _rankUserResult(
+    User user, {
     required NameMatchQuality? nameMatchQuality,
     required bool? matchesEmail,
   }) {
     if (nameMatchQuality != null) {
       assert(matchesEmail == null);
       return switch (nameMatchQuality) {
-        NameMatchQuality.exact =>        1,
-        NameMatchQuality.totalPrefix =>  2,
+        NameMatchQuality.exact => 1,
+        NameMatchQuality.totalPrefix => 2,
         NameMatchQuality.wordPrefixes => 3,
       };
     }
@@ -1003,12 +1139,13 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
   /// from 0 (best) to one less than [_numResultRanks].
   ///
   /// See also [_rankWildcardResult] and [_rankUserResult].
-  static int _rankUserGroupResult(UserGroup userGroup, {
+  static int _rankUserGroupResult(
+    UserGroup userGroup, {
     required NameMatchQuality nameMatchQuality,
   }) {
     return switch (nameMatchQuality) {
-      NameMatchQuality.exact =>        4,
-      NameMatchQuality.totalPrefix =>  5,
+      NameMatchQuality.exact => 4,
+      NameMatchQuality.totalPrefix => 5,
       NameMatchQuality.wordPrefixes => 6,
     };
   }
@@ -1024,7 +1161,9 @@ class MentionAutocompleteQuery extends ComposeAutocompleteQuery {
 
   @override
   bool operator ==(Object other) {
-    return other is MentionAutocompleteQuery && other.raw == raw && other.silent == silent;
+    return other is MentionAutocompleteQuery &&
+        other.raw == raw &&
+        other.silent == silent;
   }
 
   @override
@@ -1035,11 +1174,11 @@ extension WildcardMentionOptionExtension on WildcardMentionOption {
   /// A translation of [canonicalString], from [localizations].
   String localizedCanonicalString(ZulipLocalizations localizations) {
     return switch (this) {
-      WildcardMentionOption.all      => localizations.wildcardMentionAll,
+      WildcardMentionOption.all => localizations.wildcardMentionAll,
       WildcardMentionOption.everyone => localizations.wildcardMentionEveryone,
-      WildcardMentionOption.channel  => localizations.wildcardMentionChannel,
-      WildcardMentionOption.stream   => localizations.wildcardMentionStream,
-      WildcardMentionOption.topic    => localizations.wildcardMentionTopic,
+      WildcardMentionOption.channel => localizations.wildcardMentionChannel,
+      WildcardMentionOption.stream => localizations.wildcardMentionStream,
+      WildcardMentionOption.topic => localizations.wildcardMentionTopic,
     };
   }
 }
@@ -1056,55 +1195,55 @@ class AutocompleteDataCache {
 
   /// The normalized `fullName` of [user].
   String normalizedNameForUser(User user) {
-    return _normalizedNamesByUser[user.userId]
-      ??= AutocompleteQuery.lowercaseAndStripDiacritics(user.fullName);
+    return _normalizedNamesByUser[user.userId] ??=
+        AutocompleteQuery.lowercaseAndStripDiacritics(user.fullName);
   }
 
   final Map<int, List<String>> _normalizedNameWordsByUser = {};
 
   List<String> normalizedNameWordsForUser(User user) {
-    return _normalizedNameWordsByUser[user.userId]
-      ??= normalizedNameForUser(user).split(' ');
+    return _normalizedNameWordsByUser[user.userId] ??= normalizedNameForUser(
+      user,
+    ).split(' ');
   }
 
   final Map<int, String?> _normalizedEmailsByUser = {};
 
   /// The normalized `deliveryEmail` of [user], or null if that's null.
   String? normalizedEmailForUser(User user) {
-    return _normalizedEmailsByUser[user.userId]
-      ??= (user.deliveryEmail != null
-            ? AutocompleteQuery.lowercaseAndStripDiacritics(user.deliveryEmail!)
-            : null);
+    return _normalizedEmailsByUser[user.userId] ??= (user.deliveryEmail != null
+        ? AutocompleteQuery.lowercaseAndStripDiacritics(user.deliveryEmail!)
+        : null);
   }
 
   final Map<int, String> _normalizedNamesByUserGroup = {};
 
   /// The normalized `name` of [userGroup].
   String normalizedNameForUserGroup(UserGroup userGroup) {
-    return _normalizedNamesByUserGroup[userGroup.id]
-      ??= AutocompleteQuery.lowercaseAndStripDiacritics(userGroup.name);
+    return _normalizedNamesByUserGroup[userGroup.id] ??=
+        AutocompleteQuery.lowercaseAndStripDiacritics(userGroup.name);
   }
 
   final Map<int, List<String>> _normalizedNameWordsByUserGroup = {};
 
   List<String> normalizedNameWordsForUserGroup(UserGroup userGroup) {
-    return _normalizedNameWordsByUserGroup[userGroup.id]
-      ??= normalizedNameForUserGroup(userGroup).split(' ');
+    return _normalizedNameWordsByUserGroup[userGroup.id] ??=
+        normalizedNameForUserGroup(userGroup).split(' ');
   }
 
   final Map<int, String> _normalizedNamesByChannel = {};
 
   /// The normalized `name` of [channel].
   String normalizedNameForChannel(ZulipStream channel) {
-    return _normalizedNamesByChannel[channel.streamId]
-      ??= AutocompleteQuery.lowercaseAndStripDiacritics(channel.name);
+    return _normalizedNamesByChannel[channel.streamId] ??=
+        AutocompleteQuery.lowercaseAndStripDiacritics(channel.name);
   }
 
   final Map<int, List<String>> _normalizedNameWordsByChannel = {};
 
   List<String> normalizedNameWordsForChannel(ZulipStream channel) {
-    return _normalizedNameWordsByChannel[channel.streamId]
-      ?? normalizedNameForChannel(channel).split(' ');
+    return _normalizedNameWordsByChannel[channel.streamId] ??
+        normalizedNameForChannel(channel).split(' ');
   }
 
   void invalidateUser(int userId) {
@@ -1208,7 +1347,10 @@ class UserMentionAutocompleteResult extends MentionAutocompleteResult {
 
 /// An autocomplete result for an @-mention of all the users in a conversation.
 class WildcardMentionAutocompleteResult extends MentionAutocompleteResult {
-  WildcardMentionAutocompleteResult({required this.wildcardOption, required this.rank});
+  WildcardMentionAutocompleteResult({
+    required this.wildcardOption,
+    required this.rank,
+  });
 
   final WildcardMentionOption wildcardOption;
 
@@ -1218,7 +1360,10 @@ class WildcardMentionAutocompleteResult extends MentionAutocompleteResult {
 
 /// An autocomplete result for an @-mention of a user group.
 class UserGroupMentionAutocompleteResult extends MentionAutocompleteResult {
-  UserGroupMentionAutocompleteResult({required this.groupId, required this.rank});
+  UserGroupMentionAutocompleteResult({
+    required this.groupId,
+    required this.rank,
+  });
 
   final int groupId;
 
@@ -1227,7 +1372,8 @@ class UserGroupMentionAutocompleteResult extends MentionAutocompleteResult {
 }
 
 /// An autocomplete interaction for choosing a topic for a message.
-class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, TopicAutocompleteResult> {
+class TopicAutocompleteView
+    extends AutocompleteView<TopicAutocompleteQuery, TopicAutocompleteResult> {
   TopicAutocompleteView._({
     required super.store,
     required super.query,
@@ -1239,8 +1385,11 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
     required int channelId,
     required TopicAutocompleteQuery query,
   }) {
-    return TopicAutocompleteView._(store: store, channelId: channelId, query: query)
-      .._fetch();
+    return TopicAutocompleteView._(
+      store: store,
+      channelId: channelId,
+      query: query,
+    ).._fetch();
   }
 
   /// The channel/stream the eventual message will be sent to.
@@ -1255,21 +1404,28 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
   /// fetched topics.
   Future<void> _fetch() async {
     // TODO: handle fetch failure
-    _topics = (await store.topics.getChannelTopics(channelId)).map((e) => e.name);
+    _topics = (await store.topics.getChannelTopics(channelId))
+        .map((e) => e.name);
     return _startSearch();
   }
 
   @override
   Future<List<TopicAutocompleteResult>?> computeResults() async {
     final results = <TopicAutocompleteResult>[];
-    if (await filterCandidates(filter: _testTopic,
-          candidates: _topics, results: results)) {
+    if (await filterCandidates(
+      filter: _testTopic,
+      candidates: _topics,
+      results: results,
+    )) {
       return null;
     }
     return results;
   }
 
-  TopicAutocompleteResult? _testTopic(TopicAutocompleteQuery query, TopicName topic) {
+  TopicAutocompleteResult? _testTopic(
+    TopicAutocompleteQuery query,
+    TopicName topic,
+  ) {
     if (query.testTopic(topic, store)) {
       return TopicAutocompleteResult(topic: topic);
     }
@@ -1286,11 +1442,13 @@ class TopicAutocompleteQuery extends AutocompleteQuery {
     // TODO(#881): Sort by match relevance, like web does.
 
     if (topic.displayName == null) {
-      return AutocompleteQuery.lowercaseAndStripDiacritics(store.realmEmptyTopicDisplayName)
-        .contains(_normalized);
+      return AutocompleteQuery.lowercaseAndStripDiacritics(
+        store.realmEmptyTopicDisplayName,
+      ).contains(_normalized);
     }
-    return topic.displayName != raw
-      && AutocompleteQuery.lowercaseAndStripDiacritics(topic.displayName!).contains(_normalized);
+    return topic.displayName != raw &&
+        AutocompleteQuery.lowercaseAndStripDiacritics(topic.displayName!)
+            .contains(_normalized);
   }
 
   @override
@@ -1316,7 +1474,12 @@ class TopicAutocompleteResult extends AutocompleteResult {
 
 /// An [AutocompleteView] for a #channel autocomplete interaction,
 /// an example of a [ComposeAutocompleteView].
-class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocompleteQuery, ChannelLinkAutocompleteResult> {
+class ChannelLinkAutocompleteView
+    extends
+        AutocompleteView<
+          ChannelLinkAutocompleteQuery,
+          ChannelLinkAutocompleteResult
+        > {
   ChannelLinkAutocompleteView._({
     required super.store,
     required super.query,
@@ -1384,12 +1547,17 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
       case MentionsNarrow():
       case StarredMessagesNarrow():
       case KeywordSearchNarrow():
-        assert(false, 'No compose box, thus no autocomplete is available in ${narrow.runtimeType}.');
+        assert(
+          false,
+          'No compose box, thus no autocomplete is available in ${narrow.runtimeType}.',
+        );
     }
     return (a, b) => _compareByRelevance(a, b, composingToChannelId: channelId);
   }
 
-  static int _compareByRelevance(ZulipStream a, ZulipStream b, {
+  static int _compareByRelevance(
+    ZulipStream a,
+    ZulipStream b, {
     required int? composingToChannelId,
   }) {
     // Compare `typeahead_helper.compare_by_activity` in Zulip web;
@@ -1403,8 +1571,11 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
     //    See: [ChannelLinkAutocompleteQuery.testChannel]
 
     if (composingToChannelId != null) {
-      final composingToResult = compareByComposingTo(a, b,
-        composingToChannelId: composingToChannelId);
+      final composingToResult = compareByComposingTo(
+        a,
+        b,
+        composingToChannelId: composingToChannelId,
+      );
       if (composingToResult != 0) return composingToResult;
     }
 
@@ -1422,15 +1593,17 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
 
   /// Comparator that puts the channel being composed to, before other ones.
   @visibleForTesting
-  static int compareByComposingTo(ZulipStream a, ZulipStream b, {
+  static int compareByComposingTo(
+    ZulipStream a,
+    ZulipStream b, {
     required int composingToChannelId,
   }) {
     final composingToA = composingToChannelId == a.streamId;
     final composingToB = composingToChannelId == b.streamId;
-    return switch((composingToA, composingToB)) {
-      (true,  false) => -1,
-      (false,  true) =>  1,
-      _              =>  0,
+    return switch ((composingToA, composingToB)) {
+      (true, false) => -1,
+      (false, true) => 1,
+      _ => 0,
     };
   }
 
@@ -1440,15 +1613,15 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
   ///   pinned unmuted > unpinned unmuted > pinned muted > unpinned muted
   @visibleForTesting
   static int compareByBeingSubscribed(ZulipStream a, ZulipStream b) {
-    if (a is  Subscription && b is! Subscription) return -1;
-    if (a is! Subscription && b is  Subscription) return  1;
+    if (a is Subscription && b is! Subscription) return -1;
+    if (a is! Subscription && b is Subscription) return 1;
 
-    return switch((a, b)) {
-      (Subscription(isMuted:  false), Subscription(isMuted:   true)) => -1,
-      (Subscription(isMuted:   true), Subscription(isMuted:  false)) =>  1,
-      (Subscription(pinToTop:  true), Subscription(pinToTop: false)) => -1,
-      (Subscription(pinToTop: false), Subscription(pinToTop:  true)) =>  1,
-      _                                                              =>  0,
+    return switch ((a, b)) {
+      (Subscription(isMuted: false), Subscription(isMuted: true)) => -1,
+      (Subscription(isMuted: true), Subscription(isMuted: false)) => 1,
+      (Subscription(pinToTop: true), Subscription(pinToTop: false)) => -1,
+      (Subscription(pinToTop: false), Subscription(pinToTop: true)) => 1,
+      _ => 0,
     };
   }
 
@@ -1469,13 +1642,13 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
     //  * If the channel is newly subscribed, then it's considered as
     //    recently-active.
 
-    return switch((a.isRecentlyActive, b.isRecentlyActive)) {
+    return switch ((a.isRecentlyActive, b.isRecentlyActive)) {
       (true, false) => -1,
-      (false, true) =>  1,
+      (false, true) => 1,
       // The combination of `null` and `bool` is not possible as they're both
       // either `null` or `bool`, before or after server-10, respectively.
       // TODO(server-10): remove the preceding comment
-      _             =>  0,
+      _ => 0,
     };
   }
 
@@ -1492,16 +1665,25 @@ class ChannelLinkAutocompleteView extends AutocompleteView<ChannelLinkAutocomple
   @override
   Future<List<ChannelLinkAutocompleteResult>?> computeResults() async {
     final unsorted = <ChannelLinkAutocompleteResult>[];
-    if (await filterCandidates(filter: _testChannel,
-          candidates: sortedChannels, results: unsorted)) {
+    if (await filterCandidates(
+      filter: _testChannel,
+      candidates: sortedChannels,
+      results: unsorted,
+    )) {
       return null;
     }
 
-    return bucketSort(unsorted,
-      (r) => r.rank, numBuckets: ChannelLinkAutocompleteQuery._numResultRanks);
+    return bucketSort(
+      unsorted,
+      (r) => r.rank,
+      numBuckets: ChannelLinkAutocompleteQuery._numResultRanks,
+    );
   }
 
-  ChannelLinkAutocompleteResult? _testChannel(ChannelLinkAutocompleteQuery query, ZulipStream channel) {
+  ChannelLinkAutocompleteResult? _testChannel(
+    ChannelLinkAutocompleteQuery query,
+    ZulipStream channel,
+  ) {
     return query.testChannel(channel, store);
   }
 }
@@ -1516,27 +1698,37 @@ class ChannelLinkAutocompleteQuery extends ComposeAutocompleteQuery {
     required ZulipLocalizations localizations,
     required Narrow narrow,
   }) {
-    return ChannelLinkAutocompleteView.init(store: store, query: this, narrow: narrow);
+    return ChannelLinkAutocompleteView.init(
+      store: store,
+      query: this,
+      narrow: narrow,
+    );
   }
 
-  ChannelLinkAutocompleteResult? testChannel(ZulipStream channel, PerAccountStore store) {
+  ChannelLinkAutocompleteResult? testChannel(
+    ZulipStream channel,
+    PerAccountStore store,
+  ) {
     if (channel.isArchived) return null;
 
     final cache = store.autocompleteViewManager.autocompleteDataCache;
     final matchQuality = _matchName(
       normalizedName: cache.normalizedNameForChannel(channel),
-      normalizedNameWords: cache.normalizedNameWordsForChannel(channel));
+      normalizedNameWords: cache.normalizedNameWordsForChannel(channel),
+    );
     if (matchQuality == null) return null;
     return ChannelLinkAutocompleteResult(
-      channelId: channel.streamId, rank: _rankResult(matchQuality));
+      channelId: channel.streamId,
+      rank: _rankResult(matchQuality),
+    );
   }
 
   /// A measure of a channel result's quality in the context of the query,
   /// from 0 (best) to one less than [_numResultRanks].
   static int _rankResult(NameMatchQuality matchQuality) {
-    return switch(matchQuality) {
-      NameMatchQuality.exact        => 0,
-      NameMatchQuality.totalPrefix  => 1,
+    return switch (matchQuality) {
+      NameMatchQuality.exact => 0,
+      NameMatchQuality.totalPrefix => 1,
       NameMatchQuality.wordPrefixes => 2,
     };
   }

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -781,7 +781,7 @@ class MentionAutocompleteView
         .where(
           (userGroup) =>
               userGroup.canMentionGroup == null ||
-              store.selfInGroupSetting(userGroup.canMentionGroup!)
+              store.selfInGroupSetting(userGroup.canMentionGroup!),
         )
         .toList()
       ..sort(_userGroupComparator(store: store));
@@ -837,8 +837,9 @@ class MentionAutocompleteView
         final isChannelWildcardAvailable =
             store.zulipFeatureLevel >= 247; // TODO(server-9)
         if (isChannelWildcardAvailable &&
-            tryOption(WildcardMentionOption.channel))
+            tryOption(WildcardMentionOption.channel)) {
           break all;
+        }
         if (tryOption(WildcardMentionOption.stream)) break all;
       }
     }

--- a/lib/model/user_group.dart
+++ b/lib/model/user_group.dart
@@ -112,8 +112,9 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
         if (data.name != null) group.name = data.name!;
         if (data.description != null) group.description = data.description!;
         if (data.deactivated != null) group.deactivated = data.deactivated!;
-        if (data.canMentionGroup != null)
+        if (data.canMentionGroup != null) {
           group.canMentionGroup = data.canMentionGroup;
+        }
       case UserGroupAddMembersEvent():
         final group = _expectGroup(event.groupId);
         if (group == null) return;

--- a/lib/model/user_group.dart
+++ b/lib/model/user_group.dart
@@ -35,13 +35,15 @@ mixin ProxyUserGroupStore on UserGroupStore {
   @override
   Iterable<UserGroup> get allGroups => userGroupStore.allGroups;
   @override
-  bool selfInGroupSetting(GroupSettingValue value)
-    => userGroupStore.selfInGroupSetting(value);
+  bool selfInGroupSetting(GroupSettingValue value) =>
+      userGroupStore.selfInGroupSetting(value);
 }
 
-abstract class HasUserGroupStore extends PerAccountStoreBase with UserGroupStore, ProxyUserGroupStore {
+abstract class HasUserGroupStore extends PerAccountStoreBase
+    with UserGroupStore, ProxyUserGroupStore {
   HasUserGroupStore({required UserGroupStore groups})
-    : userGroupStore = groups, super(core: groups.core);
+    : userGroupStore = groups,
+      super(core: groups.core);
 
   @protected
   @override
@@ -51,10 +53,7 @@ abstract class HasUserGroupStore extends PerAccountStoreBase with UserGroupStore
 /// The implementation of [UserGroupStore] that does the work.
 class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
   UserGroupStoreImpl({required super.core, required List<UserGroup> groups})
-    : _groups = {
-        for (final group in groups)
-          group.id: group,
-      };
+    : _groups = {for (final group in groups) group.id: group};
 
   @override
   UserGroup? getGroup(int userGroupId) {
@@ -74,11 +73,10 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
   @override
   bool selfInGroupSetting(GroupSettingValue value) {
     return switch (value) {
-      GroupSettingValueNamed() =>
-        _selfInGroup(value.groupId),
+      GroupSettingValueNamed() => _selfInGroup(value.groupId),
       GroupSettingValueNameless() =>
-        value.directMembers.contains(selfUserId)
-          || value.directSubgroups.any(_selfInGroup),
+        value.directMembers.contains(selfUserId) ||
+            value.directSubgroups.any(_selfInGroup),
     };
   }
 
@@ -87,8 +85,8 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
     if (group == null) return false; // TODO(log); should know all groups
     // TODO(perf), TODO(#814): memoize which groups the self-user is in,
     //   to save doing this depth-first search on each permission check
-    return group.members.contains(selfUserId)
-      || group.directSubgroupIds.any(_selfInGroup);
+    return group.members.contains(selfUserId) ||
+        group.directSubgroupIds.any(_selfInGroup);
   }
 
   final Map<int, UserGroup> _groups;
@@ -111,10 +109,11 @@ class UserGroupStoreImpl extends PerAccountStoreBase with UserGroupStore {
         final group = _expectGroup(event.groupId);
         if (group == null) return;
         final data = event.data;
-        if (data.name != null)        group.name        = data.name!;
+        if (data.name != null) group.name = data.name!;
         if (data.description != null) group.description = data.description!;
         if (data.deactivated != null) group.deactivated = data.deactivated!;
-
+        if (data.canMentionGroup != null)
+          group.canMentionGroup = data.canMentionGroup;
       case UserGroupAddMembersEvent():
         final group = _expectGroup(event.groupId);
         if (group == null) return;

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -33,10 +33,11 @@ void _checkPositive(int? value, String description) {
 
 Object nullCheckError() {
   try {
+    //ignore: null_check_always_fails
     null!;
   } catch (e) {
     return e;
-  } // ignore: null_check_always_fails
+  }
 }
 
 /// A Zulip API error with the generic "BAD_REQUEST" error code.

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -32,7 +32,11 @@ void _checkPositive(int? value, String description) {
 //
 
 Object nullCheckError() {
-  try { null!; } catch (e) { return e; } // ignore: null_check_always_fails
+  try {
+    null!;
+  } catch (e) {
+    return e;
+  } // ignore: null_check_always_fails
 }
 
 /// A Zulip API error with the generic "BAD_REQUEST" error code.
@@ -40,11 +44,16 @@ Object nullCheckError() {
 /// The server returns this error code for a wide range of error conditions;
 /// it's the default within the server code when no more-specific code is chosen.
 ZulipApiException apiBadRequest({
-    String routeName = 'someRoute', String message = 'Something failed'}) {
+  String routeName = 'someRoute',
+  String message = 'Something failed',
+}) {
   return ZulipApiException(
     routeName: routeName,
-    httpStatus: 400, code: 'BAD_REQUEST',
-    data: {}, message: message);
+    httpStatus: 400,
+    code: 'BAD_REQUEST',
+    data: {},
+    message: message,
+  );
 }
 
 /// The error for the "events" route when the target event queue has been
@@ -55,8 +64,12 @@ ZulipApiException apiExceptionBadEventQueueId({
   String queueId = 'fb67bf8a-c031-47cc-84cf-ed80accacda8',
 }) {
   return ZulipApiException(
-    routeName: 'events', httpStatus: 400, code: 'BAD_EVENT_QUEUE_ID',
-    data: {'queue_id': queueId}, message: 'Bad event queue ID: $queueId');
+    routeName: 'events',
+    httpStatus: 400,
+    code: 'BAD_EVENT_QUEUE_ID',
+    data: {'queue_id': queueId},
+    message: 'Bad event queue ID: $queueId',
+  );
 }
 
 /// The error the server gives when the client's credentials
@@ -69,8 +82,11 @@ ZulipApiException apiExceptionBadEventQueueId({
 ZulipApiException apiExceptionUnauthorized({String routeName = 'someRoute'}) {
   return ZulipApiException(
     routeName: routeName,
-    httpStatus: 401, code: 'UNAUTHORIZED',
-    data: {}, message: 'Invalid API key');
+    httpStatus: 401,
+    code: 'UNAUTHORIZED',
+    data: {},
+    message: 'Invalid API key',
+  );
 }
 
 //|//////////////////////////////////////////////////////////////
@@ -102,12 +118,8 @@ const int recentZulipFeatureLevel = 476;
 const int futureZulipFeatureLevel = 9999;
 const int ancientZulipFeatureLevel = kMinAllowedZulipFeatureLevel - 1;
 
-AuthenticationMethods authMethods({
-  bool ldap = false,
-}) {
-  return AuthenticationMethods(
-    ldap: ldap,
-  );
+AuthenticationMethods authMethods({bool ldap = false}) {
+  return AuthenticationMethods(ldap: ldap);
 }
 
 GetServerSettingsResult serverSettings({
@@ -163,20 +175,25 @@ CustomProfileField customProfileField(
 }
 
 ServerEmojiData _immutableServerEmojiData({
-    required Map<String, List<String>> codeToNames}) {
+  required Map<String, List<String>> codeToNames,
+}) {
   return ServerEmojiData(
-    codeToNames: Map.unmodifiable(codeToNames.map(
-      (k, v) => MapEntry(k, List<String>.unmodifiable(v)))));
+    codeToNames: Map.unmodifiable(
+      codeToNames.map((k, v) => MapEntry(k, List<String>.unmodifiable(v))),
+    ),
+  );
 }
 
-final ServerEmojiData serverEmojiDataPopular = _immutableServerEmojiData(codeToNames: {
-  '1f44d': ['+1', 'thumbs_up', 'like'],
-  '1f389': ['tada'],
-  '1f642': ['slight_smile'],
-  '2764': ['heart', 'love', 'love_you'],
-  '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
-  '1f419': ['octopus'],
-});
+final ServerEmojiData serverEmojiDataPopular = _immutableServerEmojiData(
+  codeToNames: {
+    '1f44d': ['+1', 'thumbs_up', 'like'],
+    '1f389': ['tada'],
+    '1f642': ['slight_smile'],
+    '2764': ['heart', 'love', 'love_you'],
+    '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
+    '1f419': ['octopus'],
+  },
+);
 
 ServerEmojiData serverEmojiDataPopularPlus(ServerEmojiData data) {
   final a = serverEmojiDataPopular;
@@ -196,14 +213,16 @@ ServerEmojiData serverEmojiDataPopularPlus(ServerEmojiData data) {
 ///
 /// zulip/zulip@9feba0f16f is a Server 11 commit.
 // TODO(server-11) can drop this
-final ServerEmojiData serverEmojiDataPopularLegacy = _immutableServerEmojiData(codeToNames: {
-  '1f44d': ['+1', 'thumbs_up', 'like'],
-  '1f389': ['tada'],
-  '1f642': ['smile'],
-  '2764': ['heart', 'love', 'love_you'],
-  '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
-  '1f419': ['octopus'],
-});
+final ServerEmojiData serverEmojiDataPopularLegacy = _immutableServerEmojiData(
+  codeToNames: {
+    '1f44d': ['+1', 'thumbs_up', 'like'],
+    '1f389': ['tada'],
+    '1f642': ['smile'],
+    '2764': ['heart', 'love', 'love_you'],
+    '1f6e0': ['working_on_it', 'hammer_and_wrench', 'tools'],
+    '1f419': ['octopus'],
+  },
+);
 
 /// A fresh user-group ID, from a random but always strictly increasing sequence.
 int _nextUserGroupId() => (_lastUserGroupId += 1 + Random().nextInt(10));
@@ -217,6 +236,7 @@ UserGroup userGroup({
   String? description,
   bool isSystemGroup = false,
   bool deactivated = false,
+  GroupSettingValue? canMentionGroup,
 }) {
   return UserGroup(
     id: id ??= _nextUserGroupId(),
@@ -226,13 +246,16 @@ UserGroup userGroup({
     description: description ?? 'A group named $name',
     isSystemGroup: isSystemGroup,
     deactivated: deactivated,
+    canMentionGroup: canMentionGroup,
   );
 }
 
 final UserGroup nobodyGroup = userGroup(
   isSystemGroup: true,
-  name: 'role:nobody', description: 'Nobody',
-  members: [], directSubgroupIds: [],
+  name: 'role:nobody',
+  description: 'Nobody',
+  members: [],
+  directSubgroupIds: [],
 );
 
 GroupSettingValueNameless groupSetting({
@@ -271,7 +294,8 @@ int _nextUserId() => (_lastUserId += 1 + Random().nextInt(100));
 int _lastUserId = 1000;
 
 /// A random email address, different from previously generated ones.
-String _nextEmail() => 'mail${_lastEmailSuffix += 1 + Random().nextInt(1000)}@example.com';
+String _nextEmail() =>
+    'mail${_lastEmailSuffix += 1 + Random().nextInt(1000)}@example.com';
 int _lastEmailSuffix = 1000;
 
 /// Construct an example user.
@@ -350,6 +374,7 @@ Account account({
     possibleLegacyPushToken: possibleLegacyPushToken ?? false,
   );
 }
+
 const _account = account;
 
 /// A [User] which throws on attempting to mutate any of its fields.
@@ -360,53 +385,67 @@ const _account = account;
 /// which happens to a value in this file like [selfUser] (which will not be
 /// discarded by [TestZulipBinding.reset]).  That was the cause of issue #1712.
 class _ImmutableUser extends User {
-  _ImmutableUser.copyUser(User user) : super(
-    // When adding a field here, be sure to add the corresponding setter below.
-    userId: user.userId,
-    deliveryEmail: user.deliveryEmail,
-    email: user.email,
-    fullName: user.fullName,
-    dateJoined: user.dateJoined,
-    isActive: user.isActive,
-    isBot: user.isBot,
-    botType: user.botType,
-    botOwnerId: user.botOwnerId,
-    role: user.role,
-    timezone: user.timezone,
-    avatarUrl: user.avatarUrl,
-    avatarVersion: user.avatarVersion,
-    profileData: user.profileData == null ? null : Map.unmodifiable(user.profileData!),
-    isSystemBot: user.isSystemBot,
-    // When adding a field here, be sure to add the corresponding setter below.
-  );
+  _ImmutableUser.copyUser(User user)
+    : super(
+        // When adding a field here, be sure to add the corresponding setter below.
+        userId: user.userId,
+        deliveryEmail: user.deliveryEmail,
+        email: user.email,
+        fullName: user.fullName,
+        dateJoined: user.dateJoined,
+        isActive: user.isActive,
+        isBot: user.isBot,
+        botType: user.botType,
+        botOwnerId: user.botOwnerId,
+        role: user.role,
+        timezone: user.timezone,
+        avatarUrl: user.avatarUrl,
+        avatarVersion: user.avatarVersion,
+        profileData: user.profileData == null
+            ? null
+            : Map.unmodifiable(user.profileData!),
+        isSystemBot: user.isSystemBot,
+        // When adding a field here, be sure to add the corresponding setter below.
+      );
 
   static final Error _error = UnsupportedError(
     'Cannot mutate immutable User.\n'
     'When a test needs to have the store handle an event which will\n'
     'modify a user, use `eg.user()` to make a fresh User object\n'
-    'instead of using a shared User object like `eg.selfUser`.');
+    'instead of using a shared User object like `eg.selfUser`.',
+  );
 
   // userId already immutable
-  @override set deliveryEmail(_) => throw _error;
-  @override set email(_) => throw _error;
-  @override set fullName(_) => throw _error;
+  @override
+  set deliveryEmail(_) => throw _error;
+  @override
+  set email(_) => throw _error;
+  @override
+  set fullName(_) => throw _error;
   // dateJoined already immutable
-  @override set isActive(_) => throw _error;
+  @override
+  set isActive(_) => throw _error;
   // isBot already immutable
   // botType already immutable
-  @override set botOwnerId(_) => throw _error;
-  @override set role(_) => throw _error;
-  @override set timezone(_) => throw _error;
-  @override set avatarUrl(_) => throw _error;
-  @override set avatarVersion(_) => throw _error;
-  @override set profileData(_) => throw _error;
+  @override
+  set botOwnerId(_) => throw _error;
+  @override
+  set role(_) => throw _error;
+  @override
+  set timezone(_) => throw _error;
+  @override
+  set avatarUrl(_) => throw _error;
+  @override
+  set avatarVersion(_) => throw _error;
+  @override
+  set profileData(_) => throw _error;
   // isSystemBot already immutable
 }
 
 final User selfUser = _ImmutableUser.copyUser(user(fullName: 'Self User'));
 final User otherUser = _ImmutableUser.copyUser(user(fullName: 'Other User'));
 final User thirdUser = _ImmutableUser.copyUser(user(fullName: 'Third User'));
-final User fourthUser  = _ImmutableUser.copyUser(user(fullName: 'Fourth User'));
+final User fourthUser = _ImmutableUser.copyUser(user(fullName: 'Fourth User'));
 
 // There's no need for an [Account] analogue of [_ImmutableUser],
 // because [Account] (which is generated by Drift) is already immutable.
@@ -552,21 +591,28 @@ ZulipStream stream({
     topicsPolicy: topicsPolicy ?? .inherit,
     channelPostPolicy: channelPostPolicy ?? ChannelPostPolicy.any,
     folderId: folderId,
-    canAddSubscribersGroup: canAddSubscribersGroup ?? GroupSettingValueNamed(nobodyGroup.id),
-    canDeleteAnyMessageGroup: canDeleteAnyMessageGroup ?? GroupSettingValueNamed(nobodyGroup.id),
-    canDeleteOwnMessageGroup: canDeleteOwnMessageGroup ?? GroupSettingValueNamed(nobodyGroup.id),
+    canAddSubscribersGroup:
+        canAddSubscribersGroup ?? GroupSettingValueNamed(nobodyGroup.id),
+    canDeleteAnyMessageGroup:
+        canDeleteAnyMessageGroup ?? GroupSettingValueNamed(nobodyGroup.id),
+    canDeleteOwnMessageGroup:
+        canDeleteOwnMessageGroup ?? GroupSettingValueNamed(nobodyGroup.id),
     canSendMessageGroup: canSendMessageGroup,
-    canSubscribeGroup: canSubscribeGroup ?? GroupSettingValueNamed(nobodyGroup.id),
+    canSubscribeGroup:
+        canSubscribeGroup ?? GroupSettingValueNamed(nobodyGroup.id),
     isRecentlyActive: isRecentlyActive ?? true,
     streamWeeklyTraffic: streamWeeklyTraffic,
   );
 }
+
 const _stream = stream;
 
 GetChannelTopicsEntry getChannelTopicsEntry({int? maxId, String? name}) {
   maxId ??= 123;
-  return GetChannelTopicsEntry(maxId: maxId,
-    name: TopicName(name ?? 'Test Topic #$maxId'));
+  return GetChannelTopicsEntry(
+    maxId: maxId,
+    name: TopicName(name ?? 'Test Topic #$maxId'),
+  );
 }
 
 /// Construct an example subscription from a stream.
@@ -619,7 +665,8 @@ Subscription subscription(
 
 /// A fresh channel folder ID,
 /// from a random but always strictly increasing sequence.
-int _nextChannelFolderId() => (_lastChannelFolderId += 1 + Random().nextInt(100));
+int _nextChannelFolderId() =>
+    (_lastChannelFolderId += 1 + Random().nextInt(100));
 int _lastChannelFolderId = 1000;
 
 ChannelFolder channelFolder({
@@ -670,7 +717,10 @@ TopicNarrow topicNarrow(int channelId, String topicName, {int? with_}) {
 }
 
 UserTopicItem userTopicItem(
-    ZulipStream stream, String topic, UserTopicVisibilityPolicy policy) {
+  ZulipStream stream,
+  String topic,
+  UserTopicVisibilityPolicy policy,
+) {
   return UserTopicItem(
     streamId: stream.streamId,
     topicName: TopicName(topic),
@@ -719,13 +769,13 @@ Map<String, dynamic> _messagePropertiesFromSender(User? sender) {
   };
 }
 
-Map<String, dynamic> _messagePropertiesFromContent(String? content, String? contentMarkdown) {
+Map<String, dynamic> _messagePropertiesFromContent(
+  String? content,
+  String? contentMarkdown,
+) {
   if (contentMarkdown != null) {
     assert(content == null);
-    return {
-      'content': contentMarkdown,
-      'content_type': 'text/x-markdown',
-    };
+    return {'content': contentMarkdown, 'content_type': 'text/x-markdown'};
   } else {
     return {
       'content': content ?? '<p>This is an example message.</p>',
@@ -782,29 +832,32 @@ StreamMessage streamMessage({
   List<Submessage>? submessages,
 }) {
   _checkPositive(id, 'message ID');
-  final effectiveStream = stream ?? _stream(streamId: defaultStreamMessageStreamId);
+  final effectiveStream =
+      stream ?? _stream(streamId: defaultStreamMessageStreamId);
   // The use of JSON here is convenient in order to delegate parts of the data
   // to helper functions.  The main downside is that it loses static typing
   // of the properties as we're constructing the data.  That's probably OK
   // because (a) this is only for tests; (b) the types do get checked
   // dynamically in the constructor, so any ill-typing won't propagate further.
-  return StreamMessage.fromJson(deepToJson({
-    ..._messagePropertiesBase,
-    ..._messagePropertiesFromSender(sender),
-    ..._messagePropertiesFromContent(content, contentMarkdown),
-    'display_recipient': effectiveStream.name,
-    'stream_id': effectiveStream.streamId,
-    'reactions': reactions == null ? <Reaction>[] : Reactions(reactions),
-    'flags': flags ?? [],
-    'id': id ?? _nextMessageId(),
-    'last_edit_timestamp': lastEditTimestamp,
-    'subject': topic ?? _defaultTopic,
-    'submessages': submessages ?? [],
-    'timestamp': timestamp ?? 1678139636,
-    'type': 'stream',
-    'match_content': matchContent,
-    'match_subject': matchTopic,
-  }) as Map<String, dynamic>);
+  return StreamMessage.fromJson(
+    deepToJson({
+      ..._messagePropertiesBase,
+      ..._messagePropertiesFromSender(sender),
+      ..._messagePropertiesFromContent(content, contentMarkdown),
+      'display_recipient': effectiveStream.name,
+      'stream_id': effectiveStream.streamId,
+      'reactions': reactions == null ? <Reaction>[] : Reactions(reactions),
+      'flags': flags ?? [],
+      'id': id ?? _nextMessageId(),
+      'last_edit_timestamp': lastEditTimestamp,
+      'subject': topic ?? _defaultTopic,
+      'submessages': submessages ?? [],
+      'timestamp': timestamp ?? 1678139636,
+      'type': 'stream',
+      'match_content': matchContent,
+      'match_subject': matchTopic,
+    }) as Map<String, dynamic>,
+  );
 }
 
 /// Construct an example direct message.
@@ -830,22 +883,26 @@ DmMessage dmMessage({
 }) {
   _checkPositive(id, 'message ID');
   assert(!to.any((user) => user.userId == from.userId));
-  return DmMessage.fromJson(deepToJson({
-    ..._messagePropertiesBase,
-    ..._messagePropertiesFromSender(from),
-    ..._messagePropertiesFromContent(content, contentMarkdown),
-    'display_recipient': [from, ...to]
-      .map((u) => {'id': u.userId, 'email': u.email, 'full_name': u.fullName})
-      .toList(growable: false),
-    'reactions': <Reaction>[],
-    'flags': flags ?? [],
-    'id': id ?? _nextMessageId(),
-    'last_edit_timestamp': lastEditTimestamp,
-    'subject': '',
-    'submessages': submessages ?? [],
-    'timestamp': timestamp ?? 1678139636,
-    'type': 'private',
-  }) as Map<String, dynamic>);
+  return DmMessage.fromJson(
+    deepToJson({
+      ..._messagePropertiesBase,
+      ..._messagePropertiesFromSender(from),
+      ..._messagePropertiesFromContent(content, contentMarkdown),
+      'display_recipient': [from, ...to]
+          .map(
+            (u) => {'id': u.userId, 'email': u.email, 'full_name': u.fullName},
+          )
+          .toList(growable: false),
+      'reactions': <Reaction>[],
+      'flags': flags ?? [],
+      'id': id ?? _nextMessageId(),
+      'last_edit_timestamp': lastEditTimestamp,
+      'subject': '',
+      'submessages': submessages ?? [],
+      'timestamp': timestamp ?? 1678139636,
+      'type': 'private',
+    }) as Map<String, dynamic>,
+  );
 }
 
 /// A GetMessagesResult the server might return for
@@ -865,8 +922,9 @@ GetMessagesResult getMessagesResult({
   final resultAnchor = switch (anchor) {
     AnchorCode.oldest => 0,
     NumericAnchor(:final messageId) => messageId,
-    AnchorCode.firstUnread =>
-      throw ArgumentError("firstUnread not accepted in this helper; try NumericAnchor"),
+    AnchorCode.firstUnread => throw ArgumentError(
+      "firstUnread not accepted in this helper; try NumericAnchor",
+    ),
     AnchorCode.newest => 10_000_000_000_000_000, // that's 16 zeros
   };
 
@@ -904,8 +962,12 @@ GetMessagesResult newestGetMessagesResult({
   bool historyLimited = false,
   required List<Message> messages,
 }) {
-  return getMessagesResult(anchor: AnchorCode.newest, foundOldest: foundOldest,
-    historyLimited: historyLimited, messages: messages);
+  return getMessagesResult(
+    anchor: AnchorCode.newest,
+    foundOldest: foundOldest,
+    historyLimited: historyLimited,
+    messages: messages,
+  );
 }
 
 /// A GetMessagesResult the server might return on an initial request
@@ -938,7 +1000,8 @@ GetMessagesResult olderGetMessagesResult({
   return GetMessagesResult(
     anchor: anchor,
     foundAnchor: false,
-    foundNewest: false, // empirically always this, even when anchor happens to be latest
+    foundNewest:
+        false, // empirically always this, even when anchor happens to be latest
     foundOldest: foundOldest,
     historyLimited: historyLimited,
     messages: messages,
@@ -972,16 +1035,19 @@ StreamOutboxMessage streamOutboxMessage({
   String? topic,
   String? content,
 }) {
-  final effectiveStream = stream ?? _stream(streamId: defaultStreamMessageStreamId);
+  final effectiveStream =
+      stream ?? _stream(streamId: defaultStreamMessageStreamId);
   return OutboxMessage.fromConversation(
     StreamConversation(
-      effectiveStream.streamId, TopicName(topic ?? 'topic'),
+      effectiveStream.streamId,
+      TopicName(topic ?? 'topic'),
       displayRecipient: null,
     ),
     localMessageId: localMessageId ?? _nextLocalMessageId++,
     selfUserId: selfUserId ?? selfUser.userId,
     timestamp: timestamp ?? utcTimestamp(),
-    contentMarkdown: content ?? 'content') as StreamOutboxMessage;
+    contentMarkdown: content ?? 'content',
+  ) as StreamOutboxMessage;
 }
 
 DmOutboxMessage dmOutboxMessage({
@@ -991,14 +1057,15 @@ DmOutboxMessage dmOutboxMessage({
   int? timestamp,
   String? content,
 }) {
-  final allRecipientIds =
-    [from, ...to].map((user) => user.userId).toList()..sort();
+  final allRecipientIds = [from, ...to].map((user) => user.userId).toList()
+    ..sort();
   return OutboxMessage.fromConversation(
     DmConversation(allRecipientIds: allRecipientIds),
     localMessageId: localMessageId ?? _nextLocalMessageId++,
     selfUserId: from.userId,
     timestamp: timestamp ?? utcTimestamp(),
-    contentMarkdown: content ?? 'content') as DmOutboxMessage;
+    contentMarkdown: content ?? 'content',
+  ) as DmOutboxMessage;
 }
 
 PollWidgetData pollWidgetData({
@@ -1006,7 +1073,8 @@ PollWidgetData pollWidgetData({
   required List<String> options,
 }) {
   return PollWidgetData(
-    extraData: PollWidgetExtraData(question: question, options: options));
+    extraData: PollWidgetExtraData(question: question, options: options),
+  );
 }
 
 Submessage submessage({
@@ -1054,6 +1122,7 @@ UnreadMessagesSnapshot unreadMsgs({
     oldUnreadsMissing: oldUnreadsMissing ?? false,
   );
 }
+
 const _unreadMsgs = unreadMsgs;
 
 //|//////////////////////////////////////////////////////////////
@@ -1080,7 +1149,10 @@ DeviceUpdateEvent deviceUpdateEvent(
 }
 
 UserTopicEvent userTopicEvent(
-    int streamId, String topic, UserTopicVisibilityPolicy visibilityPolicy) {
+  int streamId,
+  String topic,
+  UserTopicVisibilityPolicy visibilityPolicy,
+) {
   return UserTopicEvent(
     id: 1,
     streamId: streamId,
@@ -1091,12 +1163,18 @@ UserTopicEvent userTopicEvent(
 }
 
 MutedUsersEvent mutedUsersEvent(List<int> userIds) {
-  return MutedUsersEvent(id: 1,
-    mutedUsers: userIds.map((id) => MutedUserItem(id: id)).toList());
+  return MutedUsersEvent(
+    id: 1,
+    mutedUsers: userIds.map((id) => MutedUserItem(id: id)).toList(),
+  );
 }
 
 MessageEvent messageEvent(Message message, {int? localMessageId}) =>
-  MessageEvent(id: 0, message: message, localMessageId: localMessageId?.toString());
+    MessageEvent(
+      id: 0,
+      message: message,
+      localMessageId: localMessageId?.toString(),
+    );
 
 DeleteMessageEvent deleteMessageEvent(List<StreamMessage> messages) {
   assert(messages.isNotEmpty);
@@ -1195,7 +1273,8 @@ UpdateMessageEvent updateMessageEventMoveFrom({
   final origMessage = origMessages.first;
   // Only present on content change.
   final origContent = (newContent != null) ? origMessage.content : null;
-  return _updateMessageMoveEvent(origMessages.map((e) => e.id).toList(),
+  return _updateMessageMoveEvent(
+    origMessages.map((e) => e.id).toList(),
     origStreamId: origMessage.streamId,
     newStreamId: newStreamId,
     origTopic: origMessage.topic,
@@ -1227,11 +1306,12 @@ UpdateMessageEvent updateMessageEventMoveTo({
   final newStreamId = (origStreamId != null) ? newMessage.streamId : null;
   // Only present on content change.
   final newContent = (origContent != null) ? newMessage.content : null;
-  return _updateMessageMoveEvent(newMessages.map((e) => e.id).toList(),
+  return _updateMessageMoveEvent(
+    newMessages.map((e) => e.id).toList(),
     origStreamId: origStreamId ?? newMessage.streamId,
     newStreamId: newStreamId,
     origTopic: origTopic ?? newMessage.topic,
-    newTopic:  newTopic,
+    newTopic: newTopic,
     origContent: origContent,
     newContent: newContent,
     flags: newMessage.flags,
@@ -1249,11 +1329,10 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
     id: 0,
     flag: flag,
     messages: messages.map((m) => m.id).toList(),
-    messageDetails: Map.fromEntries(messages.map((message) {
-      final mentioned = message.flags.any((flag) => flag.isMentionFlag);
-      return MapEntry(
-        message.id,
-        switch (message) {
+    messageDetails: Map.fromEntries(
+      messages.map((message) {
+        final mentioned = message.flags.any((flag) => flag.isMentionFlag);
+        return MapEntry(message.id, switch (message) {
           StreamMessage() => UpdateMessageFlagsMessageDetail(
             type: MessageType.stream,
             mentioned: mentioned,
@@ -1266,12 +1345,15 @@ UpdateMessageFlagsRemoveEvent updateMessageFlagsRemoveEvent(
             mentioned: mentioned,
             streamId: null,
             topic: null,
-            userIds: DmNarrow.ofMessage(message, selfUserId: selfUserId ?? selfUser.userId)
-              .otherRecipientIds,
+            userIds: DmNarrow.ofMessage(
+              message,
+              selfUserId: selfUserId ?? selfUser.userId,
+            ).otherRecipientIds,
           ),
-        },
-      );
-    })));
+        });
+      }),
+    ),
+  );
 }
 
 SubmessageEvent submessageEvent(
@@ -1292,17 +1374,25 @@ SubmessageEvent submessageEvent(
 TypingEvent typingEvent(SendableNarrow narrow, TypingOp op, int senderId) {
   switch (narrow) {
     case TopicNarrow():
-      return TypingEvent(id: 0, op: op, senderId: senderId,
+      return TypingEvent(
+        id: 0,
+        op: op,
+        senderId: senderId,
         messageType: MessageType.stream,
         streamId: narrow.channelId,
         topic: narrow.topic,
-        recipientIds: null);
+        recipientIds: null,
+      );
     case DmNarrow():
-      return TypingEvent(id: 0, op: op, senderId: senderId,
+      return TypingEvent(
+        id: 0,
+        op: op,
+        senderId: senderId,
         messageType: MessageType.direct,
         recipientIds: narrow.allRecipientIds,
         streamId: null,
-        topic: null);
+        topic: null,
+      );
   }
 }
 
@@ -1381,6 +1471,7 @@ TestGlobalStore globalStore({
     pushKeys: pushKeys,
   );
 }
+
 const _globalStore = globalStore;
 
 const String defaultRealmEmptyTopicDisplayName = 'test general chat';
@@ -1401,6 +1492,7 @@ UserSettings userSettings({
     presenceEnabled: presenceEnabled ?? true,
   );
 }
+
 const _userSettings = userSettings;
 
 InitialSnapshot initialSnapshot({
@@ -1463,7 +1555,10 @@ InitialSnapshot initialSnapshot({
     // trying to simulate a modern server without realmDeleteOwnMessagePolicy.
     realmCanDeleteOwnMessageGroup ??= GroupSettingValueNamed(nobodyGroup.id);
   }
-  assert((realmCanDeleteOwnMessageGroup != null) ^ (realmDeleteOwnMessagePolicy != null));
+  assert(
+    (realmCanDeleteOwnMessageGroup != null) ^
+        (realmDeleteOwnMessagePolicy != null),
+  );
 
   return InitialSnapshot(
     queueId: queueId ?? '1:2345',
@@ -1476,13 +1571,14 @@ InitialSnapshot initialSnapshot({
     maxChannelNameLength: maxChannelNameLength ?? 60,
     maxTopicLength: maxTopicLength ?? 60,
     serverPresencePingIntervalSeconds: serverPresencePingIntervalSeconds ?? 60,
-    serverPresenceOfflineThresholdSeconds: serverPresenceOfflineThresholdSeconds ?? 140,
+    serverPresenceOfflineThresholdSeconds:
+        serverPresenceOfflineThresholdSeconds ?? 140,
     serverTypingStartedExpiryPeriodMilliseconds:
-      serverTypingStartedExpiryPeriodMilliseconds ?? 15000,
+        serverTypingStartedExpiryPeriodMilliseconds ?? 15000,
     serverTypingStoppedWaitPeriodMilliseconds:
-      serverTypingStoppedWaitPeriodMilliseconds ?? 5000,
+        serverTypingStoppedWaitPeriodMilliseconds ?? 5000,
     serverTypingStartedWaitPeriodMilliseconds:
-      serverTypingStartedWaitPeriodMilliseconds ?? 10000,
+        serverTypingStartedWaitPeriodMilliseconds ?? 10000,
     mutedUsers: mutedUsers ?? [],
     presences: presences ?? {},
     realmEmoji: realmEmoji ?? {},
@@ -1502,13 +1598,15 @@ InitialSnapshot initialSnapshot({
     realmCanDeleteAnyMessageGroup: realmCanDeleteAnyMessageGroup,
     realmCanDeleteOwnMessageGroup: realmCanDeleteOwnMessageGroup,
     realmDeleteOwnMessagePolicy: realmDeleteOwnMessagePolicy,
-    realmWildcardMentionPolicy: realmWildcardMentionPolicy ?? RealmWildcardMentionPolicy.everyone,
+    realmWildcardMentionPolicy:
+        realmWildcardMentionPolicy ?? RealmWildcardMentionPolicy.everyone,
     // no default; allow `null` to simulate servers without this
     realmTopicsPolicy: realmTopicsPolicy,
     realmMandatoryTopics: realmMandatoryTopics ?? true,
     realmName: realmName ?? 'Example Zulip organization',
     realmWaitingPeriodThreshold: realmWaitingPeriodThreshold ?? 0,
-    realmMessageContentDeleteLimitSeconds: realmMessageContentDeleteLimitSeconds,
+    realmMessageContentDeleteLimitSeconds:
+        realmMessageContentDeleteLimitSeconds,
     realmAllowMessageEditing: realmAllowMessageEditing ?? true,
     realmMessageContentEditLimitSeconds: realmMessageContentEditLimitSeconds,
     realmEnableReadReceipts: realmEnableReadReceipts ?? true,
@@ -1517,16 +1615,18 @@ InitialSnapshot initialSnapshot({
     realmDefaultExternalAccounts: realmDefaultExternalAccounts ?? {},
     maxFileUploadSizeMib: maxFileUploadSizeMib ?? 25,
     serverThumbnailFormats: serverThumbnailFormats ?? [],
-    serverEmojiDataUrl: serverEmojiDataUrl
-      ?? realmUrl.replace(path: '/static/emoji.json'),
+    serverEmojiDataUrl:
+        serverEmojiDataUrl ?? realmUrl.replace(path: '/static/emoji.json'),
     realmModerationRequestChannelId: realmModerationRequestChannelId,
-    realmEmptyTopicDisplayName: realmEmptyTopicDisplayName ?? defaultRealmEmptyTopicDisplayName,
+    realmEmptyTopicDisplayName:
+        realmEmptyTopicDisplayName ?? defaultRealmEmptyTopicDisplayName,
     realmUsers: realmUsers ?? [selfUser],
     realmNonActiveUsers: realmNonActiveUsers ?? [],
     crossRealmBots: crossRealmBots ?? [],
     serverReportMessageTypes: serverReportMessageTypes,
   );
 }
+
 const _initialSnapshot = initialSnapshot;
 
 PerAccountStore store({
@@ -1536,14 +1636,15 @@ PerAccountStore store({
   InitialSnapshot? initialSnapshot,
 }) {
   assert(!(account != null && selfUser != null));
-  final effectiveAccount = account
-    ?? (selfUser != null ? _account(user: selfUser) : selfAccount);
+  final effectiveAccount =
+      account ?? (selfUser != null ? _account(user: selfUser) : selfAccount);
   return PerAccountStore.fromInitialSnapshot(
     globalStore: globalStore ?? _globalStore(accounts: [effectiveAccount]),
     accountId: effectiveAccount.id,
     initialSnapshot: initialSnapshot ?? _initialSnapshot(),
   );
 }
+
 const _store = store;
 
 UpdateMachine updateMachine({
@@ -1552,10 +1653,15 @@ UpdateMachine updateMachine({
   InitialSnapshot? initialSnapshot,
 }) {
   initialSnapshot ??= _initialSnapshot();
-  final store = _store(globalStore: globalStore,
-    account: account, initialSnapshot: initialSnapshot);
+  final store = _store(
+    globalStore: globalStore,
+    account: account,
+    initialSnapshot: initialSnapshot,
+  );
   return UpdateMachine.fromInitialSnapshot(
-    store: store, initialSnapshot: initialSnapshot);
+    store: store,
+    initialSnapshot: initialSnapshot,
+  );
 }
 
 PackageInfo packageInfo({

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -39,10 +39,10 @@ void main() {
     final caretPositions = <int>[];
     int i = 0;
     for (final char in markedText.codeUnits) {
-      if (char == 94 /* ^ */) {
+      if (char == 94 /* ^ */ ) {
         caretPositions.add(i);
         continue;
-      } else if (char == 126 /* ~ */) {
+      } else if (char == 126 /* ~ */ ) {
         if (expectedSyntaxStart != null) {
           throw Exception('Test error: too many ~ in input');
         }
@@ -56,15 +56,25 @@ void main() {
       case 0:
         selection = const TextSelection.collapsed(offset: -1);
       case 1:
-        selection = TextSelection(baseOffset: caretPositions[0], extentOffset: caretPositions[0]);
+        selection = TextSelection(
+          baseOffset: caretPositions[0],
+          extentOffset: caretPositions[0],
+        );
       case 2:
-        selection = TextSelection(baseOffset: caretPositions[0], extentOffset: caretPositions[1]);
+        selection = TextSelection(
+          baseOffset: caretPositions[0],
+          extentOffset: caretPositions[1],
+        );
       default:
         throw Exception('Test error: too many ^ in input');
     }
     return (
-      value: TextEditingValue(text: textBuffer.toString(), selection: selection),
-      expectedSyntaxStart: expectedSyntaxStart);
+      value: TextEditingValue(
+        text: textBuffer.toString(),
+        selection: selection,
+      ),
+      expectedSyntaxStart: expectedSyntaxStart,
+    );
   }
 
   group('ComposeContentController.autocompleteIntent', () {
@@ -79,15 +89,20 @@ void main() {
     ///
     /// For example, "~@chris^" means the text is "@chris", the selection is
     /// collapsed at index 6, and we expect the syntax to start at index 0.
-    void doTest(String markedText, ComposeAutocompleteQuery? expectedQuery, {
+    void doTest(
+      String markedText,
+      ComposeAutocompleteQuery? expectedQuery, {
       int? maxChannelName,
     }) {
       final description = expectedQuery != null
-        ? 'in ${jsonEncode(markedText)}, query ${jsonEncode(expectedQuery.raw)}'
-        : 'no query in ${jsonEncode(markedText)}';
+          ? 'in ${jsonEncode(markedText)}, query ${jsonEncode(expectedQuery.raw)}'
+          : 'no query in ${jsonEncode(markedText)}';
       test(description, () {
-        final store = eg.store(initialSnapshot:
-          eg.initialSnapshot(maxChannelNameLength: maxChannelName));
+        final store = eg.store(
+          initialSnapshot: eg.initialSnapshot(
+            maxChannelNameLength: maxChannelName,
+          ),
+        );
         final controller = ComposeContentController(store: store);
         final parsed = parseMarkedText(markedText);
         assert((expectedQuery == null) == (parsed.expectedSyntaxStart == null));
@@ -102,9 +117,12 @@ void main() {
       });
     }
 
-    MentionAutocompleteQuery mention(String raw) => MentionAutocompleteQuery(raw, silent: false);
-    MentionAutocompleteQuery silentMention(String raw) => MentionAutocompleteQuery(raw, silent: true);
-    ChannelLinkAutocompleteQuery channelLink(String raw) => ChannelLinkAutocompleteQuery(raw);
+    MentionAutocompleteQuery mention(String raw) =>
+        MentionAutocompleteQuery(raw, silent: false);
+    MentionAutocompleteQuery silentMention(String raw) =>
+        MentionAutocompleteQuery(raw, silent: true);
+    ChannelLinkAutocompleteQuery channelLink(String raw) =>
+        ChannelLinkAutocompleteQuery(raw);
     EmojiAutocompleteQuery emoji(String raw) => EmojiAutocompleteQuery(raw);
 
     doTest('', null);
@@ -114,21 +132,34 @@ void main() {
 
     // @-mentions.
 
-    doTest('^@', null);                doTest('^@_', null);
-    doTest('^@abc', null);             doTest('^@_abc', null);
-    doTest('@abc', null);              doTest('@_abc', null); // (no cursor)
+    doTest('^@', null);
+    doTest('^@_', null);
+    doTest('^@abc', null);
+    doTest('^@_abc', null);
+    doTest('@abc', null);
+    doTest('@_abc', null); // (no cursor)
 
-    doTest('@ ^', null);      // doTest('@_ ^', null); // (would fail, but OK… technically "_" could start a word in full_name)
-    doTest('@*^', null);      doTest('@_*^', null);
-    doTest('@`^', null);      doTest('@_`^', null);
-    doTest('@\\^', null);     doTest('@_\\^', null);
-    doTest('@>^', null);      doTest('@_>^', null);
-    doTest('@"^', null);      doTest('@_"^', null);
-    doTest('@\n^', null);     doTest('@_\n^', null); // control character
-    doTest('@\u0000^', null); doTest('@_\u0000^', null); // control
-    doTest('@\u061C^', null); doTest('@_\u061C^', null); // format character
-    doTest('@\u0600^', null); doTest('@_\u0600^', null); // format
-    doTest('@\uD834^', null); doTest('@_\uD834^', null); // leading surrogate
+    doTest('@ ^', null); // doTest('@_ ^', null); // (would fail, but OK… technically "_" could start a word in full_name)
+    doTest('@*^', null);
+    doTest('@_*^', null);
+    doTest('@`^', null);
+    doTest('@_`^', null);
+    doTest('@\\^', null);
+    doTest('@_\\^', null);
+    doTest('@>^', null);
+    doTest('@_>^', null);
+    doTest('@"^', null);
+    doTest('@_"^', null);
+    doTest('@\n^', null);
+    doTest('@_\n^', null); // control character
+    doTest('@\u0000^', null);
+    doTest('@_\u0000^', null); // control
+    doTest('@\u061C^', null);
+    doTest('@_\u061C^', null); // format character
+    doTest('@\u0600^', null);
+    doTest('@_\u0600^', null); // format
+    doTest('@\uD834^', null);
+    doTest('@_\uD834^', null); // leading surrogate
 
     doTest('email support@^', null);
     doTest('email support@zulip^', null);
@@ -137,60 +168,112 @@ void main() {
     doTest('email support@ with details of the issue^', null);
     doTest('email support@^ with details of the issue', null);
 
-    doTest('Ask @**Chris Bobbe**^', null); doTest('Ask @_**Chris Bobbe**^', null);
-    doTest('Ask @**Chris Bobbe^**', null); doTest('Ask @_**Chris Bobbe^**', null);
-    doTest('Ask @**Chris^ Bobbe**', null); doTest('Ask @_**Chris^ Bobbe**', null);
-    doTest('Ask @**^Chris Bobbe**', null); doTest('Ask @_**^Chris Bobbe**', null);
+    doTest('Ask @**Chris Bobbe**^', null);
+    doTest('Ask @_**Chris Bobbe**^', null);
+    doTest('Ask @**Chris Bobbe^**', null);
+    doTest('Ask @_**Chris Bobbe^**', null);
+    doTest('Ask @**Chris^ Bobbe**', null);
+    doTest('Ask @_**Chris^ Bobbe**', null);
+    doTest('Ask @**^Chris Bobbe**', null);
+    doTest('Ask @_**^Chris Bobbe**', null);
 
-    doTest('`@chris^', null); doTest('`@_chris^', null);
+    doTest('`@chris^', null);
+    doTest('`@_chris^', null);
 
     doTest('~@^_', mention('')); // Odd/unlikely, but should not crash
 
     doTest('~@__^', silentMention('_'));
 
-    doTest('~@^abc^', mention('abc')); doTest('~@_^abc^', silentMention('abc'));
-    doTest('~@a^bc^', mention('abc')); doTest('~@_a^bc^', silentMention('abc'));
-    doTest('~@ab^c^', mention('abc')); doTest('~@_ab^c^', silentMention('abc'));
-    doTest('~^@^', mention(''));       doTest('~^@_^', silentMention(''));
+    doTest('~@^abc^', mention('abc'));
+    doTest('~@_^abc^', silentMention('abc'));
+    doTest('~@a^bc^', mention('abc'));
+    doTest('~@_a^bc^', silentMention('abc'));
+    doTest('~@ab^c^', mention('abc'));
+    doTest('~@_ab^c^', silentMention('abc'));
+    doTest('~^@^', mention(''));
+    doTest('~^@_^', silentMention(''));
     // but:
-    doTest('^hello @chris^', null);    doTest('^hello @_chris^', null);
+    doTest('^hello @chris^', null);
+    doTest('^hello @_chris^', null);
 
-    doTest('~@me@zulip.com^', mention('me@zulip.com'));  doTest('~@_me@zulip.com^', silentMention('me@zulip.com'));
-    doTest('~@me@^zulip.com^', mention('me@zulip.com')); doTest('~@_me@^zulip.com^', silentMention('me@zulip.com'));
-    doTest('~@me^@zulip.com^', mention('me@zulip.com')); doTest('~@_me^@zulip.com^', silentMention('me@zulip.com'));
-    doTest('~@^me@zulip.com^', mention('me@zulip.com')); doTest('~@_^me@zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@me@zulip.com^', mention('me@zulip.com'));
+    doTest('~@_me@zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@me@^zulip.com^', mention('me@zulip.com'));
+    doTest('~@_me@^zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@me^@zulip.com^', mention('me@zulip.com'));
+    doTest('~@_me^@zulip.com^', silentMention('me@zulip.com'));
+    doTest('~@^me@zulip.com^', mention('me@zulip.com'));
+    doTest('~@_^me@zulip.com^', silentMention('me@zulip.com'));
 
-    doTest('~@abc^', mention('abc'));   doTest('~@_abc^', silentMention('abc'));
-    doTest(' ~@abc^', mention('abc'));  doTest(' ~@_abc^', silentMention('abc'));
-    doTest('(~@abc^', mention('abc'));  doTest('(~@_abc^', silentMention('abc'));
-    doTest('—~@abc^', mention('abc'));  doTest('—~@_abc^', silentMention('abc'));
-    doTest('"~@abc^', mention('abc'));  doTest('"~@_abc^', silentMention('abc'));
-    doTest('“~@abc^', mention('abc'));  doTest('“~@_abc^', silentMention('abc'));
-    doTest('。~@abc^', mention('abc')); doTest('。~@_abc^', silentMention('abc'));
-    doTest('«~@abc^', mention('abc'));  doTest('«~@_abc^', silentMention('abc'));
+    doTest('~@abc^', mention('abc'));
+    doTest('~@_abc^', silentMention('abc'));
+    doTest(' ~@abc^', mention('abc'));
+    doTest(' ~@_abc^', silentMention('abc'));
+    doTest('(~@abc^', mention('abc'));
+    doTest('(~@_abc^', silentMention('abc'));
+    doTest('—~@abc^', mention('abc'));
+    doTest('—~@_abc^', silentMention('abc'));
+    doTest('"~@abc^', mention('abc'));
+    doTest('"~@_abc^', silentMention('abc'));
+    doTest('“~@abc^', mention('abc'));
+    doTest('“~@_abc^', silentMention('abc'));
+    doTest('。~@abc^', mention('abc'));
+    doTest('。~@_abc^', silentMention('abc'));
+    doTest('«~@abc^', mention('abc'));
+    doTest('«~@_abc^', silentMention('abc'));
 
-    doTest('~@ab^c', mention('ab')); doTest('~@_ab^c', silentMention('ab'));
-    doTest('~@a^bc', mention('a'));  doTest('~@_a^bc', silentMention('a'));
-    doTest('~@^abc', mention(''));   doTest('~@_^abc', silentMention(''));
-    doTest('~@^', mention(''));      doTest('~@_^', silentMention(''));
+    doTest('~@ab^c', mention('ab'));
+    doTest('~@_ab^c', silentMention('ab'));
+    doTest('~@a^bc', mention('a'));
+    doTest('~@_a^bc', silentMention('a'));
+    doTest('~@^abc', mention(''));
+    doTest('~@_^abc', silentMention(''));
+    doTest('~@^', mention(''));
+    doTest('~@_^', silentMention(''));
 
-    doTest('~@abc ^', mention('abc '));  doTest('~@_abc ^', silentMention('abc '));
-    doTest('~@abc^ ^', mention('abc ')); doTest('~@_abc^ ^', silentMention('abc '));
-    doTest('~@ab^c ^', mention('abc ')); doTest('~@_ab^c ^', silentMention('abc '));
-    doTest('~@^abc ^', mention('abc ')); doTest('~@_^abc ^', silentMention('abc '));
+    doTest('~@abc ^', mention('abc '));
+    doTest('~@_abc ^', silentMention('abc '));
+    doTest('~@abc^ ^', mention('abc '));
+    doTest('~@_abc^ ^', silentMention('abc '));
+    doTest('~@ab^c ^', mention('abc '));
+    doTest('~@_ab^c ^', silentMention('abc '));
+    doTest('~@^abc ^', mention('abc '));
+    doTest('~@_^abc ^', silentMention('abc '));
 
-    doTest('Please ask ~@chris^', mention('chris'));             doTest('Please ask ~@_chris^', silentMention('chris'));
-    doTest('Please ask ~@chris bobbe^', mention('chris bobbe')); doTest('Please ask ~@_chris bobbe^', silentMention('chris bobbe'));
+    doTest('Please ask ~@chris^', mention('chris'));
+    doTest('Please ask ~@_chris^', silentMention('chris'));
+    doTest('Please ask ~@chris bobbe^', mention('chris bobbe'));
+    doTest('Please ask ~@_chris bobbe^', silentMention('chris bobbe'));
 
-    doTest('~@Rodion Romanovich Raskolnikov^', mention('Rodion Romanovich Raskolnikov'));
-    doTest('~@_Rodion Romanovich Raskolniko^', silentMention('Rodion Romanovich Raskolniko'));
-    doTest('~@Родион Романович Раскольников^', mention('Родион Романович Раскольников'));
-    doTest('~@_Родион Романович Раскольнико^', silentMention('Родион Романович Раскольнико'));
+    doTest(
+      '~@Rodion Romanovich Raskolnikov^',
+      mention('Rodion Romanovich Raskolnikov'),
+    );
+    doTest(
+      '~@_Rodion Romanovich Raskolniko^',
+      silentMention('Rodion Romanovich Raskolniko'),
+    );
+    doTest(
+      '~@Родион Романович Раскольников^',
+      mention('Родион Романович Раскольников'),
+    );
+    doTest(
+      '~@_Родион Романович Раскольнико^',
+      silentMention('Родион Романович Раскольнико'),
+    );
 
     // "@" sign can be (3 + 2 * maxChannelName) utf-16 code units
     // away to the left of the cursor.
-    doTest('If ~@chris^ is around, please ask him.', mention('chris'), maxChannelName: 10);
-    doTest('If ~@_chris is^ around, please ask him.', silentMention('chris is'), maxChannelName: 10);
+    doTest(
+      'If ~@chris^ is around, please ask him.',
+      mention('chris'),
+      maxChannelName: 10,
+    );
+    doTest(
+      'If ~@_chris is^ around, please ask him.',
+      silentMention('chris is'),
+      maxChannelName: 10,
+    );
     doTest('If @chris is around, please ask him.^', null, maxChannelName: 10);
     doTest('If @_chris is around, please ask him.^', null, maxChannelName: 10);
 
@@ -223,9 +306,12 @@ void main() {
 
     // Avoid interpreting emoticons as queries.
     doTest(':-^', null);
-    doTest(':)^', null); doTest(':-)^', null);
-    doTest(':(^', null); doTest(':-(^', null);
-    doTest(':/^', null); doTest(':-/^', null);
+    doTest(':)^', null);
+    doTest(':-)^', null);
+    doTest(':(^', null);
+    doTest(':-(^', null);
+    doTest(':/^', null);
+    doTest(':-/^', null);
     doTest('~:p^', emoji('p')); // ambiguously an emoticon
     doTest(':-p^', null);
 
@@ -257,50 +343,67 @@ void main() {
     doTest(':1+1^', null);
 
     // Accept punctuation before the emoji: opening…
-    doTest('(~:^', emoji('')); doTest('(~:a^', emoji('a'));
-    doTest('[~:^', emoji('')); doTest('[~:a^', emoji('a'));
-    doTest('«~:^', emoji('')); doTest('«~:a^', emoji('a'));
-    doTest('（~:^', emoji('')); doTest('（~:a^', emoji('a'));
+    doTest('(~:^', emoji(''));
+    doTest('(~:a^', emoji('a'));
+    doTest('[~:^', emoji(''));
+    doTest('[~:a^', emoji('a'));
+    doTest('«~:^', emoji(''));
+    doTest('«~:a^', emoji('a'));
+    doTest('（~:^', emoji(''));
+    doTest('（~:a^', emoji('a'));
     // … closing…
-    doTest(')~:^', emoji('')); doTest(')~:a^', emoji('a'));
-    doTest(']~:^', emoji('')); doTest(']~:a^', emoji('a'));
-    doTest('»~:^', emoji('')); doTest('»~:a^', emoji('a'));
-    doTest('）~:^', emoji('')); doTest('）~:a^', emoji('a'));
+    doTest(')~:^', emoji(''));
+    doTest(')~:a^', emoji('a'));
+    doTest(']~:^', emoji(''));
+    doTest(']~:a^', emoji('a'));
+    doTest('»~:^', emoji(''));
+    doTest('»~:a^', emoji('a'));
+    doTest('）~:^', emoji(''));
+    doTest('）~:a^', emoji('a'));
     // … and other.
-    doTest('.~:^', emoji('')); doTest('.~:a^', emoji('a'));
-    doTest(',~:^', emoji('')); doTest(',~:a^', emoji('a'));
-    doTest('，~:^', emoji('')); doTest('，~:a^', emoji('a'));
-    doTest('。~:^', emoji('')); doTest('。~:a^', emoji('a'));
+    doTest('.~:^', emoji(''));
+    doTest('.~:a^', emoji('a'));
+    doTest(',~:^', emoji(''));
+    doTest(',~:a^', emoji('a'));
+    doTest('，~:^', emoji(''));
+    doTest('，~:a^', emoji('a'));
+    doTest('。~:^', emoji(''));
+    doTest('。~:a^', emoji('a'));
 
     // #channel links.
 
-    doTest('^#',    null);
+    doTest('^#', null);
     doTest('^#abc', null);
-    doTest('#abc',  null); // (no cursor)
+    doTest('#abc', null); // (no cursor)
 
     // Link syntax can be at the start of a string.
-    doTest('~#^',    channelLink(''));
-    doTest('~##^',   channelLink('#'));
+    doTest('~#^', channelLink(''));
+    doTest('~##^', channelLink('#'));
     doTest('~#abc^', channelLink('abc'));
 
     // Link syntax can contain multiple words.
-    doTest('~#abc ^',    channelLink('abc '));
+    doTest('~#abc ^', channelLink('abc '));
     doTest('~#abc def^', channelLink('abc def'));
 
     // Link syntax can come after a word or space.
     doTest('xyz ~#abc^', channelLink('abc'));
-    doTest(' ~#abc^',    channelLink('abc'));
+    doTest(' ~#abc^', channelLink('abc'));
 
     // Link syntax can come after punctuation…
     doTest(':~#abc^', channelLink('abc'));
     doTest('!~#abc^', channelLink('abc'));
     doTest(',~#abc^', channelLink('abc'));
     doTest('.~#abc^', channelLink('abc'));
-    doTest('(~#abc^', channelLink('abc')); doTest(')~#abc^', channelLink('abc'));
-    doTest('{~#abc^', channelLink('abc')); doTest('}~#abc^', channelLink('abc'));
-    doTest('[~#abc^', channelLink('abc')); doTest(']~#abc^', channelLink('abc'));
-    doTest('“~#abc^', channelLink('abc')); doTest('”~#abc^', channelLink('abc'));
-    doTest('«~#abc^', channelLink('abc')); doTest('»~#abc^', channelLink('abc'));
+    doTest('(~#abc^', channelLink('abc'));
+    doTest(')~#abc^', channelLink('abc'));
+    doTest('{~#abc^', channelLink('abc'));
+    doTest('}~#abc^', channelLink('abc'));
+    doTest('[~#abc^', channelLink('abc'));
+    doTest(']~#abc^', channelLink('abc'));
+    doTest('“~#abc^', channelLink('abc'));
+    doTest('”~#abc^', channelLink('abc'));
+    doTest('«~#abc^', channelLink('abc'));
+    doTest('»~#abc^', channelLink('abc'));
     // … except for '#' and '@', because they start
     // channel link and mention syntaxes, respectively.
     doTest('~##abc^', channelLink('#abc'));
@@ -308,52 +411,85 @@ void main() {
 
     // Avoid interpreting as queries a URL or a common linkifier syntax.
     doTest('https://example.com/docs#install^', null);
-    doTest('zulip/zulip-flutter#124^',          null);
+    doTest('zulip/zulip-flutter#124^', null);
 
     // Query can't start with a space; channel names don't.
-    doTest('# ^',    null);
+    doTest('# ^', null);
     doTest('# abc^', null);
 
     // Query shouldn't be multiple lines.
-    doTest('#\n^',   null); doTest('#a\n^',   null); doTest('#\na^',   null); doTest('#a\nb^',   null);
-    doTest('#\r^',   null); doTest('#a\r^',   null); doTest('#\ra^',   null); doTest('#a\rb^',   null);
-    doTest('#\r\n^', null); doTest('#a\r\n^', null); doTest('#\r\na^', null); doTest('#a\r\nb^', null);
+    doTest('#\n^', null);
+    doTest('#a\n^', null);
+    doTest('#\na^', null);
+    doTest('#a\nb^', null);
+    doTest('#\r^', null);
+    doTest('#a\r^', null);
+    doTest('#\ra^', null);
+    doTest('#a\rb^', null);
+    doTest('#\r\n^', null);
+    doTest('#a\r\n^', null);
+    doTest('#\r\na^', null);
+    doTest('#a\r\nb^', null);
 
     // Query can contain a wide range of characters.
-    doTest('~#`^', channelLink('`')); doTest('~#a`b^', channelLink('a`b'));
-    doTest('~#"^', channelLink('"')); doTest('~#a"b^', channelLink('a"b'));
-    doTest('~#>^', channelLink('>')); doTest('~#a>b^', channelLink('a>b'));
-    doTest('~#&^', channelLink('&')); doTest('~#a&b^', channelLink('a&b'));
-    doTest('~#_^', channelLink('_')); doTest('~#a_b^', channelLink('a_b'));
-    doTest('~#*^', channelLink('*')); doTest('~#a*b^', channelLink('a*b'));
+    doTest('~#`^', channelLink('`'));
+    doTest('~#a`b^', channelLink('a`b'));
+    doTest('~#"^', channelLink('"'));
+    doTest('~#a"b^', channelLink('a"b'));
+    doTest('~#>^', channelLink('>'));
+    doTest('~#a>b^', channelLink('a>b'));
+    doTest('~#&^', channelLink('&'));
+    doTest('~#a&b^', channelLink('a&b'));
+    doTest('~#_^', channelLink('_'));
+    doTest('~#a_b^', channelLink('a_b'));
+    doTest('~#*^', channelLink('*'));
+    doTest('~#a*b^', channelLink('a*b'));
 
     // Avoid interpreting already-entered `#**foo**` syntax as queries.
-    doTest('#**abc**^',     null);
-    doTest('#**abc** ^',    null);
+    doTest('#**abc**^', null);
+    doTest('#**abc** ^', null);
     doTest('#**abc** def^', null);
 
     // Accept syntax like "#**foo" (as from the user finishing an autocomplete
     // and then hitting backspace to edit it), but leave the "**" out of the query.
-    doTest('~#**^',        channelLink(''));
-    doTest('~#**abc^',     channelLink('abc'));
-    doTest('~#**abc ^',    channelLink('abc '));
+    doTest('~#**^', channelLink(''));
+    doTest('~#**abc^', channelLink('abc'));
+    doTest('~#**abc ^', channelLink('abc '));
     doTest('~#**abc def^', channelLink('abc def'));
-    doTest('~#**ab*c^',    channelLink('ab*c'));
-    doTest('~#**abc*^',    channelLink('abc*'));
-    doTest('#** ^',     null);
-    doTest('#** abc^',  null);
-    doTest('#**a\n^',   null); doTest('#**\na^',   null); doTest('#**a\nb^',   null);
-    doTest('#**a\r^',   null); doTest('#**\ra^',   null); doTest('#**a\rb^',   null);
-    doTest('#**a\r\n^', null); doTest('#**\r\na^', null); doTest('#**a\r\nb^', null);
+    doTest('~#**ab*c^', channelLink('ab*c'));
+    doTest('~#**abc*^', channelLink('abc*'));
+    doTest('#** ^', null);
+    doTest('#** abc^', null);
+    doTest('#**a\n^', null);
+    doTest('#**\na^', null);
+    doTest('#**a\nb^', null);
+    doTest('#**a\r^', null);
+    doTest('#**\ra^', null);
+    doTest('#**a\rb^', null);
+    doTest('#**a\r\n^', null);
+    doTest('#**\r\na^', null);
+    doTest('#**a\r\nb^', null);
 
     // "#" sign can be (3 + 2 * maxChannelName) utf-16 code units
     // away to the left of the cursor.
-    doTest('check ~#**mobile dev^ team', channelLink('mobile dev'), maxChannelName: 5);
-    doTest('check ~#mobile dev t^eam', channelLink('mobile dev t'), maxChannelName: 5);
+    doTest(
+      'check ~#**mobile dev^ team',
+      channelLink('mobile dev'),
+      maxChannelName: 5,
+    );
+    doTest(
+      'check ~#mobile dev t^eam',
+      channelLink('mobile dev t'),
+      maxChannelName: 5,
+    );
     doTest('check #mobile dev te^am', null, maxChannelName: 5);
     doTest('check #mobile dev team for more info^', null, maxChannelName: 5);
     // '🙂' is 2 utf-16 code units.
-    doTest('check ~#**🙂🙂🙂🙂🙂^', channelLink('🙂🙂🙂🙂🙂'), maxChannelName: 5);
+    doTest(
+      'check ~#**🙂🙂🙂🙂🙂^',
+      channelLink('🙂🙂🙂🙂🙂'),
+      maxChannelName: 5,
+    );
     doTest('check #**🙂🙂🙂🙂🙂🙂^', null, maxChannelName: 5);
   });
 
@@ -362,16 +498,23 @@ void main() {
     final store = eg.store();
     await store.addUsers([eg.selfUser, eg.otherUser, eg.thirdUser]);
 
-    final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-      narrow: narrow, query: MentionAutocompleteQuery('Third'));
+    final view = MentionAutocompleteView.init(
+      store: store,
+      localizations: zulipLocalizations,
+      narrow: narrow,
+      query: MentionAutocompleteQuery('Third'),
+    );
     bool done = false;
-    view.addListener(() { done = true; });
+    view.addListener(() {
+      done = true;
+    });
     await Future(() {});
     await Future(() {});
     check(done).isTrue();
     check(view.results).single
-      .isA<UserMentionAutocompleteResult>()
-      .userId.equals(eg.thirdUser.userId);
+        .isA<UserMentionAutocompleteResult>()
+        .userId
+        .equals(eg.thirdUser.userId);
   });
 
   test('MentionAutocompleteView not starve timers', () {
@@ -392,8 +535,12 @@ void main() {
         check(searchDone).isFalse();
       });
 
-      final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-        narrow: narrow, query: MentionAutocompleteQuery('Third'));
+      final view = MentionAutocompleteView.init(
+        store: store,
+        localizations: zulipLocalizations,
+        narrow: narrow,
+        query: MentionAutocompleteQuery('Third'),
+      );
       view.addListener(() {
         searchDone = true;
       });
@@ -403,8 +550,9 @@ void main() {
       check(timerDone).isTrue();
       check(searchDone).isTrue();
       check(view.results).single
-        .isA<UserMentionAutocompleteResult>()
-        .userId.equals(eg.thirdUser.userId);
+          .isA<UserMentionAutocompleteResult>()
+          .userId
+          .equals(eg.thirdUser.userId);
     });
   });
 
@@ -412,16 +560,24 @@ void main() {
     const narrow = ChannelNarrow(1);
     final store = eg.store();
     for (int i = 1; i <= 2500; i++) {
-      await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
+      await store.addUser(
+        eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'),
+      );
     }
     for (int i = 1; i <= 2500; i++) {
       await store.addUserGroup(eg.userGroup(id: i, name: 'User Group $i'));
     }
 
     bool done = false;
-    final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-      narrow: narrow, query: MentionAutocompleteQuery('User 2222'));
-    view.addListener(() { done = true; });
+    final view = MentionAutocompleteView.init(
+      store: store,
+      localizations: zulipLocalizations,
+      narrow: narrow,
+      query: MentionAutocompleteQuery('User 2222'),
+    );
+    view.addListener(() {
+      done = true;
+    });
 
     // three batches for users
     await Future(() {});
@@ -440,80 +596,100 @@ void main() {
     check(done).isTrue();
 
     check(view.results).deepEquals(<Condition<Object?>>[
-      (it) => it
-        .isA<UserMentionAutocompleteResult>()
-        .userId.equals(2222),
-      (it) => it
-        .isA<UserGroupMentionAutocompleteResult>()
-        .groupId.equals(2222),
+      (it) => it.isA<UserMentionAutocompleteResult>().userId.equals(2222),
+      (it) => it.isA<UserGroupMentionAutocompleteResult>().groupId.equals(2222),
     ]);
   });
 
-  test('MentionAutocompleteView new query during computation replaces old', () async {
-    const narrow = ChannelNarrow(1);
-    final store = eg.store();
-    for (int i = 1; i <= 1500; i++) {
-      await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
-    }
-    for (int i = 1; i <= 1500; i++) {
-      await store.addUserGroup(eg.userGroup(id: i, name: 'User Group $i'));
-    }
+  test(
+    'MentionAutocompleteView new query during computation replaces old',
+    () async {
+      const narrow = ChannelNarrow(1);
+      final store = eg.store();
+      for (int i = 1; i <= 1500; i++) {
+        await store.addUser(
+          eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'),
+        );
+      }
+      for (int i = 1; i <= 1500; i++) {
+        await store.addUserGroup(eg.userGroup(id: i, name: 'User Group $i'));
+      }
 
-    bool done = false;
-    final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-      narrow: narrow, query: MentionAutocompleteQuery('User 1111'));
-    view.addListener(() { done = true; });
+      bool done = false;
+      final view = MentionAutocompleteView.init(
+        store: store,
+        localizations: zulipLocalizations,
+        narrow: narrow,
+        query: MentionAutocompleteQuery('User 1111'),
+      );
+      view.addListener(() {
+        done = true;
+      });
 
-    await Future(() {});
-    check(done).isFalse();
-    view.query = MentionAutocompleteQuery('User 234');
-
-    // …new query goes through all user batches
-    await Future(() {});
-    check(done).isFalse();
-    await Future(() {});
-    check(done).isFalse();
-    // …and all user-group batches
-    await Future(() {});
-    check(done).isFalse();
-    await Future(() {});
-    check(done).isTrue(); // new result is set
-
-    void checkResult() {
-      check(view.results).deepEquals(<Condition<Object?>>[
-        (it) => it
-          .isA<UserMentionAutocompleteResult>()
-          .userId.equals(234),
-        (it) => it
-          .isA<UserGroupMentionAutocompleteResult>()
-          .groupId.equals(234),
-      ]);
-    }
-    checkResult();
-
-    // new result sticks; it isn't clobbered with old query's result
-    for (int i = 0; i < 10; i++) { // for good measure
       await Future(() {});
+      check(done).isFalse();
+      view.query = MentionAutocompleteQuery('User 234');
+
+      // …new query goes through all user batches
+      await Future(() {});
+      check(done).isFalse();
+      await Future(() {});
+      check(done).isFalse();
+      // …and all user-group batches
+      await Future(() {});
+      check(done).isFalse();
+      await Future(() {});
+      check(done).isTrue(); // new result is set
+
+      void checkResult() {
+        check(view.results).deepEquals(<Condition<Object?>>[
+          (it) => it.isA<UserMentionAutocompleteResult>().userId.equals(234),
+          (it) =>
+              it.isA<UserGroupMentionAutocompleteResult>().groupId.equals(234),
+        ]);
+      }
+
       checkResult();
-    }
-  });
+
+      // new result sticks; it isn't clobbered with old query's result
+      for (int i = 0; i < 10; i++) {
+        // for good measure
+        await Future(() {});
+        checkResult();
+      }
+    },
+  );
 
   test('MentionAutocompleteView mutating user store while in progress does not '
       'prevent query from finishing', () async {
     const narrow = ChannelNarrow(1);
     final store = eg.store();
     for (int i = 1; i <= 2500; i++) {
-      await store.addUser(eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'));
+      await store.addUser(
+        eg.user(userId: i, email: 'user$i@example.com', fullName: 'User $i'),
+      );
     }
 
     bool done = false;
-    final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-      narrow: narrow, query: MentionAutocompleteQuery('User 110'));
-    view.addListener(() { done = true; });
+    final view = MentionAutocompleteView.init(
+      store: store,
+      localizations: zulipLocalizations,
+      narrow: narrow,
+      query: MentionAutocompleteQuery('User 110'),
+    );
+    view.addListener(() {
+      done = true;
+    });
 
     await Future(() {});
     check(done).isFalse();
-    await store.addUser(eg.user(userId: 11000, email: 'user11000@example.com', fullName: 'User 11000'));
+    await store.addUser(
+      eg.user(
+        userId: 11000,
+        email: 'user11000@example.com',
+        fullName: 'User 11000',
+      ),
+    );
     await Future(() {});
     check(done).isFalse();
     for (int i = 0; i < 3; i++) {
@@ -521,8 +697,9 @@ void main() {
       if (done) break;
     }
     check(done).isTrue();
-    final results = view.results
-      .map((e) => (e as UserMentionAutocompleteResult).userId);
+    final results = view.results.map(
+      (e) => (e as UserMentionAutocompleteResult).userId,
+    );
     check(results)
       ..contains(110)
       ..contains(1100)
@@ -544,27 +721,36 @@ void main() {
       if (!users.contains(selfUser)) {
         users = [...users, selfUser];
       }
-      store = eg.store(selfUser: selfUser, initialSnapshot: eg.initialSnapshot(
-        realmUsers: users,
-        recentPrivateConversations: dmConversations));
+      store = eg.store(
+        selfUser: selfUser,
+        initialSnapshot: eg.initialSnapshot(
+          realmUsers: users,
+          recentPrivateConversations: dmConversations,
+        ),
+      );
       await store.addUserGroups(userGroups);
       await store.addMessages(messages);
     }
 
     group('compareRecentMessageIds', () {
       test('both a and b are non-null', () async {
-        check(MentionAutocompleteView.compareRecentMessageIds(2, 5)).isLessThan(0);
-        check(MentionAutocompleteView.compareRecentMessageIds(5, 2)).isGreaterThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(2, 5))
+            .isLessThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(5, 2))
+            .isGreaterThan(0);
         check(MentionAutocompleteView.compareRecentMessageIds(5, 5)).equals(0);
       });
 
       test('one of a and b is null', () async {
-        check(MentionAutocompleteView.compareRecentMessageIds(null, 5)).isLessThan(0);
-        check(MentionAutocompleteView.compareRecentMessageIds(5, null)).isGreaterThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(null, 5))
+            .isLessThan(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(5, null))
+            .isGreaterThan(0);
       });
 
       test('both of a and b are null', () async {
-        check(MentionAutocompleteView.compareRecentMessageIds(null, null)).equals(0);
+        check(MentionAutocompleteView.compareRecentMessageIds(null, null))
+            .equals(0);
       });
     });
 
@@ -581,43 +767,72 @@ void main() {
 
       int compareAB({required String? topic}) {
         final realTopic = topic == null ? null : TopicName(topic);
-        final getRecencyInTopic = realTopic == null ? null
-          : store.recentSenders.latestMessageIdBySenderInTopic(
-              channelId: stream.streamId, topic: realTopic);
-        final resultAB = MentionAutocompleteView.compareByRecency(userA, userB,
+        final getRecencyInTopic = realTopic == null
+            ? null
+            : store.recentSenders.latestMessageIdBySenderInTopic(
+                channelId: stream.streamId,
+                topic: realTopic,
+              );
+        final resultAB = MentionAutocompleteView.compareByRecency(
+          userA,
+          userB,
           channelId: stream.streamId,
           getRecencyInTopic: getRecencyInTopic,
-          store: store);
-        final resultBA = MentionAutocompleteView.compareByRecency(userB, userA,
+          store: store,
+        );
+        final resultBA = MentionAutocompleteView.compareByRecency(
+          userB,
+          userA,
           channelId: stream.streamId,
           getRecencyInTopic: getRecencyInTopic,
-          store: store);
+          store: store,
+        );
         switch (resultAB) {
-          case <0: check(resultBA).isGreaterThan(0);
-          case >0: check(resultBA).isLessThan(0);
-          default: check(resultBA).equals(0);
+          case < 0:
+            check(resultBA).isGreaterThan(0);
+          case > 0:
+            check(resultBA).isLessThan(0);
+          default:
+            check(resultBA).equals(0);
         }
         return resultAB;
       }
 
       test('favor user most recent in topic', () async {
-        await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
+        await prepare(
+          messages: [message(userA, topic1), message(userB, topic1)],
+        );
         check(compareAB(topic: topic1)).isGreaterThan(0);
       });
 
-      test('favor most recent in topic ahead of most recent in stream', () async {
-        await prepare(messages: [
-          message(userA, topic1), message(userB, topic1), message(userA, topic2)]);
-        check(compareAB(topic: topic1)).isGreaterThan(0);
-      });
+      test(
+        'favor most recent in topic ahead of most recent in stream',
+        () async {
+          await prepare(
+            messages: [
+              message(userA, topic1),
+              message(userB, topic1),
+              message(userA, topic2),
+            ],
+          );
+          check(compareAB(topic: topic1)).isGreaterThan(0);
+        },
+      );
 
-      test('no activity in topic -> favor user most recent in stream', () async {
-        await prepare(messages: [message(userA, topic1), message(userB, topic1)]);
-        check(compareAB(topic: topic2)).isGreaterThan(0);
-      });
+      test(
+        'no activity in topic -> favor user most recent in stream',
+        () async {
+          await prepare(
+            messages: [message(userA, topic1), message(userB, topic1)],
+          );
+          check(compareAB(topic: topic2)).isGreaterThan(0);
+        },
+      );
 
       test('no topic provided -> favor user most recent in stream', () async {
-        await prepare(messages: [message(userA, topic1), message(userB, topic2)]);
+        await prepare(
+          messages: [message(userA, topic1), message(userB, topic2)],
+        );
         check(compareAB(topic: null)).isGreaterThan(0);
       });
 
@@ -637,40 +852,59 @@ void main() {
         store: store,
       );
 
-      test('has DMs with userA and userB, latest with userA -> prioritizes userA', () async {
-        await prepare(dmConversations: [
-          RecentDmConversation(userIds: [idA],      maxMessageId: 200),
-          RecentDmConversation(userIds: [idA, idB], maxMessageId: 100),
-        ]);
-        check(compareAB()).isLessThan(0);
-      });
+      test(
+        'has DMs with userA and userB, latest with userA -> prioritizes userA',
+        () async {
+          await prepare(
+            dmConversations: [
+              RecentDmConversation(userIds: [idA], maxMessageId: 200),
+              RecentDmConversation(userIds: [idA, idB], maxMessageId: 100),
+            ],
+          );
+          check(compareAB()).isLessThan(0);
+        },
+      );
 
-      test('has DMs with userA and userB, latest with userB -> prioritizes userB', () async {
-        await prepare(dmConversations: [
-          RecentDmConversation(userIds: [idB],      maxMessageId: 200),
-          RecentDmConversation(userIds: [idA, idB], maxMessageId: 100),
-        ]);
-        check(compareAB()).isGreaterThan(0);
-      });
+      test(
+        'has DMs with userA and userB, latest with userB -> prioritizes userB',
+        () async {
+          await prepare(
+            dmConversations: [
+              RecentDmConversation(userIds: [idB], maxMessageId: 200),
+              RecentDmConversation(userIds: [idA, idB], maxMessageId: 100),
+            ],
+          );
+          check(compareAB()).isGreaterThan(0);
+        },
+      );
 
-      test('has DMs with userA and userB, equally recent -> prioritizes neither', () async {
-        await prepare(dmConversations: [
-          RecentDmConversation(userIds: [idA, idB], maxMessageId: 100),
-        ]);
-        check(compareAB()).equals(0);
-      });
+      test(
+        'has DMs with userA and userB, equally recent -> prioritizes neither',
+        () async {
+          await prepare(
+            dmConversations: [
+              RecentDmConversation(userIds: [idA, idB], maxMessageId: 100),
+            ],
+          );
+          check(compareAB()).equals(0);
+        },
+      );
 
       test('has DMs with userA but not userB -> prioritizes userA', () async {
-        await prepare(dmConversations: [
-          RecentDmConversation(userIds: [idA], maxMessageId: 100),
-        ]);
+        await prepare(
+          dmConversations: [
+            RecentDmConversation(userIds: [idA], maxMessageId: 100),
+          ],
+        );
         check(compareAB()).isLessThan(0);
       });
 
       test('has DMs with userB but not userA -> prioritizes userB', () async {
-        await prepare(dmConversations: [
-          RecentDmConversation(userIds: [idB], maxMessageId: 100),
-        ]);
+        await prepare(
+          dmConversations: [
+            RecentDmConversation(userIds: [idB], maxMessageId: 100),
+          ],
+        );
         check(compareAB()).isGreaterThan(0);
       });
 
@@ -684,7 +918,8 @@ void main() {
       final humanUser = eg.user(isBot: false);
       final botUser = eg.user(isBot: true);
 
-      int compareAB(User a, User b) => MentionAutocompleteView.compareByBotStatus(a, b);
+      int compareAB(User a, User b) =>
+          MentionAutocompleteView.compareByBotStatus(a, b);
 
       test('userA is human, userB is bot -> favor userA', () {
         check(compareAB(humanUser, botUser)).isLessThan(0);
@@ -701,24 +936,34 @@ void main() {
     });
 
     group('compareByAlphabeticalOrder', () {
-      int compareAB(String aName, String bName) => MentionAutocompleteView.compareByAlphabeticalOrder(
-        eg.user(fullName: aName), eg.user(fullName: bName), store: store);
+      int compareAB(String aName, String bName) =>
+          MentionAutocompleteView.compareByAlphabeticalOrder(
+            eg.user(fullName: aName),
+            eg.user(fullName: bName),
+            store: store,
+          );
 
-      test("userA's fullName comes first than userB's fullName -> favor userA", () async {
-        await prepare();
-        check(compareAB('alice', 'brian')).isLessThan(0);
-        check(compareAB('alice', 'BRIAN')).isLessThan(0);
-        // TODO(i18n): add locale-aware sorting
-        // check(compareAB('čarolína', 'david')).isLessThan(0);
-      });
+      test(
+        "userA's fullName comes first than userB's fullName -> favor userA",
+        () async {
+          await prepare();
+          check(compareAB('alice', 'brian')).isLessThan(0);
+          check(compareAB('alice', 'BRIAN')).isLessThan(0);
+          // TODO(i18n): add locale-aware sorting
+          // check(compareAB('čarolína', 'david')).isLessThan(0);
+        },
+      );
 
-      test("userB's fullName comes first than userA's fullName -> favor userB", () async {
-        await prepare();
-        check(compareAB('brian', 'alice')).isGreaterThan(0);
-        check(compareAB('BRIAN', 'alice')).isGreaterThan(0);
-        // TODO(i18n): add locale-aware sorting
-        // check(compareAB('david', 'čarolína')).isGreaterThan(0);
-      });
+      test(
+        "userB's fullName comes first than userA's fullName -> favor userB",
+        () async {
+          await prepare();
+          check(compareAB('brian', 'alice')).isGreaterThan(0);
+          check(compareAB('BRIAN', 'alice')).isGreaterThan(0);
+          // TODO(i18n): add locale-aware sorting
+          // check(compareAB('david', 'čarolína')).isGreaterThan(0);
+        },
+      );
 
       test('both users have identical fullName -> favor none', () async {
         await prepare();
@@ -731,8 +976,12 @@ void main() {
 
     group('ranking across signals', () {
       void checkPrecedes(Narrow narrow, User userA, Iterable<User> usersB) {
-        final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-          narrow: narrow, query: MentionAutocompleteQuery(''));
+        final view = MentionAutocompleteView.init(
+          store: store,
+          localizations: zulipLocalizations,
+          narrow: narrow,
+          query: MentionAutocompleteQuery(''),
+        );
         for (final userB in usersB) {
           check(view.debugCompareUsers(userA, userB)).isLessThan(0);
           check(view.debugCompareUsers(userB, userA)).isGreaterThan(0);
@@ -740,8 +989,12 @@ void main() {
       }
 
       void checkRankEqual(Narrow narrow, List<User> users) {
-        final view = MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-          narrow: narrow, query: MentionAutocompleteQuery(''));
+        final view = MentionAutocompleteView.init(
+          store: store,
+          localizations: zulipLocalizations,
+          narrow: narrow,
+          query: MentionAutocompleteQuery(''),
+        );
         for (int i = 0; i < users.length; i++) {
           for (int j = i + 1; j < users.length; j++) {
             check(view.debugCompareUsers(users[i], users[j])).equals(0);
@@ -762,19 +1015,25 @@ void main() {
           eg.user(fullName: 'X', isBot: true), // runner-up, by DM recency
           eg.user(fullName: 'W', isBot: false), // runner-up, by human-vs-bot
           eg.user(fullName: 'A', isBot: true), // runner-up, by name
-          eg.user(fullName: 'B', isBot: true), // tied because no remaining criteria
+          eg.user(
+            fullName: 'B',
+            isBot: true,
+          ), // tied because no remaining criteria
           eg.user(fullName: 'b', isBot: true),
         ];
         final stream = eg.stream();
         final narrow = eg.topicNarrow(stream.streamId, 'this');
-        await prepare(users: users, messages: [
-          eg.streamMessage(sender: users[1], stream: stream, topic: 'this'),
-          eg.streamMessage(sender: users[0], stream: stream, topic: 'this'),
-          eg.streamMessage(sender: users[2], stream: stream, topic: 'other'),
-          eg.streamMessage(sender: users[1], stream: stream, topic: 'other'),
-          eg.dmMessage(from: users[3], to: [...users.skip(4), eg.selfUser]),
-          eg.dmMessage(from: users[2], to: [eg.selfUser]),
-        ]);
+        await prepare(
+          users: users,
+          messages: [
+            eg.streamMessage(sender: users[1], stream: stream, topic: 'this'),
+            eg.streamMessage(sender: users[0], stream: stream, topic: 'this'),
+            eg.streamMessage(sender: users[2], stream: stream, topic: 'other'),
+            eg.streamMessage(sender: users[1], stream: stream, topic: 'other'),
+            eg.dmMessage(from: users[3], to: [...users.skip(4), eg.selfUser]),
+            eg.dmMessage(from: users[2], to: [eg.selfUser]),
+          ],
+        );
         checkPrecedes(narrow, users[0], users.skip(1));
         checkPrecedes(narrow, users[1], users.skip(2));
         checkPrecedes(narrow, users[2], users.skip(3));
@@ -783,30 +1042,39 @@ void main() {
         checkRankEqual(narrow, [users[5], users[6]]);
       });
 
-      test('ChannelNarrow: stream recency > DM recency > human/bot > name', () async {
-        // Same principle as for TopicNarrow; see that test case above.
-        final users = [
-          eg.user(fullName: 'Z', isBot: true), // wins by stream recency
-          eg.user(fullName: 'Y', isBot: true), // runner-up, by DM recency
-          eg.user(fullName: 'X', isBot: false), // runner-up, by human-vs-bot
-          eg.user(fullName: 'A', isBot: true), // runner-up, by name
-          eg.user(fullName: 'B', isBot: true), // tied because no remaining criteria
-          eg.user(fullName: 'b', isBot: true),
-        ];
-        final stream = eg.stream();
-        final narrow = ChannelNarrow(stream.streamId);
-        await prepare(users: users, messages: [
-          eg.streamMessage(sender: users[1], stream: stream),
-          eg.streamMessage(sender: users[0], stream: stream),
-          eg.dmMessage(from: users[2], to: [...users.skip(3), eg.selfUser]),
-          eg.dmMessage(from: users[1], to: [eg.selfUser]),
-        ]);
-        checkPrecedes(narrow, users[0], users.skip(1));
-        checkPrecedes(narrow, users[1], users.skip(2));
-        checkPrecedes(narrow, users[2], users.skip(3));
-        checkPrecedes(narrow, users[3], users.skip(4));
-        checkRankEqual(narrow, [users[4], users[5]]);
-      });
+      test(
+        'ChannelNarrow: stream recency > DM recency > human/bot > name',
+        () async {
+          // Same principle as for TopicNarrow; see that test case above.
+          final users = [
+            eg.user(fullName: 'Z', isBot: true), // wins by stream recency
+            eg.user(fullName: 'Y', isBot: true), // runner-up, by DM recency
+            eg.user(fullName: 'X', isBot: false), // runner-up, by human-vs-bot
+            eg.user(fullName: 'A', isBot: true), // runner-up, by name
+            eg.user(
+              fullName: 'B',
+              isBot: true,
+            ), // tied because no remaining criteria
+            eg.user(fullName: 'b', isBot: true),
+          ];
+          final stream = eg.stream();
+          final narrow = ChannelNarrow(stream.streamId);
+          await prepare(
+            users: users,
+            messages: [
+              eg.streamMessage(sender: users[1], stream: stream),
+              eg.streamMessage(sender: users[0], stream: stream),
+              eg.dmMessage(from: users[2], to: [...users.skip(3), eg.selfUser]),
+              eg.dmMessage(from: users[1], to: [eg.selfUser]),
+            ],
+          );
+          checkPrecedes(narrow, users[0], users.skip(1));
+          checkPrecedes(narrow, users[1], users.skip(2));
+          checkPrecedes(narrow, users[2], users.skip(3));
+          checkPrecedes(narrow, users[3], users.skip(4));
+          checkRankEqual(narrow, [users[4], users[5]]);
+        },
+      );
 
       test('DmNarrow: DM recency > human/bot > name, ignore this-conversation recency and stream recency', () async {
         // Same principle as for TopicNarrow; see that test case above.
@@ -831,17 +1099,21 @@ void main() {
           eg.user(fullName: 'B', isBot: true),
           eg.user(fullName: 'b', isBot: true),
         ];
-        await prepare(users: users, messages: [
-          eg.dmMessage(from: users[3], to: [eg.selfUser]),
-          eg.dmMessage(from: users[1], to: [users[2], eg.selfUser]),
-          eg.dmMessage(from: users[0], to: [eg.selfUser]),
-          for (final user in users.skip(1))
-            eg.streamMessage(sender: user),
-        ]);
+        await prepare(
+          users: users,
+          messages: [
+            eg.dmMessage(from: users[3], to: [eg.selfUser]),
+            eg.dmMessage(from: users[1], to: [users[2], eg.selfUser]),
+            eg.dmMessage(from: users[0], to: [eg.selfUser]),
+            for (final user in users.skip(1)) eg.streamMessage(sender: user),
+          ],
+        );
         for (final narrow in [
           DmNarrow.withUser(users[3].userId, selfUserId: eg.selfUser.userId),
-          DmNarrow.withOtherUsers([users[1].userId, users[2].userId],
-            selfUserId: eg.selfUser.userId),
+          DmNarrow.withOtherUsers([
+            users[1].userId,
+            users[2].userId,
+          ], selfUserId: eg.selfUser.userId),
           DmNarrow.withUser(users[1].userId, selfUserId: eg.selfUser.userId),
         ]) {
           checkPrecedes(narrow, users[0], users.skip(1));
@@ -858,35 +1130,58 @@ void main() {
       test('CombinedFeedNarrow gives error', () async {
         await prepare(users: [eg.user(), eg.user()], messages: []);
         const narrow = CombinedFeedNarrow();
-        check(() => MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-                      narrow: narrow, query: MentionAutocompleteQuery('')))
-          .throws<AssertionError>();
+        check(
+          () => MentionAutocompleteView.init(
+            store: store,
+            localizations: zulipLocalizations,
+            narrow: narrow,
+            query: MentionAutocompleteQuery(''),
+          ),
+        ).throws<AssertionError>();
       });
 
       test('MentionsNarrow gives error', () async {
         await prepare(users: [eg.user(), eg.user()], messages: []);
         const narrow = MentionsNarrow();
-        check(() => MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-                      narrow: narrow, query: MentionAutocompleteQuery('')))
-          .throws<AssertionError>();
+        check(
+          () => MentionAutocompleteView.init(
+            store: store,
+            localizations: zulipLocalizations,
+            narrow: narrow,
+            query: MentionAutocompleteQuery(''),
+          ),
+        ).throws<AssertionError>();
       });
 
       test('StarredMessagesNarrow gives error', () async {
         await prepare(users: [eg.user(), eg.user()], messages: []);
         const narrow = StarredMessagesNarrow();
-        check(() => MentionAutocompleteView.init(store: store, localizations: zulipLocalizations,
-                      narrow: narrow, query: MentionAutocompleteQuery('')))
-          .throws<AssertionError>();
+        check(
+          () => MentionAutocompleteView.init(
+            store: store,
+            localizations: zulipLocalizations,
+            narrow: narrow,
+            query: MentionAutocompleteQuery(''),
+          ),
+        ).throws<AssertionError>();
       });
     });
 
     test('final results end-to-end', () async {
       Future<Iterable<MentionAutocompleteResult>> getResults(
-          Narrow narrow, MentionAutocompleteQuery query) async {
+        Narrow narrow,
+        MentionAutocompleteQuery query,
+      ) async {
         bool done = false;
-        final view = MentionAutocompleteView.init(store: store,
-          localizations: zulipLocalizations, narrow: narrow, query: query);
-        view.addListener(() { done = true; });
+        final view = MentionAutocompleteView.init(
+          store: store,
+          localizations: zulipLocalizations,
+          narrow: narrow,
+          query: query,
+        );
+        view.addListener(() {
+          done = true;
+        });
         await Future(() {}); // users
         await Future(() {}); // groups
         check(done).isTrue();
@@ -896,18 +1191,20 @@ void main() {
       }
 
       Condition<Object?> isUser(int userId) {
-        return (it) => it.isA<UserMentionAutocompleteResult>()
-          .userId.equals(userId);
+        return (it) =>
+            it.isA<UserMentionAutocompleteResult>().userId.equals(userId);
       }
 
       Condition<Object?> isUserGroup(int id) {
-        return (it) => it.isA<UserGroupMentionAutocompleteResult>()
-          .groupId.equals(id);
+        return (it) =>
+            it.isA<UserGroupMentionAutocompleteResult>().groupId.equals(id);
       }
 
       Condition<Object?> isWildcard(WildcardMentionOption option) {
-        return (it) => it.isA<WildcardMentionAutocompleteResult>()
-          .wildcardOption.equals(option);
+        return (it) => it
+            .isA<WildcardMentionAutocompleteResult>()
+            .wildcardOption
+            .equals(option);
       }
 
       final stream = eg.stream();
@@ -932,14 +1229,22 @@ void main() {
         eg.userGroup(id: 4, name: 'User Group Four'),
       ];
 
-      await prepare(users: users, selfUser: selfUser, userGroups: userGroups,
+      await prepare(
+        users: users,
+        selfUser: selfUser,
+        userGroups: userGroups,
         messages: [
-          eg.streamMessage(sender: users[1-1], stream: stream, topic: topic),
-          eg.streamMessage(sender: users[5-1], stream: stream, topic: 'other $topic'),
-          eg.dmMessage(from: users[1-1], to: [users[2-1], selfUser]),
-          eg.dmMessage(from: users[1-1], to: [selfUser]),
-          eg.dmMessage(from: users[4-1], to: [selfUser]),
-        ]);
+          eg.streamMessage(sender: users[1 - 1], stream: stream, topic: topic),
+          eg.streamMessage(
+            sender: users[5 - 1],
+            stream: stream,
+            topic: 'other $topic',
+          ),
+          eg.dmMessage(from: users[1 - 1], to: [users[2 - 1], selfUser]),
+          eg.dmMessage(from: users[1 - 1], to: [selfUser]),
+          eg.dmMessage(from: users[4 - 1], to: [selfUser]),
+        ],
+      );
 
       // Check the ranking of the full list of mentions,
       // i.e. the results for an empty query.
@@ -950,46 +1255,110 @@ void main() {
       // 4. Human vs. Bot users (human users come first).
       // 5. Users by name alphabetical order.
       // 6. User groups by name alphabetical order.
-      check(await getResults(topicNarrow, MentionAutocompleteQuery(''))).deepEquals([
-        isWildcard(WildcardMentionOption.all),
-        isWildcard(WildcardMentionOption.topic),
-        ...[1, 5, 4, 2, 7, 3, 6].map(isUser),
-        ...[4, 1, 3, 2].map(isUserGroup),
-      ]);
+      check(await getResults(topicNarrow, MentionAutocompleteQuery('')))
+          .deepEquals([
+            isWildcard(WildcardMentionOption.all),
+            isWildcard(WildcardMentionOption.topic),
+            ...[1, 5, 4, 2, 7, 3, 6].map(isUser),
+            ...[4, 1, 3, 2].map(isUserGroup),
+          ]);
 
       // Check the ranking applies also to results filtered by a query.
-      check(await getResults(topicNarrow, MentionAutocompleteQuery('t'))).deepEquals([
-        isWildcard(WildcardMentionOption.stream),
-        isWildcard(WildcardMentionOption.topic),
-        isUser(2), isUser(3), // 2 before 3 by DM recency
-        isUserGroup(3), isUserGroup(2), // 3 before 2 by alphabet ("…Three" before "…Two")
-      ]);
-      check(await getResults(topicNarrow, MentionAutocompleteQuery('f'))).deepEquals([
-        isUser(5), isUser(4),
-        isUserGroup(4),
-      ]);
+      check(await getResults(topicNarrow, MentionAutocompleteQuery('t')))
+          .deepEquals([
+            isWildcard(WildcardMentionOption.stream),
+            isWildcard(WildcardMentionOption.topic),
+            isUser(2), isUser(3), // 2 before 3 by DM recency
+            isUserGroup(3),
+            isUserGroup(2), // 3 before 2 by alphabet ("…Three" before "…Two")
+          ]);
+      check(await getResults(topicNarrow, MentionAutocompleteQuery('f')))
+          .deepEquals([isUser(5), isUser(4), isUserGroup(4)]);
+    });
+    test('respects canMentionGroup setting', () async {
+      final selfUser = eg.selfUser;
+      final allowedGroup = eg.userGroup(members: [selfUser.userId]);
+      final restrictedGroup = eg.userGroup(
+        canMentionGroup: GroupSettingValueNamed(eg.nobodyGroup.id),
+      );
+      final unrestrictedGroup = eg.userGroup(canMentionGroup: null);
+      final permittedGroup = eg.userGroup(
+        canMentionGroup: GroupSettingValueNamed(allowedGroup.id),
+      );
+
+      await prepare(
+        selfUser: selfUser,
+        userGroups: [
+          eg.nobodyGroup,
+          allowedGroup,
+          restrictedGroup,
+          unrestrictedGroup,
+          permittedGroup,
+        ],
+      );
+
+      final narrow = TopicNarrow(eg.stream().streamId, eg.t('topic'));
+      final view = MentionAutocompleteView.init(
+        store: store,
+        localizations: zulipLocalizations,
+        narrow: narrow,
+        query: MentionAutocompleteQuery(''),
+      );
+      bool done = false;
+      view.addListener(() {
+        done = true;
+      });
+      await Future(() {}); // users
+      await Future(() {}); // groups
+      check(done).isTrue();
+      final results = view.results;
+      view.dispose();
+
+      final resultGroupIds = results
+          .whereType<UserGroupMentionAutocompleteResult>()
+          .map((r) => r.groupId)
+          .toSet();
+
+      check(resultGroupIds.contains(unrestrictedGroup.id)).isTrue();
+      check(resultGroupIds.contains(permittedGroup.id)).isTrue();
+      check(resultGroupIds.contains(restrictedGroup.id)).isFalse();
     });
   });
 
   group('MentionAutocompleteView.computeWildcardMentionResults', () {
-    Iterable<WildcardMentionOption> getWildcardOptionsFor(String rawQuery, {
+    Iterable<WildcardMentionOption> getWildcardOptionsFor(
+      String rawQuery, {
       bool isSilent = false,
       required Narrow narrow,
       int? zulipFeatureLevel,
       ZulipLocalizations? localizations,
     }) {
       final store = eg.store(
-        account: eg.account(user: eg.selfUser, zulipFeatureLevel: zulipFeatureLevel),
-        initialSnapshot: eg.initialSnapshot(zulipFeatureLevel: zulipFeatureLevel));
+        account: eg.account(
+          user: eg.selfUser,
+          zulipFeatureLevel: zulipFeatureLevel,
+        ),
+        initialSnapshot: eg.initialSnapshot(
+          zulipFeatureLevel: zulipFeatureLevel,
+        ),
+      );
       localizations ??= zulipLocalizations;
-      final view = MentionAutocompleteView.init(store: store, localizations: localizations,
-        narrow: narrow, query: MentionAutocompleteQuery(rawQuery, silent: isSilent));
+      final view = MentionAutocompleteView.init(
+        store: store,
+        localizations: localizations,
+        narrow: narrow,
+        query: MentionAutocompleteQuery(rawQuery, silent: isSilent),
+      );
       final results = <MentionAutocompleteResult>[];
-      view.computeWildcardMentionResults(results: results,
-        isComposingChannelMessage: narrow is ChannelNarrow
-          || narrow is TopicNarrow);
+      view.computeWildcardMentionResults(
+        results: results,
+        isComposingChannelMessage:
+            narrow is ChannelNarrow || narrow is TopicNarrow,
+      );
       view.dispose();
-      return results.map((e) => (e as WildcardMentionAutocompleteResult).wildcardOption);
+      return results.map(
+        (e) => (e as WildcardMentionAutocompleteResult).wildcardOption,
+      );
     }
 
     const channelNarrow = ChannelNarrow(1);
@@ -997,41 +1366,82 @@ void main() {
     final dmNarrow = DmNarrow.withUser(10, selfUserId: 5);
 
     final testCases = [
-      ('',          channelNarrow, [WildcardMentionOption.all, WildcardMentionOption.topic]),
-      ('',          topicNarrow,   [WildcardMentionOption.all, WildcardMentionOption.topic]),
-      ('',          dmNarrow,      [WildcardMentionOption.all]),
+      (
+        '',
+        channelNarrow,
+        [WildcardMentionOption.all, WildcardMentionOption.topic],
+      ),
+      (
+        '',
+        topicNarrow,
+        [WildcardMentionOption.all, WildcardMentionOption.topic],
+      ),
+      ('', dmNarrow, [WildcardMentionOption.all]),
 
-      ('c',         channelNarrow, [WildcardMentionOption.channel, WildcardMentionOption.topic]),
-      ('ch',        topicNarrow,   [WildcardMentionOption.channel]),
-      ('str',       channelNarrow, [WildcardMentionOption.stream]),
-      ('e',         topicNarrow,   [WildcardMentionOption.everyone]),
-      ('everyone',  channelNarrow, [WildcardMentionOption.everyone]),
-      ('t',         topicNarrow,   [WildcardMentionOption.stream, WildcardMentionOption.topic]),
-      ('topic',     channelNarrow, [WildcardMentionOption.topic]),
-      ('topic etc', topicNarrow,   <WildcardMentionOption>[]),
+      (
+        'c',
+        channelNarrow,
+        [WildcardMentionOption.channel, WildcardMentionOption.topic],
+      ),
+      ('ch', topicNarrow, [WildcardMentionOption.channel]),
+      ('str', channelNarrow, [WildcardMentionOption.stream]),
+      ('e', topicNarrow, [WildcardMentionOption.everyone]),
+      ('everyone', channelNarrow, [WildcardMentionOption.everyone]),
+      (
+        't',
+        topicNarrow,
+        [WildcardMentionOption.stream, WildcardMentionOption.topic],
+      ),
+      ('topic', channelNarrow, [WildcardMentionOption.topic]),
+      ('topic etc', topicNarrow, <WildcardMentionOption>[]),
 
-      ('a',         dmNarrow,      [WildcardMentionOption.all]),
-      ('every',     dmNarrow,      [WildcardMentionOption.everyone]),
-      ('channel',   dmNarrow,      <WildcardMentionOption>[]),
-      ('stream',    dmNarrow,      <WildcardMentionOption>[]),
-      ('topic',     dmNarrow,      <WildcardMentionOption>[]),
+      ('a', dmNarrow, [WildcardMentionOption.all]),
+      ('every', dmNarrow, [WildcardMentionOption.everyone]),
+      ('channel', dmNarrow, <WildcardMentionOption>[]),
+      ('stream', dmNarrow, <WildcardMentionOption>[]),
+      ('topic', dmNarrow, <WildcardMentionOption>[]),
     ];
 
-    for (final (String query, Narrow narrow, List<WildcardMentionOption> wildcardOptions) in testCases) {
-      test('query "$query" in ${narrow.runtimeType} -> $wildcardOptions', () async {
-        check(getWildcardOptionsFor(query, narrow: narrow)).deepEquals(wildcardOptions);
-      });
+    for (final (
+          String query,
+          Narrow narrow,
+          List<WildcardMentionOption> wildcardOptions,
+        )
+        in testCases) {
+      test(
+        'query "$query" in ${narrow.runtimeType} -> $wildcardOptions',
+        () async {
+          check(getWildcardOptionsFor(query, narrow: narrow))
+              .deepEquals(wildcardOptions);
+        },
+      );
     }
 
-    WildcardTester wildcardTesterForLocale(bool Function(Locale) localePredicate) {
-      final locale = ZulipLocalizations.supportedLocales.firstWhere(localePredicate);
+    WildcardTester wildcardTesterForLocale(
+      bool Function(Locale) localePredicate,
+    ) {
+      final locale = ZulipLocalizations.supportedLocales.firstWhere(
+        localePredicate,
+      );
       final localizations = lookupZulipLocalizations(locale);
 
-      return (String query, Narrow narrow, List<WildcardMentionOption> expected) {
-        test('locale "$locale" -> query "$query" in ${narrow.runtimeType} -> $expected', () {
-          check(getWildcardOptionsFor(query, narrow: narrow,
-            localizations: localizations)).deepEquals(expected);
-        });
+      return (
+        String query,
+        Narrow narrow,
+        List<WildcardMentionOption> expected,
+      ) {
+        test(
+          'locale "$locale" -> query "$query" in ${narrow.runtimeType} -> $expected',
+          () {
+            check(
+              getWildcardOptionsFor(
+                query,
+                narrow: narrow,
+                localizations: localizations,
+              ),
+            ).deepEquals(expected);
+          },
+        );
       };
     }
 
@@ -1040,63 +1450,91 @@ void main() {
       // diacritics when written.
       // Throw if that changes, to not accidentally break fuzzy matching.
       check(option.canonicalString).equals(
-        AutocompleteQuery.lowercaseAndStripDiacritics(option.canonicalString));
+        AutocompleteQuery.lowercaseAndStripDiacritics(option.canonicalString),
+      );
     }
 
-    final testArabic = wildcardTesterForLocale((locale) => locale.languageCode == 'ar');
-    testArabic('ال',        channelNarrow, [WildcardMentionOption.all, WildcardMentionOption.topic]);
-    testArabic('الجميع',    topicNarrow,   [WildcardMentionOption.all]);
-    testArabic('الموضوع',   channelNarrow, [WildcardMentionOption.topic]);
-    testArabic('ق',         topicNarrow,   [WildcardMentionOption.channel]);
-    testArabic('دفق',       channelNarrow, [WildcardMentionOption.stream]);
-    testArabic('الكل',      dmNarrow,      [WildcardMentionOption.everyone]);
-    testArabic('top',       channelNarrow, [WildcardMentionOption.topic]);
-    testArabic('channel',   topicNarrow,   [WildcardMentionOption.channel]);
-    testArabic('every',     dmNarrow,      [WildcardMentionOption.everyone]);
+    final testArabic = wildcardTesterForLocale(
+      (locale) => locale.languageCode == 'ar',
+    );
+    testArabic('ال', channelNarrow, [
+      WildcardMentionOption.all,
+      WildcardMentionOption.topic,
+    ]);
+    testArabic('الجميع', topicNarrow, [WildcardMentionOption.all]);
+    testArabic('الموضوع', channelNarrow, [WildcardMentionOption.topic]);
+    testArabic('ق', topicNarrow, [WildcardMentionOption.channel]);
+    testArabic('دفق', channelNarrow, [WildcardMentionOption.stream]);
+    testArabic('الكل', dmNarrow, [WildcardMentionOption.everyone]);
+    testArabic('top', channelNarrow, [WildcardMentionOption.topic]);
+    testArabic('channel', topicNarrow, [WildcardMentionOption.channel]);
+    testArabic('every', dmNarrow, [WildcardMentionOption.everyone]);
 
-    final testEnglish = wildcardTesterForLocale((locale) => locale.languageCode == 'en');
-    testEnglish('topic',     topicNarrow,   [WildcardMentionOption.topic]);
-    testEnglish('Topic',     topicNarrow,   [WildcardMentionOption.topic]);
+    final testEnglish = wildcardTesterForLocale(
+      (locale) => locale.languageCode == 'en',
+    );
+    testEnglish('topic', topicNarrow, [WildcardMentionOption.topic]);
+    testEnglish('Topic', topicNarrow, [WildcardMentionOption.topic]);
 
-    final testGerman = wildcardTesterForLocale((locale) => locale.languageCode == 'de');
-    testGerman('Thema',     topicNarrow,   [WildcardMentionOption.topic]);
-    testGerman('thema',     topicNarrow,   [WildcardMentionOption.topic]);
+    final testGerman = wildcardTesterForLocale(
+      (locale) => locale.languageCode == 'de',
+    );
+    testGerman('Thema', topicNarrow, [WildcardMentionOption.topic]);
+    testGerman('thema', topicNarrow, [WildcardMentionOption.topic]);
 
-    final testPolish = wildcardTesterForLocale((locale) => locale.languageCode == 'pl');
-    testPolish('wątek',     topicNarrow,   [WildcardMentionOption.topic]);
-    testPolish('watek',     topicNarrow,   [WildcardMentionOption.topic]);
+    final testPolish = wildcardTesterForLocale(
+      (locale) => locale.languageCode == 'pl',
+    );
+    testPolish('wątek', topicNarrow, [WildcardMentionOption.topic]);
+    testPolish('watek', topicNarrow, [WildcardMentionOption.topic]);
 
     test('no wildcards for a silent mention', () {
       check(getWildcardOptionsFor('', isSilent: true, narrow: channelNarrow))
-        .isEmpty();
+          .isEmpty();
       check(getWildcardOptionsFor('all', isSilent: true, narrow: topicNarrow))
-        .isEmpty();
+          .isEmpty();
       check(getWildcardOptionsFor('everyone', isSilent: true, narrow: dmNarrow))
-        .isEmpty();
+          .isEmpty();
     });
 
     test('${WildcardMentionOption.channel} is available FL-247 onwards', () {
-      check(getWildcardOptionsFor('channel',
-          narrow: channelNarrow, zulipFeatureLevel: 247))
-        .deepEquals([WildcardMentionOption.channel]);
+      check(
+        getWildcardOptionsFor(
+          'channel',
+          narrow: channelNarrow,
+          zulipFeatureLevel: 247,
+        ),
+      ).deepEquals([WildcardMentionOption.channel]);
     });
 
     test('${WildcardMentionOption.channel} is not available before FL-247', () {
-      check(getWildcardOptionsFor('channel',
-          narrow: channelNarrow, zulipFeatureLevel: 246))
-        .deepEquals([]);
+      check(
+        getWildcardOptionsFor(
+          'channel',
+          narrow: channelNarrow,
+          zulipFeatureLevel: 246,
+        ),
+      ).deepEquals([]);
     });
 
     test('${WildcardMentionOption.topic} is available FL-224 onwards', () {
-      check(getWildcardOptionsFor('topic',
-          narrow: channelNarrow, zulipFeatureLevel: 224))
-        .deepEquals([WildcardMentionOption.topic]);
+      check(
+        getWildcardOptionsFor(
+          'topic',
+          narrow: channelNarrow,
+          zulipFeatureLevel: 224,
+        ),
+      ).deepEquals([WildcardMentionOption.topic]);
     });
 
     test('${WildcardMentionOption.topic} is not available before FL-224', () {
-      check(getWildcardOptionsFor('topic',
-          narrow: channelNarrow, zulipFeatureLevel: 223))
-        .deepEquals([]);
+      check(
+        getWildcardOptionsFor(
+          'topic',
+          narrow: channelNarrow,
+          zulipFeatureLevel: 223,
+        ),
+      ).deepEquals([]);
     });
   });
 
@@ -1106,31 +1544,49 @@ void main() {
     void doCheck(String rawQuery, User user, bool expected) {
       final result = MentionAutocompleteQuery(rawQuery).testUser(user, store);
       expected
-        ? check(result).isA<UserMentionAutocompleteResult>()
-        : check(result).isNull();
+          ? check(result).isA<UserMentionAutocompleteResult>()
+          : check(result).isNull();
     }
 
-    test('user is always excluded when not active regardless of other criteria', () {
-      store = eg.store();
+    test(
+      'user is always excluded when not active regardless of other criteria',
+      () {
+        store = eg.store();
 
-      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: false), false);
-      // When active then other criteria will be checked
-      doCheck('Full Name', eg.user(fullName: 'Full Name', isActive: true), true);
-    });
+        doCheck(
+          'Full Name',
+          eg.user(fullName: 'Full Name', isActive: false),
+          false,
+        );
+        // When active then other criteria will be checked
+        doCheck(
+          'Full Name',
+          eg.user(fullName: 'Full Name', isActive: true),
+          true,
+        );
+      },
+    );
 
-    test('user is always excluded when muted, regardless of other criteria', () async {
-      store = eg.store();
-      await store.setMutedUsers([1]);
-      doCheck('Full Name', eg.user(userId: 1, fullName: 'Full Name'), false);
-      // When not muted, then other criteria will be checked
-      doCheck('Full Name', eg.user(userId: 2, fullName: 'Full Name'), true);
-    });
+    test(
+      'user is always excluded when muted, regardless of other criteria',
+      () async {
+        store = eg.store();
+        await store.setMutedUsers([1]);
+        doCheck('Full Name', eg.user(userId: 1, fullName: 'Full Name'), false);
+        // When not muted, then other criteria will be checked
+        doCheck('Full Name', eg.user(userId: 2, fullName: 'Full Name'), true);
+      },
+    );
 
     test('user is included if fullname words match the query', () {
       store = eg.store();
 
       doCheck('', eg.user(fullName: 'Full Name'), true);
-      doCheck('', eg.user(fullName: ''), true); // Unlikely case, but should not crash
+      doCheck(
+        '',
+        eg.user(fullName: ''),
+        true,
+      ); // Unlikely case, but should not crash
       doCheck('Full Name', eg.user(fullName: 'Full Name'), true);
       doCheck('full name', eg.user(fullName: 'Full Name'), true);
       doCheck('Full Name', eg.user(fullName: 'full name'), true);
@@ -1144,7 +1600,11 @@ void main() {
       doCheck('full full', eg.user(fullName: 'Full Full Name'), true);
       doCheck('full full', eg.user(fullName: 'Full Name Full'), true);
 
-      doCheck('F', eg.user(fullName: ''), false); // Unlikely case, but should not crash
+      doCheck(
+        'F',
+        eg.user(fullName: ''),
+        false,
+      ); // Unlikely case, but should not crash
       doCheck('Fully Named', eg.user(fullName: 'Full Name'), false);
       doCheck('Full Name', eg.user(fullName: 'Full'), false);
       doCheck('Full Name', eg.user(fullName: 'Name'), false);
@@ -1154,7 +1614,11 @@ void main() {
       doCheck('Full Full', eg.user(fullName: 'Full Name'), false);
       doCheck('Name Name', eg.user(fullName: 'Full Name'), false);
       doCheck('Name Full', eg.user(fullName: 'Full Name'), false);
-      doCheck('Name Four Full Words', eg.user(fullName: 'Full Name Four Words'), false);
+      doCheck(
+        'Name Four Full Words',
+        eg.user(fullName: 'Full Name Four Words'),
+        false,
+      );
       doCheck('F Full', eg.user(fullName: 'Full Name Four Words'), false);
       doCheck('Four F', eg.user(fullName: 'Full Name Four Words'), false);
     });
@@ -1168,8 +1632,10 @@ void main() {
     int? rankOf(String queryStr, Object candidate) {
       final query = MentionAutocompleteQuery(queryStr);
       final result = switch (candidate) {
-        WildcardMentionOption() => query.testWildcardOption(candidate,
-          localizations: GlobalLocalizations.zulipLocalizations),
+        WildcardMentionOption() => query.testWildcardOption(
+          candidate,
+          localizations: GlobalLocalizations.zulipLocalizations,
+        ),
         User() => query.testUser(candidate, (store ??= eg.store())),
         UserGroup() => query.testUserGroup(candidate, (store ??= eg.store())),
         _ => throw StateError('invalid candidate'),
@@ -1189,7 +1655,9 @@ void main() {
       // (i.e. throw here if it's not a match)
       final firstCandidateRank = rankOf(query, candidates.first)!;
 
-      final ranks = candidates.skip(1).map((candidate) => rankOf(query, candidate));
+      final ranks = candidates
+          .skip(1)
+          .map((candidate) => rankOf(query, candidate));
       check(ranks).every((it) => it.equals(firstCandidateRank));
     }
 
@@ -1218,15 +1686,15 @@ void main() {
       checkAllSameRank('édith piaf', users); // exact
       checkAllSameRank('edith piaf', users); // exact
 
-      checkAllSameRank('Édith Pi',   users); // total-prefix
-      checkAllSameRank('Edith Pi',   users); // total-prefix
-      checkAllSameRank('édith pi',   users); // total-prefix
-      checkAllSameRank('edith pi',   users); // total-prefix
+      checkAllSameRank('Édith Pi', users); // total-prefix
+      checkAllSameRank('Edith Pi', users); // total-prefix
+      checkAllSameRank('édith pi', users); // total-prefix
+      checkAllSameRank('edith pi', users); // total-prefix
 
-      checkAllSameRank('Éd Pi',      users); // word-prefixes
-      checkAllSameRank('Ed Pi',      users); // word-prefixes
-      checkAllSameRank('éd pi',      users); // word-prefixes
-      checkAllSameRank('ed pi',      users); // word-prefixes
+      checkAllSameRank('Éd Pi', users); // word-prefixes
+      checkAllSameRank('Ed Pi', users); // word-prefixes
+      checkAllSameRank('éd pi', users); // word-prefixes
+      checkAllSameRank('ed pi', users); // word-prefixes
     });
 
     test('user name match: exact over total-prefix', () {
@@ -1251,8 +1719,8 @@ void main() {
       ];
 
       checkAllSameRank('mobile team', userGroups); // exact
-      checkAllSameRank('mobile te',   userGroups); // total-prefix
-      checkAllSameRank('mob te',      userGroups); // word-prefixes
+      checkAllSameRank('mobile te', userGroups); // total-prefix
+      checkAllSameRank('mob te', userGroups); // word-prefixes
     });
 
     test('group name match: exact over total-prefix', () {
@@ -1278,34 +1746,37 @@ void main() {
       ];
 
       checkAllSameRank('email@example.com', users);
-      checkAllSameRank('email@e',           users);
-      checkAllSameRank('email@',            users);
-      checkAllSameRank('email',             users);
-      checkAllSameRank('ema',               users);
+      checkAllSameRank('email@e', users);
+      checkAllSameRank('email@', users);
+      checkAllSameRank('email', users);
+      checkAllSameRank('ema', users);
     });
 
     test('email match is by prefix only', () {
       // "z" name to prevent accidental name match with example data
       final user = eg.user(fullName: 'z', deliveryEmail: 'email@example.com');
 
-      check(rankOf('e',           user)).isNotNull();
-      check(rankOf('mail',        user)).isNull();
-      check(rankOf('example',     user)).isNull();
+      check(rankOf('e', user)).isNotNull();
+      check(rankOf('mail', user)).isNull();
+      check(rankOf('example', user)).isNull();
       check(rankOf('example.com', user)).isNull();
     });
 
     test('full list of ranks', () {
-      final user1 = eg.user(fullName: 'some user', deliveryEmail: 'email@example.com');
+      final user1 = eg.user(
+        fullName: 'some user',
+        deliveryEmail: 'email@example.com',
+      );
       final userGroup1 = eg.userGroup(name: 'some user group');
       check([
         rankOf('', WildcardMentionOption.all), // wildcard
-        rankOf('some user', user1),            // user, exact name match
-        rankOf('some us', user1),              // user, total-prefix name match
-        rankOf('so us', user1),                // user, word-prefixes name match
+        rankOf('some user', user1), // user, exact name match
+        rankOf('some us', user1), // user, total-prefix name match
+        rankOf('so us', user1), // user, word-prefixes name match
         rankOf('some user group', userGroup1), // user group, exact name match
-        rankOf('some us', userGroup1),         // user group, total-prefix name match
-        rankOf('so us gr', userGroup1),        // user group, word-prefixes name match
-        rankOf('email', user1),                // user, no name match, email match
+        rankOf('some us', userGroup1), // user group, total-prefix name match
+        rankOf('so us gr', userGroup1), // user group, word-prefixes name match
+        rankOf('email', user1), // user, no name match, email match
       ]).deepEquals([0, 1, 2, 3, 4, 5, 6, 7]);
     });
   });
@@ -1314,12 +1785,14 @@ void main() {
     void doTest(String markedText, TopicAutocompleteQuery? expectedQuery) {
       final parsed = parseMarkedText(markedText);
 
-      final description = 'topic-input with text: $markedText produces: ${expectedQuery?.raw ?? 'No Query!'}';
+      final description =
+          'topic-input with text: $markedText produces: ${expectedQuery?.raw ?? 'No Query!'}';
       test(description, () {
         final store = eg.store();
         final controller = ComposeTopicController(
           store: store,
-          channelId: eg.stream().streamId);
+          channelId: eg.stream().streamId,
+        );
         controller.value = parsed.value;
         if (expectedQuery == null) {
           check(controller).autocompleteIntent.isNull();
@@ -1349,15 +1822,19 @@ void main() {
     final first = eg.getChannelTopicsEntry(maxId: 1, name: 'First Topic');
     final second = eg.getChannelTopicsEntry(maxId: 2, name: 'Second Topic');
     final third = eg.getChannelTopicsEntry(maxId: 3, name: 'Third Topic');
-    connection.prepare(json: GetChannelTopicsResult(
-      topics: [first, second, third]).toJson());
+    connection.prepare(
+      json: GetChannelTopicsResult(topics: [first, second, third]).toJson(),
+    );
 
     final view = TopicAutocompleteView.init(
       store: store,
       channelId: eg.stream().streamId,
-      query: TopicAutocompleteQuery('Third'));
+      query: TopicAutocompleteQuery('Third'),
+    );
     bool done = false;
-    view.addListener(() { done = true; });
+    view.addListener(() {
+      done = true;
+    });
 
     // those are here to wait for topics to be loaded
     await Future(() {});
@@ -1366,24 +1843,32 @@ void main() {
     check(view.results).single.which(isTopic(third.name));
   });
 
-  test('TopicAutocompleteView updates results when topics are loaded', () async {
-    final store = eg.store();
-    final connection = store.connection as FakeApiConnection;
-    connection.prepare(json: GetChannelTopicsResult(
-      topics: [eg.getChannelTopicsEntry(name: 'test')]
-    ).toJson());
+  test(
+    'TopicAutocompleteView updates results when topics are loaded',
+    () async {
+      final store = eg.store();
+      final connection = store.connection as FakeApiConnection;
+      connection.prepare(
+        json: GetChannelTopicsResult(
+          topics: [eg.getChannelTopicsEntry(name: 'test')],
+        ).toJson(),
+      );
 
-    final view = TopicAutocompleteView.init(
-      store: store,
-      channelId: eg.stream().streamId,
-      query: TopicAutocompleteQuery('te'));
-    bool done = false;
-    view.addListener(() { done = true; });
+      final view = TopicAutocompleteView.init(
+        store: store,
+        channelId: eg.stream().streamId,
+        query: TopicAutocompleteQuery('te'),
+      );
+      bool done = false;
+      view.addListener(() {
+        done = true;
+      });
 
-    check(done).isFalse();
-    await Future(() {});
-    check(done).isTrue();
-  });
+      check(done).isFalse();
+      await Future(() {});
+      check(done).isTrue();
+    },
+  );
 
   test('TopicAutocompleteView fetches topics once for a channel', () async {
     final store = eg.store();
@@ -1392,11 +1877,18 @@ void main() {
     final topic1 = eg.getChannelTopicsEntry(maxId: 20, name: 'server releases');
     final topic2 = eg.getChannelTopicsEntry(maxId: 10, name: 'mobile releases');
 
-    connection.prepare(json: GetChannelTopicsResult(topics: [topic1, topic2]).toJson());
-    final view1 = TopicAutocompleteView.init(store: store, channelId: 1000,
-      query: TopicAutocompleteQuery(''));
+    connection.prepare(
+      json: GetChannelTopicsResult(topics: [topic1, topic2]).toJson(),
+    );
+    final view1 = TopicAutocompleteView.init(
+      store: store,
+      channelId: 1000,
+      query: TopicAutocompleteQuery(''),
+    );
     bool done = false;
-    view1.addListener(() { done = true; });
+    view1.addListener(() {
+      done = true;
+    });
 
     check(connection.takeRequests()).last.isA<http.Request>()
       ..method.equals('GET')
@@ -1406,7 +1898,8 @@ void main() {
     await Future(() {});
     await Future(() {});
     check(done).isTrue();
-    check(view1.results).deepEquals([isTopic(topic1.name), isTopic(topic2.name)]);
+    check(view1.results)
+        .deepEquals([isTopic(topic1.name), isTopic(topic2.name)]);
 
     view1.query = TopicAutocompleteQuery('server');
     check(connection.takeRequests()).isEmpty();
@@ -1415,10 +1908,15 @@ void main() {
     view1.dispose();
 
     // No need to prepare a response as there will be no request made.
-    final view2 = TopicAutocompleteView.init(store: store, channelId: 1000,
-      query: TopicAutocompleteQuery('mobile'));
+    final view2 = TopicAutocompleteView.init(
+      store: store,
+      channelId: 1000,
+      query: TopicAutocompleteQuery('mobile'),
+    );
     done = false;
-    view2.addListener(() { done = true; });
+    view2.addListener(() {
+      done = true;
+    });
 
     check(connection.takeRequests()).isEmpty();
 
@@ -1431,7 +1929,8 @@ void main() {
   group('TopicAutocompleteQuery.testTopic', () {
     final store = eg.store();
     void doCheck(String rawQuery, String topic, bool expected) {
-      final result = TopicAutocompleteQuery(rawQuery).testTopic(eg.t(topic), store);
+      final result = TopicAutocompleteQuery(rawQuery)
+          .testTopic(eg.t(topic), store);
       expected ? check(result).isTrue() : check(result).isFalse();
     }
 
@@ -1446,21 +1945,27 @@ void main() {
 
   group('ChannelLinkAutocompleteView', () {
     Condition<Object?> isChannel(int channelId) {
-      return (it) => it.isA<ChannelLinkAutocompleteResult>()
-        .channelId.equals(channelId);
+      return (it) =>
+          it.isA<ChannelLinkAutocompleteResult>().channelId.equals(channelId);
     }
 
     test('misc', () async {
       const narrow = ChannelNarrow(1);
       final channel1 = eg.stream(streamId: 1, name: 'First');
       final channel2 = eg.stream(streamId: 2, name: 'Second');
-      final store = eg.store(initialSnapshot:
-        eg.initialSnapshot(streams: [channel1, channel2]));
+      final store = eg.store(
+        initialSnapshot: eg.initialSnapshot(streams: [channel1, channel2]),
+      );
 
-      final view = ChannelLinkAutocompleteView.init(store: store,
-        narrow: narrow, query: ChannelLinkAutocompleteQuery(''));
+      final view = ChannelLinkAutocompleteView.init(
+        store: store,
+        narrow: narrow,
+        query: ChannelLinkAutocompleteQuery(''),
+      );
       bool done = false;
-      view.addListener(() { done = true; });
+      view.addListener(() {
+        done = true;
+      });
       await Future(() {});
       check(done).isTrue();
       // Based on alphabetical order. For how the ordering works, see the
@@ -1472,13 +1977,19 @@ void main() {
       const narrow = ChannelNarrow(1);
       final channel1 = eg.stream(streamId: 1, name: 'First');
       final channel2 = eg.stream(streamId: 2, name: 'Second');
-      final store = eg.store(initialSnapshot:
-        eg.initialSnapshot(streams: [channel1, channel2]));
+      final store = eg.store(
+        initialSnapshot: eg.initialSnapshot(streams: [channel1, channel2]),
+      );
 
-      final view = ChannelLinkAutocompleteView.init(store: store,
-        narrow: narrow, query: ChannelLinkAutocompleteQuery('Fir'));
+      final view = ChannelLinkAutocompleteView.init(
+        store: store,
+        narrow: narrow,
+        query: ChannelLinkAutocompleteQuery('Fir'),
+      );
       bool done = false;
-      view.addListener(() { done = true; });
+      view.addListener(() {
+        done = true;
+      });
       await Future(() {});
       check(done).isTrue();
       check(view.results).single.which(isChannel(1));
@@ -1493,9 +2004,11 @@ void main() {
     group('sorting results', () {
       group('compareByComposingTo', () {
         int compare(int a, int b, {required int composingToChannelId}) =>
-          ChannelLinkAutocompleteView.compareByComposingTo(
-            eg.stream(streamId: a), eg.stream(streamId: b),
-            composingToChannelId: composingToChannelId);
+            ChannelLinkAutocompleteView.compareByComposingTo(
+              eg.stream(streamId: a),
+              eg.stream(streamId: b),
+              composingToChannelId: composingToChannelId,
+            );
 
         test('favor the channel being composed to', () {
           check(compare(1, 2, composingToChannelId: 1)).isLessThan(0);
@@ -1516,12 +2029,12 @@ void main() {
         final channelB = eg.stream();
 
         Subscription subA({bool? isMuted, bool? pinToTop}) =>
-          eg.subscription(channelA, isMuted: isMuted, pinToTop: pinToTop);
+            eg.subscription(channelA, isMuted: isMuted, pinToTop: pinToTop);
         Subscription subB({bool? isMuted, bool? pinToTop}) =>
-          eg.subscription(channelB, isMuted: isMuted, pinToTop: pinToTop);
+            eg.subscription(channelB, isMuted: isMuted, pinToTop: pinToTop);
 
         int compare(ZulipStream a, ZulipStream b) =>
-          ChannelLinkAutocompleteView.compareByBeingSubscribed(a, b);
+            ChannelLinkAutocompleteView.compareByBeingSubscribed(a, b);
 
         test('favor subscribed channel over unsubscribed', () {
           check(compare(subA(), channelB)).isLessThan(0);
@@ -1534,70 +2047,97 @@ void main() {
 
         group('both channels subscribed', () {
           test('favor unmuted over muted, regardless of pinned status', () {
-            check(compare(
-              subA(isMuted: false, pinToTop: true),
-              subB(isMuted: true,  pinToTop: false),
-            )).isLessThan(0);
-            check(compare(
-              subA(isMuted: false, pinToTop: false),
-              subB(isMuted: true,  pinToTop: true),
-            )).isLessThan(0);
+            check(
+              compare(
+                subA(isMuted: false, pinToTop: true),
+                subB(isMuted: true, pinToTop: false),
+              ),
+            ).isLessThan(0);
+            check(
+              compare(
+                subA(isMuted: false, pinToTop: false),
+                subB(isMuted: true, pinToTop: true),
+              ),
+            ).isLessThan(0);
 
-            check(compare(
-              subA(isMuted: true,  pinToTop: true),
-              subB(isMuted: false, pinToTop: false),
-            )).isGreaterThan(0);
-            check(compare(
-              subA(isMuted: true,  pinToTop: false),
-              subB(isMuted: false, pinToTop: true),
-            )).isGreaterThan(0);
+            check(
+              compare(
+                subA(isMuted: true, pinToTop: true),
+                subB(isMuted: false, pinToTop: false),
+              ),
+            ).isGreaterThan(0);
+            check(
+              compare(
+                subA(isMuted: true, pinToTop: false),
+                subB(isMuted: false, pinToTop: true),
+              ),
+            ).isGreaterThan(0);
           });
 
           test('same muted status, favor pinned over unpinned', () {
-            check(compare(
-              subA(isMuted: false, pinToTop: true),
-              subB(isMuted: false, pinToTop: false),
-            )).isLessThan(0);
-            check(compare(
-              subA(isMuted: false, pinToTop: false),
-              subB(isMuted: false, pinToTop: true),
-            )).isGreaterThan(0);
+            check(
+              compare(
+                subA(isMuted: false, pinToTop: true),
+                subB(isMuted: false, pinToTop: false),
+              ),
+            ).isLessThan(0);
+            check(
+              compare(
+                subA(isMuted: false, pinToTop: false),
+                subB(isMuted: false, pinToTop: true),
+              ),
+            ).isGreaterThan(0);
 
-            check(compare(
-              subA(isMuted: true, pinToTop: true),
-              subB(isMuted: true, pinToTop: false),
-            )).isLessThan(0);
-            check(compare(
-              subA(isMuted: true, pinToTop: false),
-              subB(isMuted: true, pinToTop: true),
-            )).isGreaterThan(0);
+            check(
+              compare(
+                subA(isMuted: true, pinToTop: true),
+                subB(isMuted: true, pinToTop: false),
+              ),
+            ).isLessThan(0);
+            check(
+              compare(
+                subA(isMuted: true, pinToTop: false),
+                subB(isMuted: true, pinToTop: true),
+              ),
+            ).isGreaterThan(0);
           });
 
           test('same muted and same pinned status, favor none', () {
-            check(compare(
-              subA(isMuted: false, pinToTop: false),
-              subB(isMuted: false, pinToTop: false),
-            )).equals(0);
-            check(compare(
-              subA(isMuted: false, pinToTop: true),
-              subB(isMuted: false, pinToTop: true),
-            )).equals(0);
+            check(
+              compare(
+                subA(isMuted: false, pinToTop: false),
+                subB(isMuted: false, pinToTop: false),
+              ),
+            ).equals(0);
+            check(
+              compare(
+                subA(isMuted: false, pinToTop: true),
+                subB(isMuted: false, pinToTop: true),
+              ),
+            ).equals(0);
 
-            check(compare(
-              subA(isMuted: true, pinToTop: false),
-              subB(isMuted: true, pinToTop: false),
-            )).equals(0);
-            check(compare(
-              subA(isMuted: true, pinToTop: true),
-              subB(isMuted: true, pinToTop: true),
-            )).equals(0);
+            check(
+              compare(
+                subA(isMuted: true, pinToTop: false),
+                subB(isMuted: true, pinToTop: false),
+              ),
+            ).equals(0);
+            check(
+              compare(
+                subA(isMuted: true, pinToTop: true),
+                subB(isMuted: true, pinToTop: true),
+              ),
+            ).equals(0);
           });
         });
       });
 
       group('compareByRecentActivity', () {
-        int compare(bool a, bool b) => ChannelLinkAutocompleteView.compareByRecentActivity(
-          eg.stream(isRecentlyActive: a), eg.stream(isRecentlyActive: b));
+        int compare(bool a, bool b) =>
+            ChannelLinkAutocompleteView.compareByRecentActivity(
+              eg.stream(isRecentlyActive: a),
+              eg.stream(isRecentlyActive: b),
+            );
 
         test('favor recently-active channel over inactive', () {
           check(compare(true, false)).isLessThan(0);
@@ -1611,8 +2151,11 @@ void main() {
       });
 
       group('compareByWeeklyTraffic', () {
-        int compare(int? a, int? b) => ChannelLinkAutocompleteView.compareByWeeklyTraffic(
-          eg.stream(streamWeeklyTraffic: a), eg.stream(streamWeeklyTraffic: b));
+        int compare(int? a, int? b) =>
+            ChannelLinkAutocompleteView.compareByWeeklyTraffic(
+              eg.stream(streamWeeklyTraffic: a),
+              eg.stream(streamWeeklyTraffic: b),
+            );
 
         test('favor channel with more traffic', () {
           check(compare(100, 50)).isLessThan(0);
@@ -1641,16 +2184,27 @@ void main() {
         List<ZulipStream> channels = const [],
         List<Subscription> subscriptions = const [],
       }) {
-        store = eg.store(initialSnapshot: eg.initialSnapshot(
-          streams: channels, subscriptions: subscriptions));
+        store = eg.store(
+          initialSnapshot: eg.initialSnapshot(
+            streams: channels,
+            subscriptions: subscriptions,
+          ),
+        );
       }
 
       group('compares by name', () {
         void checkPrecedes(String a, String b) {
-          final view = ChannelLinkAutocompleteView.init(store: store,
-            narrow: ChannelNarrow(1), query: ChannelLinkAutocompleteQuery(''));
-          check(view.debugCompareChannels(eg.stream(name: a), eg.stream(name: b))).isLessThan(0);
-          check(view.debugCompareChannels(eg.stream(name: b), eg.stream(name: a))).isGreaterThan(0);
+          final view = ChannelLinkAutocompleteView.init(
+            store: store,
+            narrow: ChannelNarrow(1),
+            query: ChannelLinkAutocompleteQuery(''),
+          );
+          check(
+            view.debugCompareChannels(eg.stream(name: a), eg.stream(name: b)),
+          ).isLessThan(0);
+          check(
+            view.debugCompareChannels(eg.stream(name: b), eg.stream(name: a)),
+          ).isGreaterThan(0);
           view.dispose();
         }
 
@@ -1665,15 +2219,22 @@ void main() {
           // proper method ChannelStore.compareChannelsByName,
           // rather than a more naïve string comparison.
           prepare();
-          checkPrecedes('🗄️backend',  'announce');
+          checkPrecedes('🗄️backend', 'announce');
           checkPrecedes('🗄️ BACKEND', 'announce');
         });
       });
 
       group('ranking across signals', () {
-        void checkPrecedes(Narrow narrow, ZulipStream a, Iterable<ZulipStream> bs) {
-          final view = ChannelLinkAutocompleteView.init(store: store,
-            narrow: narrow, query: ChannelLinkAutocompleteQuery(''));
+        void checkPrecedes(
+          Narrow narrow,
+          ZulipStream a,
+          Iterable<ZulipStream> bs,
+        ) {
+          final view = ChannelLinkAutocompleteView.init(
+            store: store,
+            narrow: narrow,
+            query: ChannelLinkAutocompleteQuery(''),
+          );
           for (final b in bs) {
             check(view.debugCompareChannels(a, b)).isLessThan(0);
             check(view.debugCompareChannels(b, a)).isGreaterThan(0);
@@ -1682,12 +2243,17 @@ void main() {
         }
 
         void checkRankEqual(Narrow narrow, List<ZulipStream> channels) {
-          final view = ChannelLinkAutocompleteView.init(store: store,
-            narrow: narrow, query: ChannelLinkAutocompleteQuery(''));
+          final view = ChannelLinkAutocompleteView.init(
+            store: store,
+            narrow: narrow,
+            query: ChannelLinkAutocompleteQuery(''),
+          );
           for (int i = 0; i < channels.length; i++) {
             for (int j = i + 1; j < channels.length; j++) {
-              check(view.debugCompareChannels(channels[i], channels[j])).equals(0);
-              check(view.debugCompareChannels(channels[j], channels[i])).equals(0);
+              check(view.debugCompareChannels(channels[i], channels[j]))
+                  .equals(0);
+              check(view.debugCompareChannels(channels[j], channels[i]))
+                  .equals(0);
             }
           }
           view.dispose();
@@ -1704,23 +2270,45 @@ void main() {
 
           // Next three are runners-up by being subscribed to.
           // Runner-up by being unmuted.
-          eg.subscription(eg.stream(name: 'Y',
-              isRecentlyActive: false, streamWeeklyTraffic: 0),
-            isMuted: false, pinToTop: false),
+          eg.subscription(
+            eg.stream(
+              name: 'Y',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 0,
+            ),
+            isMuted: false,
+            pinToTop: false,
+          ),
           // Runner-up by being pinned.
-          eg.subscription(eg.stream(name: 'X',
-              isRecentlyActive: false, streamWeeklyTraffic: 0),
-            isMuted: true, pinToTop: true),
+          eg.subscription(
+            eg.stream(
+              name: 'X',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 0,
+            ),
+            isMuted: true,
+            pinToTop: true,
+          ),
           // Last among subscribed ones by being unpinned.
-          eg.subscription(eg.stream(name: 'W',
-              isRecentlyActive: false, streamWeeklyTraffic: 0),
-            isMuted: true, pinToTop: false),
+          eg.subscription(
+            eg.stream(
+              name: 'W',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 0,
+            ),
+            isMuted: true,
+            pinToTop: false,
+          ),
 
           // The rest are runners-up by not being subscribed to.
           // Runner-up by being recently active.
           eg.stream(name: 'V', isRecentlyActive: true, streamWeeklyTraffic: 0),
           // Runner-up by having more weekly traffic.
-          eg.stream(name: 'U', isRecentlyActive: false, streamWeeklyTraffic: 100),
+          eg.stream(
+            name: 'U',
+            isRecentlyActive: false,
+            streamWeeklyTraffic: 100,
+          ),
           // Runner-up by name.
           eg.stream(name: 'A', isRecentlyActive: false, streamWeeklyTraffic: 0),
           // Next two are tied because no remaining criteria.
@@ -1731,17 +2319,20 @@ void main() {
           eg.topicNarrow(channels[0].streamId, 'this'),
           ChannelNarrow(channels[0].streamId),
         ]) {
-          test('${narrow.runtimeType}: composing-to channel > subscribed (unmuted > pinned) > recently active > weekly traffic > name', () {
-            prepare();
-            checkPrecedes(narrow, channels[0], channels.skip(1));
-            checkPrecedes(narrow, channels[1], channels.skip(2));
-            checkPrecedes(narrow, channels[2], channels.skip(3));
-            checkPrecedes(narrow, channels[3], channels.skip(4));
-            checkPrecedes(narrow, channels[4], channels.skip(5));
-            checkPrecedes(narrow, channels[5], channels.skip(6));
-            checkPrecedes(narrow, channels[6], channels.skip(7));
-            checkRankEqual(narrow, [channels[7], channels[8]]);
-          });
+          test(
+            '${narrow.runtimeType}: composing-to channel > subscribed (unmuted > pinned) > recently active > weekly traffic > name',
+            () {
+              prepare();
+              checkPrecedes(narrow, channels[0], channels.skip(1));
+              checkPrecedes(narrow, channels[1], channels.skip(2));
+              checkPrecedes(narrow, channels[2], channels.skip(3));
+              checkPrecedes(narrow, channels[3], channels.skip(4));
+              checkPrecedes(narrow, channels[4], channels.skip(5));
+              checkPrecedes(narrow, channels[5], channels.skip(6));
+              checkPrecedes(narrow, channels[6], channels.skip(7));
+              checkRankEqual(narrow, [channels[7], channels[8]]);
+            },
+          );
         }
 
         test('DmNarrow: subscribed (unmuted > pinned) > recently active > weekly traffic > name', () {
@@ -1750,28 +2341,66 @@ void main() {
           final channels = [
             // Next three wins by being subscribed to.
             // Wins by being unmuted.
-            eg.subscription(eg.stream(name: 'Z',
-                isRecentlyActive: false, streamWeeklyTraffic: 0),
-              isMuted: false, pinToTop: false),
+            eg.subscription(
+              eg.stream(
+                name: 'Z',
+                isRecentlyActive: false,
+                streamWeeklyTraffic: 0,
+              ),
+              isMuted: false,
+              pinToTop: false,
+            ),
             // Runner-up by being pinned.
-            eg.subscription(eg.stream(name: 'Y',
-                isRecentlyActive: false, streamWeeklyTraffic: 0),
-              isMuted: true, pinToTop: true),
+            eg.subscription(
+              eg.stream(
+                name: 'Y',
+                isRecentlyActive: false,
+                streamWeeklyTraffic: 0,
+              ),
+              isMuted: true,
+              pinToTop: true,
+            ),
             // Last among subscribed ones by being unpinned.
-            eg.subscription(eg.stream(name: 'X',
-                isRecentlyActive: false, streamWeeklyTraffic: 0),
-              isMuted: true, pinToTop: false),
+            eg.subscription(
+              eg.stream(
+                name: 'X',
+                isRecentlyActive: false,
+                streamWeeklyTraffic: 0,
+              ),
+              isMuted: true,
+              pinToTop: false,
+            ),
 
             // The rest are runners-up by not being subscribed to.
             // Runner-up by being recently active.
-            eg.stream(name: 'W', isRecentlyActive: true, streamWeeklyTraffic: 0),
+            eg.stream(
+              name: 'W',
+              isRecentlyActive: true,
+              streamWeeklyTraffic: 0,
+            ),
             // Runner-up by having more weekly traffic.
-            eg.stream(name: 'V', isRecentlyActive: false, streamWeeklyTraffic: 100),
+            eg.stream(
+              name: 'V',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 100,
+            ),
             // Runner-up by name.
-            eg.stream(name: 'A', isRecentlyActive: false, streamWeeklyTraffic: 0),
+            eg.stream(
+              name: 'A',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 0,
+            ),
             // Next two are tied because no remaining criteria.
-            eg.stream(name: 'B', isRecentlyActive: false, streamWeeklyTraffic: 0),
-            eg.stream(name: 'b', isRecentlyActive: false, streamWeeklyTraffic: 0),
+            eg.stream(
+              name: 'B',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 0,
+            ),
+            eg.stream(
+              name: 'b',
+              isRecentlyActive: false,
+              streamWeeklyTraffic: 0,
+            ),
           ];
           prepare();
           final narrow = DmNarrow.withUser(1, selfUserId: 10);
@@ -1787,43 +2416,66 @@ void main() {
         test('CombinedFeedNarrow gives error', () async {
           prepare();
           const narrow = CombinedFeedNarrow();
-          check(() => ChannelLinkAutocompleteView.init(store: store,
-                        narrow: narrow, query: ChannelLinkAutocompleteQuery('')))
-            .throws<AssertionError>();
+          check(
+            () => ChannelLinkAutocompleteView.init(
+              store: store,
+              narrow: narrow,
+              query: ChannelLinkAutocompleteQuery(''),
+            ),
+          ).throws<AssertionError>();
         });
 
         test('MentionsNarrow gives error', () async {
           prepare();
           const narrow = MentionsNarrow();
-          check(() => ChannelLinkAutocompleteView.init(store: store,
-                        narrow: narrow, query: ChannelLinkAutocompleteQuery('')))
-            .throws<AssertionError>();
+          check(
+            () => ChannelLinkAutocompleteView.init(
+              store: store,
+              narrow: narrow,
+              query: ChannelLinkAutocompleteQuery(''),
+            ),
+          ).throws<AssertionError>();
         });
 
         test('StarredMessagesNarrow gives error', () async {
           prepare();
           const narrow = StarredMessagesNarrow();
-          check(() => ChannelLinkAutocompleteView.init(store: store,
-                        narrow: narrow, query: ChannelLinkAutocompleteQuery('')))
-            .throws<AssertionError>();
+          check(
+            () => ChannelLinkAutocompleteView.init(
+              store: store,
+              narrow: narrow,
+              query: ChannelLinkAutocompleteQuery(''),
+            ),
+          ).throws<AssertionError>();
         });
 
         test('KeywordSearchNarrow gives error', () async {
           prepare();
           final narrow = KeywordSearchNarrow('');
-          check(() => ChannelLinkAutocompleteView.init(store: store,
-                        narrow: narrow, query: ChannelLinkAutocompleteQuery('')))
-            .throws<AssertionError>();
+          check(
+            () => ChannelLinkAutocompleteView.init(
+              store: store,
+              narrow: narrow,
+              query: ChannelLinkAutocompleteQuery(''),
+            ),
+          ).throws<AssertionError>();
         });
       });
 
       test('final results end-to-end', () async {
         Future<Iterable<ChannelLinkAutocompleteResult>> getResults(
-            Narrow narrow, ChannelLinkAutocompleteQuery query) async {
+          Narrow narrow,
+          ChannelLinkAutocompleteQuery query,
+        ) async {
           bool done = false;
-          final view = ChannelLinkAutocompleteView.init(store: store,
-            narrow: narrow, query: query);
-          view.addListener(() { done = true; });
+          final view = ChannelLinkAutocompleteView.init(
+            store: store,
+            narrow: narrow,
+            query: query,
+          );
+          view.addListener(() {
+            done = true;
+          });
           await Future(() {});
           check(done).isTrue();
           final results = view.results;
@@ -1832,11 +2484,19 @@ void main() {
         }
 
         final channels = [
-          eg.stream(streamId: 1, name: 'Channel One', isRecentlyActive: false,
-            streamWeeklyTraffic: 10),
+          eg.stream(
+            streamId: 1,
+            name: 'Channel One',
+            isRecentlyActive: false,
+            streamWeeklyTraffic: 10,
+          ),
           eg.stream(streamId: 2, name: 'Channel Two', isRecentlyActive: true),
-          eg.stream(streamId: 3, name: 'Channel Three', isRecentlyActive: false,
-            streamWeeklyTraffic: 100),
+          eg.stream(
+            streamId: 3,
+            name: 'Channel Three',
+            isRecentlyActive: false,
+            streamWeeklyTraffic: 100,
+          ),
           eg.stream(streamId: 4, name: 'Channel Four', isRecentlyActive: false),
           eg.stream(streamId: 5, name: 'Channel Five', isRecentlyActive: false),
           eg.stream(streamId: 6, name: 'Channel Six'),
@@ -1846,12 +2506,15 @@ void main() {
           eg.stream(streamId: 10, name: 'Channel Ten'),
         ];
 
-        prepare(channels: channels, subscriptions: [
-          eg.subscription(channels[6 - 1], isMuted: false, pinToTop: true),
-          eg.subscription(channels[7 - 1], isMuted: false, pinToTop: false),
-          eg.subscription(channels[8 - 1], isMuted: true,  pinToTop: true),
-          eg.subscription(channels[9 - 1], isMuted: true,  pinToTop: false),
-        ]);
+        prepare(
+          channels: channels,
+          subscriptions: [
+            eg.subscription(channels[6 - 1], isMuted: false, pinToTop: true),
+            eg.subscription(channels[7 - 1], isMuted: false, pinToTop: false),
+            eg.subscription(channels[8 - 1], isMuted: true, pinToTop: true),
+            eg.subscription(channels[9 - 1], isMuted: true, pinToTop: false),
+          ],
+        );
 
         final narrow = eg.topicNarrow(10, 'this');
 
@@ -1869,13 +2532,13 @@ void main() {
         // Check the ranking of the full list of options,
         // i.e. the results for an empty query.
         check(await getResults(narrow, ChannelLinkAutocompleteQuery('')))
-          .deepEquals([10, 6, 7, 8, 9, 2, 3, 1, 5, 4].map(isChannel));
+            .deepEquals([10, 6, 7, 8, 9, 2, 3, 1, 5, 4].map(isChannel));
 
         // Check the ranking applies also to results filtered by a query.
         check(await getResults(narrow, ChannelLinkAutocompleteQuery('t')))
-          .deepEquals([10, 2, 3].map(isChannel));
+            .deepEquals([10, 2, 3].map(isChannel));
         check(await getResults(narrow, ChannelLinkAutocompleteQuery('F')))
-          .deepEquals([5, 4].map(isChannel));
+            .deepEquals([5, 4].map(isChannel));
       });
     });
   });
@@ -1884,25 +2547,41 @@ void main() {
     late PerAccountStore store;
 
     void doCheck(String rawQuery, ZulipStream channel, bool expected) {
-      final result = ChannelLinkAutocompleteQuery(rawQuery).testChannel(channel, store);
+      final result = ChannelLinkAutocompleteQuery(rawQuery)
+          .testChannel(channel, store);
       expected
-        ? check(result).isA<ChannelLinkAutocompleteResult>()
-        : check(result).isNull();
+          ? check(result).isA<ChannelLinkAutocompleteResult>()
+          : check(result).isNull();
     }
 
-    test('channel is always excluded when archived, regardless of other criteria', () {
-      store = eg.store();
+    test(
+      'channel is always excluded when archived, regardless of other criteria',
+      () {
+        store = eg.store();
 
-      doCheck('Channel Name', eg.stream(name: 'Channel Name', isArchived: true), false);
-      // When not archived, then other criteria will be checked.
-      doCheck('Channel Name', eg.stream(name: 'Channel Name', isArchived: false), true);
-    });
+        doCheck(
+          'Channel Name',
+          eg.stream(name: 'Channel Name', isArchived: true),
+          false,
+        );
+        // When not archived, then other criteria will be checked.
+        doCheck(
+          'Channel Name',
+          eg.stream(name: 'Channel Name', isArchived: false),
+          true,
+        );
+      },
+    );
 
     test('testChannel: channel is included if name words match the query', () {
       store = eg.store();
 
       doCheck('', eg.stream(name: 'Channel Name'), true);
-      doCheck('', eg.stream(name: ''), true); // unlikely case, but should not crash
+      doCheck(
+        '',
+        eg.stream(name: ''),
+        true,
+      ); // unlikely case, but should not crash
       doCheck('Channel Name', eg.stream(name: 'Channel Name'), true);
       doCheck('channel name', eg.stream(name: 'Channel Name'), true);
       doCheck('Channel Name', eg.stream(name: 'channel name'), true);
@@ -1916,7 +2595,11 @@ void main() {
       doCheck('channel channel', eg.stream(name: 'Channel Channel Name'), true);
       doCheck('channel channel', eg.stream(name: 'Channel Name Channel'), true);
 
-      doCheck('C', eg.stream(name: ''), false); // unlikely case, but should not crash
+      doCheck(
+        'C',
+        eg.stream(name: ''),
+        false,
+      ); // unlikely case, but should not crash
       doCheck('Channels Names', eg.stream(name: 'Channel Name'), false);
       doCheck('Channel Name', eg.stream(name: 'Channel'), false);
       doCheck('Channel Name', eg.stream(name: 'Name'), false);
@@ -1926,7 +2609,11 @@ void main() {
       doCheck('Channel Channel', eg.stream(name: 'Channel Name'), false);
       doCheck('Name Name', eg.stream(name: 'Channel Name'), false);
       doCheck('Name Channel', eg.stream(name: 'Channel Name'), false);
-      doCheck('Name Four Channel Words', eg.stream(name: 'Channel Name Four Words'), false);
+      doCheck(
+        'Name Four Channel Words',
+        eg.stream(name: 'Channel Name Four Words'),
+        false,
+      );
       doCheck('F Channel', eg.stream(name: 'Channel Name Four Words'), false);
       doCheck('Four C', eg.stream(name: 'Channel Name Four Words'), false);
     });
@@ -1935,7 +2622,8 @@ void main() {
       int rankOf(String query, ZulipStream channel) {
         // (i.e. throw here if it's not a match)
         return ChannelLinkAutocompleteQuery(query)
-          .testChannel(channel, store)!.rank;
+            .testChannel(channel, store)!
+            .rank;
       }
 
       void checkPrecedes(String query, ZulipStream a, ZulipStream b) {
@@ -1962,15 +2650,15 @@ void main() {
         checkAllSameRank('Uber Cars', channels); // exact
         checkAllSameRank('uber cars', channels); // exact
 
-        checkAllSameRank('Über Ca',   channels); // total-prefix
-        checkAllSameRank('über ca',   channels); // total-prefix
-        checkAllSameRank('Uber Ca',   channels); // total-prefix
-        checkAllSameRank('uber ca',   channels); // total-prefix
+        checkAllSameRank('Über Ca', channels); // total-prefix
+        checkAllSameRank('über ca', channels); // total-prefix
+        checkAllSameRank('Uber Ca', channels); // total-prefix
+        checkAllSameRank('uber ca', channels); // total-prefix
 
-        checkAllSameRank('Üb Ca',     channels); // word-prefixes
-        checkAllSameRank('üb ca',     channels); // word-prefixes
-        checkAllSameRank('Ub Ca',     channels); // word-prefixes
-        checkAllSameRank('ub ca',     channels); // word-prefixes
+        checkAllSameRank('Üb Ca', channels); // word-prefixes
+        checkAllSameRank('üb ca', channels); // word-prefixes
+        checkAllSameRank('Ub Ca', channels); // word-prefixes
+        checkAllSameRank('ub ca', channels); // word-prefixes
       });
 
       test('channel name match: exact over total-prefix', () {
@@ -1992,12 +2680,16 @@ void main() {
         final channel = eg.stream(name: 'some channel');
         check([
           rankOf('some channel', channel), // exact name match
-          rankOf('some ch', channel),      // total-prefix name match
-          rankOf('so ch', channel),        // word-prefixes name match
+          rankOf('some ch', channel), // total-prefix name match
+          rankOf('so ch', channel), // word-prefixes name match
         ]).deepEquals([0, 1, 2]);
       });
     });
   });
 }
 
-typedef WildcardTester = void Function(String query, Narrow narrow, List<WildcardMentionOption> expected);
+typedef WildcardTester = void Function(
+  String query,
+  Narrow narrow,
+  List<WildcardMentionOption> expected,
+);

--- a/test/model/user_group_test.dart
+++ b/test/model/user_group_test.dart
@@ -23,16 +23,18 @@ void main() {
 
   test('initialize', () {
     final groups = [eg.userGroup(), eg.userGroup()];
-    final store = eg.store(initialSnapshot: eg.initialSnapshot(
-      realmUserGroups: groups));
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(realmUserGroups: groups),
+    );
     checkGroupsEqual(store, groups);
   });
 
   test('getGroup', () {
     final group1 = eg.userGroup();
     final group2 = eg.userGroup();
-    final store = eg.store(initialSnapshot: eg.initialSnapshot(
-      realmUserGroups: [group1, group2]));
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(realmUserGroups: [group1, group2]),
+    );
     check(store.getGroup(group1.id)).jsonEquals(group1);
     check(store.getGroup(group2.id)).jsonEquals(group2);
     check(store.getGroup(eg.userGroup().id)).isNull();
@@ -42,20 +44,34 @@ void main() {
     final group1 = eg.userGroup(deactivated: false);
     final group2 = eg.userGroup(deactivated: true);
     final group3 = eg.userGroup(deactivated: false);
-    final store = eg.store(initialSnapshot: eg.initialSnapshot(
-      realmUserGroups: [group1, group2, group3]));
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(
+        realmUserGroups: [group1, group2, group3],
+      ),
+    );
     check(sorted(store.allGroups)).jsonEquals([group1, group2, group3]);
     check(sorted(store.activeGroups)).jsonEquals([group1, group3]);
 
-    await store.handleEvent(UserGroupUpdateEvent(id: 1, groupId: group1.id,
-      data: UserGroupUpdateData(name: null, description: null, deactivated: true)));
+    await store.handleEvent(
+      UserGroupUpdateEvent(
+        id: 1,
+        groupId: group1.id,
+        data: UserGroupUpdateData(
+          name: null,
+          description: null,
+          deactivated: true,
+          canMentionGroup: null,
+        ),
+      ),
+    );
     check(sorted(store.activeGroups)).jsonEquals([group3]);
   });
 
   test('UserGroupAddEvent, UserGroupRemoveEvent', () async {
     final group1 = eg.userGroup();
-    final store = eg.store(initialSnapshot: eg.initialSnapshot(
-      realmUserGroups: [group1]));
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(realmUserGroups: [group1]),
+    );
     checkGroupsEqual(store, [group1]);
 
     final group2 = eg.userGroup();
@@ -69,31 +85,56 @@ void main() {
   test('UserGroupUpdateEvent', () async {
     final store = eg.store();
     final group = eg.userGroup(
-      name: 'a group', description: 'is a group', deactivated: false);
+      name: 'a group',
+      description: 'is a group',
+      deactivated: false,
+    );
     await store.handleEvent(UserGroupAddEvent(id: 1, group: group));
     checkGroupsEqual(store, [group]);
 
     // Handles all the properties being updated at once.
-    await store.handleEvent(UserGroupUpdateEvent(id: 2, groupId: group.id,
-      data: UserGroupUpdateData(name: 'revised group',
-        description: 'different description', deactivated: true)));
-    checkGroupsEqual(store, [{
-      ...group.toJson(),
-      'name': 'revised group',
-      'description': 'different description',
-      'deactivated': true,
-    }]);
+    await store.handleEvent(
+      UserGroupUpdateEvent(
+        id: 2,
+        groupId: group.id,
+        data: UserGroupUpdateData(
+          name: 'revised group',
+          description: 'different description',
+          deactivated: true,
+          canMentionGroup: null,
+        ),
+      ),
+    );
+    checkGroupsEqual(store, [
+      {
+        ...group.toJson(),
+        'name': 'revised group',
+        'description': 'different description',
+        'deactivated': true,
+      },
+    ]);
 
     // Handles some properties being null, still updating the one that's present.
-    await store.handleEvent(UserGroupUpdateEvent(id: 2, groupId: group.id,
-      data: UserGroupUpdateData(name: null,
-        description: null, deactivated: false)));
-    checkGroupsEqual(store, [{
-      ...group.toJson(),
-      'name': 'revised group',
-      'description': 'different description',
-      'deactivated': false,
-    }]);
+    await store.handleEvent(
+      UserGroupUpdateEvent(
+        id: 2,
+        groupId: group.id,
+        data: UserGroupUpdateData(
+          name: null,
+          description: null,
+          deactivated: false,
+          canMentionGroup: null,
+        ),
+      ),
+    );
+    checkGroupsEqual(store, [
+      {
+        ...group.toJson(),
+        'name': 'revised group',
+        'description': 'different description',
+        'deactivated': false,
+      },
+    ]);
   });
 
   group('membership', () {
@@ -103,8 +144,12 @@ void main() {
     late PerAccountStore store;
 
     void prepare(List<UserGroup> groups, {List<User>? users}) {
-      store = eg.store(initialSnapshot: eg.initialSnapshot(
-        realmUsers: users, realmUserGroups: groups));
+      store = eg.store(
+        initialSnapshot: eg.initialSnapshot(
+          realmUsers: users,
+          realmUserGroups: groups,
+        ),
+      );
     }
 
     bool isMember(UserGroup group) {
@@ -120,13 +165,7 @@ void main() {
       groups.add(eg.userGroup(directSubgroupIds: [groups[1].id]));
 
       prepare(groups);
-      check(groups.map(isMember)).deepEquals([
-        true,
-        false,
-        true,
-        true,
-        false,
-      ]);
+      check(groups.map(isMember)).deepEquals([true, false, true, true, false]);
     });
 
     test('UserGroupEvent', () async {
@@ -135,29 +174,59 @@ void main() {
       check(groups.map(isMember)).deepEquals([false, false, false, false]);
 
       // Add a membership.
-      await store.handleEvent(UserGroupAddMembersEvent(id: 0,
-        groupId: groups[0].id, userIds: [eg.selfUser.userId]));
+      await store.handleEvent(
+        UserGroupAddMembersEvent(
+          id: 0,
+          groupId: groups[0].id,
+          userIds: [eg.selfUser.userId],
+        ),
+      );
       check(groups.map(isMember)).deepEquals([true, false, false, false]);
 
       // Add a chain of transitive memberships.
-      await store.handleEvent(UserGroupAddSubgroupsEvent(id: 0,
-        groupId: groups[1].id, directSubgroupIds: [groups[0].id]));
+      await store.handleEvent(
+        UserGroupAddSubgroupsEvent(
+          id: 0,
+          groupId: groups[1].id,
+          directSubgroupIds: [groups[0].id],
+        ),
+      );
       check(groups.map(isMember)).deepEquals([true, true, false, false]);
-      await store.handleEvent(UserGroupAddSubgroupsEvent(id: 0,
-        groupId: groups[2].id, directSubgroupIds: [groups[1].id]));
+      await store.handleEvent(
+        UserGroupAddSubgroupsEvent(
+          id: 0,
+          groupId: groups[2].id,
+          directSubgroupIds: [groups[1].id],
+        ),
+      );
       check(groups.map(isMember)).deepEquals([true, true, true, false]);
 
       // Cut the middle link of the chain.
-      await store.handleEvent(UserGroupRemoveSubgroupsEvent(id: 0,
-        groupId: groups[1].id, directSubgroupIds: [groups[0].id]));
+      await store.handleEvent(
+        UserGroupRemoveSubgroupsEvent(
+          id: 0,
+          groupId: groups[1].id,
+          directSubgroupIds: [groups[0].id],
+        ),
+      );
       check(groups.map(isMember)).deepEquals([true, false, false, false]);
 
       // Restore the middle link; cut the bottom link.
-      await store.handleEvent(UserGroupAddSubgroupsEvent(id: 0,
-        groupId: groups[1].id, directSubgroupIds: [groups[0].id]));
+      await store.handleEvent(
+        UserGroupAddSubgroupsEvent(
+          id: 0,
+          groupId: groups[1].id,
+          directSubgroupIds: [groups[0].id],
+        ),
+      );
       check(groups.map(isMember)).deepEquals([true, true, true, false]);
-      await store.handleEvent(UserGroupRemoveMembersEvent(id: 0,
-        groupId: groups[0].id, userIds: [eg.selfUser.userId]));
+      await store.handleEvent(
+        UserGroupRemoveMembersEvent(
+          id: 0,
+          groupId: groups[0].id,
+          userIds: [eg.selfUser.userId],
+        ),
+      );
       check(groups.map(isMember)).deepEquals([false, false, false, false]);
     });
 
@@ -172,26 +241,45 @@ void main() {
       check(store.getGroup(group.id)!.members).deepEquals([user.userId]);
 
       // An update to a random irrelevant field has no effect.
-      await store.handleEvent(RealmUserUpdateEvent(id: 0,
-        userId: user.userId, fullName: 'New Name'));
+      await store.handleEvent(
+        RealmUserUpdateEvent(id: 0, userId: user.userId, fullName: 'New Name'),
+      );
       check(store.getGroup(group.id)!.members).deepEquals([user.userId]);
 
       // But deactivating the user removes them from groups.
-      await store.handleEvent(RealmUserUpdateEvent(id: 0,
-        userId: user.userId, isActive: false));
+      await store.handleEvent(
+        RealmUserUpdateEvent(id: 0, userId: user.userId, isActive: false),
+      );
       check(store.getGroup(group.id)!.members).isEmpty();
     });
   });
 
   test('various fields make it through', () async {
-    final store = eg.store(initialSnapshot: eg.initialSnapshot(
-      realmUserGroups: [
-        eg.userGroup(id: 3, name: 'some group', description: 'this is a group',
-          isSystemGroup: true, deactivated: false),
-      ]));
-    await store.handleEvent(UserGroupAddEvent(id: 1, group: eg.userGroup(
-      id: 5, name: 'a different group', description: 'also a group',
-      isSystemGroup: false, deactivated: true)));
+    final store = eg.store(
+      initialSnapshot: eg.initialSnapshot(
+        realmUserGroups: [
+          eg.userGroup(
+            id: 3,
+            name: 'some group',
+            description: 'this is a group',
+            isSystemGroup: true,
+            deactivated: false,
+          ),
+        ],
+      ),
+    );
+    await store.handleEvent(
+      UserGroupAddEvent(
+        id: 1,
+        group: eg.userGroup(
+          id: 5,
+          name: 'a different group',
+          description: 'also a group',
+          isSystemGroup: false,
+          deactivated: true,
+        ),
+      ),
+    );
     check(sorted(store.allGroups)).deepEquals(<Condition<Object?>>[
       (it) => it.isA<UserGroup>()
         ..id.equals(3)


### PR DESCRIPTION
Fixes #1776.

Currently the mention autocomplete only excludes system groups, ignoring the server's can_mention_group setting (already respected by the web app). This adds canMentionGroup to UserGroup and UserGroupUpdateData (following the pattern of similar settings on ZulipStream), and updates the autocomplete filter to use selfInGroupSetting (from #814) instead of just checking isSystemGroup. A null value is treated as unrestricted, matching server semantics.

Tested: Added a new test covering unrestricted, permitted, and restricted cases. Full suite passes (3,797/3,797). Not yet tested against a live server — happy to verify further if a reviewer can help.