### PR TITLE
ios: Reply to messages from notifications

### DIFF
--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -65,6 +65,7 @@ class NotificationService: UNNotificationServiceExtension {
         bestAttemptContent.title = improvedNotificationContent.title
         bestAttemptContent.subtitle = improvedNotificationContent.subtitle
         bestAttemptContent.body = improvedNotificationContent.body
+        bestAttemptContent.categoryIdentifier = "MESSAGE"
         switch improvedNotificationContent.sound {
         case .systemDefault:
           bestAttemptContent.sound = UNNotificationSound.default

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -82,7 +82,8 @@ private let replyTextUserInfoKey = "reply_text"
   ) async {
     var userInfo = response.notification.request.content.userInfo
     if response.actionIdentifier == replyNotificationAction,
-      let textResponse = response as? UNTextInputNotificationResponse {
+      let textResponse = response as? UNTextInputNotificationResponse
+    {
       userInfo[replyTextUserInfoKey] = textResponse.userText
       notificationTapEventListener?.onNotificationTapEvent(payload: userInfo)
     } else if response.actionIdentifier == UNNotificationDefaultActionIdentifier {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,10 @@
 import Flutter
 import UIKit
+import UserNotifications
+
+private let messageNotificationCategory = "MESSAGE"
+private let replyNotificationAction = "REPLY"
+private let replyTextUserInfoKey = "reply_text"
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -40,6 +45,20 @@ import UIKit
     )
 
     UNUserNotificationCenter.current().delegate = self
+    let replyAction = UNTextInputNotificationAction(
+      identifier: replyNotificationAction,
+      title: "Reply",
+      options: [],
+      textInputButtonTitle: "Send",
+      textInputPlaceholder: "Reply"
+    )
+    let messageCategory = UNNotificationCategory(
+      identifier: messageNotificationCategory,
+      actions: [replyAction],
+      intentIdentifiers: [],
+      options: []
+    )
+    UNUserNotificationCenter.current().setNotificationCategories([messageCategory])
 
     return super.application(
       application,
@@ -61,9 +80,13 @@ import UIKit
     _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse,
   ) async {
-    if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
-      let userInfo = response.notification.request.content.userInfo
-      notificationTapEventListener!.onNotificationTapEvent(payload: userInfo)
+    var userInfo = response.notification.request.content.userInfo
+    if response.actionIdentifier == replyNotificationAction,
+      let textResponse = response as? UNTextInputNotificationResponse {
+      userInfo[replyTextUserInfoKey] = textResponse.userText
+      notificationTapEventListener?.onNotificationTapEvent(payload: userInfo)
+    } else if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
+      notificationTapEventListener?.onNotificationTapEvent(payload: userInfo)
     }
   }
 }
@@ -84,15 +107,26 @@ private class NotificationHostApiImpl: NotificationHostApi {
 //   https://github.com/flutter/packages/blob/2dff6213a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift#L49-L74
 class NotificationTapEventListener: NotificationTapEventsStreamHandler {
   var eventSink: PigeonEventSink<NotificationTapEvent>?
+  private var pendingReplyPayloads: [[AnyHashable: Any]] = []
 
   override func onListen(
     withArguments arguments: Any?,
     sink: PigeonEventSink<NotificationTapEvent>
   ) {
     eventSink = sink
+    for payload in pendingReplyPayloads {
+      sink.success(IosNotificationTapEvent(payload: payload))
+    }
+    pendingReplyPayloads.removeAll()
   }
 
   func onNotificationTapEvent(payload: [AnyHashable: Any]) {
-    eventSink?.success(IosNotificationTapEvent(payload: payload))
+    guard let eventSink else {
+      if payload[replyTextUserInfoKey] != nil {
+        pendingReplyPayloads.append(payload)
+      }
+      return
+    }
+    eventSink.success(IosNotificationTapEvent(payload: payload))
   }
 }

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -185,10 +185,42 @@ class NotificationOpenService {
   static Future<void> _navigateForNotification(NotificationTapEvent event) async {
     switch (event) {
       case IosNotificationTapEvent():
+        if (event.payload[kIosNotificationReplyTextKey] is String) {
+          return _sendNotificationReply(event);
+        }
         return _navigateForNotificationIos(event);
       case AndroidNotificationTapEvent():
         return _navigateForNotificationAndroid(event);
     }
+  }
+
+  static const kIosNotificationReplyTextKey = 'reply_text';
+
+  /// Sends a reply entered from an iOS notification action.
+  static Future<void> _sendNotificationReply(IosNotificationTapEvent event) async {
+    assert(defaultTargetPlatform == TargetPlatform.iOS);
+    final replyText = event.payload[kIosNotificationReplyTextKey] as String;
+    assert(debugLog('replying to notif: ${jsonEncode(event.payload)}'));
+
+    final notificationData = tryParseIosApnsPayload(event.payload);
+    if (notificationData == null) return;
+
+    final globalStore = await ZulipBinding.instance.getGlobalStore();
+    final account = globalStore.accounts.firstWhereOrNull(
+      (account) => account.realmUrl.origin == notificationData.realmUrl.origin
+                && account.userId == notificationData.userId);
+    if (account == null) return; // TODO(log)
+
+    final narrow = notificationData.narrow;
+    if (narrow is! SendableNarrow) return;
+
+    final store = await globalStore.perAccount(account.id);
+    await store.sendMessage(destination: narrow.destination, content: replyText);
+  }
+
+  @visibleForTesting
+  static Future<void> debugSendNotificationReply(IosNotificationTapEvent event) {
+    return _sendNotificationReply(event);
   }
 
   static Future<void> _navigateForNotificationIos(IosNotificationTapEvent event) async {
@@ -243,6 +275,20 @@ class NotificationOpenService {
       showErrorDialog(context: context,
         title: zulipLocalizations.errorNotificationOpenTitle);
       return null;
+    }
+  }
+
+  static NotificationOpenPayload? tryParseIosApnsPayload(
+    Map<Object?, Object?> payload,
+  ) {
+    try {
+      return NotificationOpenPayload.parseIosApnsPayload(payload);
+    } catch (_) {
+      try {
+        return NotificationOpenPayload.parseLegacyIosApnsPayload(payload);
+      } on FormatException {
+        return null;
+      }
     }
   }
 

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -32,6 +32,8 @@ class IosNotificationTapEvent extends NotificationTapEvent {
   /// The iOS APNs payload of the notification.
   ///
   /// See [notificationTapEvents].
+  /// For a reply action, this map additionally contains the entered text
+  /// under the `reply_text` key.
   final Map<Object?, Object?> payload;
 }
 

--- a/pigeon/notifications.dart
+++ b/pigeon/notifications.dart
@@ -32,8 +32,6 @@ class IosNotificationTapEvent extends NotificationTapEvent {
   /// The iOS APNs payload of the notification.
   ///
   /// See [notificationTapEvents].
-  /// For a reply action, this map additionally contains the entered text
-  /// under the `reply_text` key.
   final Map<Object?, Object?> payload;
 }
 

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -264,10 +264,11 @@ void main() {
       await checkOpenNotification(tester, eg.selfAccount, eg.streamMessage());
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
 
-    testWidgets('iOS notification reply sends a message', (tester) async {
+    test('iOS notification reply sends a message', () async {
       addTearDown(testBinding.reset);
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
       await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
-      await prepare(tester);
 
       final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
       final connection = store.connection as FakeApiConnection;
@@ -285,7 +286,7 @@ void main() {
         ..bodyFields['content'].equals('A reply')
         ..bodyFields['type'].equals('stream')
         ..bodyFields['topic'].equals(message.topic.apiName);
-    }, variant: const TargetPlatformVariant({TargetPlatform.iOS}));
+    });
 
    testWidgets('stream message: iOS legacy plaintext', (tester) async {
       addTearDown(testBinding.reset);

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -4,9 +4,11 @@ import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:zulip/api/model/model.dart';
 import 'package:zulip/api/notifications.dart';
 import 'package:zulip/api/route/channels.dart';
+import 'package:zulip/api/route/messages.dart';
 import 'package:zulip/host/notifications.dart';
 import 'package:zulip/model/localizations.dart';
 import 'package:zulip/model/narrow.dart';
@@ -261,6 +263,29 @@ void main() {
       await prepare(tester);
       await checkOpenNotification(tester, eg.selfAccount, eg.streamMessage());
     }, variant: const TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS}));
+
+    testWidgets('iOS notification reply sends a message', (tester) async {
+      addTearDown(testBinding.reset);
+      await testBinding.globalStore.add(eg.selfAccount, eg.initialSnapshot());
+      await prepare(tester);
+
+      final store = await testBinding.globalStore.perAccount(eg.selfAccount.id);
+      final connection = store.connection as FakeApiConnection;
+      connection.prepare(json: SendMessageResult(id: 123).toJson());
+
+      final message = eg.streamMessage();
+      final payload = messageApnsPayload(eg.selfAccount, message)
+        ..[NotificationOpenService.kIosNotificationReplyTextKey] = 'A reply';
+      await NotificationOpenService.debugSendNotificationReply(
+        IosNotificationTapEvent(payload: payload));
+
+      check(connection.takeRequests()).single.isA<http.Request>()
+        ..method.equals('POST')
+        ..url.path.equals('/api/v1/messages')
+        ..bodyFields['content'].equals('A reply')
+        ..bodyFields['type'].equals('stream')
+        ..bodyFields['topic'].equals(message.topic.apiName);
+    }, variant: const TargetPlatformVariant({TargetPlatform.iOS}));
 
    testWidgets('stream message: iOS legacy plaintext', (tester) async {
       addTearDown(testBinding.reset);


### PR DESCRIPTION
## What does this do?

Adds an iOS UNTextInputNotificationAction to message notifications so users can reply without opening Zulip. The reply reuses the notification URL to locate the account and conversation, then sends through the normal per-account message store.

Reply actions are buffered until Flutter is listening, so replies also work when the app is cold-started from the notification.

## Testing

- Added a notification open test covering the iOS reply and verifying the real API request destination/content.
- flutter test test/notifications/open_test.dart passes (43 tests).
- Verified the notification reply UI on the iOS 27 simulator: notification banner, reply field, and typed reply with the Send action enabled.
- git diff --check passes.

Closes #2411
Related to #1265

<details>
<summary>iOS notification reply UI</summary>

![Notification banner](https://github.com/user-attachments/assets/fafa9407-fb65-44c4-95cb-c8ff7f380695)

![Reply field](https://github.com/user-attachments/assets/629779e9-0c5f-43a0-9666-d2d938900ec1)

![Typed reply with Send enabled](https://github.com/user-attachments/assets/b1b76270-1576-4c98-a53b-5821f1d098bc)

</details>