### PR TITLE
msglist: Drop outbox message on send success if message already fetched

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -954,8 +954,9 @@ const kSendMessageOfferRestoreWaitPeriod = Duration(seconds: 10);  // TODO(#1441
 ///         timed out.   not finished when
 ///                      wait period timed out.
 ///
-///              Event received.  Or message found in a
-///              fetch after [sendMessage] request succeeds.
+///              Event received.
+///              Or message found in a fetch
+///              and [sendMessage] succeeded, in either order.
 ///              Or [sendMessage] request succeeds and
 ///              we're sending to an unsubscribed channel.
 /// (any state) ───────────────────────────────────────► (delete)
@@ -967,6 +968,9 @@ const kSendMessageOfferRestoreWaitPeriod = Duration(seconds: 10);  // TODO(#1441
 /// Once the [sendMessage] request has succeeded, the outbox message is also
 /// deleted as soon as a message with a matching [OutboxMessage.messageId]
 /// is found in a fetch; see [MessageStoreImpl.reconcileMessages].
+/// If the message was found in a fetch while the send request was in flight,
+/// the deletion happens when the send request succeeds,
+/// which is when [OutboxMessage.messageId] becomes known.
 /// If we're sending to an unsubscribed channel, we don't expect an event
 /// (see "third buggy behavior" in #1798) so in that case
 /// the outbox message is deleted when the [sendMessage] request succeeds.
@@ -1246,6 +1250,13 @@ mixin _OutboxMessageStore on HasChannelStore {
       for (final view in _messageListViews) {
         view.notifyListenersIfOutboxMessagePresent(localMessageId);
       }
+      return;
+    }
+
+    if (messages.containsKey(result.id)) {
+      // The message already appeared in a fetch, while the send request was
+      // in flight.  Now that we know its ID, drop the outbox message.
+      _removeDeliveredOutboxMessage(outboxMessage);
       return;
     }
 

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -219,6 +219,16 @@ void main() {
         destination: streamDestination, content: 'content');
     }
 
