### PR TITLE
notif: Open iOS notifications at the message they're for

### DIFF
--- a/lib/notifications/ios_service.dart
+++ b/lib/notifications/ios_service.dart
@@ -94,9 +94,11 @@ class _IosNotifFlutterApiImpl extends IosNotifFlutterApi {
       NotificationDisplayManager.titleForNotifPayload(data, zulipLocalizations);
     final subtitle =
       NotificationDisplayManager.subtitleForNotifPayloadOnIos(data);
+    // A notification on iOS shows a single message.
+    // See [NotificationOpenPayload.messageId].
     final notificationUrl =
-      // TODO(#1565): Open at specific message on iOS too.
-      NotificationDisplayManager.notificationUrlForNotifPayload(data, messageId: null);
+      NotificationDisplayManager.notificationUrlForNotifPayload(
+        data, messageId: data.messageId);
 
     return ImprovedNotificationContent(
       title: title,

--- a/lib/notifications/ios_service.dart
+++ b/lib/notifications/ios_service.dart
@@ -107,7 +107,7 @@ class _IosNotifFlutterApiImpl extends IosNotifFlutterApi {
         // Pass the notification URL to this custom data map, so when a
         // notification is opened we can read this custom map to decide
         // which conversation to open.
-        // See NotificationOpenService (in lib/notifications/ios_service.dart).
+        // See NotificationOpenService (in lib/notifications/open.dart).
         NotificationOpenPayload.kIosNotificationUrlKey: notificationUrl.toString(),
       });
   }

--- a/lib/notifications/open.dart
+++ b/lib/notifications/open.dart
@@ -282,9 +282,8 @@ class NotificationOpenPayload {
   /// this is the earliest of them,
   /// so that opening the notification shows the whole batch (#1565).
   ///
-  /// Null when the notification doesn't identify a message:
-  /// from iOS (TODO(#1565)),
-  /// or from a notification created before this field existed.
+  /// Null when the notification doesn't identify a message,
+  /// as with a notification created before this field existed.
   final int? messageId;
 
   NotificationOpenPayload({
@@ -373,11 +372,19 @@ class NotificationOpenPayload {
         _ => throw const FormatException(),
       };
 
+      // The server sends a single message ID, in a one-element list;
+      // see `get_message_payload_apns` in
+      // zulip/zulip:zerver/lib/push_notifications.py .
+      final messageId = switch (zulipData) {
+        {'message_ids': [final int messageId]} => messageId,
+        _ => throw const FormatException(),
+      };
+
       return NotificationOpenPayload(
         realmUrl: Uri.parse(realmUrl),
         userId: userId,
         narrow: narrow,
-        messageId: null);
+        messageId: messageId);
     } else {
       // TODO(dart): simplify after https://github.com/dart-lang/language/issues/2537
       throw const FormatException();

--- a/test/notifications/ios_service_test.dart
+++ b/test/notifications/ios_service_test.dart
@@ -76,8 +76,7 @@ void main() {
         NotifPayloadDmRecipient(:var allRecipientIds) =>
           DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
       },
-      // TODO(#1565): also open at the specific message on iOS
-      messageId: null).buildNotificationUrl();
+      messageId: data.messageId).buildNotificationUrl();
 
     check(result)
       ..title.equals(expectedTitle)

--- a/test/notifications/open_test.dart
+++ b/test/notifications/open_test.dart
@@ -158,9 +158,7 @@ void main() {
           NotifPayloadDmRecipient(:var allRecipientIds) =>
             DmNarrow(allRecipientIds: allRecipientIds, selfUserId: data.userId),
         },
