### PR TITLE
msglist: Update message list on muting/unmuting a channel

### DIFF
--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -101,10 +101,10 @@ mixin ChannelStore on UserStore {
 
   /// Whether the given event will change the result of [isTopicVisibleInChannel]
   /// for its channel and topic, compared to the current state.
-  UserTopicVisibilityEffect willAffectIfTopicVisibleInChannel(UserTopicEvent event) {
+  TopicVisibilityEffect willAffectIfTopicVisibleInChannel(UserTopicEvent event) {
     final channelId = event.streamId;
     final topic = event.topicName;
-    return UserTopicVisibilityEffect._fromBeforeAfter(
+    return TopicVisibilityEffect._fromBeforeAfter(
       _isTopicVisibleInChannel(topicVisibilityPolicy(channelId, topic)),
       _isTopicVisibleInChannel(event.visibilityPolicy));
   }
@@ -138,10 +138,10 @@ mixin ChannelStore on UserStore {
 
   /// Whether the given event will change the result of [isTopicVisible]
   /// for its channel and topic, compared to the current state.
-  UserTopicVisibilityEffect willAffectIfTopicVisible(UserTopicEvent event) {
+  TopicVisibilityEffect willAffectIfTopicVisible(UserTopicEvent event) {
     final channelId = event.streamId;
     final topic = event.topicName;
-    return UserTopicVisibilityEffect._fromBeforeAfter(
+    return TopicVisibilityEffect._fromBeforeAfter(
       _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic)),
       _isTopicVisible(channelId, event.visibilityPolicy));
   }
@@ -301,10 +301,10 @@ mixin ChannelStore on UserStore {
   }
 }
 
-/// Whether and how a given [UserTopicEvent] will affect the results
+/// Whether and how a given event will affect the results
 /// that [ChannelStore.isTopicVisible] or [ChannelStore.isTopicVisibleInChannel]
 /// would give for some messages.
-enum UserTopicVisibilityEffect {
+enum TopicVisibilityEffect {
   /// The event will have no effect on the visibility results.
   none,
 
@@ -314,11 +314,11 @@ enum UserTopicVisibilityEffect {
   /// The event will change some visibility results from false to true.
   unmuted;
 
-  factory UserTopicVisibilityEffect._fromBeforeAfter(bool before, bool after) {
+  factory TopicVisibilityEffect._fromBeforeAfter(bool before, bool after) {
     return switch ((before, after)) {
-      (false, true) => UserTopicVisibilityEffect.unmuted,
-      (true, false) => UserTopicVisibilityEffect.muted,
-      _             => UserTopicVisibilityEffect.none,
+      (false, true) => TopicVisibilityEffect.unmuted,
+      (true, false) => TopicVisibilityEffect.muted,
+      _             => TopicVisibilityEffect.none,
     };
   }
 }

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -136,10 +136,13 @@ mixin ChannelStore on UserStore {
     return _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic));
   }
 
-  /// Whether the given event will change the results of [isTopicVisible],
-  /// compared to the current state.
+  /// Whether the given event will change the results of [isTopicVisible]
+  /// for some possible topic, compared to the current state.
   ///
   /// This is [TopicVisibilityEffect.none] for most types of events.
+  ///
+  /// (A change to a channel's mutedness can affect [isTopicVisible]
+  /// but never [isTopicVisibleInChannel].)
   TopicVisibilityEffect willAffectIfTopicVisible(Event event) {
     switch (event) {
       case UserTopicEvent():
@@ -148,6 +151,20 @@ mixin ChannelStore on UserStore {
         return TopicVisibilityEffect._fromBeforeAfter(
           _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic)),
           _isTopicVisible(channelId, event.visibilityPolicy));
+
+      case SubscriptionUpdateEvent()
+          when event.property == SubscriptionProperty.isMuted:
+        final subscription = subscriptions[event.channelId];
+        if (subscription == null) return TopicVisibilityEffect.none; // TODO(log)
+        // A change in the channel's mutedness affects [isTopicVisible]
+        // for exactly the topics with visibility policy
+        // [UserTopicVisibilityPolicy.none].  Possible topics with that
+        // policy always exist, so the effect is never "none" here;
+        // callers consult the per-topic state when acting on
+        // specific messages.
+        return TopicVisibilityEffect._fromBeforeAfter(
+          !subscription.isMuted,
+          !(event.value as bool));
 
       default:
         return TopicVisibilityEffect.none;
@@ -633,7 +650,6 @@ class ChannelStoreImpl extends HasUserStore with ChannelStore {
           case SubscriptionProperty.color:
             subscription.color                  = event.value as int;
           case SubscriptionProperty.isMuted:
-            // TODO(#1255) update [MessageListView] if affected
             subscription.isMuted                = event.value as bool;
           case SubscriptionProperty.pinToTop:
             subscription.pinToTop               = event.value as bool;

--- a/lib/model/channel.dart
+++ b/lib/model/channel.dart
@@ -136,14 +136,22 @@ mixin ChannelStore on UserStore {
     return _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic));
   }
 
-  /// Whether the given event will change the result of [isTopicVisible]
-  /// for its channel and topic, compared to the current state.
-  TopicVisibilityEffect willAffectIfTopicVisible(UserTopicEvent event) {
-    final channelId = event.streamId;
-    final topic = event.topicName;
-    return TopicVisibilityEffect._fromBeforeAfter(
-      _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic)),
-      _isTopicVisible(channelId, event.visibilityPolicy));
+  /// Whether the given event will change the results of [isTopicVisible],
+  /// compared to the current state.
+  ///
+  /// This is [TopicVisibilityEffect.none] for most types of events.
+  TopicVisibilityEffect willAffectIfTopicVisible(Event event) {
+    switch (event) {
+      case UserTopicEvent():
+        final channelId = event.streamId;
+        final topic = event.topicName;
+        return TopicVisibilityEffect._fromBeforeAfter(
+          _isTopicVisible(channelId, topicVisibilityPolicy(channelId, topic)),
+          _isTopicVisible(channelId, event.visibilityPolicy));
+
+      default:
+        return TopicVisibilityEffect.none;
+    }
   }
 
   bool _isTopicVisible(int channelId, UserTopicVisibilityPolicy policy) {

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -615,6 +615,12 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
     _maybeStaleChannelMessages.addAll(affectedKnownMessageIds);
   }
 
+  void handleSubscriptionUpdateEvent(SubscriptionUpdateEvent event) {
+    for (final view in _messageListViews) {
+      view.handleSubscriptionUpdateEvent(event);
+    }
+  }
+
   void handleUserTopicEvent(UserTopicEvent event) {
     for (final view in _messageListViews) {
       view.handleUserTopicEvent(event);

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -732,6 +732,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   ///
   /// See also [_allMessagesVisible].
   // When updating this, check [_allMessagesVisible], [_willAffectVisibility],
+  // [_subscriptionUpdateEventWillAffectVisibility],
   // [_mutedUsersEventWillAffectVisibility], and [messagesMoved] to see whether
   // they need to be updated too.
   // Also check the unread-count methods in [Unreads] to make sure they count
@@ -826,6 +827,27 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         if (event.streamId != channelId) return TopicVisibilityEffect.none;
         return store.willAffectIfTopicVisibleInChannel(event);
 
+      case TopicNarrow():
+      case DmNarrow():
+      case MentionsNarrow():
+      case StarredMessagesNarrow():
+      case KeywordSearchNarrow():
+        return TopicVisibilityEffect.none;
+    }
+  }
+
+  /// Whether this event could affect the result that [_messageVisible]
+  /// would ever have returned for any possible message in this message list.
+  ///
+  /// The event must have [SubscriptionProperty.isMuted]
+  /// for its [SubscriptionUpdateEvent.property].
+  TopicVisibilityEffect _subscriptionUpdateEventWillAffectVisibility(SubscriptionUpdateEvent event) {
+    assert(event.property == SubscriptionProperty.isMuted);
+    switch (narrow) {
+      case CombinedFeedNarrow():
+        return store.willAffectIfTopicVisible(event);
+
+      case ChannelNarrow():
       case TopicNarrow():
       case DmNarrow():
       case MentionsNarrow():
@@ -1170,6 +1192,56 @@ class MessageListView with ChangeNotifier, _MessageSequence {
         }
 
       case TopicVisibilityEffect.unmuted:
+        // TODO get the newly-unmuted messages from the message store
+        // For now, we simplify the task by just refetching this message list
+        // from scratch.
+        if (fetched) {
+          _reset();
+          notifyListeners();
+          fetchInitial();
+        }
+    }
+  }
+
+  void handleSubscriptionUpdateEvent(SubscriptionUpdateEvent event) {
+    if (event.property != SubscriptionProperty.isMuted) return;
+    switch (_subscriptionUpdateEventWillAffectVisibility(event)) {
+      case .none:
+        return;
+
+      case .muted:
+        bool nowHidden(TopicName topic) {
+          switch (store.topicVisibilityPolicy(event.channelId, topic)) {
+            case .none: // Was visible in the unmuted channel; now hidden.
+              return true;
+            case .muted: // Was already hidden; shouldn't be in the list anyway.
+              return true;
+            case .unmuted:
+            case .followed:
+              // Stays visible despite the channel's mutedness.
+              return false;
+            case .unknown:
+              // [ChannelStoreImpl.handleUserTopicEvent] never stores this.
+              assert(false);
+              return false;
+          }
+        }
+
+        bool removed = _removeMessagesWhere((message) =>
+          message is StreamMessage
+            && message.streamId == event.channelId
+            && nowHidden(message.topic));
+
+        removed |= _removeOutboxMessagesWhere((message) =>
+          message is StreamOutboxMessage
+            && message.conversation.streamId == event.channelId
+            && nowHidden(message.conversation.topic));
+
+        if (removed) {
+          notifyListeners();
+        }
+
+      case .unmuted:
         // TODO get the newly-unmuted messages from the message store
         // For now, we simplify the task by just refetching this message list
         // from scratch.

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -817,13 +817,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   /// Whether this event could affect the result that [_messageVisible]
   /// would ever have returned for any possible message in this message list.
-  UserTopicVisibilityEffect _willAffectVisibility(UserTopicEvent event) {
+  TopicVisibilityEffect _willAffectVisibility(UserTopicEvent event) {
     switch (narrow) {
       case CombinedFeedNarrow():
         return store.willAffectIfTopicVisible(event);
 
       case ChannelNarrow(:final channelId):
-        if (event.streamId != channelId) return UserTopicVisibilityEffect.none;
+        if (event.streamId != channelId) return TopicVisibilityEffect.none;
         return store.willAffectIfTopicVisibleInChannel(event);
 
       case TopicNarrow():
@@ -831,7 +831,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       case MentionsNarrow():
       case StarredMessagesNarrow():
       case KeywordSearchNarrow():
-        return UserTopicVisibilityEffect.none;
+        return TopicVisibilityEffect.none;
     }
   }
 
@@ -1151,10 +1151,10 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   void handleUserTopicEvent(UserTopicEvent event) {
     switch (_willAffectVisibility(event)) {
-      case UserTopicVisibilityEffect.none:
+      case TopicVisibilityEffect.none:
         return;
 
-      case UserTopicVisibilityEffect.muted:
+      case TopicVisibilityEffect.muted:
         bool removed = _removeMessagesWhere((message) =>
           message is StreamMessage
             && message.streamId == event.streamId
@@ -1169,7 +1169,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
           notifyListeners();
         }
 
-      case UserTopicVisibilityEffect.unmuted:
+      case TopicVisibilityEffect.unmuted:
         // TODO get the newly-unmuted messages from the message store
         // For now, we simplify the task by just refetching this message list
         // from scratch.

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -988,6 +988,10 @@ class PerAccountStore extends PerAccountStoreBase with
         if (event is SubscriptionRemoveEvent) {
           _messages.handleSubscriptionRemoveEvent(event);
         }
+        if (event is SubscriptionUpdateEvent) {
+          _messages.handleSubscriptionUpdateEvent(event);
+        }
+        // Update _channels last, so other handlers can compare to the old value.
         _channels.handleSubscriptionEvent(event);
         notifyListeners();
 

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -357,8 +357,8 @@ void main() {
 
       void checkChanges(PerAccountStore store,
           UserTopicVisibilityPolicy newPolicy,
-          UserTopicVisibilityEffect expectedInChannel,
-          UserTopicVisibilityEffect expectedOverall) {
+          TopicVisibilityEffect expectedInChannel,
+          TopicVisibilityEffect expectedOverall) {
         final event = mkEvent(newPolicy);
         check(store.willAffectIfTopicVisibleInChannel(event)).equals(expectedInChannel);
         check(store.willAffectIfTopicVisible         (event)).equals(expectedOverall);
@@ -373,7 +373,7 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
         checkChanges(store, UserTopicVisibilityPolicy.followed,
-          UserTopicVisibilityEffect.none, UserTopicVisibilityEffect.none);
+          TopicVisibilityEffect.none, TopicVisibilityEffect.none);
       });
 
       test('channel not muted, policy none -> muted, means muted', () async {
@@ -381,7 +381,7 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1));
         checkChanges(store, UserTopicVisibilityPolicy.muted,
-          UserTopicVisibilityEffect.muted, UserTopicVisibilityEffect.muted);
+          TopicVisibilityEffect.muted, TopicVisibilityEffect.muted);
       });
 
       test('channel muted, policy none -> followed, means none/unmuted', () async {
@@ -389,7 +389,7 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
         checkChanges(store, UserTopicVisibilityPolicy.followed,
-          UserTopicVisibilityEffect.none, UserTopicVisibilityEffect.unmuted);
+          TopicVisibilityEffect.none, TopicVisibilityEffect.unmuted);
       });
 
       test('channel muted, policy none -> muted, means muted/none', () async {
@@ -397,7 +397,7 @@ void main() {
         await store.addStream(stream1);
         await store.addSubscription(eg.subscription(stream1, isMuted: true));
         checkChanges(store, UserTopicVisibilityPolicy.muted,
-          UserTopicVisibilityEffect.muted, UserTopicVisibilityEffect.none);
+          TopicVisibilityEffect.muted, TopicVisibilityEffect.none);
       });
 
       final policies = [
@@ -432,10 +432,10 @@ void main() {
               final newVisibleInChannel = store.isTopicVisibleInChannel(stream1.streamId, eg.t('topic'));
               final newVisible          = store.isTopicVisible(stream1.streamId, eg.t('topic'));
 
-              UserTopicVisibilityEffect fromOldNew(bool oldVisible, bool newVisible) {
-                if (newVisible == oldVisible) return UserTopicVisibilityEffect.none;
-                if (newVisible) return UserTopicVisibilityEffect.unmuted;
-                return UserTopicVisibilityEffect.muted;
+              TopicVisibilityEffect fromOldNew(bool oldVisible, bool newVisible) {
+                if (newVisible == oldVisible) return TopicVisibilityEffect.none;
+                if (newVisible) return TopicVisibilityEffect.unmuted;
+                return TopicVisibilityEffect.muted;
               }
               check(willAffectInChannel)
                 .equals(fromOldNew(oldVisibleInChannel, newVisibleInChannel));

--- a/test/model/channel_test.dart
+++ b/test/model/channel_test.dart
@@ -447,6 +447,53 @@ void main() {
       }
     });
 
+    group('willAffectIfTopicVisible on SubscriptionUpdateEvent', () {
+      SubscriptionUpdateEvent mkEvent(bool isMuted) =>
+        SubscriptionUpdateEvent(id: 1,
+          channelId: stream1.streamId,
+          property: SubscriptionProperty.isMuted,
+          value: isMuted);
+
+      void doTest({
+        required bool oldIsMuted,
+        required bool newIsMuted,
+        required TopicVisibilityEffect expected,
+      }) {
+        test('channel ${oldIsMuted ? 'muted' : 'not muted'}'
+             ' -> ${newIsMuted ? 'muted' : 'not muted'},'
+             ' means ${expected.name}', () async {
+          final store = eg.store();
+          await store.addStream(stream1);
+          await store.addSubscription(
+            eg.subscription(stream1, isMuted: oldIsMuted));
+          check(store.willAffectIfTopicVisible(mkEvent(newIsMuted)))
+            .equals(expected);
+        });
+      }
+
+      doTest(oldIsMuted: false, newIsMuted: false, expected: .none);
+      doTest(oldIsMuted: false, newIsMuted: true,  expected: .muted);
+      doTest(oldIsMuted: true,  newIsMuted: false, expected: .unmuted);
+      doTest(oldIsMuted: true,  newIsMuted: true,  expected: .none);
+
+      test('channel unsubscribed, means none', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        check(store.willAffectIfTopicVisible(mkEvent(true)))
+          .equals(TopicVisibilityEffect.none);
+      });
+
+      test('other subscription property, means none', () async {
+        final store = eg.store();
+        await store.addStream(stream1);
+        await store.addSubscription(eg.subscription(stream1));
+        check(store.willAffectIfTopicVisible(SubscriptionUpdateEvent(id: 1,
+          channelId: stream1.streamId,
+          property: SubscriptionProperty.pinToTop,
+          value: true))).equals(TopicVisibilityEffect.none);
+      });
+    });
+
     void compareTopicVisibility(PerAccountStore store, List<UserTopicItem> expected) {
       final expectedStore = eg.store(initialSnapshot: eg.initialSnapshot(
         userTopics: expected,

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1525,6 +1525,150 @@ void main() {
     });
   });
 
+  group('SubscriptionUpdateEvent', () {
+    // The ChannelStore.willAffectIfTopicVisible method has its own
+    // thorough unit tests.  So these tests focus on the rest of the logic.
+
+    final stream = eg.stream();
+
+    Future<void> setChannelMuted(bool isMuted) async {
+      await store.updateSubscription(
+        stream.streamId, SubscriptionProperty.isMuted, isMuted);
+    }
+
+    test('mute a channel', () => awaitFakeAsync((async) async {
+      await prepare(narrow: const CombinedFeedNarrow());
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream));
+      await store.setUserTopic(stream, 'unmuted', UserTopicVisibilityPolicy.unmuted);
+      final otherStream = eg.stream();
+      await store.addStream(otherStream);
+      await store.addSubscription(eg.subscription(otherStream));
+      await prepareMessages(foundOldest: true, messages: [
+        eg.streamMessage(id: 1, stream: stream, topic: 'foo'),
+        eg.streamMessage(id: 2, stream: stream, topic: 'unmuted'),
+        eg.streamMessage(id: 3, stream: otherStream, topic: 'foo'),
+        eg.dmMessage(    id: 4, from: eg.otherUser, to: [eg.selfUser]),
+      ]);
+      checkHasMessageIds([1, 2, 3, 4]);
+
+      await prepareOutboxMessagesTo([
+        StreamDestination(stream.streamId, eg.t('foo')),
+        StreamDestination(stream.streamId, eg.t('unmuted')),
+        StreamDestination(otherStream.streamId, eg.t('foo')),
+      ]);
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotified(count: 3);
+
+      await setChannelMuted(true);
+      checkNotifiedOnce();
+      checkHasMessageIds([2, 3, 4]);
+      check(model).outboxMessages.deepEquals(<Condition<Object?>>[
+        (it) => it.isA<StreamOutboxMessage>().conversation
+                  ..streamId.equals(stream.streamId)
+                  ..topic.equals(eg.t('unmuted')),
+        (it) => it.isA<StreamOutboxMessage>().conversation
+                  .streamId.equals(otherStream.streamId),
+      ]);
+    }));
+
+    test('mute a channel, no affected messages -> no notification', () async {
+      await prepare(narrow: const CombinedFeedNarrow());
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream));
+      await store.setUserTopic(stream, 'unmuted', UserTopicVisibilityPolicy.unmuted);
+      await prepareMessages(foundOldest: true, messages: [
+        eg.streamMessage(id: 1, stream: stream, topic: 'unmuted'),
+      ]);
+      checkHasMessageIds([1]);
+
+      await setChannelMuted(true);
+      checkNotNotified();
+      checkHasMessageIds([1]);
+    });
+
+    test('unmute a channel -> refetch from scratch', () => awaitFakeAsync((async) async {
+      await prepare(narrow: const CombinedFeedNarrow());
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream, isMuted: true));
+      final messages = <Message>[
+        eg.dmMessage(id: 1, from: eg.otherUser, to: [eg.selfUser]),
+        eg.streamMessage(id: 2, stream: stream, topic: 'foo'),
+      ];
+      await prepareMessages(foundOldest: true, messages: messages);
+      checkHasMessageIds([1]);
+
+      connection.prepare(
+        json: newestResult(foundOldest: true, messages: messages).toJson());
+      await setChannelMuted(false);
+      checkNotifiedOnce();
+      check(model).fetched.isFalse();
+      checkHasMessageIds([]);
+
+      async.elapse(Duration.zero);
+      checkNotifiedOnce();
+      checkHasMessageIds([1, 2]);
+    }));
+
+    test('unmute a channel before initial fetch completes -> do nothing', () async {
+      await prepare(narrow: const CombinedFeedNarrow());
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream, isMuted: true));
+      final messages = [
+        eg.streamMessage(id: 1, stream: stream, topic: 'foo'),
+      ];
+
+      connection.prepare(
+        json: newestResult(foundOldest: true, messages: messages).toJson());
+      final fetchFuture = model.fetchInitial();
+
+      await setChannelMuted(false);
+      checkNotNotified();
+
+      // The new mutedness does get applied when the fetch eventually completes.
+      await fetchFuture;
+      checkNotifiedOnce();
+      checkHasMessageIds([1]);
+    });
+
+    test('in ChannelNarrow, do nothing', () async {
+      await prepare(narrow: ChannelNarrow(stream.streamId));
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream));
+      await prepareMessages(foundOldest: true, messages: [
+        eg.streamMessage(id: 1, stream: stream, topic: 'foo'),
+      ]);
+      checkHasMessageIds([1]);
+
+      // Muting the channel doesn't remove the message
+      // (whereas it would in the combined feed).
+      await setChannelMuted(true);
+      checkNotNotified();
+      checkHasMessageIds([1]);
+
+      // Unmuting the channel doesn't cause a refetch
+      // (whereas it would in the combined feed).
+      await setChannelMuted(false);
+      checkNotNotified();
+      checkHasMessageIds([1]);
+    });
+
+    test('other subscription property -> do nothing', () async {
+      await prepare(narrow: const CombinedFeedNarrow());
+      await store.addStream(stream);
+      await store.addSubscription(eg.subscription(stream));
+      await prepareMessages(foundOldest: true, messages: [
+        eg.streamMessage(id: 1, stream: stream, topic: 'foo'),
+      ]);
+      checkHasMessageIds([1]);
+
+      await store.updateSubscription(
+        stream.streamId, SubscriptionProperty.pinToTop, true);
+      checkNotNotified();
+      checkHasMessageIds([1]);
+    });
+  });
+
   group('MutedUsersEvent', () {
     final user1 = eg.user(userId: 1);
     final user2 = eg.user(userId: 2);


### PR DESCRIPTION
Fixes #1255.
    
When a channel is muted, remove its newly-hidden messages from any combined-feed message list; when unmuted, refetch from scratch, the same way we handle a topic getting unmuted.

-----

(Prompted by wanting to demo some Zulip development in person at the Recurse Center—I'll likely follow this soon with a PR to add a mute/unmute-channel button in the channel action sheet, #347.)