+    late Future<void> outboxMessageSucceedFuture;
+    Future<void> prepareOutboxMessageToSucceedAfterDelay(Duration delay) async {
+      await prepare(stream: stream);
+      await prepareMessages([eg.streamMessage(stream: stream)]);
+      connection.prepare(json: SendMessageResult(id: 1).toJson(),
+        delay: delay);
+      outboxMessageSucceedFuture = store.sendMessage(
+        destination: streamDestination, content: 'content');
+    }
+
     Future<void> receiveMessage([Message? messageReceived]) async {
       await store.handleEvent(eg.messageEvent(messageReceived ?? message,
         localMessageId: store.outboxMessages.keys.single));
@@ -294,22 +304,16 @@ void main() {
     }));
 
     test('waiting -> waitPeriodExpired -> waiting and never return to waitPeriodExpired', () => awaitFakeAsync((async) async {
-      await prepare(stream: stream);
-      await prepareMessages([eg.streamMessage(stream: stream)]);
       // Set up a [sendMessage] request that succeeds after enough delay,
       // for the outbox message to reach the waitPeriodExpired state.
-      // TODO extract helper to add prepare an outbox message with a delayed
-      //   successful [sendMessage] request if we have more tests like this
-      connection.prepare(json: SendMessageResult(id: 1).toJson(),
-        delay: kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
-      final future = store.sendMessage(
-        destination: streamDestination, content: 'content');
+      await prepareOutboxMessageToSucceedAfterDelay(
+        kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
       async.elapse(kSendMessageOfferRestoreWaitPeriod);
       checkState().equals(OutboxMessageState.waitPeriodExpired);
       checkNotified(count: 2);
 
       // Wait till the [sendMessage] request succeeds.
-      await future;
+      await outboxMessageSucceedFuture;
       checkState().equals(OutboxMessageState.waiting);
       checkNotifiedOnce();
 

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -223,7 +223,10 @@ void main() {
     Future<void> prepareOutboxMessageToSucceedAfterDelay(Duration delay) async {
       await prepare(stream: stream);
       await prepareMessages([eg.streamMessage(stream: stream)]);
-      connection.prepare(json: SendMessageResult(id: 1).toJson(),
+      // Create this after the fixture message above,
+      // so its ID is newer, as a just-sent message's would be.
+      message = eg.streamMessage(stream: stream);
+      connection.prepare(json: SendMessageResult(id: message.id).toJson(),
         delay: delay);
       outboxMessageSucceedFuture = store.sendMessage(
         destination: streamDestination, content: 'content');

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -470,6 +470,31 @@ void main() {
         checkNotifiedOnce();
       }));
 
+      test('hidden -> (delete) when message found in fetch before send request succeeds', () => awaitFakeAsync((async) async {
+        await prepareOutboxMessageToSucceedAfterDelay(
+          const Duration(milliseconds: 100));
+        checkState().equals(OutboxMessageState.hidden);
+        checkNotNotified();
+
+        // The message arrives in a fetch while the send request is in flight
+        // and the outbox message is still hidden.
+        store.reconcileMessages([message]);
+        checkState().equals(OutboxMessageState.hidden);
+        checkNotNotified();
+
+        // The send response arrives; the outbox message is deleted
+        // without ever being shown.
+        async.elapse(const Duration(milliseconds: 100));
+        await check(outboxMessageSucceedFuture).completes();
+        check(store.outboxMessages).isEmpty();
+        checkNotNotified();
+
+        // The debounce timer was canceled when the outbox message
+        // was deleted.
+        async.elapse(kLocalEchoDebounceDuration);
+        checkNotNotified();
+      }));
+
       test('waiting -> (delete) because message found in fetch', () => awaitFakeAsync((async) async {
         // Regression test for: https://github.com/zulip/zulip-flutter/issues/2397
         await prepareOutboxMessage();
@@ -478,6 +503,54 @@ void main() {
         checkNotifiedOnce();
 
         store.reconcileMessages([message]);
+        check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
+      }));
+
+      test('waiting -> (delete) when message found in fetch before send request succeeds', () => awaitFakeAsync((async) async {
+        await prepareOutboxMessageToSucceedAfterDelay(
+          kLocalEchoDebounceDuration + Duration(seconds: 1));
+        async.elapse(kLocalEchoDebounceDuration);
+        checkState().equals(OutboxMessageState.waiting);
+        checkNotifiedOnce();
+
+        // The message arrives in a fetch while the send request is in flight.
+        // It can't be recognized as this outbox message's message yet;
+        // that needs the ID from the send response.
+        store.reconcileMessages([message]);
+        checkState().equals(OutboxMessageState.waiting);
+        check(store.outboxMessages).values.single.messageId.isNull();
+        checkNotNotified();
+
+        // The send response arrives; the message in the store is recognized
+        // as this outbox message's, and the outbox message is deleted.
+        async.elapse(const Duration(seconds: 1));
+        await check(outboxMessageSucceedFuture).completes();
+        check(store.outboxMessages).isEmpty();
+        checkNotifiedOnce();
+
+        // The wait-period timer was canceled when the outbox message
+        // was deleted.
+        async.elapse(kSendMessageOfferRestoreWaitPeriod);
+        checkNotNotified();
+      }));
+
+      test('waitPeriodExpired -> (delete) when message found in fetch before send request succeeds', () => awaitFakeAsync((async) async {
+        await prepareOutboxMessageToSucceedAfterDelay(
+          kSendMessageOfferRestoreWaitPeriod + Duration(seconds: 1));
+        async.elapse(kSendMessageOfferRestoreWaitPeriod);
+        checkState().equals(OutboxMessageState.waitPeriodExpired);
+        checkNotified(count: 2);
+
+        // The message arrives in a fetch while the send request is in flight.
+        store.reconcileMessages([message]);
+        checkState().equals(OutboxMessageState.waitPeriodExpired);
+        checkNotNotified();
+
+        // The send response arrives; the outbox message is deleted,
+        // without flickering back to the waiting state first.
+        async.elapse(const Duration(seconds: 1));
+        await check(outboxMessageSucceedFuture).completes();
         check(store.outboxMessages).isEmpty();
         checkNotifiedOnce();
       }));


### PR DESCRIPTION
Partly fixes #2397.

Notable commit message:

    msglist: Drop outbox message on send success if message already fetched
    
    Partly fixes #2397.
    
    In PR #2413, we started dropping an outbox message when its event
    arrives in a fetch. This helps in the case where the event stream is
    stuck (see e.g. #1884 and #514 for ways this can happen).
    
    It should be much rarer in practice, but it's technically possible
    for a fetch to arrive with the message before we get the send
    request's success. This commit handles that ordering, as anticipated
    in my comment on #2397:
      https://github.com/zulip/zulip-flutter/issues/2397#issuecomment-5196519345
    
    In particular, if the send request is still in flight when the
    message arrives in a fetch, now we clear the outbox message when the
    send request succeeds, which is when we're able to know the message
    ID corresponding to the outbox message. (This means the
    duplicate-message symptom described in #2397 can actually still
    happen -- between the fetch arriving and the send-message-success --
    but that's unavoidable because we can't associate the outbox message
    with a real message ID until we get the send-success response.)
    
    Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>