-        // TODO(#1565): also open at the specific message on iOS
-        messageId: defaultTargetPlatform == TargetPlatform.iOS
-          ? null : data.messageId).buildNotificationUrl();
+        messageId: data.messageId).buildNotificationUrl();
     }
 
     Map<String, Object?> messageApnsPayload(
@@ -240,9 +238,7 @@ void main() {
         ..page.isA<MessageListPage>().which((it) => it
           ..initNarrow.equals(SendableNarrow.ofMessage(message,
             selfUserId: account.userId))
-          // TODO(#1565): also open at the specific message on iOS
-          ..initAnchorMessageId.equals(
-              defaultTargetPlatform == TargetPlatform.iOS ? null : message.id));
+          ..initAnchorMessageId.equals(message.id));
     }
 
     Future<void> checkOpenNotification(
@@ -674,14 +670,14 @@ void main() {
         final account = eg.account(
           realmUrl: Uri.parse('http://chat.example'),
           user: userA);
-        final payload = messageLegacyApnsPayload(eg.dmMessage(from: userB, to: [userA]),
-          account: account);
+        final message = eg.dmMessage(from: userB, to: [userA]);
+        final payload = messageLegacyApnsPayload(message, account: account);
         check(NotificationOpenPayload.parseLegacyIosApnsPayload(payload))
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<DmNarrow>()
             ..otherRecipientIds.deepEquals([1002]))
-          ..messageId.isNull();
+          ..messageId.equals(message.id);
       });
 
       test('smoke group DM', () {
@@ -691,14 +687,14 @@ void main() {
         final account = eg.account(
           realmUrl: Uri.parse('http://chat.example'),
           user: userA);
-        final payload = messageLegacyApnsPayload(eg.dmMessage(from: userC, to: [userA, userB]),
-          account: account);
+        final message = eg.dmMessage(from: userC, to: [userA, userB]);
+        final payload = messageLegacyApnsPayload(message, account: account);
         check(NotificationOpenPayload.parseLegacyIosApnsPayload(payload))
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<DmNarrow>()
             ..otherRecipientIds.deepEquals([1002, 1003]))
-          ..messageId.isNull();
+          ..messageId.equals(message.id);
       });
 
       test('smoke topic message', () {
@@ -706,17 +702,17 @@ void main() {
         final account = eg.account(
           realmUrl: Uri.parse('http://chat.example'),
           user: userA);
-        final payload = messageLegacyApnsPayload(eg.streamMessage(
+        final message = eg.streamMessage(
           stream: eg.stream(streamId: 1),
-          topic: 'topic A'),
-          account: account);
+          topic: 'topic A');
+        final payload = messageLegacyApnsPayload(message, account: account);
         check(NotificationOpenPayload.parseLegacyIosApnsPayload(payload))
           ..realmUrl.equals(Uri.parse('http://chat.example'))
           ..userId.equals(1001)
           ..narrow.which((it) => it.isA<TopicNarrow>()
             ..channelId.equals(1)
             ..topic.equals(TopicName('topic A')))
-          ..messageId.isNull();
+          ..messageId.equals(message.id);
       });
     });
 
@@ -741,7 +737,6 @@ void main() {
       });
 
       test('smoke DM, without a message ID', () {
-        // TODO(#1565): iOS omits the message ID for now.
         final url = NotificationOpenPayload(
           realmUrl: Uri.parse('http://chat.example'),
           userId: 1001,
@@ -780,7 +775,6 @@ void main() {
       });
 
       test('smoke topic, without a message ID', () {
-        // TODO(#1565): iOS omits the message ID for now.
         final url = NotificationOpenPayload(
           realmUrl: Uri.parse('http://chat.example'),
           userId: 1001,
@@ -822,7 +816,6 @@ void main() {
       });
 
       test('smoke DM, without a message ID', () {
-        // TODO(#1565): iOS omits the message ID for now.
         final url = Uri(
           scheme: 'zulip',
           host: 'notification',
@@ -863,7 +856,6 @@ void main() {
       });
 
       test('smoke topic, without a message ID', () {
-        // TODO(#1565): iOS omits the message ID for now.
         final url = Uri(
           scheme: 'zulip',
           host: 'notification',


### PR DESCRIPTION
Fixes #1565.

Tapping a notification navigated to the conversation, landing on the
first unread, which in a long thread can be thousands of messages back
and unrelated to the notification.  We fixed that on Android in
328d6f2a2; do the same on iOS.

Tested manually against Zulip Server 10.4 for legacy notifications,
and against the server's latest main for E2EE notifications.