### PR TITLE
api: In sendMessage, use `channel` when supported

### DIFF
--- a/lib/api/route/messages.dart
+++ b/lib/api/route/messages.dart
@@ -134,12 +134,13 @@ Future<SendMessageResult> sendMessage(
   String? localId,
   bool? readBySender,
 }) {
+  final supportsTypeChannel = connection.zulipFeatureLevel! >= 248; // TODO(server-9)
   final supportsTypeDirect = connection.zulipFeatureLevel! >= 174; // TODO(server-7)
   final supportsReadBySender = connection.zulipFeatureLevel! >= 236; // TODO(server-8)
   return connection.post('sendMessage', SendMessageResult.fromJson, 'messages', {
     ...(switch (destination) {
       StreamDestination() => {
-        'type': RawParameter('stream'),
+        'type': supportsTypeChannel ? RawParameter('channel') : RawParameter('stream'),
         'to': destination.streamId,
         'topic': RawParameter(destination.topic.apiName),
       },

--- a/test/api/route/messages_test.dart
+++ b/test/api/route/messages_test.dart
@@ -286,7 +286,7 @@ void main() {
           localId: '456',
           readBySender: true,
           expectedBodyFields: {
-            'type': 'stream',
+            'type': 'channel',
             'to': streamId.toString(),
             'topic': topic,
             'content': content,
@@ -299,6 +299,21 @@ void main() {
 
     test('to stream', () {
       return FakeApiConnection.with_((connection) async {
+        await checkSendMessage(connection,
+          destination: StreamDestination(streamId, eg.t(topic)), content: content,
+          readBySender: true,
+          expectedBodyFields: {
+            'type': 'channel',
+            'to': streamId.toString(),
+            'topic': topic,
+            'content': content,
+            'read_by_sender': 'true',
+          });
+      });
+    });
+
+    test('to stream, with legacy type "stream"', () {
+      return FakeApiConnection.with_(zulipFeatureLevel: 247, (connection) async {
         await checkSendMessage(connection,
           destination: StreamDestination(streamId, eg.t(topic)), content: content,
           readBySender: true,
@@ -347,7 +362,7 @@ void main() {
           destination: StreamDestination(streamId, eg.t(topic)), content: content,
           readBySender: null,
           expectedBodyFields: {
-            'type': 'stream',
+            'type': 'channel',
             'to': streamId.toString(),
             'topic': topic,
             'content': content,

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -159,7 +159,7 @@ void main() {
         ..method.equals('POST')
         ..url.path.equals('/api/v1/messages')
         ..bodyFields.deepEquals({
-          'type': 'stream',
+          'type': 'channel',
           'to': stream.streamId.toString(),
           'topic': 'world',
           'content': 'hello',

--- a/test/widgets/compose_box_test.dart
+++ b/test/widgets/compose_box_test.dart
@@ -1027,7 +1027,7 @@ void main() {
         ..method.equals('POST')
         ..url.path.equals('/api/v1/messages')
         ..bodyFields.deepEquals({
-            'type': 'stream',
+            'type': 'channel',
             'to': '123',
             'topic': 'some topic',
             'content': 'hello world',

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -1681,7 +1681,7 @@ void main() {
         ..method.equals('POST')
         ..url.path.equals('/api/v1/messages')
         ..bodyFields.deepEquals({
-          'type': 'stream',
+          'type': 'channel',
           'to': '${otherChannel.streamId}',
           'topic': 'new topic',
           'content': 'Some text',


### PR DESCRIPTION
The modern type "channel" was added in server-9 (FL-248).

This commit was part of #2339, but was suggested in https://github.com/zulip/zulip-flutter/pull/2339#discussion_r3683045408 to be moved to its own PR.