### PR TITLE
actions: Add ZulipAction.updateSubscriptionSettings

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -167,6 +167,18 @@
   "@actionSheetOptionUnpinChannel": {
     "description": "Label in the channel action sheet for unpinning the channel."
   },
+  "errorSetChannelColorFailedTitle": "Failed to set channel color",
+  "@errorSetChannelColorFailedTitle": {
+    "description": "Error title when setting the channel color fails."
+  },
+  "errorMuteChannelFailedTitle": "Failed to mute channel",
+  "@errorMuteChannelFailedTitle": {
+    "description": "Error title when muting a channel fails."
+  },
+  "errorUnmuteChannelFailedTitle": "Failed to unmute channel",
+  "@errorUnmuteChannelFailedTitle": {
+    "description": "Error title when unmuting a channel fails."
+  },
   "errorPinChannelFailedTitle": "Failed to pin channel",
   "@errorPinChannelFailedTitle": {
     "description": "Error title when pinning a channel to the top fails."
@@ -174,6 +186,46 @@
   "errorUnpinChannelFailedTitle": "Failed to unpin channel",
   "@errorUnpinChannelFailedTitle": {
     "description": "Error title when unpinning a channel from the top fails."
+  },
+  "errorEnableDesktopNotificationsFailedTitle": "Failed to enable desktop notifications",
+  "@errorEnableDesktopNotificationsFailedTitle": {
+    "description": "Error title when enabling desktop notifications for a channel fails."
+  },
+  "errorDisableDesktopNotificationsFailedTitle": "Failed to disable desktop notifications",
+  "@errorDisableDesktopNotificationsFailedTitle": {
+    "description": "Error title when disabling desktop notifications for a channel fails."
+  },
+  "errorEnableAudibleNotificationsFailedTitle": "Failed to enable audible notifications",
+  "@errorEnableAudibleNotificationsFailedTitle": {
+    "description": "Error title when enabling audible notifications for a channel fails."
+  },
+  "errorDisableAudibleNotificationsFailedTitle": "Failed to disable audible notifications",
+  "@errorDisableAudibleNotificationsFailedTitle": {
+    "description": "Error title when disabling audible notifications for a channel fails."
+  },
+  "errorEnableMobileNotificationsFailedTitle": "Failed to enable mobile notifications",
+  "@errorEnableMobileNotificationsFailedTitle": {
+    "description": "Error title when enabling mobile notifications for a channel fails."
+  },
+  "errorDisableMobileNotificationsFailedTitle": "Failed to disable mobile notifications",
+  "@errorDisableMobileNotificationsFailedTitle": {
+    "description": "Error title when disabling mobile notifications for a channel fails."
+  },
+  "errorEnableEmailNotificationsFailedTitle": "Failed to enable email notifications",
+  "@errorEnableEmailNotificationsFailedTitle": {
+    "description": "Error title when enabling email notifications for a channel fails."
+  },
+  "errorDisableEmailNotificationsFailedTitle": "Failed to disable email notifications",
+  "@errorDisableEmailNotificationsFailedTitle": {
+    "description": "Error title when disabling email notifications for a channel fails."
+  },
+  "errorSetChannelWildcardMentionsNotifyFailedTitle": "Failed to set channel wildcard-mention setting",
+  "@errorSetChannelWildcardMentionsNotifyFailedTitle": {
+    "description": "Error title when setting a channel's wildcard-mention notification setting fails."
+  },
+  "errorSetChannelSettingFailedTitle": "Failed to set channel setting",
+  "@errorSetChannelSettingFailedTitle": {
+    "description": "Error title when setting a channel subscription setting fails."
   },
   "actionSheetOptionMuteTopic": "Mute topic",
   "@actionSheetOptionMuteTopic":  {

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -400,6 +400,24 @@ abstract class ZulipLocalizations {
   /// **'Unpin from top'**
   String get actionSheetOptionUnpinChannel;
 
+  /// Error title when setting the channel color fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to set channel color'**
+  String get errorSetChannelColorFailedTitle;
+
+  /// Error title when muting a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to mute channel'**
+  String get errorMuteChannelFailedTitle;
+
+  /// Error title when unmuting a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to unmute channel'**
+  String get errorUnmuteChannelFailedTitle;
+
   /// Error title when pinning a channel to the top fails.
   ///
   /// In en, this message translates to:
@@ -411,6 +429,66 @@ abstract class ZulipLocalizations {
   /// In en, this message translates to:
   /// **'Failed to unpin channel'**
   String get errorUnpinChannelFailedTitle;
+
+  /// Error title when enabling desktop notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to enable desktop notifications'**
+  String get errorEnableDesktopNotificationsFailedTitle;
+
+  /// Error title when disabling desktop notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to disable desktop notifications'**
+  String get errorDisableDesktopNotificationsFailedTitle;
+
+  /// Error title when enabling audible notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to enable audible notifications'**
+  String get errorEnableAudibleNotificationsFailedTitle;
+
+  /// Error title when disabling audible notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to disable audible notifications'**
+  String get errorDisableAudibleNotificationsFailedTitle;
+
+  /// Error title when enabling mobile notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to enable mobile notifications'**
+  String get errorEnableMobileNotificationsFailedTitle;
+
+  /// Error title when disabling mobile notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to disable mobile notifications'**
+  String get errorDisableMobileNotificationsFailedTitle;
+
+  /// Error title when enabling email notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to enable email notifications'**
+  String get errorEnableEmailNotificationsFailedTitle;
+
+  /// Error title when disabling email notifications for a channel fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to disable email notifications'**
+  String get errorDisableEmailNotificationsFailedTitle;
+
+  /// Error title when setting a channel's wildcard-mention notification setting fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to set channel wildcard-mention setting'**
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle;
+
+  /// Error title when setting a channel subscription setting fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to set channel setting'**
+  String get errorSetChannelSettingFailedTitle;
 
   /// Label for muting a topic on action sheet.
   ///

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -147,11 +147,60 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Von oben lösen';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle =>
       'Kanal konnte nicht angeheftet werden';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Kanal konnte nicht gelöst werden';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Thema stummschalten';

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -148,10 +148,59 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Desfijar canal';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Error al fijar el canal';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Error al desfijar el canal';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Silenciar tema';

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -149,11 +149,60 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
       'Eemalda ülalt äärest esiletõstmine';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Kanali esiletõstmine ei õnnestunud';
 
   @override
   String get errorUnpinChannelFailedTitle =>
       'Kanali esiletõstmise lõpetamine ei õnnestunud';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Summuta teema';

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -147,10 +147,59 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Désépingler du haut';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Échec de l\'épinglage du canal';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Échec du désépinglage du canal';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mettre la conversation en sourdine';

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'השתקת נושא';

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -147,12 +147,61 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Rimuovi da fissati';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle =>
       'Non è stato possibile fissare il canale';
 
   @override
   String get errorUnpinChannelFailedTitle =>
       'Non è stato possibile rimuovere il canale dai fissati';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Silenzia argomento';

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -144,10 +144,59 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => '上部に固定を解除';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'チャンネルの固定に失敗しました';
 
   @override
   String get errorUnpinChannelFailedTitle => 'チャンネルの固定解除に失敗しました';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'トピックをミュート';

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_nn.dart
+++ b/lib/generated/l10n/zulip_localizations_nn.dart
@@ -144,10 +144,59 @@ class ZulipLocalizationsNn extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Løsne frå toppen';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Kunne ikkje festa kanalen';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Kunne ikkje løsna kanalen';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Demp emnet';

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -147,10 +147,59 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Odepnij z góry';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Nie udało się przypiąć kanału';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Nie udało się odpiąć kanału';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Wycisz wątek';

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -147,10 +147,59 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Открепить';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Не удалось закрепить канал';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Не удалось открепить канал';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Заглушить тему';

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Stlmiť tému';

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Utišaj temo';

--- a/lib/generated/l10n/zulip_localizations_so.dart
+++ b/lib/generated/l10n/zulip_localizations_so.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsSo extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -148,10 +148,59 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Заглушити тему';

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -145,10 +145,59 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get actionSheetOptionUnpinChannel => 'Unpin from top';
 
   @override
+  String get errorSetChannelColorFailedTitle => 'Failed to set channel color';
+
+  @override
+  String get errorMuteChannelFailedTitle => 'Failed to mute channel';
+
+  @override
+  String get errorUnmuteChannelFailedTitle => 'Failed to unmute channel';
+
+  @override
   String get errorPinChannelFailedTitle => 'Failed to pin channel';
 
   @override
   String get errorUnpinChannelFailedTitle => 'Failed to unpin channel';
+
+  @override
+  String get errorEnableDesktopNotificationsFailedTitle =>
+      'Failed to enable desktop notifications';
+
+  @override
+  String get errorDisableDesktopNotificationsFailedTitle =>
+      'Failed to disable desktop notifications';
+
+  @override
+  String get errorEnableAudibleNotificationsFailedTitle =>
+      'Failed to enable audible notifications';
+
+  @override
+  String get errorDisableAudibleNotificationsFailedTitle =>
+      'Failed to disable audible notifications';
+
+  @override
+  String get errorEnableMobileNotificationsFailedTitle =>
+      'Failed to enable mobile notifications';
+
+  @override
+  String get errorDisableMobileNotificationsFailedTitle =>
+      'Failed to disable mobile notifications';
+
+  @override
+  String get errorEnableEmailNotificationsFailedTitle =>
+      'Failed to enable email notifications';
+
+  @override
+  String get errorDisableEmailNotificationsFailedTitle =>
+      'Failed to disable email notifications';
+
+  @override
+  String get errorSetChannelWildcardMentionsNotifyFailedTitle =>
+      'Failed to set channel wildcard-mention setting';
+
+  @override
+  String get errorSetChannelSettingFailedTitle =>
+      'Failed to set channel setting';
 
   @override
   String get actionSheetOptionMuteTopic => 'Mute topic';

--- a/lib/widgets/action_sheet.dart
+++ b/lib/widgets/action_sheet.dart
@@ -704,31 +704,10 @@ class PinUnpinButton extends ActionSheetMenuItemButton {
 
   @override
   void onPressed() async {
-    try {
-      await updateSubscriptionSettings(
-        PerAccountStoreWidget.of(pageContext).connection,
-        streamId: channelId,
-        property: SubscriptionProperty.pinToTop,
-        value: !isPinned);
-    } catch (e) {
-      if (!pageContext.mounted) return;
-
-      String? errorMessage;
-      switch (e) {
-        case ZulipApiException():
-          errorMessage = e.message;
-          // TODO(#741) specific messages for common errors, like network errors
-          //   (support with reusable code)
-        default:
-      }
-
-      final zulipLocalizations = ZulipLocalizations.of(pageContext);
-      showErrorDialog(context: pageContext,
-        title: isPinned
-          ? zulipLocalizations.errorUnpinChannelFailedTitle
-          : zulipLocalizations.errorPinChannelFailedTitle,
-        message: errorMessage);
-    }
+    await ZulipAction.updateSubscriptionSettings(pageContext,
+      channelId: channelId,
+      property: .pinToTop,
+      value: !isPinned);
   }
 }
 

--- a/lib/widgets/actions.dart
+++ b/lib/widgets/actions.dart
@@ -441,6 +441,72 @@ abstract final class ZulipAction {
     }
   }
 
+  /// Update a property of the self-user's subscription to a channel,
+  /// showing an error dialog on failure.
+  ///
+  /// This is a wrapper around [channels_api.updateSubscriptionSettings].
+  static Future<void> updateSubscriptionSettings(BuildContext context, {
+    required int channelId,
+    required SubscriptionProperty property,
+    required Object value,
+  }) async {
+    try {
+      await channels_api.updateSubscriptionSettings(
+        PerAccountStoreWidget.of(context).connection,
+        streamId: channelId,
+        property: property,
+        value: value);
+    } catch (e) {
+      if (!context.mounted) return;
+
+      String? errorMessage;
+      switch (e) {
+        case ZulipApiException():
+          errorMessage = e.message;
+          // TODO(#741) specific messages for common errors, like network errors
+          //   (support with reusable code)
+        default:
+      }
+
+      final zulipLocalizations = ZulipLocalizations.of(context);
+      String Function(Object) chooseTitleForBool(String titleForTrue, String titleForFalse) {
+        return (value) {
+          if (value is! bool) {
+            assert(false); // TODO(log)
+            return zulipLocalizations.errorSetChannelSettingFailedTitle;
+          }
+          return value ? titleForTrue : titleForFalse;
+        };
+      }
+      final String Function(Object) chooseTitle = switch (property) {
+        .color => (_) => zulipLocalizations.errorSetChannelColorFailedTitle,
+        .isMuted => chooseTitleForBool(
+          zulipLocalizations.errorMuteChannelFailedTitle,
+          zulipLocalizations.errorUnmuteChannelFailedTitle),
+        .pinToTop => chooseTitleForBool(
+          zulipLocalizations.errorPinChannelFailedTitle,
+          zulipLocalizations.errorUnpinChannelFailedTitle),
+        .desktopNotifications => chooseTitleForBool(
+          zulipLocalizations.errorEnableDesktopNotificationsFailedTitle,
+          zulipLocalizations.errorDisableDesktopNotificationsFailedTitle),
+        .audibleNotifications => chooseTitleForBool(
+          zulipLocalizations.errorEnableAudibleNotificationsFailedTitle,
+          zulipLocalizations.errorDisableAudibleNotificationsFailedTitle),
+        .pushNotifications => chooseTitleForBool(
+          zulipLocalizations.errorEnableMobileNotificationsFailedTitle,
+          zulipLocalizations.errorDisableMobileNotificationsFailedTitle),
+        .emailNotifications => chooseTitleForBool(
+          zulipLocalizations.errorEnableEmailNotificationsFailedTitle,
+          zulipLocalizations.errorDisableEmailNotificationsFailedTitle),
+        .wildcardMentionsNotify => (_) => zulipLocalizations.errorSetChannelWildcardMentionsNotifyFailedTitle,
+        // Should be unreachable; callers shouldn't pass [SubscriptionProperty.unknown].
+        .unknown => (_) => zulipLocalizations.errorSetChannelSettingFailedTitle,
+      };
+      showErrorDialog(context: context,
+        title: chooseTitle(value), message: errorMessage);
+    }
+  }
+
   /// Report a message to the realm admins.
   ///
   /// On success, shows a success [SnackBar] and returns true.

--- a/test/widgets/actions_test.dart
+++ b/test/widgets/actions_test.dart
@@ -282,6 +282,106 @@ void main() {
           store.tryResolveUrl('/temp/s3kr1t-auth-token/paper.pdf')!);
       });
     });
