### PR TITLE
login: Resolve relative displayIcon URLs for external auth methods

### DIFF
--- a/lib/widgets/login.dart
+++ b/lib/widgets/login.dart
@@ -463,13 +463,19 @@ class _LoginPageState extends State<LoginPage> {
         if (showPasswordForm)
           _AlternativeAuthDivider(),
         ...externalAuthenticationMethods.map((method) {
-          final icon = method.displayIcon;
+          final displayIcon = method.displayIcon;
+          // The server may send an absolute or a realm-relative URL here;
+          // resolve it against the realm URL just as for [method.loginUrl]
+          // in [_beginWebAuth].
+          final iconUrl = displayIcon != null
+            ? widget.serverSettings.realmUrl.resolve(displayIcon)
+            : null;
           return OutlinedButton.icon(
             style: ButtonStyle(
               backgroundColor: WidgetStatePropertyAll(colorScheme.secondaryContainer),
               foregroundColor: WidgetStatePropertyAll(colorScheme.onSecondaryContainer)),
-            icon: icon != null
-              ? Image.network(icon, width: 24, height: 24)
+            icon: iconUrl != null
+              ? Image.network(iconUrl.toString(), width: 24, height: 24)
               : null,
             onPressed: !_inProgress
               ? () => _beginWebAuth(method)

--- a/test/widgets/login_test.dart
+++ b/test/widgets/login_test.dart
@@ -422,6 +422,27 @@ void main() {
         debugNetworkImageHttpClientProvider = null;
       });
 
+      testWidgets('resolves a realm-relative displayIcon URL', (tester) async {
+        // Regression test for: https://github.com/zulip/zulip-flutter/issues/1969
+        prepareBoringImageHttpClient(); // icon on social-auth button
+        final relativeIconMethod = ExternalAuthenticationMethod(
+          name: googleAuthMethod.name,
+          displayName: googleAuthMethod.displayName,
+          displayIcon: '/static/images/authentication_backends/google-icon.png',
+          loginUrl: googleAuthMethod.loginUrl,
+          signupUrl: googleAuthMethod.signupUrl);
+        final serverSettings = eg.serverSettings(
+          emailAuthEnabled: false,
+          authenticationMethods: eg.authMethods(ldap: false),
+          externalAuthenticationMethods: [relativeIconMethod]);
+        await prepare(tester, serverSettings);
+        check(find.textContaining('Google')).findsOne();
+        final image = tester.widget<Image>(find.byType(Image));
+        check((image.image as NetworkImage).url).equals(
+          serverSettings.realmUrl.resolve(relativeIconMethod.displayIcon!).toString());
+        debugNetworkImageHttpClientProvider = null;
+      });
+
       testWidgets('shows divider when email auth enabled with external methods', (tester) async {
         prepareBoringImageHttpClient(); // icon on social-auth button
         final serverSettings = eg.serverSettings(


### PR DESCRIPTION
## Problem

In the [get-server-settings](https://zulip.com/api/get-server-settings) response, each external auth method can carry a `display_icon` URL used for the icon on its login/signup button. We treated that string as always absolute and passed it straight to `Image.network`. The server has long accepted a realm-relative URL there too, and the web app already handles that case, so a relative `display_icon` currently fails to load in the app.

## Root cause

`lib/widgets/login.dart` used `method.displayIcon` directly as the `Image.network` source with no resolution step, unlike `method.loginUrl` a few lines below, which is resolved against `realmUrl` before use.

## Fix

Resolve `displayIcon` against `widget.serverSettings.realmUrl` the same way `loginUrl` already is, before handing it to `Image.network`. `Uri.resolve` already handles the case where the reference is itself absolute, so this is a single code path for both absolute and relative icons, so there is no need for a separate prefix check.

## Testing

- Added a widget test asserting that a realm-relative `displayIcon` is resolved to the correct absolute URL before reaching `Image.network`.
- The existing tests already cover the absolute-URL case (`googleAuthMethod` uses an absolute `displayIcon`), so backward compatibility is verified too.
- `flutter test --no-pub test/widgets/login_test.dart`: all 29 tests pass.
- `flutter analyze --no-pub`: no issues.
- I have not been able to verify this manually against a real Zulip server with a relative `display_icon` configured; happy to do so with pointers, or have a maintainer/reviewer confirm.

## Impact

Small, self-contained fix scoped to the login page's external-auth icon rendering. No API or model changes.

Fixes #1969
