### PR TITLE
msglist: Drop outbox message when its message arrives in a fetch

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -1223,9 +1223,7 @@ mixin _OutboxMessageStore on HasChannelStore {
       // We simultaneously reload the affected message lists from scratch, so
       // the user won't see a state where the message appears to have vanished.
       // (See _SendButtonState._send in lib/widgets/compose_box.dart.)
-      _outboxMessages.remove(localMessageId);
-      _outboxMessageDebounceTimers.remove(localMessageId)?.cancel();
-      _outboxMessageWaitPeriodTimers.remove(localMessageId)?.cancel();
+      _removeOutboxMessage(localMessageId);
       for (final view in _messageListViews) {
         view.notifyListenersIfOutboxMessagePresent(localMessageId);
       }
@@ -1282,11 +1280,20 @@ mixin _OutboxMessageStore on HasChannelStore {
     _updateOutboxMessage(localMessageId, newState: OutboxMessageState.waitPeriodExpired);
   }
 
-  OutboxMessage takeOutboxMessage(int localMessageId) {
-    assert(!_disposed);
+  /// Remove the outbox message with [localMessageId] from the store,
+  /// canceling its timers, and return it, or null if it isn't found.
+  ///
+  /// The caller is responsible for updating [MessageListView]s as appropriate.
+  OutboxMessage? _removeOutboxMessage(int localMessageId) {
     final removed = _outboxMessages.remove(localMessageId);
     _outboxMessageDebounceTimers.remove(localMessageId)?.cancel();
     _outboxMessageWaitPeriodTimers.remove(localMessageId)?.cancel();
+    return removed;
+  }
+
+  OutboxMessage takeOutboxMessage(int localMessageId) {
+    assert(!_disposed);
+    final removed = _removeOutboxMessage(localMessageId);
     if (removed == null) {
       throw StateError(
         'Removing unknown outbox message with localMessageId: $localMessageId');
@@ -1307,9 +1314,7 @@ mixin _OutboxMessageStore on HasChannelStore {
       final localMessageId = int.parse(event.localMessageId!, radix: 10);
       // The outbox message can be missing if the user removes it before the
       // event arrives.  Nothing to do in that case.
-      _outboxMessages.remove(localMessageId);
-      _outboxMessageDebounceTimers.remove(localMessageId)?.cancel();
-      _outboxMessageWaitPeriodTimers.remove(localMessageId)?.cancel();
+      _removeOutboxMessage(localMessageId);
     }
   }
 

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -1047,6 +1047,12 @@ sealed class OutboxMessage<T extends Conversation> extends MessageBase<T> {
   ///  * [MessageStoreImpl.sendMessage], where this ID is assigned.
   final int localMessageId;
 
+  /// The ID of the [Message] this request is anticipated to produce,
+  /// from the [sendMessage] response ([SendMessageResult.id]),
+  /// or null if a successful response hasn't arrived.
+  int? get messageId => _messageId;
+  int? _messageId;
+
   @override
   int? get id => null;
 
@@ -1191,8 +1197,9 @@ mixin _OutboxMessageStore on HasChannelStore {
       kSendMessageOfferRestoreWaitPeriod,
       () => _handleOutboxWaitPeriodExpired(localMessageId));
 
+    final SendMessageResult result;
     try {
-      await _apiSendMessage(connection,
+      result = await _apiSendMessage(connection,
         destination: destination,
         content: content,
         readBySender: true,
@@ -1212,10 +1219,12 @@ mixin _OutboxMessageStore on HasChannelStore {
       rethrow;
     }
     if (_disposed) return;
-    if (!_outboxMessages.containsKey(localMessageId)) {
+    final outboxMessage = _outboxMessages[localMessageId];
+    if (outboxMessage == null) {
       // The message event already arrived; nothing to do.
       return;
     }
+    outboxMessage._messageId = result.id;
 
     if (destination is StreamDestination && subscriptions[destination.streamId] == null) {
       // We don't expect an event (we're sending to an unsubscribed channel);
@@ -1234,8 +1243,7 @@ mixin _OutboxMessageStore on HasChannelStore {
     // Cancel the timer that would have had us start presuming that the
     // send might have failed.
     _outboxMessageWaitPeriodTimers.remove(localMessageId)?.cancel();
-    if (_outboxMessages[localMessageId]!.state
-          == OutboxMessageState.waitPeriodExpired) {
+    if (outboxMessage.state == OutboxMessageState.waitPeriodExpired) {
       // The user was offered to restore the message since the request did not
       // complete for a while.  Since the request was successful, we expect the
       // message event to arrive eventually.  Stop inviting the the user to

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -435,6 +435,8 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
         ifAbsent: () => _reconcileUnrecognizedMessage(message),
         (current) => _reconcileRecognizedMessage(current, message));
     }
+
+    _removeDeliveredOutboxMessages();
   }
 
   Message _reconcileUnrecognizedMessage(Message incoming) {
@@ -952,15 +954,19 @@ const kSendMessageOfferRestoreWaitPeriod = Duration(seconds: 10);  // TODO(#1441
 ///         timed out.   not finished when
 ///                      wait period timed out.
 ///
-///              Event received.  Or [sendMessage]
-///              request succeeds and we're sending to
-///              an unsubscribed channel.
+///              Event received.  Or message found in a
+///              fetch after [sendMessage] request succeeds.
+///              Or [sendMessage] request succeeds and
+///              we're sending to an unsubscribed channel.
 /// (any state) ───────────────────────────────────────► (delete)
 /// ```
 ///
 /// During its lifecycle, it is guaranteed that the outbox message is deleted
 /// as soon a message event with a matching [MessageEvent.localMessageId]
 /// arrives.
+/// Once the [sendMessage] request has succeeded, the outbox message is also
+/// deleted as soon as a message with a matching [OutboxMessage.messageId]
+/// is found in a fetch; see [MessageStoreImpl.reconcileMessages].
 /// If we're sending to an unsubscribed channel, we don't expect an event
 /// (see "third buggy behavior" in #1798) so in that case
 /// the outbox message is deleted when the [sendMessage] request succeeds.
@@ -1001,8 +1007,9 @@ enum OutboxMessageState {
 ///
 /// A request remains "outstanding" even after the [sendMessage] HTTP request
 /// completes, whether with success or failure.
-/// The outbox-message persists until either the corresponding [MessageEvent]
-/// arrives to replace it, or the user discards it (perhaps to try again).
+/// The outbox-message persists until either the corresponding message
+/// arrives to replace it (in a [MessageEvent] or, once the request has
+/// succeeded, in a fetch), or the user discards it (perhaps to try again).
 /// For details, see the state diagram at [OutboxMessageState],
 /// and [MessageStore.takeOutboxMessage].
 sealed class OutboxMessage<T extends Conversation> extends MessageBase<T> {
@@ -1116,6 +1123,9 @@ mixin _OutboxMessageStore on HasChannelStore {
   /// A fresh ID to use for [OutboxMessage.localMessageId],
   /// unique within this instance.
   int _nextLocalMessageId = 1;
+
+  /// As in [MessageStoreImpl.messages].
+  Map<int, Message> get messages;
 
   /// As in [MessageStoreImpl._messageListViews].
   Set<MessageListView> get _messageListViews;
@@ -1315,6 +1325,40 @@ mixin _OutboxMessageStore on HasChannelStore {
       view.removeOutboxMessage(removed);
     }
     return removed;
+  }
+
+  /// Remove any outbox messages whose anticipated [Message],
+  /// as identified by [OutboxMessage.messageId], is in [messages],
+  /// updating message-list views accordingly.
+  ///
+  /// This is how outbox messages get removed when their messages
+  /// are received through a fetch instead of a [MessageEvent];
+  /// see [MessageStoreImpl.reconcileMessages].
+  void _removeDeliveredOutboxMessages() {
+    assert(!_disposed);
+    // This runs on every fetch (see [MessageStoreImpl.reconcileMessages]);
+    // return cheaply in the common case of an empty outbox.
+    if (_outboxMessages.isEmpty) return;
+    final delivered = _outboxMessages.values
+      .where((outboxMessage) {
+        final messageId = outboxMessage._messageId;
+        return messageId != null && messages.containsKey(messageId);
+      })
+      .toList();
+    for (final outboxMessage in delivered) {
+      _removeDeliveredOutboxMessage(outboxMessage);
+    }
+  }
+
+  /// Remove [outboxMessage], whose anticipated [Message]
+  /// (see [OutboxMessage.messageId]) must be in [messages],
+  /// updating message-list views accordingly.
+  void _removeDeliveredOutboxMessage(OutboxMessage outboxMessage) {
+    assert(messages.containsKey(outboxMessage._messageId));
+    _removeOutboxMessage(outboxMessage.localMessageId);
+    for (final view in _messageListViews) {
+      view.handleOutboxMessageDelivered(outboxMessage);
+    }
   }
 
   void _handleMessageEventOutbox(MessageEvent event) {

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1100,6 +1100,16 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     }
   }
 
+  /// Remove the [outboxMessage] from the view, its anticipated message
+  /// (see [OutboxMessage.messageId]) having been received in a fetch.
+  ///
+  /// This is a no-op if the message is not found.
+  void handleOutboxMessageDelivered(OutboxMessage outboxMessage) {
+    if (_removeOutboxMessage(outboxMessage)) {
+      notifyListeners();
+    }
+  }
+
   void handleUserTopicEvent(UserTopicEvent event) {
     switch (_canAffectVisibility(event)) {
       case UserTopicVisibilityEffect.none:

--- a/test/model/message_checks.dart
+++ b/test/model/message_checks.dart
@@ -4,6 +4,7 @@ import 'package:zulip/model/message.dart';
 
 extension OutboxMessageChecks<T extends Conversation> on Subject<OutboxMessage<T>> {
   Subject<int> get localMessageId => has((x) => x.localMessageId, 'localMessageId');
+  Subject<int?> get messageId => has((x) => x.messageId, 'messageId');
   Subject<OutboxMessageState> get state => has((x) => x.state, 'state');
   Subject<bool> get hidden => has((x) => x.hidden, 'hidden');
 }

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -132,7 +132,8 @@ void main() {
     String topic = 'some topic',
   }) async {
     for (int i = 0; i < count; i++) {
-      connection.prepare(json: SendMessageResult(id: 123).toJson());
+      // Distinct IDs, as distinct sent messages would have.
+      connection.prepare(json: SendMessageResult(id: 123 + i).toJson());
       await store.sendMessage(
         destination: StreamDestination(stream.streamId, eg.t(topic)),
         content: 'content');
@@ -140,8 +141,9 @@ void main() {
   }
 
   Future<void> prepareOutboxMessagesTo(List<MessageDestination> destinations) async {
-    for (final destination in destinations) {
-      connection.prepare(json: SendMessageResult(id: 123).toJson());
+    for (final (i, destination) in destinations.indexed) {
+      // Distinct IDs, as distinct sent messages would have.
+      connection.prepare(json: SendMessageResult(id: 123 + i).toJson());
       await store.sendMessage(destination: destination, content: 'content');
     }
   }

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -195,14 +195,16 @@ void main() {
       bool isChannelSubscribed = true,
       int? zulipFeatureLevel,
     }) async {
-      message = eg.streamMessage(stream: stream);
       await prepare(
         narrow: narrow,
         stream: stream,
         isChannelSubscribed: isChannelSubscribed,
         zulipFeatureLevel: zulipFeatureLevel);
       await prepareMessages([eg.streamMessage(stream: stream)]);
-      connection.prepare(json: SendMessageResult(id: 1).toJson());
+      // Create this after the fixture message above,
+      // so its ID is newer, as a just-sent message's would be.
+      message = eg.streamMessage(stream: stream);
+      connection.prepare(json: SendMessageResult(id: message.id).toJson());
       await store.sendMessage(
         destination: destination ?? streamDestination, content: 'content');
     }
@@ -250,6 +252,11 @@ void main() {
       await receiveMessage(eg.streamMessage(stream: stream, topic: 'foo'));
       check(store.outboxMessages).isEmpty();
       checkNotifiedOnce();
+    }));
+
+    test('record message ID from send response', () => awaitFakeAsync((async) async {
+      await prepareOutboxMessage();
+      check(store.outboxMessages).values.single.messageId.equals(message.id);
     }));
 
     test('hidden -> waiting and never transition to waitPeriodExpired', () => awaitFakeAsync((async) async {

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -463,6 +463,29 @@ void main() {
         checkNotifiedOnce();
       }));
 
+      test('waiting -> (delete) because message found in fetch', () => awaitFakeAsync((async) async {
+        // Regression test for: https://github.com/zulip/zulip-flutter/issues/2397
+        await prepareOutboxMessage();
+        async.elapse(kLocalEchoDebounceDuration);
+        checkState().equals(OutboxMessageState.waiting);
+        checkNotifiedOnce();
+
+        store.reconcileMessages([message]);
+        check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
+      }));
+
+      test('no delete when unrelated message found in fetch', () => awaitFakeAsync((async) async {
+        await prepareOutboxMessage();
+        async.elapse(kLocalEchoDebounceDuration);
+        checkState().equals(OutboxMessageState.waiting);
+        checkNotifiedOnce();
+
+        store.reconcileMessages([eg.streamMessage(stream: stream)]);
+        checkState().equals(OutboxMessageState.waiting);
+        checkNotNotified();
+      }));
+
       test('waitPeriodExpired -> (delete) when event arrives before send request fails', () => awaitFakeAsync((async) async {
         // Set up an error to fail `sendMessage` with a delay, leaving time for
         // the message event to arrive.


### PR DESCRIPTION
This PR fixes the common case of #2397:

> - [ ] The common case is that the send-message request completes first, and the fetch arrives later, carrying the message. This is covered by the `reconcileMessage` proposal above.

I did the following for a manual test on my iPhone:

- Open the app under WiFi connectivity
- Prepare a message to send
- Turn off WiFi, falling back to cellular
- Send the message; see the outbox spinner on it
- Open a different message list where the message should appear, e.g. by tapping the topic header. (Do this within 90 seconds; see #2396.)
  - Before: the message appeared, but the outbox placeholder was still present, looking like a duplicate.
  - After: the message appears without the outbox duplicate.

Optionally, to see item 3 in https://github.com/zulip/zulip-flutter/issues/2397#issuecomment-5196519345:

> - [ ] If we act on the fetched `Message` by removing the outbox placeholder from all the narrows where it appears, including message lists below the top of the nav stack, then ideally we'd replace it synchronously with the delivered `Message` in all those same narrows. (E.g. a channel narrow and a topic narrow, where the fetch happened in the topic narrow but the outbox message was removed from both narrows.)

Tap "back" and see that the outbox placeholder is also gone from the first message list, but that the delivered message isn't present. We can fix that in a followup.