### PR TITLE
msglist: Invalidate haveNewest when a fetch reveals newer messages

### DIFF
--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -418,6 +418,7 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
 
   void reconcileMessages(List<Message> messages) {
     assert(!_disposed);
+    List<Message>? newlyLearned;
     for (int i = 0; i < messages.length; i++) {
       final message = messages[i];
 
@@ -432,8 +433,18 @@ class MessageStoreImpl extends HasChannelStore with MessageStore, _OutboxMessage
       // as a cause of inaccuracies.
 
       messages[i] = this.messages.update(message.id,
-        ifAbsent: () => _reconcileUnrecognizedMessage(message),
+        ifAbsent: () {
+          final result = _reconcileUnrecognizedMessage(message);
+          (newlyLearned ??= []).add(result);
+          return result;
+        },
         (current) => _reconcileRecognizedMessage(current, message));
+    }
+
+    if (newlyLearned case final newlyLearned?) {
+      for (final view in _messageListViews) {
+        view.handleMessagesLearnedFromFetch(newlyLearned);
+      }
     }
 
     _removeDeliveredOutboxMessages();

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -458,6 +458,22 @@ mixin _MessageSequence {
     return true;
   }
 
+  /// Mark this sequence as no longer having the newest messages,
+  /// so that a subsequent [MessageListView.fetchNewer] can find them.
+  ///
+  /// This removes all [outboxMessages],
+  /// preserving the invariant that those are present only when [haveNewest].
+  /// See [MessageListView._syncOutboxMessagesFromStore],
+  /// which will restore the outbox messages
+  /// when a fetch again reaches the newest messages.
+  ///
+  /// This does not call [notifyListeners].
+  void _invalidateHaveNewest() {
+    assert(haveNewest);
+    _removeOutboxMessagesWhere((_) => true);
+    _haveNewest = false;
+  }
+
   /// Reset all [_MessageSequence] data, and cancel any active fetches.
   void _reset() {
     generation += 1;
@@ -1093,7 +1109,8 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   void jumpToEnd() {
     assert(fetched);
     assert(!haveNewest);
-    assert(anchor != AnchorCode.newest);
+    // [anchor] is usually not [AnchorCode.newest] here, but it can be,
+    // when [haveNewest] was invalidated.  See [handleMessagesLearnedFromFetch].
     _anchor = AnchorCode.newest;
     _reset();
     notifyListeners();
@@ -1155,6 +1172,48 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     if (_removeOutboxMessage(outboxMessage)) {
       notifyListeners();
     }
+  }
+
+  /// Called when the store has newly learned of messages from a fetch,
+  /// whether by this view or another.
+  /// See [MessageStoreImpl.reconcileMessages].
+  ///
+  /// If any of the messages belong in this view
+  /// but are newer than the messages it has,
+  /// then stop claiming to have the newest messages
+  /// ([haveNewest] becomes false),
+  /// so that a subsequent [fetchNewer] will find them.
+  ///
+  /// Normally such messages would already have been added to this view,
+  /// on a message event.
+  /// But the event queue might be delayed or stuck
+  /// while fetches continue to succeed
+  /// (see #2397, and e.g. #514 and #2415 for ways this can happen).
+  /// In that case this is how the view learns
+  /// its impression of being caught up is stale.
+  ///
+  /// A view on a search narrow never invalidates this way,
+  /// because the client can't tell which messages belong in it
+  /// (see [Narrow.containsMessage]).
+  /// So such a view can keep claiming [haveNewest] when it's stale.
+  void handleMessagesLearnedFromFetch(List<Message> newlyLearned) {
+    if (!haveNewest) return;
+    final anchorId = newestFetchedMessageId;
+    if (anchorId == null) {
+      // A [fetchNewer] would have no message to anchor its request at.
+      // TODO if a newly-learned message belongs in this view, reset and
+      //   refetch, as in [_messagesMovedIntoMessageList].  The view has
+      //   never had any messages, so there's no content to preserve.
+      return;
+    }
+    final hasNewerMessage = newlyLearned.any((message) =>
+      // A message at or before [anchorId] wouldn't be found by [fetchNewer],
+      // so don't invalidate for it.  (A message the view lacks, with an ID
+      // in the already-fetched range, can arise from a message move.)
+      message.id > anchorId && _messageBelongsHere(message));
+    if (!hasNewerMessage) return;
+    _invalidateHaveNewest();
+    notifyListeners();
   }
 
   void handleUserTopicEvent(UserTopicEvent event) {

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -791,6 +791,11 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     }
   }
 
+  /// Whether [message] belongs in this view:
+  /// it's known to be in [narrow], and it's visible ([_messageVisible]).
+  bool _messageBelongsHere(MessageBase message) =>
+    narrow.containsMessage(message) == true && _messageVisible(message);
+
   /// Whether [_messageVisible] is true for all possible messages.
   ///
   /// This is useful for an optimization.
@@ -1092,9 +1097,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
 
   bool _shouldAddOutboxMessage(OutboxMessage outboxMessage) {
     assert(haveNewest);
-    return !outboxMessage.hidden
-      && narrow.containsMessage(outboxMessage) == true
-      && _messageVisible(outboxMessage);
+    return !outboxMessage.hidden && _messageBelongsHere(outboxMessage);
   }
 
   /// Reads [MessageStore.outboxMessages] and copies to [outboxMessages]
@@ -1246,7 +1249,7 @@ class MessageListView with ChangeNotifier, _MessageSequence {
       return;
     }
 
-    if (narrow.containsMessage(message) != true || !_messageVisible(message)) {
+    if (!_messageBelongsHere(message)) {
       assert(event.localMessageId == null || outboxMessages.none((message) =>
         message.localMessageId == int.parse(event.localMessageId!, radix: 10)));
       return;

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -1184,6 +1184,10 @@ class MessageListView with ChangeNotifier, _MessageSequence {
   /// ([haveNewest] becomes false),
   /// so that a subsequent [fetchNewer] will find them.
   ///
+  /// If the view has never had any messages,
+  /// a [fetchNewer] would have nothing to anchor its request at.
+  /// In that case, reset and refetch from scratch instead.
+  ///
   /// Normally such messages would already have been added to this view,
   /// on a message event.
   /// But the event queue might be delayed or stuck
@@ -1201,9 +1205,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     final anchorId = newestFetchedMessageId;
     if (anchorId == null) {
       // A [fetchNewer] would have no message to anchor its request at.
-      // TODO if a newly-learned message belongs in this view, reset and
-      //   refetch, as in [_messagesMovedIntoMessageList].  The view has
-      //   never had any messages, so there's no content to preserve.
+      // But the view has never had any messages,
+      // so there's no content to preserve. Just refetch from scratch.
+      if (newlyLearned.any(_messageBelongsHere)) {
+        _reset();
+        notifyListeners();
+        fetchInitial();
+      }
       return;
     }
     final hasNewerMessage = newlyLearned.any((message) =>

--- a/lib/model/message_list.dart
+++ b/lib/model/message_list.dart
@@ -141,10 +141,13 @@ mixin _MessageSequence {
   /// The corresponding item index is [middleItem].
   int middleMessage = 0;
 
-  /// The ID of the oldest message fetched so far in this narrow.
+  /// The ID of the oldest message fetched so far in this narrow,
+  /// or of the first message added on a message event
+  /// when none had been fetched.
   ///
   /// This is used as the anchor for fetching the next batch of older messages
-  /// and will be `null` if no messages of this narrow have been fetched yet.
+  /// and will be `null` if no messages of this narrow
+  /// have been fetched or added yet.
   ///
   /// A message with this ID might not appear in [messages]:
   /// - The message may be in a muted conversation.
@@ -154,10 +157,12 @@ mixin _MessageSequence {
   int? get oldestFetchedMessageId => _oldestFetchedMessageId;
   int? _oldestFetchedMessageId;
 
-  /// The ID of the newest message fetched so far in this narrow.
+  /// The ID of the newest message fetched so far in this narrow,
+  /// or of a newer message added on a message event while [haveNewest].
   ///
   /// This is used as the anchor for fetching the next batch of newer messages
-  /// and will be `null` if no messages of this narrow have been fetched yet.
+  /// and will be `null` if no messages of this narrow
+  /// have been fetched or added yet.
   ///
   /// A message with this ID might not appear in [messages]:
   /// - The message may be in a muted conversation.
@@ -1272,6 +1277,13 @@ class MessageListView with ChangeNotifier, _MessageSequence {
     _removeOutboxMessageItems();
     // TODO insert in middle of [messages] instead, when appropriate
     _addMessage(message);
+    // Keep [newestFetchedMessageId] up to date as the anchor for a future
+    // [fetchNewer], so that such a fetch can't return this message again
+    // (which would corrupt [messages] with a duplicate).
+    _newestFetchedMessageId = message.id;
+    // If the view had no messages at all, this message also bounds
+    // the history on the other end.
+    _oldestFetchedMessageId ??= message.id;
     _removeOutboxMessageOfEvent(event);
     _reprocessOutboxMessages();
     notifyListeners();

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -331,6 +331,34 @@ void main() {
         ..outboxMessages.length.equals(1);
     }));
 
+    test('sent message found in fetch; outbox message removed', () => awaitFakeAsync((async) async {
+      final stream = eg.stream();
+      await prepare(
+        narrow: eg.topicNarrow(stream.streamId, 'topic'), stream: stream);
+
+      await prepareOutboxMessages(count: 1, stream: stream, topic: 'topic');
+      final messageId = store.outboxMessages.values.single.messageId!;
+      async.elapse(kLocalEchoDebounceDuration);
+      checkNotNotified();
+      check(model)
+        ..fetched.isFalse()
+        ..outboxMessages.isEmpty();
+
+      // The fetch finds the message the outbox message was sent as
+      // (see [OutboxMessage.messageId]).  The view must show it just once,
+      // with no stale outbox copy.
+      connection.prepare(json: newestResult(foundOldest: true, messages: [
+        eg.streamMessage(id: messageId, stream: stream, topic: 'topic',
+          sender: eg.selfUser)]).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(store.outboxMessages).isEmpty();
+      check(model)
+        ..fetched.isTrue()
+        ..outboxMessages.isEmpty()
+        ..messages.single.id.equals(messageId);
+    }));
+
     test('outbox messages not added until haveNewest', () => awaitFakeAsync((async) async {
       final stream = eg.stream();
       await prepare(

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -2679,10 +2679,11 @@ void main() {
           anchor: AnchorCode.newest)
         ..addListener(() => notifiedCount2++);
 
+      final initialMessage = eg.streamMessage(stream: stream, topic: 'hello');
       for (final m in [model1, model2]) {
         connection.prepare(json: newestResult(
           foundOldest: false,
-          messages: [eg.streamMessage(stream: stream, topic: 'hello')]).toJson());
+          messages: [initialMessage]).toJson());
         await m.fetchInitial();
       }
 

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -958,6 +958,43 @@ void main() {
           ..oldestFetchedMessageId.equals(200)..newestFetchedMessageId.equals(299);
       });
     });
+
+    test('message event', () async {
+      await prepare();
+      connection.prepare(json: newestResult(
+        foundOldest: true,
+        messages: channelMessages(fromId: 100, count: 100),
+      ).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model).newestFetchedMessageId.equals(199);
+
+      await store.addMessage(channelMessage(id: 200));
+      checkNotifiedOnce();
+      check(model)
+        ..messages.last.id.equals(200)
+        ..newestFetchedMessageId.equals(200);
+    });
+
+    test('message event when no messages fetched', () async {
+      await prepare();
+      connection.prepare(json: newestResult(
+        foundOldest: true, messages: []).toJson());
+      await model.fetchInitial();
+      checkNotifiedOnce();
+      check(model)
+        ..oldestFetchedMessageId.isNull()..newestFetchedMessageId.isNull();
+
+      await store.addMessage(channelMessage(id: 100));
+      checkNotifiedOnce();
+      check(model)
+        ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(100);
+
+      await store.addMessage(channelMessage(id: 200));
+      checkNotifiedOnce();
+      check(model)
+        ..oldestFetchedMessageId.equals(100)..newestFetchedMessageId.equals(200);
+    });
   });
 
   // TODO(#1569): test jumpToEnd
@@ -3831,6 +3868,13 @@ void checkInvariants(MessageListView model) {
     .isTrue();
   check(isSortedWithoutDuplicates(model.outboxMessages.map((m) => m.localMessageId).toList()))
     .isTrue();
+
+  if (model.messages.isNotEmpty) {
+    check(model).oldestFetchedMessageId.isNotNull()
+      .isLessOrEqual(model.messages.first.id);
+    check(model).newestFetchedMessageId.isNotNull()
+      .isGreaterOrEqual(model.messages.last.id);
+  }
 
   check(model).middleMessage
     ..isGreaterOrEqual(0)

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1359,6 +1359,257 @@ void main() {
     });
   });
 
+  group('handleMessagesLearnedFromFetch', () {
+    final channel = eg.stream();
+    final narrow = ChannelNarrow(channel.streamId);
+    final initialMessageIds = List.generate(30, (i) => 1000 + i);
+
+    Future<void> prepareNarrow() async {
+      await prepare(narrow: narrow, stream: channel);
+      // The anchor is [AnchorCode.newest], so the fetch finds the newest.
+      await prepareMessages(foundOldest: true, messages: [
+        for (final id in initialMessageIds)
+          eg.streamMessage(id: id, stream: channel, topic: 'topic')]);
+      check(model).haveNewest.isTrue();
+    }
+
+    test('newer message in narrow -> invalidate haveNewest; fetchNewer finds it', () async {
+      await prepareNarrow();
+
+      // Another message list's fetch learns of a newer message in the narrow
+      // (the event queue being stuck, no message event has arrived).
+      final message = eg.streamMessage(id: 2000, stream: channel, topic: 'topic');
+      store.reconcileMessages([message]);
+      checkNotifiedOnce();
+      check(model).haveNewest.isFalse();
+      checkHasMessageIds(initialMessageIds);
+
+      // A subsequent fetchNewer (which the UI would prompt) finds the message.
+      connection.prepare(json: newerResult(
+        anchor: initialMessageIds.last, foundNewest: true,
+        messages: [message]).toJson());
+      final fetchFuture = model.fetchNewer();
+      checkNotifiedOnce();
+      check(model).busyFetchingMore.isTrue();
+
+      await fetchFuture;
+      checkNotifiedOnce();
+      check(model)
+        ..haveNewest.isTrue()
+        ..busyFetchingMore.isFalse();
+      checkHasMessageIds([...initialMessageIds, 2000]);
+    });
+
+    test('message not in narrow -> no effect', () async {
+      await prepareNarrow();
+
+      store.reconcileMessages([
+        eg.dmMessage(id: 2000, from: eg.otherUser, to: [eg.selfUser])]);
+      checkNotNotified();
+      check(model).haveNewest.isTrue();
+    });
+
+    test('message in narrow but muted -> no effect', () async {
+      await prepareNarrow();
+      await store.setUserTopic(channel, 'muted topic', UserTopicVisibilityPolicy.muted);
+      checkNotNotified();
+
+      store.reconcileMessages([
+        eg.streamMessage(id: 2000, stream: channel, topic: 'muted topic')]);
+      checkNotNotified();
+      check(model).haveNewest.isTrue();
+    });
+
+    test('message not newer than the view -> no effect', () async {
+      // A message the view lacks, with an ID inside its fetched history,
+      // can arise from a message move.  A fetchNewer wouldn't find it,
+      // so don't invalidate.
+      await prepareNarrow();
+
+      store.reconcileMessages([
+        eg.streamMessage(id: 999, stream: channel, topic: 'topic')]);
+      checkNotNotified();
+      check(model).haveNewest.isTrue();
+    });
+
+    test('message in fetched range but not in view -> no effect', () async {
+      // The end of the fetched range is in a muted topic, so [messages]
+      // ends before [newestFetchedMessageId].  A message learned within
+      // that range (as from a message move) is newer than all the messages
+      // in the view, but a fetchNewer wouldn't find it, so don't invalidate.
+      await prepare(narrow: narrow, stream: channel);
+      await store.setUserTopic(channel, 'muted topic', UserTopicVisibilityPolicy.muted);
+      await prepareMessages(foundOldest: true, messages: [
+        for (final id in initialMessageIds.take(25))
+          eg.streamMessage(id: id, stream: channel, topic: 'topic'),
+        for (final id in initialMessageIds.skip(26))
+          eg.streamMessage(id: id, stream: channel, topic: 'muted topic')]);
+      check(model).haveNewest.isTrue();
+      checkHasMessageIds(initialMessageIds.take(25));
+
+      store.reconcileMessages([
+        eg.streamMessage(id: initialMessageIds[25], stream: channel, topic: 'topic')]);
+      checkNotNotified();
+      check(model).haveNewest.isTrue();
+    });
+
+    test('message already known to store -> no effect', () async {
+      await prepareNarrow();
+
+      store.reconcileMessages([
+        eg.streamMessage(id: initialMessageIds.last, stream: channel, topic: 'topic')]);
+      checkNotNotified();
+      check(model).haveNewest.isTrue();
+    });
+
+    test('newer message from event -> fetchNewer anchors there', () async {
+      // A message added on an event extends the range a fetchNewer
+      // would be redundant over.  Anchoring the fetch before it
+      // would corrupt the view with a duplicate.
+      await prepareNarrow();
+      await store.addMessage(
+        eg.streamMessage(id: 1100, stream: channel, topic: 'topic'));
+      checkNotifiedOnce();
+      checkHasMessageIds([...initialMessageIds, 1100]);
+
+      final message = eg.streamMessage(id: 2000, stream: channel, topic: 'topic');
+      store.reconcileMessages([message]);
+      checkNotifiedOnce();
+      check(model).haveNewest.isFalse();
+
+      connection.prepare(json: newerResult(
+        anchor: 1100, foundNewest: true, messages: [message]).toJson());
+      final fetchFuture = model.fetchNewer();
+      checkNotifiedOnce();
+      await fetchFuture;
+      checkNotifiedOnce();
+      checkLastRequest(
+        narrow: narrow.apiEncode(),
+        anchor: '1100',
+        includeAnchor: false,
+        numBefore: 0,
+        numAfter: kMessageListFetchBatchSize,
+        allowEmptyTopicName: true,
+      );
+      checkHasMessageIds([...initialMessageIds, 1100, 2000]);
+    });
+
+    test('all messages from events, none from a fetch -> invalidate', () async {
+      // Regression test for a crash: with no messages ever fetched,
+      // [MessageListView.fetchNewer] has no fetched message to anchor at,
+      // but it can anchor at a message added on an event.
+      await prepare(narrow: narrow, stream: channel);
+      await prepareMessages(foundOldest: true, messages: []);
+      await store.addMessage(
+        eg.streamMessage(id: 1000, stream: channel, topic: 'topic'));
+      checkNotifiedOnce();
+      checkHasMessageIds([1000]);
+
+      final message = eg.streamMessage(id: 2000, stream: channel, topic: 'topic');
+      store.reconcileMessages([message]);
+      checkNotifiedOnce();
+      check(model).haveNewest.isFalse();
+
+      connection.prepare(json: newerResult(
+        anchor: 1000, foundNewest: true, messages: [message]).toJson());
+      final fetchFuture = model.fetchNewer();
+      checkNotifiedOnce();
+      await fetchFuture;
+      checkNotifiedOnce();
+      check(model).haveNewest.isTrue();
+      checkHasMessageIds([1000, 2000]);
+    });
+
+    test('when not haveNewest -> no effect', () async {
+      await prepare(narrow: narrow, stream: channel,
+        anchor: NumericAnchor(initialMessageIds.first));
+      await prepareMessages(foundOldest: true, foundNewest: false, messages: [
+        for (final id in initialMessageIds)
+          eg.streamMessage(id: id, stream: channel, topic: 'topic')]);
+      check(model).haveNewest.isFalse();
+
+      store.reconcileMessages([
+        eg.streamMessage(id: 2000, stream: channel, topic: 'topic')]);
+      checkNotNotified();
+      check(model).haveNewest.isFalse();
+    });
+
+    test('empty narrow -> no effect', () async {
+      // TODO make this case reset and refetch.  See TODO in
+      //   [MessageListView.handleMessagesLearnedFromFetch].
+      await prepare(narrow: narrow, stream: channel);
+      await prepareMessages(foundOldest: true, messages: []);
+      check(model).haveNewest.isTrue();
+      check(model).messages.isEmpty();
+
+      store.reconcileMessages([
+        eg.streamMessage(id: 2000, stream: channel, topic: 'topic')]);
+      checkNotNotified();
+      check(model).haveNewest.isTrue();
+    });
+
+    test('outbox messages removed, and restored when fetch reaches end', () => awaitFakeAsync((async) async {
+      await prepareNarrow();
+      connection.prepare(httpException: SocketException('failed'));
+      await check(store.sendMessage(
+        destination: StreamDestination(channel.streamId, eg.t('topic')),
+        content: 'content')).throws();
+      check(model).outboxMessages.single;
+      checkNotifiedOnce();
+
+      // Learning of someone else's newer message invalidates [haveNewest],
+      // which requires removing the outbox messages from the view
+      // (they belong only at the true end of history).
+      final message = eg.streamMessage(id: 2000, stream: channel, topic: 'topic');
+      store.reconcileMessages([message]);
+      checkNotifiedOnce();
+      check(model)
+        ..haveNewest.isFalse()
+        ..outboxMessages.isEmpty();
+      // ... but they remain in the store.
+      check(store.outboxMessages).length.equals(1);
+
+      // When a fetch again reaches the newest messages,
+      // the outbox messages reappear, after the newly fetched message.
+      connection.prepare(json: newerResult(
+        anchor: initialMessageIds.last, foundNewest: true,
+        messages: [message]).toJson());
+      final fetchFuture = model.fetchNewer();
+      checkNotifiedOnce();
+      await fetchFuture;
+      checkNotifiedOnce();
+      check(model)
+        ..haveNewest.isTrue()
+        ..outboxMessages.single;
+      checkHasMessageIds([...initialMessageIds, 2000]);
+    }));
+
+    test('jumpToEnd after invalidation', () => awaitFakeAsync((async) async {
+      // Regression test for an assertion failure: invalidation can leave
+      // [MessageListView.anchor] still at [AnchorCode.newest],
+      // and the scroll-to-bottom button calls [MessageListView.jumpToEnd]
+      // whenever not [haveNewest].
+      await prepareNarrow();
+      check(model).anchor.equals(AnchorCode.newest);
+
+      final message = eg.streamMessage(id: 2000, stream: channel, topic: 'topic');
+      store.reconcileMessages([message]);
+      checkNotifiedOnce();
+      check(model).haveNewest.isFalse();
+
+      connection.prepare(json: newestResult(foundOldest: true, messages: [
+        for (final id in initialMessageIds)
+          eg.streamMessage(id: id, stream: channel, topic: 'topic'),
+        message]).toJson());
+      model.jumpToEnd();
+      checkNotifiedOnce();
+      async.elapse(Duration.zero);
+      checkNotifiedOnce();
+      check(model).haveNewest.isTrue();
+      checkHasMessageIds([...initialMessageIds, 2000]);
+    }));
+  });
+
   group('UserTopicEvent', () {
     // The ChannelStore.willAffectIfTopicVisible/InChannel methods have their
     // own thorough unit tests.  So these tests focus on the rest of the logic.

--- a/test/model/message_list_test.dart
+++ b/test/model/message_list_test.dart
@@ -1534,18 +1534,35 @@ void main() {
       check(model).haveNewest.isFalse();
     });
 
-    test('empty narrow -> no effect', () async {
-      // TODO make this case reset and refetch.  See TODO in
-      //   [MessageListView.handleMessagesLearnedFromFetch].
+    test('empty narrow -> reset and refetch', () => awaitFakeAsync((async) async {
       await prepare(narrow: narrow, stream: channel);
       await prepareMessages(foundOldest: true, messages: []);
       check(model).haveNewest.isTrue();
       check(model).messages.isEmpty();
 
-      store.reconcileMessages([
-        eg.streamMessage(id: 2000, stream: channel, topic: 'topic')]);
-      checkNotNotified();
+      final message = eg.streamMessage(id: 2000, stream: channel, topic: 'topic');
+      connection.prepare(delay: const Duration(seconds: 2), json: newestResult(
+        foundOldest: true, messages: [message]).toJson());
+      store.reconcileMessages([message]);
+      check(model).fetched.isFalse();
+      checkNotifiedOnce();
+
+      async.elapse(const Duration(seconds: 2));
+      checkHasMessageIds([2000]);
       check(model).haveNewest.isTrue();
+      checkNotifiedOnce();
+    }));
+
+    test('empty narrow, message in muted topic -> no effect', () async {
+      await prepare(narrow: narrow, stream: channel);
+      await store.setUserTopic(channel, 'muted topic', UserTopicVisibilityPolicy.muted);
+      await prepareMessages(foundOldest: true, messages: []);
+      check(model).haveNewest.isTrue();
+
+      store.reconcileMessages([
+        eg.streamMessage(id: 2000, stream: channel, topic: 'muted topic')]);
+      checkNotNotified();
+      check(model).fetched.isTrue();
     });
 
     test('outbox messages removed, and restored when fetch reaches end', () => awaitFakeAsync((async) async {

--- a/test/model/message_test.dart
+++ b/test/model/message_test.dart
@@ -480,7 +480,9 @@ void main() {
         // and the outbox message is still hidden.
         store.reconcileMessages([message]);
         checkState().equals(OutboxMessageState.hidden);
-        checkNotNotified();
+        // The view was notified only because the newer message
+        // invalidated [MessageListView.haveNewest].
+        checkNotifiedOnce();
 
         // The send response arrives; the outbox message is deleted
         // without ever being shown.
@@ -520,14 +522,17 @@ void main() {
         store.reconcileMessages([message]);
         checkState().equals(OutboxMessageState.waiting);
         check(store.outboxMessages).values.single.messageId.isNull();
-        checkNotNotified();
+        // The view was notified because the newer message invalidated
+        // [MessageListView.haveNewest], removing the outbox message from it.
+        checkNotifiedOnce();
 
         // The send response arrives; the message in the store is recognized
         // as this outbox message's, and the outbox message is deleted.
+        // (The view already removed it, on the invalidation.)
         async.elapse(const Duration(seconds: 1));
         await check(outboxMessageSucceedFuture).completes();
         check(store.outboxMessages).isEmpty();
-        checkNotifiedOnce();
+        checkNotNotified();
 
         // The wait-period timer was canceled when the outbox message
         // was deleted.
@@ -545,14 +550,17 @@ void main() {
         // The message arrives in a fetch while the send request is in flight.
         store.reconcileMessages([message]);
         checkState().equals(OutboxMessageState.waitPeriodExpired);
-        checkNotNotified();
+        // The view was notified because the newer message invalidated
+        // [MessageListView.haveNewest], removing the outbox message from it.
+        checkNotifiedOnce();
 
         // The send response arrives; the outbox message is deleted,
         // without flickering back to the waiting state first.
+        // (The view already removed it, on the invalidation.)
         async.elapse(const Duration(seconds: 1));
         await check(outboxMessageSucceedFuture).completes();
         check(store.outboxMessages).isEmpty();
-        checkNotifiedOnce();
+        checkNotNotified();
       }));
 
       test('no delete when unrelated message found in fetch', () => awaitFakeAsync((async) async {
@@ -563,7 +571,10 @@ void main() {
 
         store.reconcileMessages([eg.streamMessage(stream: stream)]);
         checkState().equals(OutboxMessageState.waiting);
-        checkNotNotified();
+        // The view was notified, but only because the newer message
+        // invalidated [MessageListView.haveNewest];
+        // the outbox message remains in the store.
+        checkNotifiedOnce();
       }));
 
       test('waitPeriodExpired -> (delete) when event arrives before send request fails', () => awaitFakeAsync((async) async {


### PR DESCRIPTION
Fixes #2397.

This fixes the last remaining checkbox in https://github.com/zulip/zulip-flutter/issues/2397#issuecomment-5196519345:

> - [ ] Removing an outbox placeholder removes it from all message lists. If the event stream is stuck but the message has arrived in a fetch (through either of the above paths), then the message will be shown _in the message list that performed the fetch_, but not in any other message lists until they do their own fetch, and the outbox placeholder will be absent. So from those other message lists, until the event comes in, it'll look like the message was dropped. One proposal to address this: for any other message lists where the message belongs, if they think they're caught up to the newest messages (`haveNewest` is true) but they don't have this message, just correct that impression (set `haveNewest` to false) and prompt them to fetch-newer.

