### PR TITLE
api: Recognize connection failures in more cases

### DIFF
--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -190,10 +190,19 @@ class ApiConnection {
       // while the response is still being downloaded, improving latency.
       final jsonStream = jsonUtf8Decoder.bind(response.stream);
       json = await jsonStream.single as Map<String, dynamic>?;
-    } on http.RequestAbortedException catch (e) {
-      // The timeout in [_withTimeout] fired while we were reading the response.
-      _throwNetworkException(routeName, e);
-    } catch (e) {
+    } on http.ClientException catch (e) {
+      // A network error, like the connection being interrupted
+      // partway through receiving the response body; or the timeout
+      // in [_withTimeout] firing while we were reading it, which
+      // arrives here as an [http.RequestAbortedException].
+      // On an HTTP error status, though, that status is the more useful
+      // signal: fall through, and throw from it below.
+      if (httpStatus == 200) _throwNetworkException(routeName, e);
+    } on IOException catch (e) {
+      // As above: a network error, arriving with its original type.
+      if (httpStatus == 200) _throwNetworkException(routeName, e);
+    } catch (_) {
+      // The response body arrived but wasn't valid UTF-8-encoded JSON.
       // We'll throw something below, seeing `json` is null.
     }
 
@@ -225,6 +234,8 @@ class ApiConnection {
   /// then the request is aborted, tearing down the connection,
   /// and this throws a [NetworkException]
   /// with kind [NetworkExceptionKind.connectionFailed].
+  /// (But if an error response's headers had already arrived,
+  /// the exception reflects that HTTP status instead.)
   Future<T> get<T>(String routeName, T Function(Map<String, dynamic>) fromJson,
       String path, Map<String, dynamic>? params, {Duration? timeout}) async {
     final url = realmUrl.replace(

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -301,6 +301,32 @@ class ApiConnection {
   }
 }
 
+/// OS-level socket error texts that can arrive as the whole message of a
+/// bare [http.ClientException], the exception type erased on the way
+/// (see #2417).
+///
+/// (The pipeline, as of Dart 3.14 / package:http 1.6.0, August 2026:
+/// dart:io wraps the OS error text in a [SocketException];
+/// `_HttpClientConnection`'s socket-error handler flattens that to
+/// `HttpException(message)`; and `IOClient` rethrows it as a
+/// `ClientException`.)
+///
+/// These are strerror(3) texts, so the set is inherently best-effort:
+/// this covers the common POSIX texts (shared by Android, iOS, and Linux,
+/// except as noted); texts from other platforms can be added as observed.
+// TODO(#461): moot once we use the platform-native HTTP clients,
+//   which classify these errors natively.
+const _erasedSocketErrorMessages = {
+  'Software caused connection abort', // ECONNABORTED
+  'Connection reset by peer', // ECONNRESET
+  'Connection timed out', // ETIMEDOUT
+  'Operation timed out', // ETIMEDOUT (Darwin)
+  'No route to host', // EHOSTUNREACH
+  'Network is unreachable', // ENETUNREACH
+  'Network is down', // ENETDOWN
+  'Broken pipe', // EPIPE
+};
+
 /// Throw a [NetworkException] wrapping the given exception
 /// from the underlying HTTP client.
 Never _throwNetworkException(String routeName, Object cause) {
@@ -316,6 +342,21 @@ Never _throwNetworkException(String routeName, Object cause) {
     SocketException() && http.ClientException(:final message) =>
       (.connectionFailed, message),
     SocketException() => (.connectionFailed, zulipLocalizations.errorNetworkRequestFailed),
+    // A connection that died mid-request, its type erased to a bare
+    // ClientException on the way to us, so that only the message
+    // identifies it.  See #2417 for how these arise and why we match
+    // on the message; take care not to match persistent failures,
+    // like redirect loops, which would falsely classify as routine.
+    // TODO(upstream): have IOClient preserve the type instead, as it
+    //   already does for SocketException.
+    http.ClientException(:final message)
+        // dart:io's orderly-close messages, from _HttpParser
+        // and _HttpClientConnection…
+        when message.startsWith('Connection closed')
+          // …and their one stray, from _HttpClientConnection.send:
+          || message == 'Socket closed before request was sent'
+          || _erasedSocketErrorMessages.contains(message) =>
+      (.connectionFailed, zulipLocalizations.errorNetworkRequestFailed),
     http.ClientException(:final message) => (.other, message),
     TlsException(:final message) => (.other, message),
     _ => (.other, zulipLocalizations.errorNetworkRequestFailed),

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -201,9 +201,15 @@ class ApiConnection {
     } on IOException catch (e) {
       // As above: a network error, arriving with its original type.
       if (httpStatus == 200) _throwNetworkException(routeName, e);
-    } catch (_) {
+    } on FormatException {
       // The response body arrived but wasn't valid UTF-8-encoded JSON.
       // We'll throw something below, seeing `json` is null.
+    } on TypeError {
+      // The body was valid JSON, but not a JSON object.  As above.
+    } catch (e) { // TODO(log)
+      // Unexpected.  In debug mode, fail loudly; in a release build,
+      // fall through and throw below, seeing `json` is null.
+      assert(false, 'unexpected error reading response body: $e');
     }
 
     if (httpStatus != 200 || json == null) {

--- a/lib/api/exception.dart
+++ b/lib/api/exception.dart
@@ -38,8 +38,8 @@ sealed class ApiRequestException implements Exception {
 /// because the cause's concrete type depends on
 /// which HTTP client implementation is in use.
 enum NetworkExceptionKind {
-  /// The connection couldn't be established, or was lost,
-  /// below the level of any HTTP response.
+  /// The connection couldn't be established,
+  /// or was lost before or while receiving the response.
   ///
   /// This includes a request timing out,
   /// which we treat as the connection having died
@@ -55,8 +55,10 @@ enum NetworkExceptionKind {
   other,
 }
 
-/// A network-level error that prevented even getting an HTTP response
-/// to some Zulip API network request.
+/// A network-level error that prevented getting a usable HTTP response
+/// to some Zulip API network request:
+/// either no response at all,
+/// or a success response cut off partway through the body.
 ///
 /// This is the antonym of [HttpException].
 class NetworkException extends ApiRequestException {
@@ -65,9 +67,11 @@ class NetworkException extends ApiRequestException {
 
   /// The exception describing the underlying error.
   ///
-  /// This can be any exception value that [http.Client.send] throws.
+  /// This can be any exception value that [http.Client.send] throws,
+  /// or one thrown while reading the response body.
   /// Ideally that would always be an [http.ClientException],
-  /// but empirically it can be [TlsException] and possibly others.
+  /// but empirically it can be [TlsException], [IOException],
+  /// and possibly others.
   ///
   /// The concrete type depends on which HTTP client implementation
   /// the app is using, so prefer [kind] for making decisions;

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -557,6 +557,14 @@ void main() {
     await checkMalformed(  json: {'x': 3},   fromJson: (json) => json['x'] as String);
   });
 
+  test('unexpected error while reading response body fails an assert', () async {
+    // (In a release build, this would instead fall through
+    // to be treated like a malformed response.)
+    await check(tryRequest(body: '{"result',
+        bodyException: StateError('surprise')))
+      .throws<AssertionError>();
+  });
+
   test('malformed API success responses: exception preserves details', () async {
     int distinctivelyNamedFromJson(Map<String, dynamic> json) {
       throw DistinctiveError("something is wrong");

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -365,6 +365,33 @@ void main() {
       ..asString.equals('NetworkException: Network request failed ((foo: bar))'));
   });
 
+  test('API network errors while receiving response body', () async {
+    // Regression test for: https://github.com/zulip/zulip-flutter/issues/2418
+    void checkRequest<T extends Object>(
+        T exception, Condition<NetworkException> condition) {
+      unawaited(check(
+        tryRequest(body: '{"result": "succ', bodyException: exception))
+        .throws<NetworkException>((it) => it
+          ..routeName.equals(kExampleRouteName)
+          ..cause.equals(exception)
+          ..which(condition)));
+    }
+
+    checkRequest(
+      http.ClientException('Connection closed before full body was received'),
+      (it) => it.kind.equals(.connectionFailed));
+    checkRequest(const SocketException('Connection reset by peer'),
+      (it) => it.kind.equals(.connectionFailed));
+    checkRequest(const TlsException('Oops'),
+      (it) => it.kind.equals(.other));
+
+    // On an HTTP error status, though, that status is the more useful
+    // signal; the network error doesn't obscure it.
+    unawaited(check(tryRequest(httpStatus: 500, body: '{"resu',
+        bodyException: const SocketException('Connection reset by peer')))
+      .throws<Server5xxException>());
+  });
+
   test('API request timeout', () => awaitFakeAsync((async) async {
     await FakeApiConnection.with_((connection) async {
       connection.prepare(delay: const Duration(seconds: 300), json: {});
@@ -386,6 +413,16 @@ void main() {
           ..routeName.equals(kExampleRouteName)
           ..kind.equals(.connectionFailed)
           ..cause.isA<http.RequestAbortedException>());
+    });
+  }));
+
+  test('HTTP status wins over a timeout while reading the response body', () => awaitFakeAsync((async) async {
+    await FakeApiConnection.with_((connection) async {
+      connection.prepare(httpStatus: 500, body: 'splat',
+        bodyDelay: const Duration(seconds: 300));
+      await check(connection.get(kExampleRouteName, (json) => json,
+          'example/route', {}, timeout: const Duration(seconds: 90)))
+        .throws<Server5xxException>();
     });
   }));
 
@@ -620,15 +657,18 @@ Future<T> tryRequest<T extends Object?>({
   int? httpStatus,
   Map<String, dynamic>? json,
   String? body,
+  Object? bodyException,
   T Function(Map<String, dynamic>)? fromJson,
 }) {
   assert((exception != null && json == null && body == null)
       || (exception == null && json != null && body == null)
       || (exception == null && json == null && body != null));
+  assert(exception == null || bodyException == null);
   fromJson ??= (((Map<String, dynamic> x) => x) as T Function(Map<String, dynamic>));
   return FakeApiConnection.with_((connection) {
     connection.prepare(
-      httpException: exception, httpStatus: httpStatus, json: json, body: body);
+      httpException: exception, httpStatus: httpStatus, json: json, body: body,
+      bodyException: bodyException);
     return connection.get(kExampleRouteName, fromJson!, 'example/route', {});
   });
 }

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -298,6 +298,63 @@ void main() {
       ..kind.equals(.other)
       ..message.equals('Oops')
       ..asString.equals('NetworkException: Oops (ClientException: Oops)'));
+    // What `IOClient` actually throws when the connection dies mid-request:
+    // dart:io's HttpException, rewrapped as a plain ClientException,
+    // recognizable only by its message.
+    checkRequest(
+      http.ClientException('Connection closed before full header was received'),
+      (it) => it
+        ..kind.equals(.connectionFailed)
+        ..message.equals(zulipLocalizations.errorNetworkRequestFailed));
+    checkRequest(
+      http.ClientException('Connection closed while receiving data'),
+      (it) => it
+        ..kind.equals(.connectionFailed)
+        ..message.equals(zulipLocalizations.errorNetworkRequestFailed));
+    // An asynchronous socket error while awaiting the response arrives
+    // with the OS error text as the whole message.  This one is routine
+    // on Android when the OS cuts network access in the background…
+    checkRequest(
+      http.ClientException('Software caused connection abort'),
+      (it) => it
+        ..kind.equals(.connectionFailed)
+        ..message.equals(zulipLocalizations.errorNetworkRequestFailed));
+    // …and the rest of the strerror family arrives the same way.
+    checkRequest(
+      http.ClientException('Connection reset by peer'),
+      (it) => it
+        ..kind.equals(.connectionFailed)
+        ..message.equals(zulipLocalizations.errorNetworkRequestFailed));
+    checkRequest(
+      http.ClientException('Operation timed out'),
+      (it) => it
+        ..kind.equals(.connectionFailed)
+        ..message.equals(zulipLocalizations.errorNetworkRequestFailed));
+    // A connection that died while the request was still being sent
+    // gets its own message, outside the "Connection closed" family.
+    checkRequest(
+      http.ClientException('Socket closed before request was sent'),
+      (it) => it
+        ..kind.equals(.connectionFailed)
+        ..message.equals(zulipLocalizations.errorNetworkRequestFailed));
+    // Redirect errors arrive through the same rethrow (RedirectException
+    // implements HttpException), but are persistent failures; they keep
+    // the reported kind.
+    checkRequest(http.ClientException('Redirect loop detected'), (it) => it
+      ..kind.equals(.other)
+      ..message.equals('Redirect loop detected'));
+    // So does a request started after [ApiConnection.close] tore down
+    // the client; there'd be no client left to retry it on.
+    // (A request still in flight at close time instead fails with
+    // 'Connection closed before full header was received', matched
+    // above as connectionFailed.  That's accurate -- the connection
+    // was lost -- and callers that retry on connectionFailed, like
+    // the poll loop, check for disposal before retrying.)
+    checkRequest(
+      http.ClientException('HTTP request failed. Client is already closed.'),
+      (it) => it
+        ..kind.equals(.other)
+        ..message.equals('HTTP request failed. Client is already closed.'));
     checkRequest(const TlsException('Oops'), (it) => it
       ..kind.equals(.other)
       ..message.equals('Oops')

--- a/test/api/fake_api.dart
+++ b/test/api/fake_api.dart
@@ -27,12 +27,14 @@ class _PreparedSuccess extends _PreparedResponse {
   final int httpStatus;
   final List<int> bytes;
   final Duration bodyDelay;
+  final Object? bodyException;
 
   _PreparedSuccess({
     super.delay,
     required this.httpStatus,
     required this.bytes,
     this.bodyDelay = Duration.zero,
+    this.bodyException,
   });
 }
 
@@ -66,11 +68,18 @@ class FakeHttpClient extends http.BaseClient {
   /// after being started.
   /// On success, the response body arrives a further `bodyDelay`
   /// after the response's headers.
+  ///
+  /// If `bodyException` is non-null, then `exception` must be null,
+  /// and the response's body stream will throw the given exception
+  /// after emitting the body's bytes,
+  /// like when a network connection fails partway through
+  /// receiving the response body.
   void prepare({
     Object? exception,
     int? httpStatus,
     Map<String, dynamic>? json,
     String? body,
+    Object? bodyException,
     Duration delay = Duration.zero,
     Duration bodyDelay = Duration.zero,
   }) {
@@ -78,7 +87,7 @@ class FakeHttpClient extends http.BaseClient {
     //   prepared responses when the test ends.
     if (exception != null) {
       assert(httpStatus == null && json == null && body == null
-        && bodyDelay == Duration.zero);
+        && bodyException == null && bodyDelay == Duration.zero);
       _preparedResponses.addLast(_PreparedException(exception: exception, delay: delay));
     } else {
       assert((json == null) || (body == null));
@@ -90,6 +99,7 @@ class FakeHttpClient extends http.BaseClient {
       _preparedResponses.addLast(_PreparedSuccess(
         httpStatus: httpStatus ?? 200,
         bytes: utf8.encode(resolvedBody),
+        bodyException: bodyException,
         delay: delay,
         bodyDelay: bodyDelay,
       ));
@@ -122,10 +132,11 @@ class FakeHttpClient extends http.BaseClient {
     switch (response) {
       case _PreparedException(:var exception):
         computation = () => throw exception;
-      case _PreparedSuccess(:var bytes, :var httpStatus, :var bodyDelay):
+      case _PreparedSuccess(:var bytes, :var httpStatus, :var bodyDelay,
+                            :var bodyException):
         computation = () => http.StreamedResponse(
           _bodyStream(request, bytes: bytes, bodyDelay: bodyDelay,
-            abortTrigger: abortTrigger),
+            bodyException: bodyException, abortTrigger: abortTrigger),
           httpStatus, request: request);
     }
     final result = Future.delayed(response.delay, computation);
@@ -141,18 +152,25 @@ class FakeHttpClient extends http.BaseClient {
   /// The response body, mimicking [IOClient]'s abort behavior:
   /// if [abortTrigger] fires before the body has been delivered,
   /// inject an [http.RequestAbortedException] and close the stream.
+  ///
+  /// If [bodyException] is non-null, it is delivered as an error
+  /// on the stream, after the body's bytes.
   http.ByteStream _bodyStream(http.BaseRequest request, {
     required List<int> bytes,
     required Duration bodyDelay,
+    required Object? bodyException,
     required Future<void>? abortTrigger,
   }) {
-    if (abortTrigger == null && bodyDelay == Duration.zero) {
+    if (abortTrigger == null && bodyDelay == Duration.zero
+        && bodyException == null) {
       return http.ByteStream.fromBytes(bytes);
     }
     final controller = StreamController<List<int>>();
     Timer(bodyDelay, () {
       if (controller.isClosed) return;
-      controller..add(bytes)..close();
+      controller.add(bytes);
+      if (bodyException != null) controller.addError(bodyException);
+      controller.close();
     });
     abortTrigger?.whenComplete(() {
       if (controller.isClosed) return;
@@ -287,12 +305,19 @@ class FakeApiConnection extends ApiConnection {
   /// after being started.
   /// On success, the response body arrives a further `bodyDelay`
   /// after the response's headers.
+  ///
+  /// If `bodyException` is non-null, then `httpException` and `apiException`
+  /// must be null, and the response's body stream will throw
+  /// the given exception after emitting the body's bytes,
+  /// like when a network connection fails partway through
+  /// receiving the response body.
   void prepare({
     Object? httpException,
     ZulipApiException? apiException,
     int? httpStatus,
     Map<String, dynamic>? json,
     String? body,
+    Object? bodyException,
     Duration delay = Duration.zero,
     Duration bodyDelay = Duration.zero,
   }) {
@@ -317,7 +342,7 @@ class FakeApiConnection extends ApiConnection {
     }
 
     if (apiException != null) {
-      assert(httpException == null
+      assert(httpException == null && bodyException == null
         && httpStatus == null && json == null && body == null);
       httpStatus = apiException.httpStatus;
       json = {
@@ -331,6 +356,7 @@ class FakeApiConnection extends ApiConnection {
     client.prepare(
       exception: httpException,
       httpStatus: httpStatus, json: json, body: body,
+      bodyException: bodyException,
       delay: delay, bodyDelay: bodyDelay,
     );
   }


### PR DESCRIPTION
Fixes #2417, #2418.

## Manual testing

### For the #2417 fix

In our `_throwNetworkException` classifier, log what `kind` is decided:

```diff
@@ -336,6 +338,8 @@ Never _throwNetworkException(String routeName, Object cause) {
     TlsException(:final message) => (.other, message),
     _ => (.other, zulipLocalizations.errorNetworkRequestFailed),
   };
+  assert(debugLog('network exception: $routeName:'
+    ' ${cause.runtimeType}: $cause -> $kind'));
   throw NetworkException(routeName: routeName,
     kind: kind, cause: cause, message: message);
 }
```

On Android, I started up the app and waited for event-polling to start. Then I cut the network:

```
adb shell svc wifi disable && adb shell svc data disable
```

The first event-polling error comes to the classifier as a `ClientException` with message "Software caused connection abort".

Logged on `main` (note `kind` is `.other`):

```
I/flutter (22771): network exception: getEvents: ClientException: ClientException: Software caused connection abort, uri=[…] -> NetworkExceptionKind.other
```

Logged on this PR (note `kind` is `.connectionFailed`):

```
I/flutter (22771): network exception: getEvents: ClientException: ClientException: Software caused connection abort, uri=[…] -> NetworkExceptionKind.connectionFailed
```

Then can restore the network with

```
adb shell svc wifi enable && adb shell svc data enable
```

### For the #2418 fix

Additionally, in `ApiConnection.send`, log when headers are received, and add an artificial delay to give yourself time to cut the network before the body finishes coming in:

```diff
diff --git lib/api/core.dart lib/api/core.dart
index f71b4ed3d..f82d6eb4e 100644
--- lib/api/core.dart
+++ lib/api/core.dart
@@ -184,6 +184,8 @@ class ApiConnection {
     }

     final int httpStatus = response.statusCode;
+    assert(debugLog('received headers for $routeName: $httpStatus'));
+    await Future<void>.delayed(const Duration(seconds: 10));
     Map<String, dynamic>? json;
     try {
       // The stream-oriented `bind` method allows decoding to happen in chunks
```

I started the app and waited for `received headers for registerQueue: 200` in the logs.

Immediately cut the network (see `adb` commands above).

The first error is a `ClientException` with message "Connection closed while receiving data".

On `main`, we wrongly treat this as a `MalformedServerResponseException`. I see this in the logs:

```
I/flutter (22771): Error fetching initial snapshot: Server gave malformed response; HTTP status 200
```

and we give an error-message snackbar which shows that message to the user (via "Details"):

| Snackbar | Details |
| --- | --- |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d5ec9ae6-bc00-4b6b-ba79-db161021a97d" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/195c2055-5f7e-419b-80ae-907e91f46bb2" /> |

On this PR, we retry quietly, with no error snackbar. Our classifier receives the `ClientException` and gives it `.connectionFailed`:

```
I/flutter (22771): network exception: registerQueue: ClientException: ClientException: Connection closed while receiving data, uri=https://chat.zulip.org/api/v1/register -> NetworkExceptionKind.connectionFailed
```