### PR TITLE
avatar: Compute Gravatar URLs when client_gravatar is enabled (#255)

### DIFF
--- a/lib/api/model/events.dart
+++ b/lib/api/model/events.dart
@@ -618,6 +618,7 @@ class RealmUserUpdateCustomProfileField {
 
 /// A [RealmUserEvent] with op `update`: https://zulip.com/api/get-events#realm_user-update
 @JsonSerializable(fieldRename: FieldRename.snake)
+@NullableStringJsonConverter()
 class RealmUserUpdateEvent extends RealmUserEvent {
   @override
   @JsonKey(includeToJson: true)
@@ -626,7 +627,9 @@ class RealmUserUpdateEvent extends RealmUserEvent {
   @JsonKey(readValue: _readFromPerson) final int userId;
 
   @JsonKey(readValue: _readFromPerson) final String? fullName;
-  @JsonKey(readValue: _readFromPerson) final String? avatarUrl;
+  @JsonKey(readValue: _readNullableStringFromPerson)
+  @NullableStringJsonConverter()
+  final JsonNullable<String>? avatarUrl;
   // @JsonKey(readValue: _readFromPerson) final String? avatarSource; // TODO obsolete?
   // @JsonKey(readValue: _readFromPerson) final String? avatarUrlMedium; // TODO obsolete?
   @JsonKey(readValue: _readFromPerson) final int? avatarVersion;

--- a/lib/api/model/events.g.dart
+++ b/lib/api/model/events.g.dart
@@ -412,7 +412,10 @@ RealmUserUpdateEvent _$RealmUserUpdateEventFromJson(
       .toInt(),
   fullName: RealmUserUpdateEvent._readFromPerson(json, 'full_name') as String?,
   avatarUrl:
-      RealmUserUpdateEvent._readFromPerson(json, 'avatar_url') as String?,
+      _$JsonConverterFromJson<JsonNullable<String>, JsonNullable<String>>(
+        RealmUserUpdateEvent._readNullableStringFromPerson(json, 'avatar_url'),
+        const NullableStringJsonConverter().fromJson,
+      ),
   avatarVersion:
       (RealmUserUpdateEvent._readFromPerson(json, 'avatar_version') as num?)
           ?.toInt(),
@@ -452,7 +455,11 @@ Map<String, dynamic> _$RealmUserUpdateEventToJson(
   'op': instance.op,
   'user_id': instance.userId,
   'full_name': instance.fullName,
-  'avatar_url': instance.avatarUrl,
+  'avatar_url':
+      _$JsonConverterToJson<JsonNullable<String>, JsonNullable<String>>(
+        instance.avatarUrl,
+        const NullableStringJsonConverter().toJson,
+      ),
   'avatar_version': instance.avatarVersion,
   'timezone': instance.timezone,
   'bot_owner_id': instance.botOwnerId,

--- a/lib/api/model/model.dart
+++ b/lib/api/model/model.dart
@@ -10,6 +10,8 @@ import 'submessage.dart';
 export 'json.dart' show JsonNullable;
 export 'reaction.dart';
 
+import 'json.dart';
+
 part 'model.g.dart';
 
 /// A Zulip "group-setting value": https://zulip.com/api/group-setting-values
@@ -475,6 +477,7 @@ class UserGroup {
 /// For docs, search for "realm_users:"
 /// in <https://zulip.com/api/register-queue>.
 @JsonSerializable(fieldRename: FieldRename.snake)
+@NullableStringJsonConverter()
 class User {
   // When adding a field to this class:
   //  * If a [RealmUserUpdateEvent] can update it, be sure to add
@@ -498,7 +501,14 @@ class User {
   @JsonKey(unknownEnumValue: UserRole.unknown)
   UserRole role;
   String timezone;
-  String? avatarUrl; // TODO(#255) distinguish null from missing, as a `JsonNullable<String>?`
+  /// The user's avatar URL from the server, distinguishing omitted vs null.
+  ///
+  /// Dart `null` means the JSON property was omitted (use `/avatar/{id}`).
+  /// [JsonNullable] with a null [JsonNullable.value] means the server sent
+  /// `'avatar_url': null` (Gravatar; see [client_gravatar] on register).
+  /// [JsonNullable] with a non-null value is an uploaded or absolute URL.
+  @JsonKey(readValue: JsonNullable.readStringFromJson)
+  JsonNullable<String>? avatarUrl;
   int avatarVersion;
 
   // null for bots, which don't have custom profile fields.

--- a/lib/api/model/model.g.dart
+++ b/lib/api/model/model.g.dart
@@ -171,7 +171,11 @@ User _$UserFromJson(Map<String, dynamic> json) => User(
     unknownValue: UserRole.unknown,
   ),
   timezone: json['timezone'] as String,
-  avatarUrl: json['avatar_url'] as String?,
+  avatarUrl:
+      _$JsonConverterFromJson<JsonNullable<String>, JsonNullable<String>>(
+        JsonNullable.readStringFromJson(json, 'avatar_url'),
+        const NullableStringJsonConverter().fromJson,
+      ),
   avatarVersion: (json['avatar_version'] as num).toInt(),
   profileData:
       (User._readProfileData(json, 'profile_data') as Map<String, dynamic>?)
@@ -196,7 +200,11 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
   'bot_owner_id': instance.botOwnerId,
   'role': instance.role,
   'timezone': instance.timezone,
-  'avatar_url': instance.avatarUrl,
+  'avatar_url':
+      _$JsonConverterToJson<JsonNullable<String>, JsonNullable<String>>(
+        instance.avatarUrl,
+        const NullableStringJsonConverter().toJson,
+      ),
   'avatar_version': instance.avatarVersion,
   'profile_data': instance.profileData?.map(
     (k, e) => MapEntry(k.toString(), e),
@@ -212,6 +220,16 @@ const _$UserRoleEnumMap = {
   UserRole.guest: 600,
   UserRole.unknown: null,
 };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);
 
 ProfileFieldUserData _$ProfileFieldUserDataFromJson(
   Map<String, dynamic> json,

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -30,7 +30,7 @@ Future<InitialSnapshot> registerQueue(ApiConnection connection, {
     // for the reasons in the dartdoc above.
     // (We might change these; we'll just need to update types to match.)
     'apply_markdown': true,
-    'client_gravatar': false, // TODO(#255): turn on
+    'client_gravatar': true,
     // 'include_subscribers': false, // the default
     'slim_presence': true,
     'client_capabilities': {

--- a/lib/model/avatar_url.dart
+++ b/lib/model/avatar_url.dart
@@ -1,3 +1,9 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+import '../api/model/json.dart';
+
 /// The size threshold above which is "medium" size for an avatar.
 ///
 /// This is in physical pixels, i.e. image pixels:
@@ -11,22 +17,35 @@ const defaultUploadSizePx = 100;
 abstract class AvatarUrl {
   /// The right [AvatarUrl] subclass for the given user data.
   ///
-  /// [resolvedUrl] is the user's `avatar_url` resolved against the realm URL,
-  /// or null if the server omitted the field; see `user_avatar_url_field_optional`
-  /// at https://zulip.com/api/register-queue#parameter-client_capabilities .
+  /// [avatarUrl] is the user's `avatar_url` field:
+  ///  * Dart `null` — property omitted; use `/avatar/{user_id}`
+  ///    (see `user_avatar_url_field_optional` at
+  ///    https://zulip.com/api/register-queue#parameter-client_capabilities ).
+  ///  * `JsonNullable(null)` — `'avatar_url': null`; compute Gravatar from [email]
+  ///    (see `client_gravatar` on register).
+  ///  * `JsonNullable(url)` — uploaded avatar or absolute Gravatar URL string.
+  ///
+  /// [resolvedUrl] is the non-null string value of [avatarUrl] resolved against
+  /// the realm URL, when present.
   factory AvatarUrl.fromUserData({
+    required JsonNullable<String>? avatarUrl,
     required Uri? resolvedUrl,
+    required String email,
     required int userId,
     required Uri realmUrl,
   }) {
-    // TODO(#255): handle computing gravatars
-    if (resolvedUrl == null) {
+    if (avatarUrl == null) {
       return FallbackAvatarUrl(realmUrl: realmUrl, userId: userId);
-    } else if (resolvedUrl.toString().startsWith(GravatarUrl.origin)) {
-      return GravatarUrl(resolvedUrl: resolvedUrl);
-    } else {
-      return UploadedAvatarUrl(resolvedUrl: resolvedUrl);
     }
+    if (avatarUrl.value == null) {
+      return GravatarUrl.fromEmail(email: email);
+    }
+    assert(resolvedUrl != null);
+    final url = resolvedUrl!;
+    if (url.toString().startsWith('${GravatarUrl.origin}/')) {
+      return GravatarUrl(resolvedUrl: url);
+    }
+    return UploadedAvatarUrl(resolvedUrl: url);
   }
 
   Uri get(int sizePhysicalPx);
@@ -34,6 +53,15 @@ abstract class AvatarUrl {
 
 class GravatarUrl implements AvatarUrl {
   GravatarUrl({required Uri resolvedUrl}) : standardUrl = resolvedUrl;
+
+  /// Build a Gravatar URL from an email, as in zulip-mobile's `GravatarURL`.
+  ///
+  /// See https://secure.gravatar.com/site/implement/images/
+  factory GravatarUrl.fromEmail({required String email}) {
+    final hash = md5.convert(utf8.encode(email.toLowerCase())).toString();
+    return GravatarUrl(
+      resolvedUrl: Uri.parse('$origin/avatar/$hash?d=identicon'));
+  }
 
   static String origin = 'https://secure.gravatar.com';
 

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -255,7 +255,7 @@ class UserStoreImpl extends HasRealmStore with UserStore {
           return; // TODO log
         }
         if (event.fullName != null)       user.fullName       = event.fullName!;
-        if (event.avatarUrl != null)      user.avatarUrl      = event.avatarUrl!;
+        if (event.avatarUrl != null)      user.avatarUrl      = event.avatarUrl;
         if (event.avatarVersion != null)  user.avatarVersion  = event.avatarVersion!;
         if (event.timezone != null)       user.timezone       = event.timezone!;
         if (event.botOwnerId != null)     user.botOwnerId     = event.botOwnerId!;

--- a/lib/widgets/user.dart
+++ b/lib/widgets/user.dart
@@ -74,15 +74,21 @@ class AvatarImage extends StatelessWidget {
     }
 
     Uri? resolvedUrl;
-    if (user.avatarUrl != null) {
-      resolvedUrl = store.tryResolveUrl(user.avatarUrl!);
+    final rawAvatarUrl = user.avatarUrl;
+    if (rawAvatarUrl?.value != null) {
+      resolvedUrl = store.tryResolveUrl(rawAvatarUrl!.value!);
       if (resolvedUrl == null) { // TODO(log)
         return _AvatarPlaceholder(size: size);
       }
     }
 
-    final avatarUrl = AvatarUrl.fromUserData(resolvedUrl: resolvedUrl,
-      userId: userId, realmUrl: store.realmUrl);
+    final avatarUrl = AvatarUrl.fromUserData(
+      avatarUrl: rawAvatarUrl,
+      resolvedUrl: resolvedUrl,
+      email: user.email,
+      userId: userId,
+      realmUrl: store.realmUrl,
+    );
     final physicalSize = (MediaQuery.devicePixelRatioOf(context) * size).ceil();
 
     return RealmContentNetworkImage(

--- a/test/api/model/events_checks.dart
+++ b/test/api/model/events_checks.dart
@@ -26,7 +26,7 @@ extension DeviceUpdateEventChecks on Subject<DeviceUpdateEvent> {
 extension RealmUserUpdateEventChecks on Subject<RealmUserUpdateEvent> {
   Subject<int> get userId => has((e) => e.userId, 'userId');
   Subject<String?> get fullName => has((e) => e.fullName, 'fullName');
-  Subject<String?> get avatarUrl => has((e) => e.avatarUrl, 'avatarUrl');
+  Subject<JsonNullable<String>?> get avatarUrl => has((e) => e.avatarUrl, 'avatarUrl');
   Subject<int?> get avatarVersion => has((e) => e.avatarVersion, 'avatarVersion');
   Subject<String?> get timezone => has((e) => e.timezone, 'timezone');
   Subject<int?> get botOwnerId => has((e) => e.botOwnerId, 'botOwnerId');

--- a/test/api/model/model_checks.dart
+++ b/test/api/model/model_checks.dart
@@ -39,7 +39,7 @@ extension UserChecks on Subject<User> {
   Subject<int?> get botOwnerId => has((x) => x.botOwnerId, 'botOwnerId');
   Subject<UserRole> get role => has((x) => x.role, 'role');
   Subject<String> get timezone => has((x) => x.timezone, 'timezone');
-  Subject<String?> get avatarUrl => has((x) => x.avatarUrl, 'avatarUrl');
+  Subject<JsonNullable<String>?> get avatarUrl => has((x) => x.avatarUrl, 'avatarUrl');
   Subject<int> get avatarVersion => has((x) => x.avatarVersion, 'avatarVersion');
   Subject<Map<int, ProfileFieldUserData>?> get profileData => has((x) => x.profileData, 'profileData');
   Subject<bool> get isSystemBot => has((x) => x.isSystemBot, 'isSystemBot');

--- a/test/api/route/events_test.dart
+++ b/test/api/route/events_test.dart
@@ -25,7 +25,7 @@ void main() {
             'idle_queue_timeout': jsonEncode(idleQueueTimeout),
 
           'apply_markdown': jsonEncode(true),
-          'client_gravatar': jsonEncode(false),
+          'client_gravatar': jsonEncode(true),
           'slim_presence': jsonEncode(true),
 
           'client_capabilities': jsonEncode({

--- a/test/example_data.dart
+++ b/test/example_data.dart
@@ -311,7 +311,7 @@ User user({
     botOwnerId: botOwnerId,
     role: role ?? UserRole.member,
     timezone: 'UTC',
-    avatarUrl: avatarUrl,
+    avatarUrl: avatarUrl != null ? JsonNullable(avatarUrl) : null,
     avatarVersion: 0,
     profileData: profileData,
     isSystemBot: false,

--- a/test/model/avatar_url_test.dart
+++ b/test/model/avatar_url_test.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:checks/checks.dart';
+import 'package:crypto/crypto.dart';
 import 'package:test/scaffolding.dart';
+import 'package:zulip/api/model/json.dart';
 import 'package:zulip/model/avatar_url.dart';
 
 void main() {
@@ -7,30 +11,52 @@ void main() {
   const largeSize = 120;
 
   const userId = 123;
+  const email = 'user123@zulip.example';
   final realmUrl = Uri.parse('https://zulip.example/');
 
-  AvatarUrl fromUserData(Uri? resolvedUrl) => AvatarUrl.fromUserData(
-    resolvedUrl: resolvedUrl, userId: userId, realmUrl: realmUrl);
+  AvatarUrl fromUserData({
+    JsonNullable<String>? avatarUrl,
+    Uri? resolvedUrl,
+    String email = email,
+  }) => AvatarUrl.fromUserData(
+    avatarUrl: avatarUrl,
+    resolvedUrl: resolvedUrl,
+    email: email,
+    userId: userId,
+    realmUrl: realmUrl,
+  );
 
   group('GravatarUrl', () {
-    test('gravatar url', () {
+    test('server-provided gravatar url', () {
       final url = '${GravatarUrl.origin}/avatar/1234';
-      final avatarUrl = fromUserData(Uri.parse(url));
+      final avatarUrl = fromUserData(
+        avatarUrl: JsonNullable(url),
+        resolvedUrl: Uri.parse(url),
+      );
 
       check(avatarUrl.get(defaultSize).toString()).equals('$url?s=30');
+    });
+
+    test('computed from email when avatar_url is null', () {
+      final hash = md5.convert(utf8.encode(email.toLowerCase())).toString();
+      final avatarUrl = fromUserData(avatarUrl: const JsonNullable(null));
+
+      check(avatarUrl).isA<GravatarUrl>();
+      check(avatarUrl.get(defaultSize).toString())
+        .equals('${GravatarUrl.origin}/avatar/$hash?d=identicon&s=30');
     });
   });
 
   group('FallbackAvatarUrl', () {
-    test('standard size', () {
-      final avatarUrl = fromUserData(null);
+    test('standard size when avatar_url omitted', () {
+      final avatarUrl = fromUserData();
 
       check(avatarUrl.get(defaultSize).toString())
         .equals('https://zulip.example/avatar/$userId');
     });
 
-    test('larger size', () {
-      final avatarUrl = fromUserData(null);
+    test('larger size when avatar_url omitted', () {
+      final avatarUrl = fromUserData();
 
       check(avatarUrl.get(largeSize).toString())
         .equals('https://zulip.example/avatar/$userId/medium');
@@ -40,14 +66,20 @@ void main() {
   group('UploadedAvatarUrl', () {
     test('png image', () {
       const url = 'https://zulip.example/image.png';
-      final avatarUrl = fromUserData(Uri.parse(url));
+      final avatarUrl = fromUserData(
+        avatarUrl: const JsonNullable(url),
+        resolvedUrl: Uri.parse(url),
+      );
 
       check(avatarUrl.get(defaultSize).toString()).equals(url);
     });
 
     test('png image, larger size', () {
       const url = 'https://zulip.example/image.png';
-      final avatarUrl = fromUserData(Uri.parse(url));
+      final avatarUrl = fromUserData(
+        avatarUrl: const JsonNullable(url),
+        resolvedUrl: Uri.parse(url),
+      );
       final expectedUrl = url.replaceAll('.png', '-medium.png');
 
       check(avatarUrl.get(largeSize).toString()).equals(expectedUrl);

--- a/test/widgets/message_list_test.dart
+++ b/test/widgets/message_list_test.dart
@@ -2388,7 +2388,8 @@ void main() {
       }
 
       Future<void> handleNewAvatarEventAndPump(WidgetTester tester, String avatarUrl) async {
-        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId, avatarUrl: avatarUrl));
+        await store.handleEvent(RealmUserUpdateEvent(id: 1, userId: user.userId,
+          avatarUrl: JsonNullable(avatarUrl)));
         await tester.pump();
       }
 
@@ -2396,7 +2397,7 @@ void main() {
 
       await setupMessageListPage(tester, users: [user],
         messages: [eg.streamMessage(sender: user)]);
-      checkResultForSender(user.avatarUrl);
+      checkResultForSender(user.avatarUrl?.value);
 
       await handleNewAvatarEventAndPump(tester, '/foo.png');
       checkResultForSender('/foo.png');


### PR DESCRIPTION
## Summary

Fixes #255.

- Use `JsonNullable<String>?` for `User.avatarUrl` (and realm-user updates) so omitted vs null are distinct.
- When `avatar_url` is null, compute Gravatar from the user's email (`md5` of lowercased email, `d=identicon`), same approach as zulip-mobile.
- Enable `client_gravatar: true` on register.
- Keep the `/avatar/{user_id}` fallback when the field is omitted.

## Test plan

- [x] `flutter test test/model/avatar_url_test.dart`
- [x] `flutter test test/api/route/events_test.dart`
- [x] `flutter test test/widgets/user_test.dart`
- [x] `flutter test test/api/model/model_test.dart`
- [x] `flutter test test/api/model/events_test.dart`
- [x] Avatar update coverage in `test/widgets/message_list_test.dart`
- [ ] Manual check on a realm with Gravatar users