### PR TITLE
Reaction chip label width

### DIFF
--- a/lib/widgets/emoji.dart
+++ b/lib/widgets/emoji.dart
@@ -15,6 +15,7 @@ class EmojiWidget extends StatelessWidget {
     this.imagePlaceholderStyle = EmojiImagePlaceholderStyle.square,
     this.imageAnimationMode = ImageAnimationMode.animateConditionally,
     this.buildCustomTextEmoji,
+    this.onImageError,
   });
 
   final EmojiDisplay emojiDisplay;
@@ -48,6 +49,14 @@ class EmojiWidget extends StatelessWidget {
   /// is used.
   final Widget Function()? buildCustomTextEmoji;
 
+  /// Called when this is an image emoji and the image failed to load,
+  /// so the placeholder in [imagePlaceholderStyle] is shown instead.
+  ///
+  /// Called during build.
+  /// If the caller rebuilds in response (e.g. with [State.setState]),
+  /// it must schedule that for after the current frame.
+  final VoidCallback? onImageError;
+
   Widget _buildTextEmoji() {
     return buildCustomTextEmoji?.call()
       ?? Text(textEmojiForEmojiName(emojiDisplay.emojiName));
@@ -61,11 +70,14 @@ class EmojiWidget extends StatelessWidget {
         emojiDisplay: emojiDisplay,
         size: squareDimension,
         textScaler: squareDimensionScaler,
-        errorBuilder: (_, _, _) => switch (imagePlaceholderStyle) {
-          EmojiImagePlaceholderStyle.square =>
-            SizedBox.square(dimension: squareDimensionScaler.scale(squareDimension)),
-          EmojiImagePlaceholderStyle.nothing => SizedBox.shrink(),
-          EmojiImagePlaceholderStyle.text => _buildTextEmoji(),
+        errorBuilder: (_, _, _) {
+          onImageError?.call();
+          return switch (imagePlaceholderStyle) {
+            EmojiImagePlaceholderStyle.square =>
+              SizedBox.square(dimension: squareDimensionScaler.scale(squareDimension)),
+            EmojiImagePlaceholderStyle.nothing => SizedBox.shrink(),
+            EmojiImagePlaceholderStyle.text => _buildTextEmoji(),
+          };
         },
         animationMode: imageAnimationMode),
       UnicodeEmojiDisplay() => UnicodeEmojiWidget(

--- a/lib/widgets/emoji_reaction.dart
+++ b/lib/widgets/emoji_reaction.dart
@@ -146,7 +146,7 @@ class ReactionChipsList extends StatelessWidget {
   }
 }
 
-class ReactionChip extends StatelessWidget {
+class ReactionChip extends StatefulWidget {
   final bool showName;
   final int messageId;
   final ReactionWithVotes reactionWithVotes;
@@ -158,11 +158,41 @@ class ReactionChip extends StatelessWidget {
     required this.reactionWithVotes,
   });
 
+  @override
+  State<ReactionChip> createState() => _ReactionChipState();
+}
+
+class _ReactionChipState extends State<ReactionChip> {
+  /// Whether this is an image emoji whose image failed to load,
+  /// so that a text emoji is being shown instead.
+  bool _imageFailed = false;
+
+  @override
+  void didUpdateWidget(covariant ReactionChip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final reaction = widget.reactionWithVotes;
+    final oldReaction = oldWidget.reactionWithVotes;
+    if (reaction.reactionType != oldReaction.reactionType
+        || reaction.emojiCode != oldReaction.emojiCode) {
+      _imageFailed = false;
+    }
+  }
+
+  void _handleImageError() {
+    if (_imageFailed) return;
+    // This is called during build (see [EmojiWidget.onImageError]),
+    // so wait for the current frame before rebuilding.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() => _imageFailed = true);
+    });
+  }
+
   // Linear in the number of voters (of course);
   // best to avoid calling this unless we know there are few voters.
   String _voterNames(PerAccountStore store, ZulipLocalizations zulipLocalizations) {
     final selfUserId = store.selfUserId;
-    final userIds = reactionWithVotes.userIds;
+    final userIds = widget.reactionWithVotes.userIds;
     final result = <String>[];
     if (userIds.contains(selfUserId)) {
       // Putting "You" first is helpful when this is used in the semantics label.
@@ -180,15 +210,15 @@ class ReactionChip extends StatelessWidget {
     final store = PerAccountStoreWidget.of(context);
     final zulipLocalizations = ZulipLocalizations.of(context);
 
-    final reactionType = reactionWithVotes.reactionType;
-    final emojiCode = reactionWithVotes.emojiCode;
-    final emojiName = reactionWithVotes.emojiName;
-    final userIds = reactionWithVotes.userIds;
+    final reactionType = widget.reactionWithVotes.reactionType;
+    final emojiCode = widget.reactionWithVotes.emojiCode;
+    final emojiName = widget.reactionWithVotes.emojiName;
+    final userIds = widget.reactionWithVotes.userIds;
 
     final selfVoted = userIds.contains(store.selfUserId);
     final String label;
     final String semanticsLabel;
-    if (showName) {
+    if (widget.showName) {
       final names = _voterNames(store, zulipLocalizations);
       label = names;
       semanticsLabel = zulipLocalizations.reactionChipLabel(emojiName, names);
@@ -228,6 +258,7 @@ class ReactionChip extends StatelessWidget {
       squareDimension: _squareEmojiSize,
       squareDimensionScaler: _squareEmojiScalerClamped(context),
       imagePlaceholderStyle: EmojiImagePlaceholderStyle.text,
+      onImageError: _handleImageError,
       buildCustomTextEmoji: () => _TextEmoji(
         emojiName: emojiName, selected: selfVoted),
     );
@@ -241,13 +272,13 @@ class ReactionChip extends StatelessWidget {
         highlightColor: highlightColor,
         onLongPress: () {
           showViewReactionsSheet(PageRoot.contextOf(context),
-            messageId: messageId,
+            messageId: widget.messageId,
             initialReactionType: reactionType,
             initialEmojiCode: emojiCode);
         },
         onTap: () {
           (selfVoted ? removeReaction : addReaction).call(store.connection,
-            messageId: messageId,
+            messageId: widget.messageId,
             reactionType: reactionType,
             emojiCode: emojiCode,
             emojiName: emojiName,
@@ -260,17 +291,25 @@ class ReactionChip extends StatelessWidget {
           child: LayoutBuilder(
             builder: (context, constraints) {
               final maxRowWidth = constraints.maxWidth;
-              // To give text emojis some room so they need fewer line breaks
-              // when the label is long.
-              // TODO(#433) This is a bit overzealous. The shorter width
-              //   won't be necessary when the text emoji is very short, or
-              //   in the near-universal case of small, square emoji (i.e.
-              //   Unicode and image emoji). But it's not simple to recognize
-              //   those cases here: we don't know at this point whether we'll
-              //   be showing a text emoji, because we use that for various
-              //   error conditions (including when an image fails to load,
-              //   which we learn about especially late).
-              final maxLabelWidth = (maxRowWidth - 6) * 0.75; // 6 is padding
+              // For a text emoji, give the emoji some room
+              // so it needs fewer line breaks when the label is long,
+              // by narrowing the label to part of the row's width.
+              // A square emoji (i.e. Unicode or image emoji,
+              // the near-universal case) doesn't need that room,
+              // so the label can have all the width the emoji doesn't use.
+              // An image emoji can still end up as a text emoji
+              // when its image fails to load; we learn about that
+              // especially late, so [_imageFailed] triggers a rebuild
+              // to switch to the text-emoji layout.  (#433)
+              final asTextEmoji = emojiDisplay is TextEmojiDisplay || _imageFailed;
+              final double maxLabelWidth;
+              if (asTextEmoji) {
+                maxLabelWidth = (maxRowWidth - 6) * 0.75; // 6 is padding
+              } else {
+                final emojiWidth = _squareEmojiScalerClamped(context)
+                  .scale(_squareEmojiSize);
+                maxLabelWidth = maxRowWidth - emojiWidth - 12; // 12 is padding
+              }
 
               final labelScaler = _labelTextScalerClamped(context);
               return Row(

--- a/test/widgets/emoji_reaction_test.dart
+++ b/test/widgets/emoji_reaction_test.dart
@@ -279,6 +279,128 @@ void main() {
       }
     }
 
+    group('chip label width', () {
+      // The width [setupChipsInBox] gives the list, and the chip's own
+      // horizontal padding; see [ReactionChip.build].
+      const maxRowWidth = 245.0 - (4 + 5);
+      // The padding around the emoji and around the label, within the chip's
+      // row; see [ReactionChip.build].
+      const rowPadding = (3 + 3) + (3 + 3);
+      // [_squareEmojiSize], unscaled.
+      const squareEmojiWidth = 17.0;
+
+      final user1 = eg.user(fullName: 'Long Name With Many Words In It');
+      final user2 = eg.user(fullName: 'longnamelongnamelongnamelongname');
+      final user3 = eg.user(fullName: 'Another Quite Long Name Here');
+      final voters = [user1, user2, user3];
+
+      // Long enough that the chip's max label width actually constrains it.
+      final label = voters.map((user) => user.fullName).join(', ');
+
+      /// Pump the chip with [voters] reacting with [jsonEmoji].
+      ///
+      /// Pumping again reuses the chip's [State], as happens when a
+      /// message's reactions change.
+      Future<void> pumpChipWith(WidgetTester tester,
+          Map<String, String> jsonEmoji) async {
+        await setupChipsInBox(tester, reactions: [
+          for (final user in voters)
+            Reaction.fromJson({ ...jsonEmoji, 'user_id': user.userId}),
+        ]);
+        // Let an image emoji's load failure, and the relayout it prompts,
+        // settle before we measure.
+        await tester.pump();
+        await tester.pump();
+      }
+
+      /// Set up the store and pump one chip, with [voters] reacting
+      /// with [jsonEmoji].
+      ///
+      /// Serves the emoji's image with [imageStatus], so that passing
+      /// something other than [HttpStatus.ok] makes the image fail to load.
+      Future<void> pumpChip(WidgetTester tester, {
+        required Map<String, String> jsonEmoji,
+        Emojiset emojiset = Emojiset.google,
+        int imageStatus = HttpStatus.ok,
+      }) async {
+        await prepare();
+        await store.addUsers(voters);
+        await store.handleEvent(RealmEmojiUpdateEvent(id: 1, realmEmoji: {
+          '181': eg.realmEmojiItem(emojiCode: '181', emojiName: 'twocents'),
+        }));
+        await store.handleEvent(UserSettingsUpdateEvent(id: 1,
+          property: UserSettingName.displayEmojiReactionUsers, value: true));
+        await store.handleEvent(UserSettingsUpdateEvent(id: 1,
+          property: UserSettingName.emojiset, value: emojiset));
+
+        // Otherwise a load in an earlier test is reused here, and a test
+        // that wants the load to fail never sees it fail.
+        imageCache.clear();
+        imageCache.clearLiveImages();
+
+        final httpClient = FakeImageHttpClient();
+        debugNetworkImageHttpClientProvider = () => httpClient;
+        httpClient.request.response
+          ..statusCode = imageStatus
+          ..content = kSolidBlueAvatar;
+
+        await pumpChipWith(tester, jsonEmoji);
+      }
+
+      // TODO(upstream) Do this in an addTearDown, once we can:
+      //   https://github.com/flutter/flutter/issues/123189
+      void resetImageHttpClient() {
+        debugNetworkImageHttpClientProvider = null;
+      }
+
+      /// The max width the chip allows its label.
+      double labelMaxWidth(WidgetTester tester) {
+        final container = tester.widget<Container>(find.ancestor(
+          of: find.text(label), matching: find.byType(Container)).first);
+        return container.constraints!.maxWidth;
+      }
+
+      testWidgets('square emoji: label gets the width the emoji does not use',
+          (tester) async {
+        await pumpChip(tester, jsonEmoji: u1); // a Unicode emoji, so square
+        check(labelMaxWidth(tester))
+          .equals(maxRowWidth - squareEmojiWidth - rowPadding);
+        resetImageHttpClient();
+      });
+
+      testWidgets('text emoji: label leaves the emoji a quarter of the width',
+          (tester) async {
+        await pumpChip(tester, jsonEmoji: u1, emojiset: Emojiset.text);
+        check(labelMaxWidth(tester)).equals((maxRowWidth - 6) * 0.75);
+        resetImageHttpClient();
+      });
+
+      testWidgets('image emoji that loads: treated as a square emoji',
+          (tester) async {
+        await pumpChip(tester, jsonEmoji: i1);
+        check(labelMaxWidth(tester))
+          .equals(maxRowWidth - squareEmojiWidth - rowPadding);
+        resetImageHttpClient();
+      });
+
+      testWidgets('image emoji that fails to load: treated as a text emoji',
+          (tester) async {
+        await pumpChip(tester, jsonEmoji: i1, imageStatus: HttpStatus.notFound);
+        check(labelMaxWidth(tester)).equals((maxRowWidth - 6) * 0.75);
+        resetImageHttpClient();
+      });
+
+      testWidgets('image emoji that failed, then a different emoji: '
+          'square again', (tester) async {
+        await pumpChip(tester, jsonEmoji: i1, imageStatus: HttpStatus.notFound);
+        check(labelMaxWidth(tester)).equals((maxRowWidth - 6) * 0.75);
+        await pumpChipWith(tester, u1); // a Unicode emoji, so square
+        check(labelMaxWidth(tester))
+          .equals(maxRowWidth - squareEmojiWidth - rowPadding);
+        resetImageHttpClient();
+      });
+    });
+
     testWidgets('show "Muted user" label for muted reactors', (tester) async {
       final user1 = eg.user(userId: 1, fullName: 'User 1');
       final user2 = eg.user(userId: 2, fullName: 'User 2');


### PR DESCRIPTION
Fixes: #433

A reaction chip reserved 25% of its width for the emoji:

    final maxLabelWidth = (maxRowWidth - 6) * 0.75; // 6 is padding

That much room is right for a text emoji, which is rendered as
literal text like `:some_long_name:` and needs the space to avoid
frequent line breaks. But a Unicode or image emoji is a fixed-size
square, `_squareEmojiSize` wide, which is much less than a quarter of
a typical chip. So in the near-universal case the label wrapped
sooner than it had to, which is the symptom in #433.

The TODO on that line explained why it hadn't been fixed:

> we don't know at this point whether we'll be showing a text emoji,
> because we use that for various error conditions (including when an
> image fails to load, which we learn about especially late).

That's the real obstacle, and it's what most of this branch is about.
`emojiDisplay` tells us the intended rendering, but an
`ImageEmojiDisplay` still degrades to a text emoji when its image
fails to load — and that's discovered inside the image's
`errorBuilder`, in a descendant, well after the `LayoutBuilder` above
it has computed a width.

So: give `EmojiWidget` an `onImageError` callback, and make
`ReactionChip` stateful so it can note the failure and lay out again
as a text emoji. The chip now picks its width from whether it is
*actually* showing a text emoji, not merely whether it intended to.

Two details worth flagging for review:

* `onImageError` fires during build, so a caller that rebuilds in
  response has to defer that to after the current frame.
  `ReactionChip` uses `addPostFrameCallback`. The dartdoc says so,
  but I'd welcome a better shape for this if there is one.

* `didUpdateWidget` clears the failure flag when the chip's
  `reactionType` or `emojiCode` changes, since Flutter may recycle
  the `State` for a different emoji that loads fine.

The cost is one extra frame for an emoji whose image fails: the chip
lays out square, learns of the failure, then lays out as text. That's
a one-frame reflow on an already-broken emoji, which seemed a fair
trade for getting the common case right.

## Screenshots

The failure case is produced by forcing every image emoji down its
`errorBuilder` path, so the chip falls back to a text emoji.

| | before | after |
| --- | --- | --- |
| **image emoji loads** | <img width="300" alt="before, image emoji loads" src="https://github.com/user-attachments/assets/7b11f5b8-8d4d-4a3e-99a8-25d760718306"> | <img width="300" alt="after, image emoji loads" src="https://github.com/user-attachments/assets/2d801941-6806-4d58-81e2-99d929954fbe"> |
| **image emoji fails to load** | <img width="300" alt="before, image emoji fails to load" src="https://github.com/user-attachments/assets/a829ba5e-d8f1-4f2e-b94f-684219799cce"> | <img width="300" alt="after, image emoji fails to load" src="https://github.com/user-attachments/assets/11ba9f82-653b-449c-ac49-a5c5450c5697"> |

## Commits

* `emoji: Add EmojiWidget.onImageError, …` — the API addition alone.
* `emoji_reaction: Give the label the width a square emoji does not use`
  — the fix.
* `emoji_reaction: Test reaction-chip label width` — tests.

## Testing

Five widget tests covering the width the chip allows its label:
a square emoji, a text emoji, an image emoji that loads, an image
emoji that fails to load, and that same chip once a different emoji
replaces it.

I checked that each test actually covers the change, by reverting
each piece and confirming the expected tests fail: reverting the
layout logic fails the two square-emoji cases while the text-emoji
cases still pass; removing `didUpdateWidget` fails only the
replacement case; removing the `onImageError` call fails the two
image-failure cases.

One wrinkle: the image cases clear `imageCache` first. Without that,
the successful load in an earlier test is reused, and the test that
wants the load to fail never sees it fail.

Full suite passes; `flutter analyze` is clean.

## Open questions

* The text-emoji branch keeps the original `- 6`, while the new
  square branch subtracts the full `12` of row padding. I left the
  existing behavior alone rather than fold in a drive-by change, but
  the two now sit side by side and the inconsistency is visible.
  Happy to make them agree if you'd prefer.

* The tests restate `_squareEmojiSize` and the padding values, since
  they're private. Would you rather they assert the relationship
  (square label wider than text label) than exact pixels, or should
  those constants be visible to tests?