### PR TITLE
topic autocomplete: Show New option when query does not match any topic

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -1530,6 +1530,10 @@
   "@wildcardMentionTopicDescription": {
     "description": "Description for \"@topic\" wildcard-mention autocomplete options when writing a channel message."
   },
+  "topicAutocompleteNewOptionLabel": "New",
+  "@topicAutocompleteNewOptionLabel": {
+    "description": "Label for the topic autocomplete option matching the user's query when no exact topic exists."
+  },
   "systemGroupNameEveryoneOnInternet": "Everyone on the internet",
   "@systemGroupNameEveryoneOnInternet": {
     "description": "Display name for the system group that includes everyone on the internet."

--- a/lib/generated/l10n/zulip_localizations.dart
+++ b/lib/generated/l10n/zulip_localizations.dart
@@ -2210,6 +2210,12 @@ abstract class ZulipLocalizations {
   /// **'Notify topic'**
   String get wildcardMentionTopicDescription;
 
+  /// Label for the topic autocomplete option matching the user's query when no exact topic exists.
+  ///
+  /// In en, this message translates to:
+  /// **'New'**
+  String get topicAutocompleteNewOptionLabel;
+
   /// Display name for the system group that includes everyone on the internet.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/zulip_localizations_ar.dart
+++ b/lib/generated/l10n/zulip_localizations_ar.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsAr extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'إخطار الموضوع';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_de.dart
+++ b/lib/generated/l10n/zulip_localizations_de.dart
@@ -1312,6 +1312,9 @@ class ZulipLocalizationsDe extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Thema benachrichtigen';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Jeder im Internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_el.dart
+++ b/lib/generated/l10n/zulip_localizations_el.dart
@@ -1281,6 +1281,9 @@ class ZulipLocalizationsEl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_en.dart
+++ b/lib/generated/l10n/zulip_localizations_en.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsEn extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_es.dart
+++ b/lib/generated/l10n/zulip_localizations_es.dart
@@ -1300,6 +1300,9 @@ class ZulipLocalizationsEs extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notificar tema';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Todo el mundo en Internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_et.dart
+++ b/lib/generated/l10n/zulip_localizations_et.dart
@@ -1297,6 +1297,9 @@ class ZulipLocalizationsEt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_fr.dart
+++ b/lib/generated/l10n/zulip_localizations_fr.dart
@@ -1320,6 +1320,9 @@ class ZulipLocalizationsFr extends ZulipLocalizations {
       'Notifier les participants à cette conversation';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Tout le monde sur Internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_he.dart
+++ b/lib/generated/l10n/zulip_localizations_he.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsHe extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hu.dart
+++ b/lib/generated/l10n/zulip_localizations_hu.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsHu extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_hy.dart
+++ b/lib/generated/l10n/zulip_localizations_hy.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsHy extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_it.dart
+++ b/lib/generated/l10n/zulip_localizations_it.dart
@@ -1306,6 +1306,9 @@ class ZulipLocalizationsIt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notifica argomento';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Chiunque su internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ja.dart
+++ b/lib/generated/l10n/zulip_localizations_ja.dart
@@ -1251,6 +1251,9 @@ class ZulipLocalizationsJa extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'トピック参加者に通知';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'インターネット上の全員';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_kk.dart
+++ b/lib/generated/l10n/zulip_localizations_kk.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsKk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_lv.dart
+++ b/lib/generated/l10n/zulip_localizations_lv.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsLv extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nb.dart
+++ b/lib/generated/l10n/zulip_localizations_nb.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsNb extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_nn.dart
+++ b/lib/generated/l10n/zulip_localizations_nn.dart
@@ -1284,6 +1284,9 @@ class ZulipLocalizationsNn extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Varsle emne';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Alle på Internett';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pl.dart
+++ b/lib/generated/l10n/zulip_localizations_pl.dart
@@ -1298,6 +1298,9 @@ class ZulipLocalizationsPl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Powiadom w wątku';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_pt.dart
+++ b/lib/generated/l10n/zulip_localizations_pt.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsPt extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_ru.dart
+++ b/lib/generated/l10n/zulip_localizations_ru.dart
@@ -1310,6 +1310,9 @@ class ZulipLocalizationsRu extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Оповестить тему';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Все пользователи интернета';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sk.dart
+++ b/lib/generated/l10n/zulip_localizations_sk.dart
@@ -1282,6 +1282,9 @@ class ZulipLocalizationsSk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_sl.dart
+++ b/lib/generated/l10n/zulip_localizations_sl.dart
@@ -1317,6 +1317,9 @@ class ZulipLocalizationsSl extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Obvesti udeležence teme';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_so.dart
+++ b/lib/generated/l10n/zulip_localizations_so.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsSo extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_uk.dart
+++ b/lib/generated/l10n/zulip_localizations_uk.dart
@@ -1299,6 +1299,9 @@ class ZulipLocalizationsUk extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Повідомити канал';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_vi.dart
+++ b/lib/generated/l10n/zulip_localizations_vi.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsVi extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/generated/l10n/zulip_localizations_zh.dart
+++ b/lib/generated/l10n/zulip_localizations_zh.dart
@@ -1280,6 +1280,9 @@ class ZulipLocalizationsZh extends ZulipLocalizations {
   String get wildcardMentionTopicDescription => 'Notify topic';
 
   @override
+  String get topicAutocompleteNewOptionLabel => 'New';
+
+  @override
   String get systemGroupNameEveryoneOnInternet => 'Everyone on the internet';
 
   @override

--- a/lib/model/autocomplete.dart
+++ b/lib/model/autocomplete.dart
@@ -1261,12 +1261,33 @@ class TopicAutocompleteView extends AutocompleteView<TopicAutocompleteQuery, Top
 
   @override
   Future<List<TopicAutocompleteResult>?> computeResults() async {
-    final results = <TopicAutocompleteResult>[];
+    final existingResults = <TopicAutocompleteResult>[];
     if (await filterCandidates(filter: _testTopic,
-          candidates: _topics, results: results)) {
+          candidates: _topics, results: existingResults)) {
       return null;
     }
-    return results;
+
+    if (existingResults.isEmpty || query.raw.trim().isEmpty) {
+      return existingResults;
+    }
+
+    final queryTopic = store.processTopicLikeServer(TopicName(query.raw.trim()));
+    final topicsPolicy = store.effectiveTopicsPolicy(channelId);
+    if (queryTopic.displayName == null
+          ? topicsPolicy == ChannelTopicsPolicy.disableEmptyTopic
+          : topicsPolicy == ChannelTopicsPolicy.emptyTopicOnly) {
+      return existingResults;
+    }
+
+    final queryTopicExists = _topics.any((topic) => topic == queryTopic);
+    if (queryTopicExists) {
+      return existingResults;
+    }
+
+    return [
+      TopicAutocompleteResult(topic: queryTopic, isNew: true),
+      ...existingResults,
+    ];
   }
 
   TopicAutocompleteResult? _testTopic(TopicAutocompleteQuery query, TopicName topic) {
@@ -1289,8 +1310,8 @@ class TopicAutocompleteQuery extends AutocompleteQuery {
       return AutocompleteQuery.lowercaseAndStripDiacritics(store.realmEmptyTopicDisplayName)
         .contains(_normalized);
     }
-    return topic.displayName != raw
-      && AutocompleteQuery.lowercaseAndStripDiacritics(topic.displayName!).contains(_normalized);
+    return AutocompleteQuery.lowercaseAndStripDiacritics(topic.displayName!)
+      .contains(_normalized);
   }
 
   @override
@@ -1311,7 +1332,11 @@ class TopicAutocompleteQuery extends AutocompleteQuery {
 class TopicAutocompleteResult extends AutocompleteResult {
   final TopicName topic;
 
-  TopicAutocompleteResult({required this.topic});
+  /// Whether this result represents a new topic taken from the query,
+  /// rather than an existing topic.
+  final bool isNew;
+
+  TopicAutocompleteResult({required this.topic, this.isNew = false});
 }
 
 /// An [AutocompleteView] for a #channel autocomplete interaction,

--- a/lib/widgets/autocomplete.dart
+++ b/lib/widgets/autocomplete.dart
@@ -499,6 +499,7 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
     // See Figma:
     //   https://www.figma.com/design/1JTNtYo9memgW7vV6d0ygq/Zulip-Mobile?node-id=7953-30436&m=dev
 
+    final zulipLocalizations = ZulipLocalizations.of(context);
     final designVariables = DesignVariables.of(context);
 
     final style = TextStyle(
@@ -521,14 +522,26 @@ class TopicAutocomplete extends AutocompleteField<TopicAutocompleteQuery, TopicA
           padding: const EdgeInsetsDirectional.fromSTEB(12, 2, 10, 2),
           child: Align(
             alignment: AlignmentDirectional.centerStart,
-            child: Text.rich(
-              topicLabelSpan(
-                context: context,
-                topic: option.topic,
-                fontSize: style.fontSize!,
-                color: style.color!),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: style)))));
+            child: Row(
+              spacing: 10,
+              children: [
+                Expanded(
+                  child: Text.rich(
+                    topicLabelSpan(
+                      context: context,
+                      topic: option.topic,
+                      fontSize: style.fontSize!,
+                      color: style.color!),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: style)),
+                if (option.isNew)
+                  Text(zulipLocalizations.topicAutocompleteNewOptionLabel,
+                    style: TextStyle(
+                      fontSize: 14,
+                      height: 16 / 14,
+                      fontStyle: FontStyle.italic,
+                      color: designVariables.contextMenuItemMeta)),
+              ])))));
   }
 }