+
+    group('updateSubscriptionSettings', () {
+      final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
+      final channel = eg.stream();
+
+      testWidgets('smoke', (tester) async {
+        await prepare(tester);
+        connection.prepare(json: {});
+        final future = ZulipAction.updateSubscriptionSettings(context,
+          channelId: channel.streamId,
+          property: .isMuted,
+          value: true);
+        await tester.pump(Duration.zero);
+        await future;
+        check(connection.lastRequest).isA<http.Request>()
+          ..method.equals('POST')
+          ..url.path.equals('/api/v1/users/me/subscriptions/properties')
+          ..bodyFields.deepEquals({
+            'subscription_data': jsonEncode([{
+              'stream_id': channel.streamId,
+              'property': 'is_muted',
+              'value': true,
+            }]),
+          });
+        checkNoDialog(tester);
+      });
+
+      group('error dialog title', () {
+        Future<void> doTest(WidgetTester tester, {
+          required SubscriptionProperty property,
+          required Object value,
+          required String expectedTitle,
+        }) async {
+          await prepare(tester);
+          connection.prepare(apiException: eg.apiBadRequest(message: 'oops'));
+          final future = ZulipAction.updateSubscriptionSettings(context,
+            channelId: channel.streamId, property: property, value: value);
+          await tester.pump(Duration.zero);
+          await future;
+          checkErrorDialog(tester,
+            expectedTitle: expectedTitle, expectedMessage: 'oops');
+        }
+
+        testWidgets('color', (tester) => doTest(tester,
+          property: .color, value: 0xffabcdef,
+          expectedTitle: zulipLocalizations.errorSetChannelColorFailedTitle));
+
+        testWidgets('isMuted true', (tester) => doTest(tester,
+          property: .isMuted, value: true,
+          expectedTitle: zulipLocalizations.errorMuteChannelFailedTitle));
+
+        testWidgets('isMuted false', (tester) => doTest(tester,
+          property: .isMuted, value: false,
+          expectedTitle: zulipLocalizations.errorUnmuteChannelFailedTitle));
+
+        testWidgets('pinToTop true', (tester) => doTest(tester,
+          property: .pinToTop, value: true,
+          expectedTitle: zulipLocalizations.errorPinChannelFailedTitle));
+
+        testWidgets('pinToTop false', (tester) => doTest(tester,
+          property: .pinToTop, value: false,
+          expectedTitle: zulipLocalizations.errorUnpinChannelFailedTitle));
+
+        testWidgets('desktopNotifications true', (tester) => doTest(tester,
+          property: .desktopNotifications, value: true,
+          expectedTitle: zulipLocalizations.errorEnableDesktopNotificationsFailedTitle));
+
+        testWidgets('desktopNotifications false', (tester) => doTest(tester,
+          property: .desktopNotifications, value: false,
+          expectedTitle: zulipLocalizations.errorDisableDesktopNotificationsFailedTitle));
+
+        testWidgets('audibleNotifications true', (tester) => doTest(tester,
+          property: .audibleNotifications, value: true,
+          expectedTitle: zulipLocalizations.errorEnableAudibleNotificationsFailedTitle));
+
+        testWidgets('audibleNotifications false', (tester) => doTest(tester,
+          property: .audibleNotifications, value: false,
+          expectedTitle: zulipLocalizations.errorDisableAudibleNotificationsFailedTitle));
+
+        testWidgets('pushNotifications true', (tester) => doTest(tester,
+          property: .pushNotifications, value: true,
+          expectedTitle: zulipLocalizations.errorEnableMobileNotificationsFailedTitle));
+
+        testWidgets('pushNotifications false', (tester) => doTest(tester,
+          property: .pushNotifications, value: false,
+          expectedTitle: zulipLocalizations.errorDisableMobileNotificationsFailedTitle));
+
+        testWidgets('emailNotifications true', (tester) => doTest(tester,
+          property: .emailNotifications, value: true,
+          expectedTitle: zulipLocalizations.errorEnableEmailNotificationsFailedTitle));
+
+        testWidgets('emailNotifications false', (tester) => doTest(tester,
+          property: .emailNotifications, value: false,
+          expectedTitle: zulipLocalizations.errorDisableEmailNotificationsFailedTitle));
+
+        testWidgets('wildcardMentionsNotify', (tester) => doTest(tester,
+          property: .wildcardMentionsNotify, value: true,
+          expectedTitle: zulipLocalizations.errorSetChannelWildcardMentionsNotifyFailedTitle));
+      });
+    });
   });
 
   group('PlatformActions', () {


### PR DESCRIPTION
This pulls the API call and error handling out of PinUnpinButton in the channel action sheet, generalizing the error-dialog title to cover all SubscriptionProperty values, so that future callers can update other subscription settings, like isMuted.

-----

(Prompted by wanting to demo some Zulip development in person at the Recurse Center—I'll likely follow this soon with a PR to add a mute/unmute-channel button in the channel action sheet, #347.)