### PR TITLE
store: Abort stalled poll request when network connectivity changes

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - app_settings (6.1.2):
     - Flutter
   - CocoaAsyncSocket (7.6.5)
+  - connectivity_plus (0.0.1):
+    - Flutter
   - device_info_plus (0.0.1):
     - Flutter
   - DKImagePickerController/Core (4.3.9):
@@ -130,6 +132,7 @@ PODS:
 
 DEPENDENCIES:
   - app_settings (from `.symlinks/plugins/app_settings/ios`)
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
@@ -164,6 +167,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   app_settings:
     :path: ".symlinks/plugins/app_settings/ios"
+  connectivity_plus:
+    :path: ".symlinks/plugins/connectivity_plus/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
@@ -194,6 +199,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_settings: 0341ec6daa4f0c50f5a421bf0ad7c36084db6e90
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60

--- a/lib/api/core.dart
+++ b/lib/api/core.dart
@@ -192,9 +192,9 @@ class ApiConnection {
       json = await jsonStream.single as Map<String, dynamic>?;
     } on http.ClientException catch (e) {
       // A network error, like the connection being interrupted
-      // partway through receiving the response body; or the timeout
-      // in [_withTimeout] firing while we were reading it, which
-      // arrives here as an [http.RequestAbortedException].
+      // partway through receiving the response body; or the request
+      // being aborted while we were reading it -- the timeout in
+      // [_withTimeout] fired, or a caller's abort trigger (see [get]).
       // On an HTTP error status, though, that status is the more useful
       // signal: fall through, and throw from it below.
       if (httpStatus == 200) _throwNetworkException(routeName, e);
@@ -242,15 +242,29 @@ class ApiConnection {
   /// with kind [NetworkExceptionKind.connectionFailed].
   /// (But if an error response's headers had already arrived,
   /// the exception reflects that HTTP status instead.)
+  ///
+  /// If [abortTrigger] completes before the request has completed,
+  /// including reading the response body,
+  /// the request is aborted in the same way.
+  /// The [abortTrigger] future must not complete with an error.
   Future<T> get<T>(String routeName, T Function(Map<String, dynamic>) fromJson,
-      String path, Map<String, dynamic>? params, {Duration? timeout}) async {
+      String path, Map<String, dynamic>? params, {
+    Duration? timeout,
+    Future<void>? abortTrigger,
+  }) async {
     final url = realmUrl.replace(
       path: "/api/v1/$path", queryParameters: encodeParameters(params));
-    if (timeout == null) {
-      return send(routeName, fromJson, http.Request('GET', url));
+    Future<T> doSend(Future<void>? abortTrigger) {
+      return send(routeName, fromJson, switch (abortTrigger) {
+        null => http.Request('GET', url),
+        _    => http.AbortableRequest('GET', url, abortTrigger: abortTrigger),
+      });
     }
-    return _withTimeout(timeout, (abortTrigger) => send(routeName, fromJson,
-      http.AbortableRequest('GET', url, abortTrigger: abortTrigger)));
+    if (timeout == null) return doSend(abortTrigger);
+    return _withTimeout(timeout, (timeoutTrigger) => doSend(
+      abortTrigger == null
+        ? timeoutTrigger
+        : Future.any([timeoutTrigger, abortTrigger])));
   }
 
   Future<T> post<T>(String routeName, T Function(Map<String, dynamic>) fromJson,
@@ -349,7 +363,8 @@ const _erasedSocketErrorMessages = {
 Never _throwNetworkException(String routeName, Object cause) {
   final zulipLocalizations = GlobalLocalizations.zulipLocalizations;
   final (NetworkExceptionKind kind, String message) = switch (cause) {
-    // Our own timeout, from [ApiConnection._withTimeout].  Skip the
+    // Our own abort: the timeout from [ApiConnection._withTimeout],
+    // or a caller's abort trigger (see [ApiConnection.get]).  Skip the
     // exception's message: it names a package-internal mechanism
     // ("Request aborted by `abortTrigger`"), which wouldn't mean much to a user.
     http.RequestAbortedException() =>

--- a/lib/api/route/events.dart
+++ b/lib/api/route/events.dart
@@ -78,12 +78,13 @@ enum _IdleQueueTimeout {
 Future<GetEventsResult> getEvents(ApiConnection connection, {
   required String queueId, int? lastEventId, bool? dontBlock,
   Duration? timeout,
+  Future<void>? abortTrigger,
 }) {
   return connection.get('getEvents', GetEventsResult.fromJson, 'events', {
     'queue_id': RawParameter(queueId),
     'last_event_id': ?lastEventId,
     'dont_block': ?dontBlock,
-  }, timeout: timeout);
+  }, timeout: timeout, abortTrigger: abortTrigger);
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/model/binding.dart
+++ b/lib/model/binding.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:connectivity_plus/connectivity_plus.dart' as connectivity_plus;
 import 'package:device_info_plus/device_info_plus.dart' as device_info_plus;
 import 'package:file_picker/file_picker.dart' as file_picker;
 import 'package:firebase_core/firebase_core.dart' as firebase_core;
@@ -21,6 +22,7 @@ import '../host/notifications.dart' as notif_pigeon;
 import '../log.dart';
 import 'store.dart';
 
+export 'package:connectivity_plus/connectivity_plus.dart' show ConnectivityResult;
 export 'package:file_picker/file_picker.dart' show FilePickerResult, FileType, PlatformFile;
 export 'package:image_picker/image_picker.dart' show ImageSource, XFile;
 
@@ -142,6 +144,38 @@ abstract class ZulipBinding {
   /// A broadcast stream of the app's lifecycle-state changes,
   /// via [AppLifecycleListener.onStateChange].
   Stream<AppLifecycleState> get appLifecycleStateChanges;
+
+  /// A broadcast stream of updates on the device's network connectivity,
+  /// via package:connectivity_plus.
+  ///
+  /// An event describes the connectivity state as a whole, not a delta.
+  ///
+  /// While the app is in the background, updates may be dropped
+  /// rather than delivered on returning to the foreground;
+  /// to learn of a change that happened in the background,
+  /// use [checkConnectivity].
+  /// For the Android behavior, see the plugin README:
+  ///   https://github.com/fluttercommunity/plus_plugins/blob/connectivity_plus-v7.3.1/packages/connectivity_plus/connectivity_plus/README.md#android
+  /// For iOS, see the guard in the plugin implementation:
+  ///   https://github.com/fluttercommunity/plus_plugins/blob/connectivity_plus-v7.3.1/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus/Sources/connectivity_plus/ConnectivityPlusPlugin.swift#L87-L92
+  ///
+  /// A subscriber's first event may describe the current state
+  /// rather than a change:
+  /// both platform implementations emit the current state
+  /// when the underlying platform channel gains its first listener,
+  /// while a subscriber that joins an already-listening channel
+  /// just sees the next change.  For the initial emissions, see:
+  ///   https://github.com/fluttercommunity/plus_plugins/blob/connectivity_plus-v7.3.1/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java#L87-L89
+  ///   https://github.com/fluttercommunity/plus_plugins/blob/connectivity_plus-v7.3.1/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus/Sources/connectivity_plus/ConnectivityPlusPlugin.swift#L73-L80
+  ///
+  /// This wraps [connectivity_plus.Connectivity.onConnectivityChanged].
+  Stream<List<connectivity_plus.ConnectivityResult>> get connectivityChanges;
+
+  /// The device's current network connectivity,
+  /// via package:connectivity_plus.
+  ///
+  /// This wraps [connectivity_plus.Connectivity.checkConnectivity].
+  Future<List<connectivity_plus.ConnectivityResult>> checkConnectivity();
 
   /// Provides device and operating system information,
   /// via package:device_info_plus.
@@ -489,6 +523,14 @@ class LiveZulipBinding extends ZulipBinding {
     AppLifecycleListener(onStateChange: controller.add);
     return controller.stream;
   }
+
+  @override
+  Stream<List<connectivity_plus.ConnectivityResult>> get connectivityChanges =>
+    connectivity_plus.Connectivity().onConnectivityChanged;
+
+  @override
+  Future<List<connectivity_plus.ConnectivityResult>> checkConnectivity() =>
+    connectivity_plus.Connectivity().checkConnectivity();
 
   @override
   Future<BaseDeviceInfo?> get deviceInfo => _deviceInfo;

--- a/lib/model/connectivity.dart
+++ b/lib/model/connectivity.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show AppLifecycleState;
+
+import '../log.dart';
+import 'binding.dart';
+
+/// Watches the device's network connectivity,
+/// for signs that connections in use may have silently gone dead.
+///
+/// The main way a connection dies with neither end closing it
+/// is a network change: the device moves from Wi-Fi to cellular, say.
+/// On such a change, a consumer will want to give up on
+/// connections it opened before the change,
+/// and retry on the new network.
+///
+/// To do that, a consumer records [updateCount]
+/// when it opens a connection, and listens on [retrySignals].
+/// On an event, if [updateCount] has moved
+/// since the connection was opened,
+/// the network may have changed under it:
+/// give up on the connection and retry.
+/// (A change impeaches only connections that predate it;
+/// a connection opened after the change
+/// already uses the post-change network.)
+class ConnectivityMonitor {
+  ConnectivityMonitor() {
+    _connectivitySubscription = ZulipBinding.instance.connectivityChanges
+      .listen(_handleConnectivityUpdate,
+        onError: (Object e) {
+          // Connectivity-triggered retries are an optimization; without
+          // them, consumers still recover via their own timeouts.
+          assert(debugLog('Error on connectivity stream: $e')); // TODO(log)
+        });
+    _lifecycleSubscription = ZulipBinding.instance.appLifecycleStateChanges
+      .listen(_handleAppLifecycleStateChange);
+    // Establish a baseline, so that a subsequent update can be recognized
+    // as an actual change.  (The stream may or may not send the current
+    // state as its first event; asking directly works either way.)
+    // Not awaited: nothing needs to wait for this,
+    // and a change that lands first simply becomes the baseline.
+    unawaited(_recheckConnectivity());
+  }
+
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+  StreamSubscription<AppLifecycleState>? _lifecycleSubscription;
+
+  /// The device's network connectivity, per the latest update we've seen,
+  /// or null if we haven't seen one yet.
+  Set<ConnectivityResult>? _lastResults;
+
+  /// The number of connectivity updates recorded so far,
+  /// the first of them being a baseline rather than a change.
+  ///
+  /// A consumer of [retrySignals] records this value
+  /// when opening a connection,
+  /// to recognize later whether the network may have changed under it;
+  /// see the class doc.
+  int get updateCount => _updateCount;
+  int _updateCount = 0;
+
+  /// Counter guarding [_recheckConnectivity] results against staleness.
+  ///
+  /// Advances on every update handled (even one recording no change)
+  /// and at the start of every recheck,
+  /// so that a recheck's result is used
+  /// only if nothing fresher could have arrived meanwhile.
+  int _updateEpoch = 0;
+
+  /// A paced signal to give up on connections
+  /// that predate the latest network change,
+  /// and retry on the current network.
+  ///
+  /// An event is emitted when the network changes,
+  /// to a state with connectivity --
+  /// but at most one per [retrySignalCooldown]:
+  /// when connectivity flaps rapidly
+  /// (repeated handoffs in a moving vehicle, say),
+  /// signaling every change would mean
+  /// consumers retrying at the flapping rate.
+  /// A change during the cooldown is still recorded immediately
+  /// (see [updateCount]), and is signaled when the cooldown ends.
+  Stream<void> get retrySignals => _retrySignalsController.stream;
+  final _retrySignalsController = StreamController<void>.broadcast();
+
+  /// The floor on the spacing of [retrySignals] events.
+  static const retrySignalCooldown = Duration(seconds: 10);
+
+  // A timer, rather than a comparison of wall-clock timestamps, so that
+  // a clock step -- as when NTP corrects the clock just after a network
+  // change -- cannot distort the cooldown.
+  Timer? _cooldownTimer;
+
+  /// Whether a change was recorded while [_cooldownTimer] was running,
+  /// so that a retry signal is due when the cooldown ends.
+  bool _retrySignalDeferred = false;
+
+  /// Handle an update on the device's network connectivity,
+  /// from [ZulipBinding.connectivityChanges] or [_recheckConnectivity].
+  void _handleConnectivityUpdate(List<ConnectivityResult> result) {
+    assert(!_disposed); // The subscription is canceled in [dispose].
+    _updateEpoch++;
+    // The list is the active network's transports, in the plugin's
+    // fixed check order; the order carries no meaning, so compare as sets.
+    final resultSet = result.toSet();
+    final previous = _lastResults;
+    if (setEquals(previous, resultSet)) return;
+    _lastResults = resultSet;
+    _updateCount++;
+    if (previous == null) return; // Just a baseline, not a change.
+    if (resultSet.contains(ConnectivityResult.none)) {
+      // With no connectivity, a retry cannot succeed.  Signal nothing,
+      // and act when connectivity comes back.
+      return;
+    }
+    if (_cooldownTimer != null) {
+      // Connectivity is flapping; don't signal every change.
+      _retrySignalDeferred = true;
+      return;
+    }
+    _emitRetrySignal();
+  }
+
+  /// Emit a [retrySignals] event, and start the cooldown;
+  /// when the cooldown ends, emit again if a change was deferred to then.
+  void _emitRetrySignal() {
+    _cooldownTimer = Timer(retrySignalCooldown, () {
+      _cooldownTimer = null;
+      if (!_retrySignalDeferred) return;
+      _retrySignalDeferred = false;
+      if (_lastResults!.contains(ConnectivityResult.none)) return;
+      _emitRetrySignal();
+    });
+    _retrySignalsController.add(null);
+  }
+
+  /// Fetch the current connectivity state, and handle it
+  /// like an update from [ZulipBinding.connectivityChanges],
+  /// unless a newer update arrives first.
+  Future<void> _recheckConnectivity() async {
+    final epochBefore = ++_updateEpoch;
+    final List<ConnectivityResult> result;
+    try {
+      result = await ZulipBinding.instance.checkConnectivity();
+    } catch (e) { // TODO(log)
+      assert(debugLog('Error in checkConnectivity: $e'));
+      return;
+    }
+    if (_disposed) return;
+    if (_updateEpoch != epochBefore) {
+      // An update arrived, or a newer recheck began, while we were checking.
+      // Ours is a snapshot from before that, so may be stale; discard it.
+      return;
+    }
+    _handleConnectivityUpdate(result);
+  }
+
+  void _handleAppLifecycleStateChange(AppLifecycleState state) {
+    assert(!_disposed); // The subscription is canceled in [dispose].
+    if (state != .resumed) return;
+    // Connectivity updates can be dropped while the app is in the
+    // background, rather than delivered on returning to the foreground
+    // (see [ZulipBinding.connectivityChanges]).  So check whether the
+    // network changed while we were away.
+    unawaited(_recheckConnectivity());
+  }
+
+  bool _disposed = false;
+
+  void dispose() {
+    assert(!_disposed);
+    _connectivitySubscription?.cancel();
+    _lifecycleSubscription?.cancel();
+    _cooldownTimer?.cancel();
+    _retrySignalsController.close();
+    _disposed = true;
+  }
+}

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1698,24 +1698,44 @@ class UpdateMachine {
 
   StreamSubscription<AppLifecycleState>? _appLifecycleSubscription;
 
-  /// Non-null just when the most recent poll failure suggests
-  /// the device was asleep or the app was in the background,
-  /// so that waking should discard the accumulated backoff state.
+  /// Non-null just when the poll loop is in, or headed for, a backoff wait
+  /// after a transport failure: one where no complete response arrived,
+  /// so that the network is a plausible culprit.
   ///
   /// Completing it aborts the backoff wait in progress, if any.
-  /// See [_handleAppLifecycleStateChange].
+  /// See [_abortPollBackoff] and [_handleAppLifecycleStateChange].
   Completer<void>? _pollBackoffAbortTrigger;
+
+  /// Whether waking should discard the backoff state
+  /// from the latest poll failure,
+  /// aborting the backoff wait in progress, if any.
+  ///
+  /// Waking is weaker evidence about a failure's cause than a
+  /// connectivity change is: it should cut backoff short only when the
+  /// failure looked sleep-induced (a failed connection; see #1884),
+  /// not for other transport failures.
+  bool _pollBackoffAbortableOnWake = false;
+
+  /// Abort the backoff wait of [_pollBackoffAbortTrigger],
+  /// if one is in progress,
+  /// and discard the accumulated backoff state
+  /// so that after any further failure, backoff starts over small.
+  void _abortPollBackoff() {
+    final trigger = _pollBackoffAbortTrigger;
+    _pollBackoffMachine = null;
+    _pollBackoffAbortTrigger = null;
+    trigger?.complete();
+  }
 
   void _handleAppLifecycleStateChange(AppLifecycleState state) {
     assert(!_disposed); // The subscription is canceled in [dispose].
     if (state != .resumed) return;
-    if (_pollBackoffAbortTrigger case final trigger?) {
+    if (_pollBackoffAbortableOnWake && _pollBackoffMachine != null) {
       // Retry immediately, and if the network still isn't back
       // (it can take a moment after waking), let backoff start over small.
+      // (With no wait in progress, this just discards the backoff state.)
       assert(debugLog('App returned to foreground; aborting poll backoff.'));
-      _pollBackoffMachine = null;
-      _pollBackoffAbortTrigger = null;
-      trigger.complete();
+      _abortPollBackoff();
     }
   }
 
@@ -1746,6 +1766,7 @@ class UpdateMachine {
     // If server logs show pressure from too many requests, we can investigate.
     _pollBackoffMachine = null;
     _pollBackoffAbortTrigger = null;
+    _pollBackoffAbortableOnWake = false;
 
     store.isRecoveringEventStream = false;
     _accumulatedTransientFailureCount = 0;
@@ -1810,9 +1831,17 @@ class UpdateMachine {
     if (shouldReportToUser) {
       _maybeReportToUserTransientError(error);
     }
-    _pollBackoffAbortTrigger = abortBackoffOnWake ? Completer() : null;
+    // Any NetworkException means the transport failed before a complete
+    // response arrived, so the network is a plausible culprit and a
+    // network-connectivity change is evidence about the failure's cause:
+    // let such a change abort the wait, for an immediate retry.
+    // When the server did respond (a 5xx or a rate limit), a network
+    // change is no such evidence; let the wait run.
+    _pollBackoffAbortTrigger = (error is NetworkException) ? Completer() : null;
+    _pollBackoffAbortableOnWake = abortBackoffOnWake;
     await (_pollBackoffMachine ??= BackoffMachine())
       .wait(abortTrigger: _pollBackoffAbortTrigger?.future);
+    _pollBackoffAbortTrigger = null;
     if (_disposed) return;
     assert(debugLog('… Backoff wait complete, retrying poll.'));
   }

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -1654,6 +1654,13 @@ class UpdateMachine {
 
   void poll() async {
     assert(!_disposed);
+    // Before subscribing to lifecycle events, so that even in tests
+    // (where the monitor is created lazily, by this first access)
+    // the monitor's lifecycle listener runs before ours,
+    // as it does in the live app.
+    assert(_retrySignalSubscription == null);
+    _retrySignalSubscription = _connectivityMonitor.retrySignals
+      .listen(_handleConnectivityRetrySignal);
     assert(_appLifecycleSubscription == null);
     _appLifecycleSubscription = ZulipBinding.instance.appLifecycleStateChanges
       .listen(_handleAppLifecycleStateChange);
@@ -1665,6 +1672,12 @@ class UpdateMachine {
         }
 
         final GetEventsResult result;
+        assert(_pollAbortTrigger == null);
+        final abortTrigger = Completer<void>();
+        _pollAbortTrigger = abortTrigger;
+        // Note which network this request is made on, in effect;
+        // see [_handleConnectivityRetrySignal].
+        _pollConnectivityCount = _connectivityMonitor.updateCount;
         try {
           result = await getEvents(store.connection,
             queueId: store.queueId,
@@ -1676,9 +1689,14 @@ class UpdateMachine {
             dontBlock: store.isRecoveringEventStream ? true : null,
             // If the request outlives this, assume the connection is dead
             // even if it still looks open; give up on it and retry.  See #514.
-            timeout: store.eventQueueLongpollTimeout);
+            timeout: store.eventQueueLongpollTimeout,
+            // On a network-connectivity change, we abort the request;
+            // see [_handleConnectivityRetrySignal].  (#2415)
+            abortTrigger: abortTrigger.future);
+          _pollAbortTrigger = null;
           if (_disposed) return;
         } catch (e, stackTrace) {
+          _pollAbortTrigger = null;
           if (_disposed) return;
           await _handlePollRequestError(e, stackTrace); // may rethrow
           if (_disposed) return;
@@ -1728,12 +1746,37 @@ class UpdateMachine {
 
   StreamSubscription<AppLifecycleState>? _appLifecycleSubscription;
 
+  ConnectivityMonitor get _connectivityMonitor =>
+    store._globalStore.connectivityMonitor;
+
+  StreamSubscription<void>? _retrySignalSubscription;
+
+  /// The value of [ConnectivityMonitor.updateCount] as of the start
+  /// of the poll request now (or most recently) in flight.
+  ///
+  /// If the count has moved on, the network may have changed under
+  /// the request; see [_handleConnectivityRetrySignal].
+  int _pollConnectivityCount = 0;
+
+  /// Non-null just while a poll request is in flight.
+  ///
+  /// Completing it aborts the request, which then fails and is retried
+  /// just as if it had hit the request timeout.
+  /// Little is lost in the abort, even mid-response:
+  /// these responses aren't large, and the server retains events
+  /// until we ack them via `last_event_id`,
+  /// so the retry just fetches the same events again.
+  ///
+  /// See [_handleConnectivityRetrySignal].
+  Completer<void>? _pollAbortTrigger;
+
   /// Non-null just when the poll loop is in, or headed for, a backoff wait
   /// after a transport failure: one where no complete response arrived,
   /// so that the network is a plausible culprit.
   ///
   /// Completing it aborts the backoff wait in progress, if any.
-  /// See [_abortPollBackoff] and [_handleAppLifecycleStateChange].
+  /// See [_abortPollBackoff], [_handleConnectivityRetrySignal],
+  /// and [_handleAppLifecycleStateChange].
   Completer<void>? _pollBackoffAbortTrigger;
 
   /// Whether waking should discard the backoff state
@@ -1757,6 +1800,38 @@ class UpdateMachine {
     trigger?.complete();
   }
 
+  /// Handle a [ConnectivityMonitor.retrySignals] event:
+  /// the network changed,
+  /// so a poll request from before the change,
+  /// or the backoff wait after such a request failed,
+  /// is probably a lost cause.
+  ///
+  /// Abort the request (see [_pollAbortTrigger])
+  /// or the backoff wait (see [_pollBackoffAbortTrigger]),
+  /// so that polling retries promptly on the new network.
+  void _handleConnectivityRetrySignal(void _) {
+    assert(!_disposed); // The subscription is canceled in [dispose].
+    if (_pollConnectivityCount == _connectivityMonitor.updateCount) {
+      // The current request started after the network change;
+      // the change is no evidence against it.
+      return;
+    }
+    if (_pollAbortTrigger case final trigger?) {
+      // No backoff wait is in progress (a request is in flight);
+      // here [_abortPollBackoff] just discards the stale backoff state,
+      // so the retry after this abort is prompt.
+      assert(_pollBackoffAbortTrigger == null);
+      assert(debugLog('Network connectivity changed; aborting stalled poll.'));
+      _pollAbortTrigger = null;
+      _abortPollBackoff();
+      trigger.complete();
+    } else if (_pollBackoffAbortTrigger != null) {
+      // Retry immediately on the new network.
+      assert(debugLog('Network connectivity changed; aborting poll backoff.'));
+      _abortPollBackoff();
+    }
+  }
+
   void _handleAppLifecycleStateChange(AppLifecycleState state) {
     assert(!_disposed); // The subscription is canceled in [dispose].
     if (state != .resumed) return;
@@ -1764,6 +1839,17 @@ class UpdateMachine {
       // Retry immediately, and if the network still isn't back
       // (it can take a moment after waking), let backoff start over small.
       // (With no wait in progress, this just discards the backoff state.)
+      //
+      // Known harmless race: the monitor's resume recheck may record a
+      // background network change only after this retry has started,
+      // and then falsely impeach it -- one wasted abort, and a prompt
+      // second retry.
+      // TODO(upstream): would dissolve given a synchronous
+      //   checkConnectivity (the monitor's resume listener runs first,
+      //   so the change would be recorded before this retry starts);
+      //   possible in principle now that Flutter's platform and UI
+      //   threads are merged, cf.
+      //     https://github.com/fluttercommunity/plus_plugins/issues/3553
       assert(debugLog('App returned to foreground; aborting poll backoff.'));
       _abortPollBackoff();
     }
@@ -1990,6 +2076,7 @@ class UpdateMachine {
   void dispose() {
     assert(!_disposed);
     _appLifecycleSubscription?.cancel();
+    _retrySignalSubscription?.cancel();
     _disposed = true;
   }
 

--- a/lib/model/store.dart
+++ b/lib/model/store.dart
@@ -24,6 +24,7 @@ import '../notifications/ios_service.dart';
 import 'actions.dart';
 import 'autocomplete.dart';
 import 'binding.dart';
+import 'connectivity.dart';
 import 'database.dart';
 import 'emoji.dart';
 import 'localizations.dart';
@@ -97,6 +98,11 @@ abstract class GlobalStoreBackend {
 /// settings. It also includes a small amount of data for each account: enough
 /// to authenticate as the active account, if there is one.
 ///
+/// Besides data, this object owns machinery that serves the stores
+/// app-wide, like [connectivityMonitor] --
+/// much as a [PerAccountStore] owns [PerAccountStore.connection]
+/// and [PerAccountStore.updateMachine].
+///
 /// For other data associated with a particular account, a [GlobalStore]
 /// provides a [PerAccountStore] for each account, which can be reached with
 /// [GlobalStore.perAccount] or [GlobalStore.perAccountSync].
@@ -128,6 +134,30 @@ abstract class GlobalStore extends ChangeNotifier {
   final GlobalSettingsStore settings;
 
   final GlobalPushKeyStore pushKeys;
+
+  /// A monitor of the device's network connectivity, shared app-wide.
+  ///
+  /// Lazy, so that constructing a [GlobalStore] doesn't require
+  /// [ZulipBinding] to be initialized.
+  /// The live app starts it eagerly; see [startConnectivityMonitor].
+  ConnectivityMonitor get connectivityMonitor =>
+    _connectivityMonitor ??= ConnectivityMonitor();
+  ConnectivityMonitor? _connectivityMonitor;
+
+  /// Ensure [connectivityMonitor] has started watching.
+  ///
+  /// Call this at app startup:
+  /// a change can be recognized only against a baseline,
+  /// so the earlier the monitor starts,
+  /// the sooner its signals -- and the current state,
+  /// for any consumer that wants that -- become meaningful.
+  void startConnectivityMonitor() => connectivityMonitor;
+
+  @override
+  void dispose() {
+    _connectivityMonitor?.dispose();
+    super.dispose();
+  }
 
   /// Construct a new [ApiConnection], real or fake as appropriate.
   ///

--- a/lib/widgets/store.dart
+++ b/lib/widgets/store.dart
@@ -95,6 +95,10 @@ class _GlobalStoreWidgetState extends State<GlobalStoreWidget> {
     super.initState();
     (() async {
       final store = await ZulipBinding.instance.getGlobalStoreUniquely();
+      // Here rather than in the store itself, so that processes with no UI
+      // (the notification-handling processes, in particular) don't
+      // needlessly watch connectivity.
+      store.startConnectivityMonitor();
       if (widget.blockingFuture != null) {
         await widget.blockingFuture!.catchError((_) {});
       }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import app_settings
+import connectivity_plus
 import device_info_plus
 import file_picker
 import file_selector_macos
@@ -20,6 +21,7 @@ import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppSettingsPlugin.register(with: registry.registrar(forPlugin: "AppSettingsPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - app_settings (5.1.1):
     - FlutterMacOS
   - CocoaAsyncSocket (7.6.5)
+  - connectivity_plus (0.0.1):
+    - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
   - file_picker (0.0.1):
@@ -93,6 +95,7 @@ PODS:
 
 DEPENDENCIES:
   - app_settings (from `Flutter/ephemeral/.symlinks/plugins/app_settings/macos`)
+  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
@@ -122,6 +125,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   app_settings:
     :path: Flutter/ephemeral/.symlinks/plugins/app_settings/macos
+  connectivity_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   file_picker:
@@ -150,6 +155,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_settings: cd21e176b56f8172043640ade81322a98896bff4
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
+  connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -202,6 +202,22 @@ packages:
       url: "https://github.com/gaaclarke/color_models.git"
     source: git
     version: "1.3.3"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   convert:
     dependency: "direct main"
     description:
@@ -774,6 +790,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.6"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
 
   app_settings: ^7.0.0
   collection: ^1.17.2
+  connectivity_plus: ^7.3.1
   convert: ^3.1.1
   crypto: ^3.0.3
   csslib: ^1.0.2

--- a/test/api/core_test.dart
+++ b/test/api/core_test.dart
@@ -437,6 +437,67 @@ void main() {
     });
   }));
 
+  /// Test that a request under [ApiConnection.get]'s [abortTrigger]
+  /// (and possibly a timeout) fails as an aborted request does,
+  /// after [expectedElapsed].
+  void testAbortedRequest(String description, {
+    bool responseStarted = false,
+    Duration? timeout,
+    bool fireAbortTrigger = true,
+    required Duration expectedElapsed,
+  }) {
+    test(description, () => awaitFakeAsync((async) async {
+      await FakeApiConnection.with_((connection) async {
+        const responseDelay = Duration(seconds: 300);
+        connection.prepare(
+          delay: responseStarted ? Duration.zero : responseDelay,
+          bodyDelay: responseStarted ? responseDelay : Duration.zero,
+          json: {});
+        final abortTrigger = Completer<void>();
+        final future = connection.get(kExampleRouteName, (json) => json,
+          'example/route', {},
+          timeout: timeout, abortTrigger: abortTrigger.future);
+        if (fireAbortTrigger) {
+          async.elapse(const Duration(seconds: 30));
+          abortTrigger.complete();
+        }
+        await check(future).throws<NetworkException>((it) => it
+          ..routeName.equals(kExampleRouteName)
+          ..kind.equals(.connectionFailed)
+          ..cause.isA<http.RequestAbortedException>());
+        check(async.elapsed).equals(expectedElapsed);
+      });
+    }));
+  }
+
+  testAbortedRequest('API request aborted by abortTrigger',
+    expectedElapsed: const Duration(seconds: 30));
+
+  testAbortedRequest('API request aborted by abortTrigger while reading response body',
+    responseStarted: true,
+    expectedElapsed: const Duration(seconds: 30));
+
+  testAbortedRequest('abortTrigger aborts request before its timeout',
+    timeout: const Duration(seconds: 90),
+    expectedElapsed: const Duration(seconds: 30));
+
+  testAbortedRequest('timeout still applies when abortTrigger never fires',
+    timeout: const Duration(seconds: 90),
+    fireAbortTrigger: false,
+    expectedElapsed: const Duration(seconds: 90));
+
+  test('no effect when abortTrigger fires after request completes', () => awaitFakeAsync((async) async {
+    await FakeApiConnection.with_((connection) async {
+      final abortTrigger = Completer<void>();
+      connection.prepare(json: {'x': 3});
+      final result = await connection.get(kExampleRouteName, (json) => json['x'],
+        'example/route', {}, abortTrigger: abortTrigger.future);
+      check(result).equals(3);
+      abortTrigger.complete();
+      async.flushMicrotasks();
+    });
+  }));
+
   test('API 4xx errors, well formed', () async {
     Future<void> checkRequest({
       int httpStatus = 400,

--- a/test/model/binding.dart
+++ b/test/model/binding.dart
@@ -79,6 +79,7 @@ class TestZulipBinding extends ZulipBinding {
     _resetLaunchUrl();
     _resetCloseInAppWebView();
     _resetAppLifecycleStateChanges();
+    _resetConnectivity();
     _resetDeviceInfo();
     _resetPackageInfo();
     _resetFirebase();
@@ -275,6 +276,62 @@ class TestZulipBinding extends ZulipBinding {
   @override
   Stream<AppLifecycleState> get appLifecycleStateChanges =>
     _appLifecycleStateChangesController.stream;
+
+  void _resetConnectivity() {
+    _connectivityChanges = null;
+    connectivityResult = _defaultConnectivityResult;
+    connectivityCheckDelay = Duration.zero;
+    connectivityCheckError = null;
+  }
+
+  /// The value that `ZulipBinding.instance.checkConnectivity` should return.
+  ///
+  /// Also updated by [notifyConnectivityChanged], to keep the fake
+  /// self-consistent.
+  List<ConnectivityResult> connectivityResult = _defaultConnectivityResult;
+  static const _defaultConnectivityResult = [ConnectivityResult.wifi];
+
+  /// How long [checkConnectivity] takes to complete.
+  ///
+  /// The result reflects [connectivityResult] as of when the call was made,
+  /// like a real check's result reflects the state when the platform
+  /// sampled it.
+  Duration connectivityCheckDelay = Duration.zero;
+
+  /// If non-null, [checkConnectivity] throws this instead of returning.
+  Object? connectivityCheckError;
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async {
+    final result = connectivityResult;
+    final error = connectivityCheckError;
+    if (connectivityCheckDelay != Duration.zero) {
+      await Future<void>.delayed(connectivityCheckDelay);
+    }
+    if (error != null) throw error;
+    return result;
+  }
+
+  /// Simulate a network-connectivity change,
+  /// causing [connectivityChanges] to fire
+  /// and updating [connectivityResult] to match.
+  void notifyConnectivityChanged(List<ConnectivityResult> result) {
+    connectivityResult = result;
+    _connectivityChangesController.add(result);
+  }
+
+  /// Simulate an error event on [connectivityChanges].
+  void notifyConnectivityError(Object error) {
+    _connectivityChangesController.addError(error);
+  }
+
+  StreamController<List<ConnectivityResult>> get _connectivityChangesController =>
+    _connectivityChanges ??= StreamController.broadcast();
+  StreamController<List<ConnectivityResult>>? _connectivityChanges;
+
+  @override
+  Stream<List<ConnectivityResult>> get connectivityChanges =>
+    _connectivityChangesController.stream;
 
   /// The value that `ZulipBinding.instance.deviceInfo` should return.
   BaseDeviceInfo deviceInfoResult = _defaultDeviceInfoResult;

--- a/test/model/connectivity_test.dart
+++ b/test/model/connectivity_test.dart
@@ -1,0 +1,229 @@
+import 'package:checks/checks.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:test/scaffolding.dart';
+import 'package:zulip/model/binding.dart';
+import 'package:zulip/model/connectivity.dart';
+
+import '../fake_async.dart';
+import 'binding.dart';
+
+void main() {
+  TestZulipBinding.ensureInitialized();
+
+  group('ConnectivityMonitor', () {
+    late ConnectivityMonitor monitor;
+    late int signalCount;
+
+    void prepare(FakeAsync async, {
+      List<ConnectivityResult> connectivity = const [ConnectivityResult.wifi],
+    }) {
+      addTearDown(testBinding.reset);
+      testBinding.connectivityResult = connectivity;
+      monitor = ConnectivityMonitor();
+      signalCount = 0;
+      monitor.retrySignals.listen((_) => signalCount++);
+      // Let the baseline get established.
+      async.flushMicrotasks();
+    }
+
+    test('signal on a change; updateCount advances', () => awaitFakeAsync((async) async {
+      prepare(async);
+      final countBefore = monitor.updateCount;
+
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+      check(monitor.updateCount).isGreaterThan(countBefore);
+    }));
+
+    test('no signal on a report of unchanged connectivity', () => awaitFakeAsync((async) async {
+      prepare(async,
+        connectivity: [ConnectivityResult.wifi, ConnectivityResult.vpn]);
+      final countBefore = monitor.updateCount;
+
+      // The same set in a different order is not a change.
+      testBinding.notifyConnectivityChanged(
+        [ConnectivityResult.vpn, ConnectivityResult.wifi]);
+      async.flushMicrotasks();
+      check(signalCount).equals(0);
+      check(monitor.updateCount).equals(countBefore);
+    }));
+
+    test('no signal on losing connectivity; signal when it returns', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      // Losing connectivity entirely prompts no signal:
+      // a retry could not succeed anyway.
+      testBinding.notifyConnectivityChanged([ConnectivityResult.none]);
+      async.flushMicrotasks();
+      check(signalCount).equals(0);
+
+      testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+    }));
+
+    test('signals are paced: change during cooldown signals at cooldown end', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      // The first change signals immediately…
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+
+      // …but another hard on its heels is recorded without a signal…
+      async.elapse(const Duration(seconds: 5));
+      final countBefore = monitor.updateCount;
+      testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+      check(monitor.updateCount).isGreaterThan(countBefore);
+
+      // …until the cooldown ends.
+      async.elapse(const Duration(seconds: 5));
+      check(signalCount).equals(2);
+
+      // With no further changes, no further signals.
+      async.elapse(const Duration(minutes: 1));
+      check(signalCount).equals(2);
+    }));
+
+    test('no deferred signal when connectivity is gone at cooldown end', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+
+      // A change lands during the cooldown… but then connectivity is lost,
+      // so the cooldown ends without the deferred signal…
+      async.elapse(const Duration(seconds: 3));
+      testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+      async.elapse(const Duration(seconds: 3));
+      testBinding.notifyConnectivityChanged([ConnectivityResult.none]);
+      async.elapse(const Duration(seconds: 10));
+      check(signalCount).equals(1);
+
+      // …and the signal comes when connectivity returns.
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(2);
+    }));
+
+    test('recheck on resume discovers a change', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      // The network changed while the app was in the background, with the
+      // connectivity update dropped rather than delivered, as happens on
+      // both Android and iOS (see [ZulipBinding.connectivityChanges]).
+      // On resume, the change is discovered by checking.
+      testBinding.connectivityResult = [ConnectivityResult.mobile];
+      testBinding.notifyAppLifecycleStateChanged(.resumed);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+    }));
+
+    test('no signal on resume when connectivity unchanged', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      // A brief trip to the app switcher and back, with no network change.
+      testBinding.notifyAppLifecycleStateChanged(.resumed);
+      async.flushMicrotasks();
+      check(signalCount).equals(0);
+    }));
+
+    test('stale checkConnectivity result discarded', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      // A recheck on resume is slow to resolve…
+      testBinding.connectivityCheckDelay = const Duration(seconds: 2);
+      testBinding.notifyAppLifecycleStateChanged(.resumed);
+      async.flushMicrotasks();
+
+      // …and meanwhile the network actually changes.
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+
+      // The recheck's result is from before that change, so it's
+      // discarded: it doesn't count as a change back to wifi…
+      final countBefore = monitor.updateCount;
+      async.elapse(const Duration(seconds: 2));
+      check(monitor.updateCount).equals(countBefore);
+
+      // …so a later real change back to wifi is recognized as a change.
+      async.elapse(const Duration(seconds: 10));
+      testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+      async.flushMicrotasks();
+      check(signalCount).equals(2);
+    }));
+
+    test('overlapping rechecks: the older result is discarded', () => awaitFakeAsync((async) async {
+      // Each recheck samples the state as of when it starts
+      // (see [TestZulipBinding.checkConnectivity]),
+      // and the platform's replies resolve in FIFO order.
+      addTearDown(testBinding.reset);
+      testBinding.connectivityResult = const [ConnectivityResult.wifi];
+      testBinding.connectivityCheckDelay = const Duration(seconds: 2);
+      monitor = ConnectivityMonitor(); // baseline recheck samples [wifi]
+      signalCount = 0;
+      monitor.retrySignals.listen((_) => signalCount++);
+
+      // The network changes before the baseline recheck resolves,
+      // and a resume prompts a second recheck, sampling the new state.
+      async.elapse(const Duration(seconds: 1));
+      testBinding.connectivityResult = const [ConnectivityResult.mobile];
+      testBinding.notifyAppLifecycleStateChanged(.resumed);
+
+      // The stale first result is discarded
+      // and the second becomes the baseline…
+      async.elapse(const Duration(seconds: 2));
+      // …so a change back to wifi is recognized as a change.
+      testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+    }));
+
+    test('survive a failed checkConnectivity', () => awaitFakeAsync((async) async {
+      addTearDown(testBinding.reset);
+      testBinding.connectivityCheckError = Exception('platform error');
+      monitor = ConnectivityMonitor(); // baseline recheck fails
+      signalCount = 0;
+      monitor.retrySignals.listen((_) => signalCount++);
+      async.flushMicrotasks();
+
+      // With the baseline recheck failed, the first stream update
+      // has to serve as the baseline, even if it is in fact a change…
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(0);
+
+      // …and from there, changes are recognized as usual.
+      testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+    }));
+
+    test('survive an error on the connectivity stream', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      // An error from the platform doesn't crash anything…
+      testBinding.notifyConnectivityError(Exception('platform error'));
+      async.flushMicrotasks();
+
+      // …and later updates are still delivered and handled.
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(1);
+    }));
+
+    test('no effect after dispose', () => awaitFakeAsync((async) async {
+      prepare(async);
+
+      monitor.dispose();
+      testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+      async.flushMicrotasks();
+      check(signalCount).equals(0);
+    }));
+  });
+}

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -953,6 +953,12 @@ void main() {
       });
     }
 
+    void prepareHeartbeat(int eventId, {Duration delay = Duration.zero}) {
+      connection.prepare(delay: delay, json: GetEventsResult(events: [
+        HeartbeatEvent(id: eventId),
+      ], queueId: null).toJson());
+    }
+
     // These cases are ordered by how far the request got before it failed.
 
     void prepareUnexpectedLoopError() {
@@ -1158,6 +1164,35 @@ void main() {
         connection.prepare(json: GetEventsResult(events: [
           HeartbeatEvent(id: 2),
         ], queueId: null).toJson());
+        async.flushTimers();
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        check(updateMachine.lastEventId).equals(2);
+      }));
+
+      test('no abort when backoff is from a non-connectionFailed network error', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 10);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        // Fail with a transport error that isn't a failed connection
+        // (its kind is [NetworkExceptionKind.other]); see #1884 for why
+        // waking should cut short only failed-connection backoffs.
+        prepareNetworkException();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        checkLastRequest(lastEventId: 1);
+        final machineBefore = updateMachine.debugPollBackoffMachine;
+
+        // Coming to the foreground doesn't cut the backoff short,
+        // and doesn't discard the accumulated backoff state either.
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+        check(connection.lastRequest).isNull();
+        check(updateMachine.debugPollBackoffMachine).identicalTo(machineBefore);
+
+        // Polling continues after the backoff.
+        prepareHeartbeat(2);
         async.flushTimers();
         checkLastRequest(lastEventId: 1, expectDontBlock: true);
         check(updateMachine.lastEventId).equals(2);

--- a/test/model/store_test.dart
+++ b/test/model/store_test.dart
@@ -17,6 +17,7 @@ import 'package:zulip/api/route/events.dart';
 import 'package:zulip/api/route/realm.dart';
 import 'package:zulip/log.dart';
 import 'package:zulip/model/actions.dart';
+import 'package:zulip/model/binding.dart';
 import 'package:zulip/model/presence.dart';
 import 'package:zulip/model/server_support.dart';
 import 'package:zulip/model/store.dart';
@@ -959,6 +960,13 @@ void main() {
       ], queueId: null).toJson());
     }
 
+    /// Prepare a response that never arrives:
+    /// the connection died silently (see #514).
+    void prepareStuckPollResponse() {
+      connection.prepare(delay: const Duration(seconds: 300),
+        json: GetEventsResult(events: [], queueId: null).toJson());
+    }
+
     // These cases are ordered by how far the request got before it failed.
 
     void prepareUnexpectedLoopError() {
@@ -1212,6 +1220,195 @@ void main() {
 
         updateMachine.dispose();
         testBinding.notifyAppLifecycleStateChanged(.resumed);
+        async.flushMicrotasks();
+      }));
+    });
+
+    group('abort stalled poll on connectivity change', () {
+      /// Start a poll request that gets stuck
+      /// (see [prepareStuckPollResponse]).
+      void startStuckPoll(FakeAsync async) {
+        prepareStuckPollResponse();
+        updateMachine.debugAdvanceLoop();
+        async.flushMicrotasks();
+        checkLastRequest(lastEventId: 1);
+      }
+
+      test('abort request stuck awaiting response', () => awaitFakeAsync((async) async {
+        // Regression test for: https://github.com/zulip/zulip-flutter/issues/2415
+        BackoffMachine.debugDuration = const Duration(seconds: 1);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        startStuckPoll(async);
+        async.elapse(const Duration(seconds: 30));
+
+        // On a connectivity change, the stuck request is aborted.
+        // It fails like any failed request -- the recovering state
+        // shows -- but with the backoff state discarded, so the retry
+        // goes out after just the initial backoff.
+        prepareHeartbeat(2);
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+        async.flushMicrotasks();
+        check(store).isRecoveringEventStream.isTrue();
+        async.elapse(const Duration(seconds: 1));
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        check(updateMachine.lastEventId).equals(2);
+        check(store).isRecoveringEventStream.isFalse();
+      }));
+
+      test('abort discards accumulated backoff state', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 1);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        // Fail once, so that backoff state accumulates; from a server
+        // error, so that no backoff-abort trigger is armed.
+        prepareServer5xxException();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        checkLastRequest(lastEventId: 1);
+
+        // The retry gets stuck.
+        prepareStuckPollResponse();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(const Duration(seconds: 1));
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        final machineBefore = updateMachine.debugPollBackoffMachine;
+        check(machineBefore).isNotNull();
+
+        // The abort discards the accumulated backoff state: the machine
+        // the failed request's error handling creates is a fresh one.
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+        async.flushMicrotasks();
+        check(updateMachine.debugPollBackoffMachine)
+          ..isNotNull()
+          ..not((it) => it.identicalTo(machineBefore));
+      }));
+
+      test('abort backoff wait from a non-connectionFailed transport failure', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 10);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        // Fail with a transport error that isn't a failed connection
+        // (its kind is [NetworkExceptionKind.other]), entering a backoff
+        // wait.  A wake wouldn't abort this wait…
+        prepareNetworkException();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        checkLastRequest(lastEventId: 1);
+        check(async.pendingTimers).length.equals(1);
+
+        // …but a connectivity change does: the transport failed, so the
+        // network is a plausible culprit, and the network just changed.
+        prepareHeartbeat(2);
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+        async.flushMicrotasks();
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        // The change also discarded the accumulated backoff state.
+        check(updateMachine.debugPollBackoffMachine).isNull();
+        async.elapse(Duration.zero);
+        check(updateMachine.lastEventId).equals(2);
+      }));
+
+      test('no abort of backoff wait from a server error', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 10);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        // Fail from the server itself: the network demonstrably worked,
+        // so a connectivity change is no reason to retry sooner.
+        prepareServer5xxException();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(Duration.zero);
+        checkLastRequest(lastEventId: 1);
+        check(async.pendingTimers).length.equals(1);
+
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+        async.flushMicrotasks();
+        check(connection.lastRequest).isNull();
+
+        // Polling continues after the backoff.
+        prepareHeartbeat(2);
+        async.flushTimers();
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        check(updateMachine.lastEventId).equals(2);
+      }));
+
+      test('deferred retry signal aborts a retry that predates the change', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 1);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        startStuckPoll(async);
+
+        // The first change aborts the poll…
+        prepareStuckPollResponse();
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+        async.elapse(const Duration(seconds: 1));
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+
+        // …but another change hard on its heels doesn't abort the retry
+        // immediately…
+        async.elapse(const Duration(seconds: 4));
+        testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+        async.flushMicrotasks();
+        check(connection.lastRequest).isNull();
+
+        // …only when the deferred signal comes at the cooldown's end:
+        // the retry predates that change, so its connection is suspect too.
+        prepareHeartbeat(2);
+        updateMachine.debugAdvanceLoop();
+        async.elapse(const Duration(seconds: 6));
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+        check(updateMachine.lastEventId).equals(2);
+      }));
+
+      test('deferred retry signal is moot once a fresh request has started', () => awaitFakeAsync((async) async {
+        BackoffMachine.debugDuration = const Duration(seconds: 1);
+        addTearDown(() => BackoffMachine.debugDuration = null);
+        await preparePoll(lastEventId: 1);
+
+        startStuckPoll(async);
+
+        // A change aborts the poll; the retry is slow but healthy.
+        prepareHeartbeat(2, delay: const Duration(seconds: 5));
+        updateMachine.debugAdvanceLoop();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
+        async.elapse(const Duration(seconds: 1));
+        checkLastRequest(lastEventId: 1, expectDontBlock: true);
+
+        // Another change lands during the cooldown, deferred.
+        async.elapse(const Duration(seconds: 2));
+        testBinding.notifyConnectivityChanged([ConnectivityResult.wifi]);
+        async.flushMicrotasks();
+        check(connection.lastRequest).isNull();
+
+        // The retry completes, and the next poll goes out --
+        // a request made after the change, on the current network.
+        prepareStuckPollResponse();
+        updateMachine.debugAdvanceLoop();
+        async.elapse(const Duration(seconds: 3));
+        checkLastRequest(lastEventId: 2);
+        check(updateMachine.lastEventId).equals(2);
+
+        // So when the cooldown ends, the deferred change is moot:
+        // the poll is left alone.
+        async.elapse(const Duration(seconds: 5));
+        check(connection.lastRequest).isNull();
+      }));
+
+      test('no effect after dispose', () => awaitFakeAsync((async) async {
+        await preparePoll(lastEventId: 1);
+
+        updateMachine.dispose();
+        testBinding.notifyConnectivityChanged([ConnectivityResult.mobile]);
         async.flushMicrotasks();
       }));
     });

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   firebase_core
   share_plus


### PR DESCRIPTION
Fixes #2415.

This PR is stacked atop #2427.

Since PR #2396, a `GET /events` request on a silently-dead connection is aborted after the server-recommended timeout (90s by default) and retried quietly. The main way a connection dies silently is a network change, like from Wi-Fi to cellular, and until a response starts to arrive, a poll stuck that way is indistinguishable from a healthy idle long-poll, so the user can wait out up to the full 90s looking at stale data.

This PR aborts and retries the stuck request when the network changes, except if the network status is reported to us as "none" (in which case a retry would be useless).