--- a/test/model/autocomplete_checks.dart
+++ b/test/model/autocomplete_checks.dart
@@ -32,6 +32,7 @@ extension UserGroupMentionAutocompleteResultChecks on Subject<UserGroupMentionAu
 
 extension TopicAutocompleteResultChecks on Subject<TopicAutocompleteResult> {
   Subject<TopicName> get topic => has((r) => r.topic, 'topic');
+  Subject<bool> get isNew => has((r) => r.isNew, 'isNew');
 }
 
 extension ChannelLinkAutocompleteResultChecks on Subject<ChannelLinkAutocompleteResult> {

--- a/test/model/autocomplete_test.dart
+++ b/test/model/autocomplete_test.dart
@@ -1339,8 +1339,10 @@ void main() {
     doTest('a^bc^', TopicAutocompleteQuery('abc'));
   });
 
-  Condition<Object?> isTopic(TopicName topic) {
-    return (it) => it.isA<TopicAutocompleteResult>().topic.equals(topic);
+  Condition<Object?> isTopic(TopicName topic, {bool isNew = false}) {
+    return (it) => it.isA<TopicAutocompleteResult>()
+      ..topic.equals(topic)
+      ..isNew.equals(isNew);
   }
 
   test('TopicAutocompleteView misc', () async {
@@ -1363,7 +1365,48 @@ void main() {
     await Future(() {});
     await Future(() {});
     check(done).isTrue();
-    check(view.results).single.which(isTopic(third.name));
+    // 'Third' does not match 'Third Topic' case-sensitively, so 'Third' (new) is prepended.
+    check(view.results).deepEquals([
+      isTopic(eg.t('Third'), isNew: true),
+      isTopic(third.name),
+    ]);
+  });
+
+  test('TopicAutocompleteView prepends new option when query does not match case-sensitively', () async {
+    final store = eg.store();
+    final connection = store.connection as FakeApiConnection;
+    final topic1 = eg.getChannelTopicsEntry(maxId: 20, name: 'new topic');
+    final topic2 = eg.getChannelTopicsEntry(maxId: 10, name: 'new topic 1');
+    connection.prepare(json: GetChannelTopicsResult(topics: [topic1, topic2]).toJson());
+
+    final view = TopicAutocompleteView.init(
+      store: store,
+      channelId: eg.stream().streamId,
+      query: TopicAutocompleteQuery('new topi'));
+    bool done = false;
+    view.addListener(() { done = true; });
+
+    await Future(() {});
+    await Future(() {});
+    check(done).isTrue();
+    check(view.results).deepEquals([
+      isTopic(eg.t('new topi'), isNew: true),
+      isTopic(topic1.name),
+      isTopic(topic2.name),
+    ]);
+
+    // When query matches an existing topic case-sensitively, no new option is prepended.
+    view.query = TopicAutocompleteQuery('new topic');
+    await Future(() {});
+    check(view.results).deepEquals([
+      isTopic(topic1.name),
+      isTopic(topic2.name),
+    ]);
+
+    // When query does not match any existing topic, result is empty.
+    view.query = TopicAutocompleteQuery('nonexistent');
+    await Future(() {});
+    check(view.results).isEmpty();
   });
 
   test('TopicAutocompleteView updates results when topics are loaded', () async {
@@ -1411,12 +1454,15 @@ void main() {
     view1.query = TopicAutocompleteQuery('server');
     check(connection.takeRequests()).isEmpty();
     await Future(() {});
-    check(view1.results).single.which(isTopic(topic1.name));
+    check(view1.results).deepEquals([
+      isTopic(eg.t('server'), isNew: true),
+      isTopic(topic1.name),
+    ]);
     view1.dispose();
 
     // No need to prepare a response as there will be no request made.
     final view2 = TopicAutocompleteView.init(store: store, channelId: 1000,
-      query: TopicAutocompleteQuery('mobile'));
+      query: TopicAutocompleteQuery('mobile releases'));
     done = false;
     view2.addListener(() { done = true; });
 
@@ -1437,7 +1483,7 @@ void main() {
 
     test('topic is included if it matches the query', () {
       doCheck('', 'Top Name', true);
-      doCheck('Name', 'Name', false);
+      doCheck('Name', 'Name', true);
       doCheck('name', 'Name', true);
       doCheck('name', 'Nam', false);
       doCheck('nam', 'Name', true);

--- a/test/widgets/autocomplete_test.dart
+++ b/test/widgets/autocomplete_test.dart
@@ -728,5 +728,52 @@ void main() {
       await tester.pump(Duration.zero);
       check(controller.value).text.equals('');
     });
+
+    testWidgets('non-exact matching query shows "New" option and choosing it updates topic and focus', (tester) async {
+      final topic1 = eg.getChannelTopicsEntry(maxId: 1, name: 'new topic');
+      final topic2 = eg.getChannelTopicsEntry(maxId: 2, name: 'new topic 1');
+      final topicInputFinder = await setupToTopicInput(tester, topics: [topic1, topic2]);
+      final topicController = tester.widget<TextField>(topicInputFinder).controller!;
+
+      // TODO(#226): Remove this extra edit when this bug is fixed.
+      await tester.enterText(topicInputFinder, 'new');
+      await tester.enterText(topicInputFinder, 'new topi');
+      await tester.pumpAndSettle();
+
+      // "new topi" (New) option appears along with "new topic" and "new topic 1"
+      final newOptionFinder = find.ancestor(
+        of: find.text('new topi'),
+        matching: find.byType(InkWell));
+      check(newOptionFinder).findsOne();
+      check(find.text('New')).findsOne();
+      check(find.text('new topic')).findsOne();
+      check(find.text('new topic 1')).findsOne();
+
+      // Tap on "new topi" (New)
+      await tester.tap(newOptionFinder);
+      await tester.pumpAndSettle();
+
+      check(topicController.text).equals('new topi');
+      check(find.text('New')).findsNothing();
+
+      final contentInputFinder = find.byWidgetPredicate((widget) => widget is TextField
+        && widget.controller is ComposeContentController);
+      check(tester.widget<TextField>(contentInputFinder).focusNode!.hasFocus).isTrue();
+    });
+
+    testWidgets('exact case-sensitive match does not show "New" option', (tester) async {
+      final topic1 = eg.getChannelTopicsEntry(maxId: 1, name: 'new topic');
+      final topic2 = eg.getChannelTopicsEntry(maxId: 2, name: 'new topic 1');
+      final topicInputFinder = await setupToTopicInput(tester, topics: [topic1, topic2]);
+
+      // TODO(#226): Remove this extra edit when this bug is fixed.
+      await tester.enterText(topicInputFinder, 'new');
+      await tester.enterText(topicInputFinder, 'new topic');
+      await tester.pumpAndSettle();
+
+      check(find.text('New')).findsNothing();
+      check(find.ancestor(of: find.text('new topic'), matching: find.byType(InkWell))).findsOne();
+      check(find.text('new topic 1')).findsOne();
+    });
   });
 }


### PR DESCRIPTION
Fixes: #2324

### Problem
In Zulip Web, when choosing a topic to send a message to, if the query string doesn't match any existing channel topic case-sensitively, a new option is added at the top of the autocomplete option list for the exact query string with a trailing "New" label (as long as the query matches at least one existing topic, e.g. as a prefix or case-insensitive match).

Previously in the mobile app, `TopicAutocompleteQuery.testTopic` explicitly filtered out exact matches (`topic.displayName != raw`) and had no mechanism to present a "New" topic option at the top of the autocomplete list.

### Solution
- **Localization**: Added `topicAutocompleteNewOptionLabel` ("New") to `assets/l10n/app_en.arb` and generated localization classes.
- **Model**:
  - Added `final bool isNew;` to `TopicAutocompleteResult` (defaulting to `false`).
  - Removed `topic.displayName != raw` from `TopicAutocompleteQuery.testTopic` so that candidate filtering is based purely on normalized substring match.
  - In `TopicAutocompleteView.computeResults`, if candidate results exist and the query does not match any existing topic case-sensitively (and complies with the channel's `effectiveTopicsPolicy`), prepend `TopicAutocompleteResult(topic: queryTopic, isNew: true)` at index 0.
- **UI**:
  - In `TopicAutocomplete.buildItem`, rendered the topic along with a trailing `Text` showing `zulipLocalizations.topicAutocompleteNewOptionLabel` in italics with `contextMenuItemMeta` color when `option.isNew` is true.
- **Tests**:
  - Updated `TopicAutocompleteQuery.testTopic` tests and `TopicAutocompleteView` tests in `test/model/autocomplete_test.dart`.
  - Added widget tests in `test/widgets/autocomplete_test.dart` to verify that the "New" badge appears for non-exact matches, updates the topic input & focus on tap, and is not shown for exact case-sensitive matches.

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
